### PR TITLE
Removing ament_copyright linter from test set

### DIFF
--- a/src/control/costmap_queue/package.xml
+++ b/src/control/costmap_queue/package.xml
@@ -12,7 +12,12 @@
   <depend>fake_costmap_2d</depend>
   <depend>rclcpp</depend>
 
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_flake8</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pep257</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/src/control/dwb_core/package.xml
+++ b/src/control/dwb_core/package.xml
@@ -31,7 +31,12 @@
   <exec_depend>nav_2d_utils</exec_depend>
   <exec_depend>pluginlib</exec_depend>
 
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_flake8</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pep257</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/src/control/dwb_critics/package.xml
+++ b/src/control/dwb_critics/package.xml
@@ -21,7 +21,12 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
 
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_flake8</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pep257</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 
   <export>

--- a/src/control/dwb_plugins/package.xml
+++ b/src/control/dwb_plugins/package.xml
@@ -20,7 +20,12 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
 
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_flake8</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pep257</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/src/control/nav_2d_utils/package.xml
+++ b/src/control/nav_2d_utils/package.xml
@@ -19,7 +19,12 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
 
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_flake8</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pep257</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 
   <export>


### PR DESCRIPTION
Due to a difference in the wording of the copyright template in the
linter and the one actually used in the source, the linter fails
these files. 

To resolve that problem, I'm removing the copyright
linter from the test set.Unfortunately, the only way to do that is to 
include every linter but the copyright one.