### PR TITLE
Costmap_2d Static & Inflation plugin layer port & Removing Boost dependencies 

### DIFF
--- a/src/libs/costmap_2d/CMakeLists.txt
+++ b/src/libs/costmap_2d/CMakeLists.txt
@@ -30,8 +30,8 @@ find_package(pluginlib REQUIRED)
 
 #	TODO(bpwilcox): port remaining packages
 #find_package(tf2_sensor_msgs REQUIRED)
-#find_package(dynamic_reconfigure REQUIRED)
-#find_package(message_filters REQUIRED)
+#find_package(dynamic_reconfigure REQUIRED) 
+find_package(message_filters REQUIRED)
 #find_package(voxel_grid REQUIRED)
 
 remove_definitions(-DDISABLE_LIBUSB-1.0)
@@ -80,6 +80,7 @@ set(dependencies
   xmlrpcpp
   pluginlib
   tf2_geometry_msgs
+  message_filters
 )
 
 ament_target_dependencies(nav2_costmap_2d
@@ -93,8 +94,8 @@ target_link_libraries(nav2_costmap_2d
 add_library(layers
   plugins/inflation_layer.cpp
 
-  # TODO(bpwilcox): port additional plugin layers
-  #plugins/static_layer.cpp
+	#	TODO(bpwilcox): port additional plugin layers
+  plugins/static_layer.cpp
   #plugins/obstacle_layer.cpp
   #plugins/voxel_layer.cpp
   #src/observation_buffer.cpp

--- a/src/libs/costmap_2d/CMakeLists.txt
+++ b/src/libs/costmap_2d/CMakeLists.txt
@@ -10,7 +10,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   #add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
@@ -27,11 +26,11 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(xmlrpcpp REQUIRED)
 find_package(laser_geometry REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(message_filters REQUIRED)
 
-#	TODO(bpwilcox): port remaining packages
+# TODO(bpwilcox): port remaining packages
 #find_package(tf2_sensor_msgs REQUIRED)
 #find_package(dynamic_reconfigure REQUIRED) 
-find_package(message_filters REQUIRED)
 #find_package(voxel_grid REQUIRED)
 
 remove_definitions(-DDISABLE_LIBUSB-1.0)
@@ -39,20 +38,19 @@ find_package(Eigen3 REQUIRED)
 #find_package(Boost REQUIRED COMPONENTS system thread)
 
 include_directories(
-	include
-	${ament_INCLUDE_DIRS}
-	${EIGEN3_INCLUDE_DIRS}
+  include
+  ${ament_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 add_definitions(${EIGEN3_DEFINITIONS})
 
-#	TODO(bpwilcox): Separate msgs generation into separate package
+# TODO(bpwilcox): Separate msgs generation into separate package
 #rosidl_generate_interfaces(${PROJECT_NAME}
 #  "msg/VoxelGrid.msg"
 #
 #	DEPENDENCIES std_msgs geometry_msgs map_msgs
 #)
-
 
 add_library(nav2_costmap_2d
   src/array_parser.cpp
@@ -88,7 +86,7 @@ ament_target_dependencies(nav2_costmap_2d
 add_library(layers
   plugins/inflation_layer.cpp
 
-	#	TODO(bpwilcox): port additional plugin layers
+  # TODO(bpwilcox): port additional plugin layers
   plugins/static_layer.cpp
   #plugins/obstacle_layer.cpp
   #plugins/voxel_layer.cpp
@@ -97,18 +95,18 @@ add_library(layers
 ament_target_dependencies(layers
   ${dependencies}
  )
-target_link_libraries(layers
+ target_link_libraries(layers
   nav2_costmap_2d
 )
 
-#	TODO(bpwilcox): port costmap_2d_markers
+# TODO(bpwilcox): port costmap_2d_markers
 #add_executable(costmap_2d_markers src/costmap_2d_markers.cpp)
 #ament_target_dependencies(costmap_2d_markers ${${PROJECT_NAME}_EXPORTED_TARGETS} ${ament_EXPORTED_TARGETS})
 #target_link_libraries(costmap_2d_markers
   #costmap_2d
 #)
 
-#	TODO(bpwilcox): port costmap_2d_cloud
+# TODO(bpwilcox): port costmap_2d_cloud
 #add_executable(costmap_2d_cloud src/costmap_2d_cloud.cpp)
 #ament_target_dependencies(costmap_2d_cloud ${${PROJECT_NAME}_EXPORTED_TARGETS} ${ament_EXPORTED_TARGETS})
 #target_link_libraries(costmap_2d_cloud

--- a/src/libs/costmap_2d/CMakeLists.txt
+++ b/src/libs/costmap_2d/CMakeLists.txt
@@ -36,13 +36,12 @@ find_package(message_filters REQUIRED)
 
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system thread)
+#find_package(Boost REQUIRED COMPONENTS system thread)
 
 include_directories(
-  include
-  ${ament_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIRS}
+	include
+	${ament_INCLUDE_DIRS}
+	${EIGEN3_INCLUDE_DIRS}
 )
 
 add_definitions(${EIGEN3_DEFINITIONS})
@@ -87,15 +86,11 @@ ament_target_dependencies(nav2_costmap_2d
   ${dependencies}
 )
 
-target_link_libraries(nav2_costmap_2d
-  ${Boost_LIBRARIES}
-)
-
 add_library(layers
   plugins/inflation_layer.cpp
 
 	#	TODO(bpwilcox): port additional plugin layers
-  plugins/static_layer.cpp
+  #plugins/static_layer.cpp
   #plugins/obstacle_layer.cpp
   #plugins/voxel_layer.cpp
   #src/observation_buffer.cpp
@@ -105,7 +100,6 @@ ament_target_dependencies(layers
  )
 target_link_libraries(layers
   nav2_costmap_2d
-  ${Boost_LIBRARIES}
 )
 
 #	TODO(bpwilcox): port costmap_2d_markers

--- a/src/libs/costmap_2d/CMakeLists.txt
+++ b/src/libs/costmap_2d/CMakeLists.txt
@@ -63,10 +63,9 @@ add_library(nav2_costmap_2d
   src/costmap_2d_publisher.cpp
   src/costmap_math.cpp
   src/footprint.cpp
-  src/costmap_layer.cpp
-  # TODO(bpwilcox): need ROS PCL dependencies to port
-  #src/observation_buffer.cpp
-
+  src/costmap_layer.cpp	
+  #	TODO(bpwilcox): need tf2_sensor_msgs ported
+  # src/observation_buffer.cpp  
 )
 
 set(dependencies
@@ -90,7 +89,7 @@ add_library(layers
   plugins/inflation_layer.cpp
 
 	#	TODO(bpwilcox): port additional plugin layers
-  #plugins/static_layer.cpp
+  plugins/static_layer.cpp
   #plugins/obstacle_layer.cpp
   #plugins/voxel_layer.cpp
   #src/observation_buffer.cpp

--- a/src/libs/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/src/libs/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -40,8 +40,11 @@
 
 #include <vector>
 #include <queue>
+#include <mutex>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
 #include <geometry_msgs/msg/point.hpp>
-#include <boost/thread.hpp>
 
 namespace costmap_2d
 {
@@ -296,7 +299,7 @@ public:
   unsigned int cellDistance(double world_dist);
 
   // Provide a typedef to ease future code maintenance
-  typedef boost::recursive_mutex mutex_t;
+  typedef std::recursive_mutex mutex_t;
   mutex_t * getMutex()
   {
     return access_;

--- a/src/libs/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/src/libs/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -262,7 +262,7 @@ private:
   void mapUpdateLoop(double frequency);
   bool map_update_thread_shutdown_;
   bool stop_updates_, initialized_, stopped_, robot_stopped_;
-  boost::thread * map_update_thread_;  ///< @brief A thread for updating the map
+  std::thread * map_update_thread_;  ///< @brief A thread for updating the map
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Time last_publish_;
   rclcpp::Duration publish_cycle_;
@@ -274,7 +274,7 @@ private:
   //dynamic_reconfigure::Server<costmap_2d::Costmap2DConfig> *dsrv_;
   //costmap_2d::Costmap2DConfig old_config_;
 
-  boost::recursive_mutex configuration_mutex_;
+  std::recursive_mutex configuration_mutex_;
 
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr footprint_pub_;
   rclcpp::Subscription<geometry_msgs::msg::Polygon>::SharedPtr footprint_sub_;

--- a/src/libs/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/src/libs/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -44,7 +44,6 @@
 // TODO(bpwilcox): Resolve dynamic reconfigure dependencies
 //#include <costmap_2d/InflationPluginConfig.h>
 //#include <dynamic_reconfigure/server.h>
-#include <boost/thread.hpp>
 
 namespace costmap_2d
 {
@@ -129,7 +128,7 @@ public:
 
 protected:
   virtual void onFootprintChanged();
-  boost::recursive_mutex * inflation_access_;
+  std::recursive_mutex * inflation_access_;
 
 private:
   /**

--- a/src/libs/costmap_2d/include/costmap_2d/observation.h
+++ b/src/libs/costmap_2d/include/costmap_2d/observation.h
@@ -32,8 +32,8 @@
 #ifndef COSTMAP_2D_OBSERVATION_H_
 #define COSTMAP_2D_OBSERVATION_H_
 
-#include <geometry_msgs/Point.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <geometry_msgs/msg/point.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 namespace costmap_2d
 {
@@ -66,7 +66,7 @@ public:
    * @param obstacle_range The range out to which an observation should be able to insert obstacles
    * @param raytrace_range The range out to which an observation should be able to clear via raytracing
    */
-  Observation(geometry_msgs::Point & origin, const sensor_msgs::PointCloud2 & cloud,
+  Observation(geometry_msgs::msg::Point & origin, const sensor_msgs::msg::PointCloud2 & cloud,
       double obstacle_range, double raytrace_range)
     : origin_(origin), cloud_(new sensor_msgs::PointCloud2(cloud)),
     obstacle_range_(obstacle_range), raytrace_range_(raytrace_range)
@@ -88,14 +88,14 @@ public:
    * @param cloud The point cloud of the observation
    * @param obstacle_range The range out to which an observation should be able to insert obstacles
    */
-  Observation(const sensor_msgs::PointCloud2 & cloud, double obstacle_range)
+  Observation(const sensor_msgs::msg::PointCloud2 & cloud, double obstacle_range)
     : cloud_(new sensor_msgs::PointCloud2(cloud)), obstacle_range_(obstacle_range),
     raytrace_range_(0.0)
   {
   }
 
-  geometry_msgs::Point origin_;
-  sensor_msgs::PointCloud2 * cloud_;
+  geometry_msgs::msg::Point origin_;
+  sensor_msgs::msg::PointCloud2 * cloud_;
   double obstacle_range_, raytrace_range_;
 };
 

--- a/src/libs/costmap_2d/include/costmap_2d/observation_buffer.h
+++ b/src/libs/costmap_2d/include/costmap_2d/observation_buffer.h
@@ -46,8 +46,6 @@
 
 #include <sensor_msgs/PointCloud2.h>
 
-// Thread support
-#include <boost/thread.hpp>
 
 namespace costmap_2d
 {
@@ -148,7 +146,7 @@ private:
   std::list<Observation> observation_list_;
   std::string topic_name_;
   double min_obstacle_height_, max_obstacle_height_;
-  boost::recursive_mutex lock_;  ///< @brief A lock for accessing data in callbacks safely
+  std::recursive_mutex lock_;  ///< @brief A lock for accessing data in callbacks safely
   double obstacle_range_, raytrace_range_;
   double tf_tolerance_;
 };

--- a/src/libs/costmap_2d/include/costmap_2d/observation_buffer.h
+++ b/src/libs/costmap_2d/include/costmap_2d/observation_buffer.h
@@ -40,11 +40,11 @@
 #include <vector>
 #include <list>
 #include <string>
-#include <ros/time.h>
+#include "rclcpp/time.hpp"
 #include <costmap_2d/observation.h>
 #include <tf2_ros/buffer.h>
 
-#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 
 namespace costmap_2d
@@ -96,7 +96,7 @@ public:
    * <b>Note: The burden is on the user to make sure the transform is available... ie they should use a MessageNotifier</b>
    * @param  cloud The cloud to be buffered
    */
-  void bufferCloud(const sensor_msgs::PointCloud2 & cloud);
+  void bufferCloud(const sensor_msgs::msg::PointCloud2 & cloud);
 
   /**
    * @brief  Pushes copies of all current observations onto the end of the vector passed in
@@ -138,9 +138,10 @@ private:
   void purgeStaleObservations();
 
   tf2_ros::Buffer & tf2_buffer_;
-  const ros::Duration observation_keep_time_;
-  const ros::Duration expected_update_rate_;
-  ros::Time last_updated_;
+  const rclcpp::Duration observation_keep_time_;
+  const rclcpp::Duration expected_update_rate_;
+  rclcpp::Clock clock_;
+  rclcpp::Time last_updated_;
   std::string global_frame_;
   std::string sensor_frame_;
   std::list<Observation> observation_list_;

--- a/src/libs/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/src/libs/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -86,7 +86,7 @@ public:
    * @param buffer A pointer to the observation buffer to update
    */
   void laserScanCallback(const sensor_msgs::LaserScanConstPtr & message,
-      const boost::shared_ptr<costmap_2d::ObservationBuffer> & buffer);
+      const std::shared_ptr<costmap_2d::ObservationBuffer> & buffer);
 
   /**
    * @brief A callback to handle buffering LaserScan messages which need filtering to turn Inf values into range_max.
@@ -94,7 +94,7 @@ public:
    * @param buffer A pointer to the observation buffer to update
    */
   void laserScanValidInfCallback(const sensor_msgs::LaserScanConstPtr & message,
-      const boost::shared_ptr<ObservationBuffer> & buffer);
+      const std::shared_ptr<ObservationBuffer> & buffer);
 
   /**
    * @brief  A callback to handle buffering PointCloud messages
@@ -102,7 +102,7 @@ public:
    * @param buffer A pointer to the observation buffer to update
    */
   void pointCloudCallback(const sensor_msgs::PointCloudConstPtr & message,
-      const boost::shared_ptr<costmap_2d::ObservationBuffer> & buffer);
+      const std::shared_ptr<costmap_2d::ObservationBuffer> & buffer);
 
   /**
    * @brief  A callback to handle buffering PointCloud2 messages
@@ -110,7 +110,7 @@ public:
    * @param buffer A pointer to the observation buffer to update
    */
   void pointCloud2Callback(const sensor_msgs::PointCloud2ConstPtr & message,
-      const boost::shared_ptr<costmap_2d::ObservationBuffer> & buffer);
+      const std::shared_ptr<costmap_2d::ObservationBuffer> & buffer);
 
   // for testing purposes
   void addStaticObservation(costmap_2d::Observation & obs, bool marking, bool clearing);
@@ -163,11 +163,11 @@ protected:
 
   laser_geometry::LaserProjection projector_;  ///< @brief Used to project laser scans into point clouds
 
-  std::vector<boost::shared_ptr<message_filters::SubscriberBase> > observation_subscribers_;  ///< @brief Used for the observation message filters
-  std::vector<boost::shared_ptr<tf2_ros::MessageFilterBase> > observation_notifiers_;  ///< @brief Used to make sure that transforms are available for each sensor
-  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > observation_buffers_;  ///< @brief Used to store observations from various sensors
-  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > marking_buffers_;  ///< @brief Used to store observation buffers used for marking obstacles
-  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > clearing_buffers_;  ///< @brief Used to store observation buffers used for clearing obstacles
+  std::vector<std::shared_ptr<message_filters::SubscriberBase> > observation_subscribers_;  ///< @brief Used for the observation message filters
+  std::vector<std::shared_ptr<tf2_ros::MessageFilterBase> > observation_notifiers_;  ///< @brief Used to make sure that transforms are available for each sensor
+  std::vector<std::shared_ptr<costmap_2d::ObservationBuffer> > observation_buffers_;  ///< @brief Used to store observations from various sensors
+  std::vector<std::shared_ptr<costmap_2d::ObservationBuffer> > marking_buffers_;  ///< @brief Used to store observation buffers used for marking obstacles
+  std::vector<std::shared_ptr<costmap_2d::ObservationBuffer> > clearing_buffers_;  ///< @brief Used to store observation buffers used for clearing obstacles
 
   // Used only for testing purposes
   std::vector<costmap_2d::Observation> static_clearing_observations_, static_marking_observations_;

--- a/src/libs/costmap_2d/include/costmap_2d/static_layer.h
+++ b/src/libs/costmap_2d/include/costmap_2d/static_layer.h
@@ -38,13 +38,13 @@
 #ifndef COSTMAP_2D_STATIC_LAYER_H_
 #define COSTMAP_2D_STATIC_LAYER_H_
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <costmap_2d/costmap_layer.h>
 #include <costmap_2d/layered_costmap.h>
-#include <costmap_2d/GenericPluginConfig.h>
-#include <dynamic_reconfigure/server.h>
-#include <nav_msgs/OccupancyGrid.h>
-#include <map_msgs/OccupancyGridUpdate.h>
+//#include <costmap_2d/GenericPluginConfig.h>
+//#include <dynamic_reconfigure/server.h>
+#include <nav_msgs/msg/occupancy_grid.h>
+#include <map_msgs/msg/occupancy_grid_update.h>
 #include <message_filters/subscriber.h>
 
 namespace costmap_2d
@@ -76,9 +76,9 @@ private:
    * map along with its size will determine what parts of the costmap's
    * static map are overwritten.
    */
-  void incomingMap(const nav_msgs::OccupancyGridConstPtr & new_map);
-  void incomingUpdate(const map_msgs::OccupancyGridUpdateConstPtr & update);
-  void reconfigureCB(costmap_2d::GenericPluginConfig & config, uint32_t level);
+  void incomingMap(const nav_msgs::msg::OccupancyGrid::SharedPtr new_map);
+  void incomingUpdate(const map_msgs::msg::OccupancyGridUpdateConstPtr & update);
+  //void reconfigureCB(costmap_2d::GenericPluginConfig & config, uint32_t level);
 
   unsigned char interpretValue(unsigned char value);
 
@@ -93,10 +93,11 @@ private:
   bool first_map_only_;      ///< @brief Store the first static map and reuse it on reinitializing
   bool trinary_costmap_;
   ros::Subscriber map_sub_, map_update_sub_;
-
+  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr map_sub_;
+  rclcpp::Subscription<map_msgs::msg::OccupancyGridUpdate>::SharedPtr map_update_sub_;
   unsigned char lethal_threshold_, unknown_cost_value_;
 
-  dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig> * dsrv_;
+  //dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig> * dsrv_;
 };
 
 }  // namespace costmap_2d

--- a/src/libs/costmap_2d/include/costmap_2d/static_layer.h
+++ b/src/libs/costmap_2d/include/costmap_2d/static_layer.h
@@ -43,8 +43,8 @@
 #include <costmap_2d/layered_costmap.h>
 //#include <costmap_2d/GenericPluginConfig.h>
 //#include <dynamic_reconfigure/server.h>
-#include <nav_msgs/msg/occupancy_grid.h>
-#include <map_msgs/msg/occupancy_grid_update.h>
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <map_msgs/msg/occupancy_grid_update.hpp>
 #include <message_filters/subscriber.h>
 
 namespace costmap_2d
@@ -77,7 +77,9 @@ private:
    * static map are overwritten.
    */
   void incomingMap(const nav_msgs::msg::OccupancyGrid::SharedPtr new_map);
-  void incomingUpdate(const map_msgs::msg::OccupancyGridUpdateConstPtr & update);
+  void incomingUpdate(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update);
+  //TODO(bpwilcox): Replace dynamic_reconfigure functionality
+
   //void reconfigureCB(costmap_2d::GenericPluginConfig & config, uint32_t level);
 
   unsigned char interpretValue(unsigned char value);
@@ -92,11 +94,11 @@ private:
   bool use_maximum_;
   bool first_map_only_;      ///< @brief Store the first static map and reuse it on reinitializing
   bool trinary_costmap_;
-  ros::Subscriber map_sub_, map_update_sub_;
   rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr map_sub_;
   rclcpp::Subscription<map_msgs::msg::OccupancyGridUpdate>::SharedPtr map_update_sub_;
   unsigned char lethal_threshold_, unknown_cost_value_;
 
+  //TODO(bpwilcox): Replace dynamic_reconfigure functionality
   //dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig> * dsrv_;
 };
 

--- a/src/libs/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/src/libs/costmap_2d/include/costmap_2d/testing_helper.h
@@ -60,7 +60,7 @@ unsigned int countValues(costmap_2d::Costmap2D & costmap, unsigned char value, b
 void addStaticLayer(costmap_2d::LayeredCostmap & layers, tf2_ros::Buffer & tf)
 {
   costmap_2d::StaticLayer * slayer = new costmap_2d::StaticLayer();
-  layers.addPlugin(boost::shared_ptr<costmap_2d::Layer>(slayer));
+  layers.addPlugin(std::shared_ptr<costmap_2d::Layer>(slayer));
   slayer->initialize(&layers, "static", &tf);
 }
 
@@ -69,7 +69,7 @@ costmap_2d::ObstacleLayer * addObstacleLayer(costmap_2d::LayeredCostmap & layers
 {
   costmap_2d::ObstacleLayer * olayer = new costmap_2d::ObstacleLayer();
   olayer->initialize(&layers, "obstacles", &tf);
-  layers.addPlugin(boost::shared_ptr<costmap_2d::Layer>(olayer));
+  layers.addPlugin(std::shared_ptr<costmap_2d::Layer>(olayer));
   return olayer;
 }
 
@@ -101,7 +101,7 @@ costmap_2d::InflationLayer * addInflationLayer(costmap_2d::LayeredCostmap & laye
 {
   costmap_2d::InflationLayer * ilayer = new costmap_2d::InflationLayer();
   ilayer->initialize(&layers, "inflation", &tf);
-  boost::shared_ptr<costmap_2d::Layer> ipointer(ilayer);
+  std::shared_ptr<costmap_2d::Layer> ipointer(ilayer);
   layers.addPlugin(ipointer);
   return ilayer;
 }

--- a/src/libs/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/src/libs/costmap_2d/include/costmap_2d/testing_helper.h
@@ -35,7 +35,6 @@ char printableCost(unsigned char cost)
 
 void printMap(costmap_2d::Costmap2D & costmap)
 {
-
   printf("map:\n");
   for (int i = 0; i < costmap.getSizeInCellsY(); i++) {
     for (int j = 0; j < costmap.getSizeInCellsX(); j++) {
@@ -61,13 +60,9 @@ unsigned int countValues(costmap_2d::Costmap2D & costmap, unsigned char value, b
 
 void addStaticLayer(costmap_2d::LayeredCostmap & layers, tf2_ros::Buffer & tf)
 {
-
   costmap_2d::StaticLayer * slayer = new costmap_2d::StaticLayer();
-
   layers.addPlugin(std::shared_ptr<costmap_2d::Layer>(slayer));
-
   slayer->initialize(&layers, "static", &tf);
-
 }
 
 costmap_2d::ObstacleLayer * addObstacleLayer(costmap_2d::LayeredCostmap & layers,

--- a/src/libs/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/src/libs/costmap_2d/include/costmap_2d/testing_helper.h
@@ -1,13 +1,14 @@
 #ifndef COSTMAP_2D_TESTING_HELPER_H
 #define COSTMAP_2D_TESTING_HELPER_H
 
+#include "rclcpp/rclcpp.hpp"
 #include <costmap_2d/cost_values.h>
 #include <costmap_2d/costmap_2d.h>
 #include <costmap_2d/static_layer.h>
 #include <costmap_2d/obstacle_layer.h>
 #include <costmap_2d/inflation_layer.h>
 
-#include <sensor_msgs/point_cloud2_iterator.h>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
 
 const double MAX_Z(1.0);
 
@@ -34,6 +35,7 @@ char printableCost(unsigned char cost)
 
 void printMap(costmap_2d::Costmap2D & costmap)
 {
+
   printf("map:\n");
   for (int i = 0; i < costmap.getSizeInCellsY(); i++) {
     for (int j = 0; j < costmap.getSizeInCellsX(); j++) {
@@ -59,9 +61,13 @@ unsigned int countValues(costmap_2d::Costmap2D & costmap, unsigned char value, b
 
 void addStaticLayer(costmap_2d::LayeredCostmap & layers, tf2_ros::Buffer & tf)
 {
+
   costmap_2d::StaticLayer * slayer = new costmap_2d::StaticLayer();
+
   layers.addPlugin(std::shared_ptr<costmap_2d::Layer>(slayer));
+
   slayer->initialize(&layers, "static", &tf);
+
 }
 
 costmap_2d::ObstacleLayer * addObstacleLayer(costmap_2d::LayeredCostmap & layers,

--- a/src/libs/costmap_2d/package.xml
+++ b/src/libs/costmap_2d/package.xml
@@ -42,6 +42,7 @@
   <depend>xmlrpcpp</depend>
   <depend>pluginlib</depend>
   <depend>libpcl-all-dev</depend>
+ 	<depend>message_filters</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/src/libs/costmap_2d/package.xml
+++ b/src/libs/costmap_2d/package.xml
@@ -42,7 +42,7 @@
   <depend>xmlrpcpp</depend>
   <depend>pluginlib</depend>
   <depend>libpcl-all-dev</depend>
- 	<depend>message_filters</depend>
+  <depend>message_filters</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/src/libs/costmap_2d/plugins/inflation_layer.cpp
+++ b/src/libs/costmap_2d/plugins/inflation_layer.cpp
@@ -66,13 +66,13 @@ InflationLayer::InflationLayer()
   last_max_y_(std::numeric_limits<float>::max())
 {
   inflation_access_ = new std::recursive_mutex();
+  enabled_ = true;
 }
 
 void InflationLayer::onInitialize()
 {
   {
     std::unique_lock<std::recursive_mutex> lock(*inflation_access_);
-    //ros::NodeHandle nh("~/" + name_), g_nh;
 
     auto private_nh = rclcpp::Node::make_shared(name_);
     rclcpp::Node::SharedPtr g_nh;
@@ -102,6 +102,9 @@ void InflationLayer::onInitialize()
   }
 
   matchSize();
+  //TODO(bpwilcox): Values hard-coded from config file default, replace with dynamic approach
+  setInflationParameters(0.55, 10);
+
 }
 // TODO(bpwilcox): Resolve dynamic reconfigure dependencies
 /*

--- a/src/libs/costmap_2d/plugins/obstacle_layer.cpp
+++ b/src/libs/costmap_2d/plugins/obstacle_layer.cpp
@@ -128,7 +128,7 @@ void ObstacleLayer::onInitialize()
 
     // create an observation buffer
     observation_buffers_.push_back(
-        boost::shared_ptr<ObservationBuffer
+        std::shared_ptr<ObservationBuffer
         >(new ObservationBuffer(topic, observation_keep_time, expected_update_rate,
             min_obstacle_height,
             max_obstacle_height, obstacle_range, raytrace_range, *tf_, global_frame_,
@@ -152,17 +152,17 @@ void ObstacleLayer::onInitialize()
 
     // create a callback for the topic
     if (data_type == "LaserScan") {
-      boost::shared_ptr<message_filters::Subscriber<sensor_msgs::LaserScan>
+      std::shared_ptr<message_filters::Subscriber<sensor_msgs::LaserScan>
       > sub(new message_filters::Subscriber<sensor_msgs::LaserScan>(g_nh, topic, 50));
 
-      boost::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::LaserScan> > filter(
+      std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::LaserScan> > filter(
           new tf2_ros::MessageFilter<sensor_msgs::LaserScan>(*sub, *tf_, global_frame_, 50, g_nh));
 
       if (inf_is_valid) {
-        filter->registerCallback(boost::bind(&ObstacleLayer::laserScanValidInfCallback, this, _1,
+        filter->registerCallback(std::bind(&ObstacleLayer::laserScanValidInfCallback, this, _1,
               observation_buffers_.back()));
       } else {
-        filter->registerCallback(boost::bind(&ObstacleLayer::laserScanCallback, this, _1,
+        filter->registerCallback(std::bind(&ObstacleLayer::laserScanCallback, this, _1,
               observation_buffers_.back()));
       }
 
@@ -171,7 +171,7 @@ void ObstacleLayer::onInitialize()
 
       observation_notifiers_.back()->setTolerance(ros::Duration(0.05));
     } else if (data_type == "PointCloud") {
-      boost::shared_ptr<message_filters::Subscriber<sensor_msgs::PointCloud>
+      std::shared_ptr<message_filters::Subscriber<sensor_msgs::PointCloud>
       > sub(new message_filters::Subscriber<sensor_msgs::PointCloud>(g_nh, topic, 50));
 
       if (inf_is_valid) {
@@ -179,16 +179,16 @@ void ObstacleLayer::onInitialize()
             "obstacle_layer: inf_is_valid option is not applicable to PointCloud observations.");
       }
 
-      boost::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::PointCloud>
+      std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::PointCloud>
       > filter(new tf2_ros::MessageFilter<sensor_msgs::PointCloud>(*sub, *tf_, global_frame_, 50,
             g_nh));
       filter->registerCallback(
-          boost::bind(&ObstacleLayer::pointCloudCallback, this, _1, observation_buffers_.back()));
+          std::bind(&ObstacleLayer::pointCloudCallback, this, _1, observation_buffers_.back()));
 
       observation_subscribers_.push_back(sub);
       observation_notifiers_.push_back(filter);
     } else {
-      boost::shared_ptr<message_filters::Subscriber<sensor_msgs::PointCloud2>
+      std::shared_ptr<message_filters::Subscriber<sensor_msgs::PointCloud2>
       > sub(new message_filters::Subscriber<sensor_msgs::PointCloud2>(g_nh, topic, 50));
 
       if (inf_is_valid) {
@@ -196,11 +196,11 @@ void ObstacleLayer::onInitialize()
             "obstacle_layer: inf_is_valid option is not applicable to PointCloud observations.");
       }
 
-      boost::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::PointCloud2>
+      std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::PointCloud2>
       > filter(new tf2_ros::MessageFilter<sensor_msgs::PointCloud2>(*sub, *tf_, global_frame_, 50,
             g_nh));
       filter->registerCallback(
-          boost::bind(&ObstacleLayer::pointCloud2Callback, this, _1, observation_buffers_.back()));
+          std::bind(&ObstacleLayer::pointCloud2Callback, this, _1, observation_buffers_.back()));
 
       observation_subscribers_.push_back(sub);
       observation_notifiers_.push_back(filter);
@@ -221,7 +221,7 @@ void ObstacleLayer::onInitialize()
 void ObstacleLayer::setupDynamicReconfigure(ros::NodeHandle & nh)
 {
   dsrv_ = new dynamic_reconfigure::Server<costmap_2d::ObstaclePluginConfig>(nh);
-  dynamic_reconfigure::Server<costmap_2d::ObstaclePluginConfig>::CallbackType cb = boost::bind(
+  dynamic_reconfigure::Server<costmap_2d::ObstaclePluginConfig>::CallbackType cb = std::bind(
       &ObstacleLayer::reconfigureCB, this, _1, _2);
   dsrv_->setCallback(cb);
 }
@@ -241,7 +241,7 @@ void ObstacleLayer::reconfigureCB(costmap_2d::ObstaclePluginConfig & config, uin
 }
 
 void ObstacleLayer::laserScanCallback(const sensor_msgs::LaserScanConstPtr & message,
-    const boost::shared_ptr<ObservationBuffer> & buffer)
+    const std::shared_ptr<ObservationBuffer> & buffer)
 {
   // project the laser into a point cloud
   sensor_msgs::PointCloud2 cloud;
@@ -264,7 +264,7 @@ void ObstacleLayer::laserScanCallback(const sensor_msgs::LaserScanConstPtr & mes
 }
 
 void ObstacleLayer::laserScanValidInfCallback(const sensor_msgs::LaserScanConstPtr & raw_message,
-    const boost::shared_ptr<ObservationBuffer> & buffer)
+    const std::shared_ptr<ObservationBuffer> & buffer)
 {
   // Filter positive infinities ("Inf"s) to max_range.
   float epsilon = 0.0001;  // a tenth of a millimeter
@@ -296,7 +296,7 @@ void ObstacleLayer::laserScanValidInfCallback(const sensor_msgs::LaserScanConstP
 }
 
 void ObstacleLayer::pointCloudCallback(const sensor_msgs::PointCloudConstPtr & message,
-    const boost::shared_ptr<ObservationBuffer> & buffer)
+    const std::shared_ptr<ObservationBuffer> & buffer)
 {
   sensor_msgs::PointCloud2 cloud2;
 
@@ -312,7 +312,7 @@ void ObstacleLayer::pointCloudCallback(const sensor_msgs::PointCloudConstPtr & m
 }
 
 void ObstacleLayer::pointCloud2Callback(const sensor_msgs::PointCloud2ConstPtr & message,
-    const boost::shared_ptr<ObservationBuffer> & buffer)
+    const std::shared_ptr<ObservationBuffer> & buffer)
 {
   // buffer the point cloud
   buffer->lock();

--- a/src/libs/costmap_2d/plugins/static_layer.cpp
+++ b/src/libs/costmap_2d/plugins/static_layer.cpp
@@ -38,7 +38,7 @@
  *********************************************************************/
 #include <costmap_2d/static_layer.h>
 #include <costmap_2d/costmap_math.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <tf2/convert.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
@@ -134,7 +134,7 @@ void StaticLayer::onInitialize()
   } */
 
   //dsrv_ = new dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>(nh);
-  //dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>::CallbackType cb = boost::bind(
+  //dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>::CallbackType cb = std::bind(
   //    &StaticLayer::reconfigureCB, this, _1, _2);
   //dsrv_->setCallback(cb);
 }

--- a/src/libs/costmap_2d/plugins/static_layer.cpp
+++ b/src/libs/costmap_2d/plugins/static_layer.cpp
@@ -63,8 +63,6 @@ StaticLayer::~StaticLayer()
 
 void StaticLayer::onInitialize()
 {
-
-
   auto nh = rclcpp::Node::make_shared(name_);
   rclcpp::Node::SharedPtr g_nh;
   g_nh = rclcpp::Node::make_shared("costmap_2d_static");

--- a/src/libs/costmap_2d/plugins/voxel_layer.cpp
+++ b/src/libs/costmap_2d/plugins/voxel_layer.cpp
@@ -68,7 +68,7 @@ void VoxelLayer::onInitialize()
 void VoxelLayer::setupDynamicReconfigure(ros::NodeHandle & nh)
 {
   voxel_dsrv_ = new dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig>(nh);
-  dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig>::CallbackType cb = boost::bind(
+  dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig>::CallbackType cb = std::bind(
       &VoxelLayer::reconfigureCB, this, _1, _2);
   voxel_dsrv_->setCallback(cb);
 }

--- a/src/libs/costmap_2d/src/costmap_2d.cpp
+++ b/src/libs/costmap_2d/src/costmap_2d.cpp
@@ -57,14 +57,14 @@ Costmap2D::Costmap2D(unsigned int cells_size_x, unsigned int cells_size_y, doubl
 void Costmap2D::deleteMaps()
 {
   // clean up data
-  boost::unique_lock<mutex_t> lock(*access_);
+  std::unique_lock<mutex_t> lock(*access_);
   delete[] costmap_;
   costmap_ = NULL;
 }
 
 void Costmap2D::initMaps(unsigned int size_x, unsigned int size_y)
 {
-  boost::unique_lock<mutex_t> lock(*access_);
+  std::unique_lock<mutex_t> lock(*access_);
   delete[] costmap_;
   costmap_ = new unsigned char[size_x * size_y];
 }
@@ -86,13 +86,13 @@ void Costmap2D::resizeMap(unsigned int size_x, unsigned int size_y, double resol
 
 void Costmap2D::resetMaps()
 {
-  boost::unique_lock<mutex_t> lock(*access_);
+  std::unique_lock<mutex_t> lock(*access_);
   memset(costmap_, default_value_, size_x_ * size_y_ * sizeof(unsigned char));
 }
 
 void Costmap2D::resetMap(unsigned int x0, unsigned int y0, unsigned int xn, unsigned int yn)
 {
-  boost::unique_lock<mutex_t> lock(*(access_));
+  std::unique_lock<mutex_t> lock(*(access_));
   unsigned int len = xn - x0;
   for (unsigned int y = y0 * size_x_ + x0; y < yn * size_x_ + x0; y += size_x_) {
     memset(costmap_ + y, default_value_, len * sizeof(unsigned char));

--- a/src/libs/costmap_2d/src/costmap_2d_cloud.cpp
+++ b/src/libs/costmap_2d/src/costmap_2d_cloud.cpp
@@ -191,7 +191,7 @@ int main(int argc, char ** argv)
   ros::Publisher pub_marked = n.advertise<sensor_msgs::PointCloud>("voxel_marked_cloud", 2);
   ros::Publisher pub_unknown = n.advertise<sensor_msgs::PointCloud>("voxel_unknown_cloud", 2);
   ros::Subscriber sub = n.subscribe<costmap_2d::VoxelGrid
-    >("voxel_grid", 1, boost::bind(voxelCallback, pub_marked, pub_unknown, _1));
+    >("voxel_grid", 1, std::bind(voxelCallback, pub_marked, pub_unknown, _1));
 
   ros::spin();
 }

--- a/src/libs/costmap_2d/src/costmap_2d_markers.cpp
+++ b/src/libs/costmap_2d/src/costmap_2d_markers.cpp
@@ -142,7 +142,7 @@ int main(int argc, char ** argv)
 
   ros::Publisher pub = n.advertise<visualization_msgs::Marker>("visualization_marker", 1);
   ros::Subscriber sub =
-    n.subscribe<costmap_2d::VoxelGrid>("voxel_grid", 1, boost::bind(voxelCallback, pub, _1));
+    n.subscribe<costmap_2d::VoxelGrid>("voxel_grid", 1, std::bind(voxelCallback, pub, _1));
   g_marker_ns = n.resolveName("voxel_grid");
 
   ros::spin();

--- a/src/libs/costmap_2d/src/costmap_2d_publisher.cpp
+++ b/src/libs/costmap_2d/src/costmap_2d_publisher.cpp
@@ -35,7 +35,6 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#include <boost/bind.hpp>
 #include <costmap_2d/costmap_2d_publisher.h>
 #include <costmap_2d/cost_values.h>
 
@@ -96,7 +95,7 @@ void Costmap2DPublisher::onNewSubscription(const ros::SingleSubscriberPublisher&
 // prepare grid_ message for publication.
 void Costmap2DPublisher::prepareGrid()
 {
-  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
+  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
   double resolution = costmap_->getResolution();
 
   grid_.header.frame_id = global_frame_;
@@ -145,7 +144,7 @@ void Costmap2DPublisher::publishCostmap()
     prepareGrid();
     costmap_pub_->publish(grid_);
   } else if (x0_ < xn_) {
-    boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
+    std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
     // Publish Just an Update
     map_msgs::msg::OccupancyGridUpdate update;
     update.header.stamp = rclcpp::Time();

--- a/src/libs/costmap_2d/src/costmap_2d_ros.cpp
+++ b/src/libs/costmap_2d/src/costmap_2d_ros.cpp
@@ -232,9 +232,7 @@ void Costmap2DROS::resetOldParameters(rclcpp::Node::SharedPtr nh)
       super_map.setStruct(&map);
       plugins.push_back(super_map);
 
-      //ros::NodeHandle map_layer(nh, "static_layer");
-      //auto map_layer = rclcpp::Node::make_shared("static_layer",nh->get_name);
-      auto map_layer = rclcpp::Node::make_shared("static_layer");
+      auto map_layer = rclcpp::Node::make_shared("static_layer", std::string(nh->get_name()));
 
       move_parameter(nh, map_layer, "map_topic");
       move_parameter(nh, map_layer, "unknown_cost_value");
@@ -242,7 +240,7 @@ void Costmap2DROS::resetOldParameters(rclcpp::Node::SharedPtr nh)
       move_parameter(nh, map_layer, "track_unknown_space", false);
     }
   }
-  auto obstacles = rclcpp::Node::make_shared("obstacle_layer");
+  auto obstacles = rclcpp::Node::make_shared("obstacle_layer", std::string(nh->get_name()));
   //ros::NodeHandle obstacles(nh, "obstacle_layer");
 
   if (parameters_client->has_parameter("map_type")) {
@@ -280,7 +278,7 @@ void Costmap2DROS::resetOldParameters(rclcpp::Node::SharedPtr nh)
   }
   move_parameter(nh, obstacles, "observation_sources");
 
-  auto inflation = rclcpp::Node::make_shared("obstacle_layer");
+  auto inflation = rclcpp::Node::make_shared("obstacle_layer", std::string(nh->get_name()));
   //ros::NodeHandle inflation(nh, "inflation_layer");
 
   move_parameter(nh, inflation, "cost_scaling_factor");

--- a/src/libs/costmap_2d/src/costmap_2d_ros.cpp
+++ b/src/libs/costmap_2d/src/costmap_2d_ros.cpp
@@ -39,6 +39,7 @@
 #include <costmap_2d/costmap_2d_ros.h>
 #include <cstdio>
 #include <string>
+#include <sys/time.h>
 #include <algorithm>
 #include <vector>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -183,7 +184,7 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
 
   // TODO(bpwilcox): resolve dynamic reconfigure dependencies
   //dsrv_ = new dynamic_reconfigure::Server<Costmap2DConfig>(ros::NodeHandle("~/" + name));
-  //dynamic_reconfigure::Server<Costmap2DConfig>::CallbackType cb = boost::bind(&Costmap2DROS::reconfigureCB, this, _1,
+  //dynamic_reconfigure::Server<Costmap2DConfig>::CallbackType cb = std::bind(&Costmap2DROS::reconfigureCB, this, _1,
   //                                                                            _2);
   //dsrv_->setCallback(cb);
 }
@@ -340,7 +341,7 @@ void Costmap2DROS::reconfigureCB(costmap_2d::Costmap2DConfig &config, uint32_t l
 
   old_config_ = config;
 
-  map_update_thread_ = new boost::thread(boost::bind(&Costmap2DROS::mapUpdateLoop, this, map_update_frequency));
+  map_update_thread_ = new std::thread(std::bind(&Costmap2DROS::mapUpdateLoop, this, map_update_frequency));
 } */
 
 // TODO(bpwilcox): resolve dynamic reconfigure dependencies
@@ -392,7 +393,7 @@ void Costmap2DROS::setUnpaddedRobotFootprint(const std::vector<geometry_msgs::ms
 void Costmap2DROS::movementCB()
 {
   // don't allow configuration to happen while this check occurs
-  // boost::recursive_mutex::scoped_lock mcl(configuration_mutex_);
+  // std::recursive_mutex::scoped_lock mcl(configuration_mutex_);
 
   geometry_msgs::msg::PoseStamped new_pose;
   if (!getRobotPose(new_pose)) {

--- a/src/libs/costmap_2d/src/footprint.cpp
+++ b/src/libs/costmap_2d/src/footprint.cpp
@@ -29,9 +29,6 @@
 #include <string>
 
 #include <costmap_2d/costmap_math.h>
-#include <boost/tokenizer.hpp>
-#include <boost/foreach.hpp>
-#include <boost/algorithm/string.hpp>
 #include <costmap_2d/footprint.h>
 #include <costmap_2d/array_parser.h>
 #include <geometry_msgs/msg/point32.hpp>

--- a/src/libs/costmap_2d/src/layered_costmap.cpp
+++ b/src/libs/costmap_2d/src/layered_costmap.cpp
@@ -84,7 +84,7 @@ void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double 
     double origin_y,
     bool size_locked)
 {
-  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
+  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
   size_locked_ = size_locked;
   costmap_.resizeMap(size_x, size_y, resolution, origin_x, origin_y);
   for (vector<std::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
@@ -98,7 +98,7 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
 {
   // Lock for the remainder of this function, some plugins (e.g. VoxelLayer)
   // implement thread unsafe updateBounds() functions.
-  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
+  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
 
   // if we're using a rolling buffer costmap... we need to update the origin using the robot's position
   if (rolling_window_) {


### PR DESCRIPTION
In this PR, the static layer & inflation layer plugins have been ported and compile properly. After a manual inspection of the plugins, they appear to work fine and generate reasonable results, though some additional work needs to be done in order to incorporate the plugins properly in the Costmap2DROS class (particularly with parameters). 

Some intial work on the observation buffer was done but was blocked from completion until tf2_sensor_msgs is also ported (will file an issue). 

Also, Boost dependencies have been removed from costmap_2d. 