### PR TITLE
Changing executable build to use library instead of object files.

### DIFF
--- a/src/control/nav2_controller_example/CMakeLists.txt
+++ b/src/control/nav2_controller_example/CMakeLists.txt
@@ -24,7 +24,6 @@ include_directories(
 set(executable_name dwa_controller)
 
 add_executable(${executable_name}
-  src/dwa_controller.cpp
   src/main.cpp
 )
 
@@ -45,6 +44,8 @@ set(dependencies
 ament_target_dependencies(${executable_name}
   ${dependencies}
 )
+
+target_link_libraries(${executable_name} ${library_name})
 
 ament_target_dependencies(${library_name}
   ${dependencies}

--- a/src/localization/nav2_amcl/CMakeLists.txt
+++ b/src/localization/nav2_amcl/CMakeLists.txt
@@ -30,7 +30,6 @@ include_directories(
 set(executable_name amcl)
 
 add_executable(${executable_name}
-  src/amcl_node.cpp
   src/main.cpp
 )
 
@@ -38,11 +37,6 @@ set(library_name ${executable_name}_core)
 
 add_library(${library_name}
   src/amcl_node.cpp
-)
-
-target_link_libraries(${executable_name}
-  ${Boost_LIBRARIES}
-  boost_system
 )
 
 set(dependencies
@@ -59,6 +53,12 @@ set(dependencies
 
 ament_target_dependencies(${executable_name}
   ${dependencies}
+)
+
+target_link_libraries(${executable_name}
+  ${library_name}
+  ${Boost_LIBRARIES}
+  boost_system
 )
 
 ament_target_dependencies(${library_name}

--- a/src/mission_execution/nav2_mission_executor/CMakeLists.txt
+++ b/src/mission_execution/nav2_mission_executor/CMakeLists.txt
@@ -24,7 +24,6 @@ set(executable_name mission_executor)
 
 add_executable(${executable_name}
   src/main.cpp
-  src/mission_executor.cpp
 )
 
 set(library_name ${executable_name}_core)
@@ -43,6 +42,8 @@ set(dependencies
 ament_target_dependencies(${executable_name}
   ${dependencies}
 )
+
+target_link_libraries(${executable_name} ${library_name})
 
 ament_target_dependencies(${library_name}
   ${dependencies}

--- a/src/navigation/nav2_bt_navigator/CMakeLists.txt
+++ b/src/navigation/nav2_bt_navigator/CMakeLists.txt
@@ -23,7 +23,6 @@ include_directories(
 set(executable_name bt_navigator)
 
 add_executable(${executable_name}
-  src/bt_navigator.cpp
   src/main.cpp
 )
 
@@ -43,6 +42,8 @@ set(dependencies
 ament_target_dependencies(${executable_name}
   ${dependencies}
 )
+
+target_link_libraries(${executable_name} ${library_name})
 
 ament_target_dependencies(${library_name}
   ${dependencies}

--- a/src/navigation/nav2_simple_navigator/CMakeLists.txt
+++ b/src/navigation/nav2_simple_navigator/CMakeLists.txt
@@ -23,7 +23,6 @@ include_directories(
 set(executable_name simple_navigator)
 
 add_executable(${executable_name}
-  src/simple_navigator.cpp
   src/main.cpp
 )
 
@@ -43,6 +42,8 @@ set(dependencies
 ament_target_dependencies(${executable_name}
   ${dependencies}
 )
+
+target_link_libraries(${executable_name} ${library_name})
 
 ament_target_dependencies(${library_name}
   ${dependencies}

--- a/src/planning/nav2_astar_planner/CMakeLists.txt
+++ b/src/planning/nav2_astar_planner/CMakeLists.txt
@@ -24,7 +24,6 @@ include_directories(
 set(executable_name astar_planner)
 
 add_executable(${executable_name}
-  src/astar_planner.cpp
   src/main.cpp
 )
 
@@ -46,6 +45,8 @@ set(dependencies
 ament_target_dependencies(${executable_name}
   ${dependencies}
 )
+
+target_link_libraries(${executable_name} ${library_name})
 
 ament_target_dependencies(${library_name}
   ${dependencies}

--- a/src/planning/nav2_dijkstra_planner/CMakeLists.txt
+++ b/src/planning/nav2_dijkstra_planner/CMakeLists.txt
@@ -28,8 +28,6 @@ include_directories(
 set(executable_name dijkstra_planner)
 
 add_executable(${executable_name}
-  src/dijkstra_planner.cpp
-  src/navfn.cpp
   src/main.cpp
 )
 
@@ -55,6 +53,8 @@ set(dependencies
 ament_target_dependencies(${executable_name}
   ${dependencies}
 )
+
+target_link_libraries(${executable_name} ${library_name})
 
 ament_target_dependencies(${library_name}
   ${dependencies}

--- a/src/world_model/nav2_costmap_world_model/CMakeLists.txt
+++ b/src/world_model/nav2_costmap_world_model/CMakeLists.txt
@@ -26,7 +26,6 @@ include_directories(
 set(executable_name costmap_world_model)
 
 add_executable(${executable_name}
-  src/costmap_world_model.cpp
   src/main.cpp
 )
 
@@ -50,6 +49,8 @@ set(dependencies
 ament_target_dependencies(${executable_name}
   ${dependencies}
 )
+
+target_link_libraries(${executable_name} ${library_name})
 
 ament_target_dependencies(${library_name}
   ${dependencies}


### PR DESCRIPTION
Fixes #126 

This fixes the CMakeLists.txt throughout the repo so the executable targets depend on the library targets instead of including the library source files directly.