### PR TITLE
C++ integration and unit test template.

### DIFF
--- a/src/control/CMakeLists.txt
+++ b/src/control/CMakeLists.txt
@@ -15,9 +15,18 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(task REQUIRED)
+find_package(geometry_msgs REQUIRED)
 
 include_directories(
   include
+)
+
+set(PROJECT_DEPENDENCIES
+rclcpp
+std_msgs
+nav2_msgs
+task
+geometry_msgs
 )
 
 add_executable(dwa_controller
@@ -26,10 +35,7 @@ add_executable(dwa_controller
 )
 
 ament_target_dependencies(dwa_controller
-  rclcpp
-  std_msgs
-  nav2_msgs
-  task
+  ${PROJECT_DEPENDENCIES}
 )
 
 install(TARGETS dwa_controller
@@ -54,6 +60,10 @@ if(BUILD_TESTING)
   ament_cpplint()
   ament_lint_cmake()
   ament_uncrustify()
+
+  find_package(ament_cmake_pytest REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+  add_subdirectory(test)
 endif()
 
 ament_export_include_directories(include)

--- a/src/control/package.xml
+++ b/src/control/package.xml
@@ -13,10 +13,16 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>nav2_msgs</build_depend>
   <build_depend>task</build_depend>
+  <build_depend>geometry_msgs</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
+  <exec_depend>task</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/control/test/CMakeLists.txt
+++ b/src/control/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(TEST_LAUNCH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test_launch_files)
+add_subdirectory(unit)
+add_subdirectory(integration)

--- a/src/control/test/integration/CMakeLists.txt
+++ b/src/control/test/integration/CMakeLists.txt
@@ -1,0 +1,15 @@
+ament_add_gtest_executable(test_dwa_controller_node
+  test_dwa_controller_node.cpp
+)
+ament_target_dependencies(test_dwa_controller_node
+  ${PROJECT_DEPENDENCIES}
+)
+
+ament_add_test(test_dwa_controller
+  GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_dwa_controller_launch.py"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  ENV
+    TEST_LAUNCH_DIR=${TEST_LAUNCH_DIR}
+    TEST_EXECUTABLE=$<TARGET_FILE:test_dwa_controller_node>
+)

--- a/src/control/test/integration/test_dwa_controller_launch.py
+++ b/src/control/test/integration/test_dwa_controller_launch.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+from launch import LaunchDescription
+from launch import LaunchService
+from launch.actions import ExecuteProcess
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing import LaunchTestService
+from launch.substitutions import ThisLaunchFileDir
+
+
+def main(argv=sys.argv[1:]):
+    launchFile = os.path.join(os.getenv('TEST_LAUNCH_DIR'), 'dwa_controller_node.launch.py')
+    testExecutable = os.getenv('TEST_EXECUTABLE')
+    ld = LaunchDescription([
+        IncludeLaunchDescription(PythonLaunchDescriptionSource( [launchFile] )),
+        ])
+    test1_action = ExecuteProcess(
+        cmd=[testExecutable],
+        name='test_dwa_contoller_node',
+        output='screen'
+    )
+    ld.add_action(test1_action)
+    lts = LaunchTestService()
+    lts.add_test_action(ld, test1_action)
+    ls = LaunchService(argv=argv)
+    ls.include_launch_description(ld)
+    return lts.run(ls)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/control/test/integration/test_dwa_controller_node.cpp
+++ b/src/control/test/integration/test_dwa_controller_node.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <control/FollowPathTaskClient.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <memory>
+#include <iostream>
+
+class TestNode : public ::testing::Test
+{
+public:
+  TestNode()
+  {
+    std::cout << "Starting" << std::endl;
+    rclcpp::init(0, nullptr);
+    node = rclcpp::Node::make_shared("dwa_controller_test");
+    client = std::make_unique<FollowPathTaskClient>("DwaController", node.get());
+    while (node->count_subscribers("/DwaController_command") < 1) {
+      rclcpp::spin_some(node);
+    }
+  }
+  ~TestNode()
+  {
+    rclcpp::shutdown();
+  }
+
+protected:
+  std::shared_ptr<rclcpp::Node> node;
+  std::unique_ptr<FollowPathTaskClient> client;
+};
+
+TEST_F(TestNode, ResultReturned)
+{
+  FollowPathCommand c;
+  client->executeAsync(std::make_shared<FollowPathCommand>(c));
+  FollowPathResult r;
+  auto r_ptr = std::make_shared<FollowPathResult>(r);
+  while (client->waitForResult(r_ptr, 10) == TaskStatus::RUNNING) {
+    std::cout << "Waiting" << std::endl;
+    rclcpp::spin_some(node);
+  }
+  SUCCEED();
+}

--- a/src/control/test/integration/test_dwa_controller_node.cpp
+++ b/src/control/test/integration/test_dwa_controller_node.cpp
@@ -17,24 +17,26 @@
 #include <control/FollowPathTaskClient.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <memory>
-#include <iostream>
+
+// rclcpp::init can only be called once per process, so this needs to be a global variable
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+RclCppFixture g_rclcppfixture;
 
 class TestNode : public ::testing::Test
 {
 public:
   TestNode()
   {
-    std::cout << "Starting" << std::endl;
-    rclcpp::init(0, nullptr);
     node = rclcpp::Node::make_shared("dwa_controller_test");
     client = std::make_unique<FollowPathTaskClient>("DwaController", node.get());
     while (node->count_subscribers("/DwaController_command") < 1) {
       rclcpp::spin_some(node);
     }
-  }
-  ~TestNode()
-  {
-    rclcpp::shutdown();
   }
 
 protected:
@@ -48,8 +50,7 @@ TEST_F(TestNode, ResultReturned)
   client->executeAsync(std::make_shared<FollowPathCommand>(c));
   FollowPathResult r;
   auto r_ptr = std::make_shared<FollowPathResult>(r);
-  while (client->waitForResult(r_ptr, 10) == TaskStatus::RUNNING) {
-    std::cout << "Waiting" << std::endl;
+  while (client->waitForResult(r_ptr, 1000) == TaskStatus::RUNNING) {
     rclcpp::spin_some(node);
   }
   SUCCEED();

--- a/src/control/test/test_launch_files/dwa_controller_node.launch.py
+++ b/src/control/test/test_launch_files/dwa_controller_node.launch.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+import launch_ros.actions
+
+def generate_launch_description():
+    return LaunchDescription([
+        launch_ros.actions.Node(
+            package='control',
+            node_executable='dwa_controller',
+            output='screen')
+    ])

--- a/src/control/test/unit/CMakeLists.txt
+++ b/src/control/test/unit/CMakeLists.txt
@@ -1,0 +1,6 @@
+include_directories( ${PROJECT_SOURCE_DIR}/src )
+
+ament_add_gtest(test_dwa_trajectory_generator test_dwa_trajectory_generator.cpp)
+ament_target_dependencies( test_dwa_trajectory_generator
+  ${PROJECT_DEPENDENCIES}
+)

--- a/src/control/test/unit/test_dwa_trajectory_generator.cpp
+++ b/src/control/test/unit/test_dwa_trajectory_generator.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+TEST(SimplePassingTest, SimplePassingTest)
+{
+  SUCCEED();
+}


### PR DESCRIPTION
This is an example of how to do a integration test in C++ using the seperate launch script.

Note that the test is currently timing out because it never receives the response message. I'm thinking this is a problem with the task client library or I'm using it in some unsupported way, but I haven't debugged yet.