### PR TITLE
Cleaning up build exports and imports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@
 *.exe
 *.out
 *.app
+
+#colcon output
+build
+log
+install
+

--- a/src/control/CMakeLists.txt
+++ b/src/control/CMakeLists.txt
@@ -42,6 +42,20 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_cppcheck REQUIRED)
+  find_package(ament_cmake_cpplint REQUIRED)
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
+  # This forces cppcheck to consider all files in this project to be C++,
+  # including the headers which end with .h, which cppcheck would normally
+  # consider to be C instead.
+  ament_cppcheck(LANGUAGE "c++")
+  ament_cpplint()
+  ament_lint_cmake()
+  ament_uncrustify()
+endif()
+
 ament_export_include_directories(include)
 
 ament_package()

--- a/src/control/CMakeLists.txt
+++ b/src/control/CMakeLists.txt
@@ -14,34 +14,34 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
+find_package(task REQUIRED)
 
 include_directories(
   include
-  ../task/include
-  ../robot/include
-  )
-
-link_directories(${CMAKE_BINARY_DIR}/../libs)
+)
 
 add_executable(dwa_controller
   src/DwaController.cpp
   src/main.cpp
-  )
+)
 
-target_link_libraries(dwa_controller
-  robot
-  )
-
-ament_target_dependencies(dwa_controller 
-  rclcpp 
+ament_target_dependencies(dwa_controller
+  rclcpp
   std_msgs
   nav2_msgs
-  robot
-  )
+  task
+)
 
 install(TARGETS dwa_controller
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME})
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY include/
+  DESTINATION include/
+)
+
+ament_export_include_directories(include)
 
 ament_package()

--- a/src/control/package.xml
+++ b/src/control/package.xml
@@ -6,14 +6,18 @@
   <description>TODO</description>
   <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <license>Apache License 2.0</license>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>nav2_msgs</build_depend>
   <build_depend>task</build_depend>
+
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/control/package.xml
+++ b/src/control/package.xml
@@ -4,14 +4,13 @@
   <name>control</name>
   <version>0.1.0</version>
   <description>TODO</description>
-  <author email="oregon.robotics.team@intel.com">Oregon Robotics Team</author>
   <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <license>Apache License 2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>nav2_msgs</build_depend>
-  <build_depend>robot</build_depend>
+  <build_depend>task</build_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
@@ -19,4 +18,3 @@
     <build_type>ament_cmake</build_type>
   </export>
 </package>
-

--- a/src/mission_execution/CMakeLists.txt
+++ b/src/mission_execution/CMakeLists.txt
@@ -14,32 +14,30 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
+find_package(task REQUIRED)
+find_package(navigation REQUIRED)
 
 include_directories(
   include
-  ../task/include
-  ../navigation/include
-  )
-
-link_directories(${CMAKE_BINARY_DIR}/../libs)
+)
 
 add_executable(mission_execution
   src/main.cpp
   src/MissionExecution.cpp
-  )
+)
 
-target_link_libraries(mission_execution
-  )
-
-ament_target_dependencies(mission_execution 
-  rclcpp 
+ament_target_dependencies(mission_execution
+  rclcpp
   std_msgs
   nav2_msgs
-  )
+  task
+  navigation
+)
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME})
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
 
 ament_package()

--- a/src/mission_execution/CMakeLists.txt
+++ b/src/mission_execution/CMakeLists.txt
@@ -40,4 +40,18 @@ install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_cppcheck REQUIRED)
+  find_package(ament_cmake_cpplint REQUIRED)
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
+  # This forces cppcheck to consider all files in this project to be C++,
+  # including the headers which end with .h, which cppcheck would normally
+  # consider to be C instead.
+  ament_cppcheck(LANGUAGE "c++")
+  ament_cpplint()
+  ament_lint_cmake()
+  ament_uncrustify()
+endif()
+
 ament_package()

--- a/src/mission_execution/package.xml
+++ b/src/mission_execution/package.xml
@@ -11,10 +11,11 @@
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>nav2_msgs</build_depend>
+  <build_depend>task</build_depend>
+  <build_depend>navigation</build_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>
 </package>
-

--- a/src/mission_execution/package.xml
+++ b/src/mission_execution/package.xml
@@ -7,14 +7,18 @@
   <author email="oregon.robotics.team@intel.com">Oregon Robotics Team</author>
   <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <license>Apache License 2.0</license>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>nav2_msgs</build_depend>
   <build_depend>task</build_depend>
   <build_depend>navigation</build_depend>
+
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/nav2_msgs/package.xml
+++ b/src/nav2_msgs/package.xml
@@ -7,16 +7,21 @@
   <author email="oregon.robotics.team@intel.com">Oregon Robotics Team</author>
   <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <license>Apache License 2.0</license>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
+
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+
   <member_of_group>rosidl_interface_packages</member_of_group>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/navigation/CMakeLists.txt
+++ b/src/navigation/CMakeLists.txt
@@ -48,6 +48,20 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_cppcheck REQUIRED)
+  find_package(ament_cmake_cpplint REQUIRED)
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
+  # This forces cppcheck to consider all files in this project to be C++,
+  # including the headers which end with .h, which cppcheck would normally
+  # consider to be C instead.
+  ament_cppcheck(LANGUAGE "c++")
+  ament_cpplint()
+  ament_lint_cmake()
+  ament_uncrustify()
+endif()
+
 ament_export_include_directories(include)
 
 ament_package()

--- a/src/navigation/CMakeLists.txt
+++ b/src/navigation/CMakeLists.txt
@@ -14,38 +14,40 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
+find_package(task REQUIRED)
+find_package(planning REQUIRED)
+find_package(control REQUIRED)
+find_package(robot REQUIRED)
 
 include_directories(
   include
-  ../task/include
-  ../robot/include
-  ../planning/include
-  ../control/include
-  )
-
-link_directories(${CMAKE_BINARY_DIR}/../libs)
+)
 
 add_executable(simple_navigator
   src/SimpleNavigator.cpp
   src/main.cpp
-  )
+)
 
-target_link_libraries(simple_navigator
-  robot
-  )
-
-ament_target_dependencies(simple_navigator 
-  rclcpp 
+ament_target_dependencies(simple_navigator
+  rclcpp
   std_msgs
   nav2_msgs
+  task
   planning
   control
   robot
-  )
+)
 
 install(TARGETS simple_navigator
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME})
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY include/
+  DESTINATION include/
+)
+
+ament_export_include_directories(include)
 
 ament_package()

--- a/src/navigation/package.xml
+++ b/src/navigation/package.xml
@@ -11,10 +11,13 @@
   <build_depend>rclcpp</build_depend>
   <build_depend>nav2_msgs</build_depend>
   <build_depend>robot</build_depend>
+  <build_depend>task</build_depend>
+  <build_depend>planning</build_depend>
+  <build_depend>control</build_depend>
+  <build_depend>robot</build_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>
 </package>
-

--- a/src/navigation/package.xml
+++ b/src/navigation/package.xml
@@ -7,7 +7,9 @@
   <author email="oregon.robotics.team@intel.com">Oregon Robotics Team</author>
   <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <license>Apache License 2.0</license>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>rclcpp</build_depend>
   <build_depend>nav2_msgs</build_depend>
   <build_depend>robot</build_depend>
@@ -15,8 +17,10 @@
   <build_depend>planning</build_depend>
   <build_depend>control</build_depend>
   <build_depend>robot</build_depend>
+
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/planning/CMakeLists.txt
+++ b/src/planning/CMakeLists.txt
@@ -14,31 +14,34 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
+find_package(task REQUIRED)
 
 include_directories(
   include
-  ../task/include
-  )
-
-link_directories(${CMAKE_BINARY_DIR}/../libs)
+)
 
 add_executable(astar_planner
   src/AStarPlanner.cpp
   src/main.cpp
-  )
+)
 
-target_link_libraries(astar_planner
-  )
-
-ament_target_dependencies(astar_planner 
-  rclcpp 
+ament_target_dependencies(astar_planner
+  rclcpp
   std_msgs
   nav2_msgs
-  )
+  task
+)
 
 install(TARGETS astar_planner
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME})
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY include/
+  DESTINATION include/
+)
+
+ament_export_include_directories(include)
 
 ament_package()

--- a/src/planning/CMakeLists.txt
+++ b/src/planning/CMakeLists.txt
@@ -42,6 +42,20 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_cppcheck REQUIRED)
+  find_package(ament_cmake_cpplint REQUIRED)
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
+  # This forces cppcheck to consider all files in this project to be C++,
+  # including the headers which end with .h, which cppcheck would normally
+  # consider to be C instead.
+  ament_cppcheck(LANGUAGE "c++")
+  ament_cpplint()
+  ament_lint_cmake()
+  ament_uncrustify()
+endif()
+
 ament_export_include_directories(include)
 
 ament_package()

--- a/src/planning/package.xml
+++ b/src/planning/package.xml
@@ -7,13 +7,17 @@
   <author email="oregon.robotics.team@intel.com">Oregon Robotics Team</author>
   <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <license>Apache License 2.0</license>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>rclcpp</build_depend>
   <build_depend>nav2_msgs</build_depend>
   <build_depend>robot</build_depend>
   <build_depend>task</build_depend>
+
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/robot/CMakeLists.txt
+++ b/src/robot/CMakeLists.txt
@@ -30,6 +30,20 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_cppcheck REQUIRED)
+  find_package(ament_cmake_cpplint REQUIRED)
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
+  # This forces cppcheck to consider all files in this project to be C++,
+  # including the headers which end with .h, which cppcheck would normally
+  # consider to be C instead.
+  ament_cppcheck(LANGUAGE "c++")
+  ament_cpplint()
+  ament_lint_cmake()
+  ament_uncrustify()
+endif()
+
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 

--- a/src/robot/package.xml
+++ b/src/robot/package.xml
@@ -1,19 +1,12 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
-  <name>planning</name>
+  <name>robot</name>
   <version>0.1.0</version>
   <description>TODO</description>
-  <author email="oregon.robotics.team@intel.com">Oregon Robotics Team</author>
   <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <license>Apache License 2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>nav2_msgs</build_depend>
-  <build_depend>robot</build_depend>
-  <build_depend>task</build_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>nav2_msgs</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/robot/package.xml
+++ b/src/robot/package.xml
@@ -6,7 +6,9 @@
   <description>TODO</description>
   <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <license>Apache License 2.0</license>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/task/CMakeLists.txt
+++ b/src/task/CMakeLists.txt
@@ -22,6 +22,20 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_cppcheck REQUIRED)
+  find_package(ament_cmake_cpplint REQUIRED)
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  find_package(ament_cmake_uncrustify REQUIRED)
+  # This forces cppcheck to consider all files in this project to be C++,
+  # including the headers which end with .h, which cppcheck would normally
+  # consider to be C instead.
+  ament_cppcheck(LANGUAGE "c++")
+  ament_cpplint()
+  ament_lint_cmake()
+  ament_uncrustify()
+endif()
+
 ament_export_include_directories(include)
 
 ament_package()

--- a/src/task/CMakeLists.txt
+++ b/src/task/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(robot)
+project(task)
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
@@ -11,19 +11,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
 
 include_directories(
   include
-)
-
-add_library(robot STATIC
-  src/RosRobot.cpp
-)
-
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
 install(DIRECTORY include/
@@ -31,6 +23,5 @@ install(DIRECTORY include/
 )
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
 
 ament_package()

--- a/src/task/package.xml
+++ b/src/task/package.xml
@@ -6,11 +6,15 @@
   <description>TODO</description>
   <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <license>Apache License 2.0</license>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
+
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/task/package.xml
+++ b/src/task/package.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
-  <name>planning</name>
+  <name>task</name>
   <version>0.1.0</version>
   <description>TODO</description>
-  <author email="oregon.robotics.team@intel.com">Oregon Robotics Team</author>
   <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <license>Apache License 2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>rclcpp</build_depend>
-  <build_depend>nav2_msgs</build_depend>
-  <build_depend>robot</build_depend>
-  <build_depend>task</build_depend>
+  <build_depend>std_msgs</build_depend>
   <exec_depend>rclcpp</exec_depend>
-  <exec_depend>nav2_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
I turned task and robot into actual packages that export their header files so that the other packages could pick them up without needing explicit paths. This seems to be more like the ros2 standard.

The rest is just cleanup to remove unnecessary statements given the new packages.