### PR TITLE
Simplifying CMakelists to use the standard test suite.

### DIFF
--- a/src/control/nav2_dwa_controller/CMakeLists.txt
+++ b/src/control/nav2_dwa_controller/CMakeLists.txt
@@ -61,17 +61,8 @@ install(DIRECTORY include/
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_export_include_directories(include)

--- a/src/control/nav2_dwa_controller/package.xml
+++ b/src/control/nav2_dwa_controller/package.xml
@@ -19,6 +19,9 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>nav2_planning_msgs</exec_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/libs/nav2_libs_msgs/CMakeLists.txt
+++ b/src/libs/nav2_libs_msgs/CMakeLists.txt
@@ -22,20 +22,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs
 )
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
-endif()
-
 ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()

--- a/src/libs/nav2_robot/CMakeLists.txt
+++ b/src/libs/nav2_robot/CMakeLists.txt
@@ -31,17 +31,8 @@ install(DIRECTORY include/
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_export_include_directories(include)

--- a/src/libs/nav2_robot/package.xml
+++ b/src/libs/nav2_robot/package.xml
@@ -9,6 +9,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/libs/nav2_tasks/CMakeLists.txt
+++ b/src/libs/nav2_tasks/CMakeLists.txt
@@ -31,17 +31,8 @@ rosidl_generate_interfaces(nav2_tasks
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_export_include_directories(include)

--- a/src/libs/nav2_tasks/package.xml
+++ b/src/libs/nav2_tasks/package.xml
@@ -21,6 +21,9 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>

--- a/src/libs/nav2_util/CMakeLists.txt
+++ b/src/libs/nav2_util/CMakeLists.txt
@@ -62,17 +62,8 @@ install(DIRECTORY include/
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_export_include_directories(include)

--- a/src/libs/nav2_util/package.xml
+++ b/src/libs/nav2_util/package.xml
@@ -15,6 +15,9 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>nav2_libs_msgs</exec_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/localization/nav2_amcl/CMakeLists.txt
+++ b/src/localization/nav2_amcl/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(tf2 REQUIRED)
 find_package(nav2_util REQUIRED)
 
 include_directories(
-  include 
+  include
   ${Boost_INCLUDE_DIRS}
   )
 
@@ -70,6 +70,11 @@ install(TARGETS ${executable_name} ${library_name}
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
   )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_export_include_directories(include)
 

--- a/src/localization/nav2_amcl/package.xml
+++ b/src/localization/nav2_amcl/package.xml
@@ -34,6 +34,10 @@
   <build_depend>tf2_ros</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>nav2_util</build_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/mission_execution/nav2_mission_execution_msgs/CMakeLists.txt
+++ b/src/mission_execution/nav2_mission_execution_msgs/CMakeLists.txt
@@ -21,20 +21,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs
 )
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
-endif()
-
 ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()

--- a/src/mission_execution/nav2_mission_executor/CMakeLists.txt
+++ b/src/mission_execution/nav2_mission_executor/CMakeLists.txt
@@ -55,17 +55,8 @@ install(TARGETS ${executable_name} ${library_name}
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_package()

--- a/src/mission_execution/nav2_mission_executor/package.xml
+++ b/src/mission_execution/nav2_mission_executor/package.xml
@@ -18,6 +18,9 @@
   <exec_depend>nav2_tasks</exec_depend>
   <exec_depend>nav2_mission_execution_msgs</exec_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/navigation/nav2_bt_navigator/CMakeLists.txt
+++ b/src/navigation/nav2_bt_navigator/CMakeLists.txt
@@ -59,17 +59,8 @@ install(DIRECTORY include/
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_export_include_directories(include)

--- a/src/navigation/nav2_bt_navigator/package.xml
+++ b/src/navigation/nav2_bt_navigator/package.xml
@@ -17,6 +17,9 @@
   <exec_depend>nav2_tasks</exec_depend>
   <exec_depend>nav2_planning_msgs</exec_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/navigation/nav2_simple_navigator/CMakeLists.txt
+++ b/src/navigation/nav2_simple_navigator/CMakeLists.txt
@@ -59,17 +59,8 @@ install(DIRECTORY include/
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_export_include_directories(include)

--- a/src/navigation/nav2_simple_navigator/package.xml
+++ b/src/navigation/nav2_simple_navigator/package.xml
@@ -17,6 +17,9 @@
   <exec_depend>nav2_tasks</exec_depend>
   <exec_depend>nav2_planning_msgs</exec_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/planning/nav2_astar_planner/CMakeLists.txt
+++ b/src/planning/nav2_astar_planner/CMakeLists.txt
@@ -62,17 +62,8 @@ install(DIRECTORY include/
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_export_include_directories(include)

--- a/src/planning/nav2_astar_planner/package.xml
+++ b/src/planning/nav2_astar_planner/package.xml
@@ -18,6 +18,9 @@
   <exec_depend>nav2_tasks</exec_depend>
   <exec_depend>nav2_planning_msgs</exec_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/planning/nav2_dijkstra_planner/CMakeLists.txt
+++ b/src/planning/nav2_dijkstra_planner/CMakeLists.txt
@@ -67,17 +67,8 @@ install(DIRECTORY include/
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_export_include_directories(include)

--- a/src/planning/nav2_dijkstra_planner/package.xml
+++ b/src/planning/nav2_dijkstra_planner/package.xml
@@ -22,6 +22,9 @@
   <exec_depend>nav2_util_msgs</exec_depend>
   <exec_depend>nav2_world_model_msgs</exec_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/planning/nav2_planning_msgs/CMakeLists.txt
+++ b/src/planning/nav2_planning_msgs/CMakeLists.txt
@@ -22,20 +22,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs
 )
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
-endif()
-
 ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()

--- a/src/world_model/nav2_costmap_world_model/CMakeLists.txt
+++ b/src/world_model/nav2_costmap_world_model/CMakeLists.txt
@@ -59,17 +59,8 @@ install(TARGETS ${executable_name} ${library_name}
   RUNTIME DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_export_include_directories(include)

--- a/src/world_model/nav2_costmap_world_model/package.xml
+++ b/src/world_model/nav2_costmap_world_model/package.xml
@@ -20,6 +20,9 @@
   <exec_depend>nav2_util_msgs</exec_depend>
   <exec_depend>nav2_world_model_msgs</exec_depend>
 
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/world_model/nav2_world_model_msgs/CMakeLists.txt
+++ b/src/world_model/nav2_world_model_msgs/CMakeLists.txt
@@ -22,20 +22,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs nav2_libs_msgs
 )
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  # This forces cppcheck to consider all files in this project to be C++,
-  # including the headers which end with .h, which cppcheck would normally
-  # consider to be C instead.
-  ament_cppcheck(LANGUAGE "c++")
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
-endif()
-
 ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()


### PR DESCRIPTION
There is a an existing set of ament packages that perform all the standard tests (eg uncrustify, cppcheck, etc) automatically.

Updating the code to use this new version.

I'll wait on starting a review until after I rebase from some of the other PRs that are about to go in.