### PR TITLE
Replacing  costmap stub with costmap_2d package in WorldModel

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -148,6 +148,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(nav2_costmap_2d layers)
+ament_export_libraries(layers nav2_costmap_2d)
 ament_export_dependencies(${dependencies})
 ament_package()

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -52,6 +52,7 @@ namespace nav2_costmap_2d
 
 InflationLayer::InflationLayer()
   : inflation_radius_(0),
+  inscribed_radius_(0),
   weight_(0),
   inflate_unknown_(false),
   cell_inflation_radius_(0),

--- a/nav2_costmap_world_model/CMakeLists.txt
+++ b/nav2_costmap_world_model/CMakeLists.txt
@@ -12,12 +12,8 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(nav2_tasks)
 find_package(nav2_util)
 find_package(nav2_msgs)
-find_package(nav_msgs)
 find_package(nav2_costmap_2d REQUIRED)
 
 include_directories(
@@ -38,13 +34,8 @@ add_library(${library_name}
 
 set(dependencies
   rclcpp
-  std_msgs
-  nav2_tasks
   nav2_util
   nav2_msgs
-  tf2_ros
-  tf2
-  nav_msgs
   nav2_costmap_2d
 )
 

--- a/nav2_costmap_world_model/CMakeLists.txt
+++ b/nav2_costmap_world_model/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(nav2_tasks)
 find_package(nav2_util)
 find_package(nav2_msgs)
 find_package(nav_msgs)
+find_package(nav2_costmap_2d REQUIRED)
 
 include_directories(
   include
@@ -44,6 +45,7 @@ set(dependencies
   tf2_ros
   tf2
   nav_msgs
+  nav2_costmap_2d
 )
 
 ament_target_dependencies(${executable_name}

--- a/nav2_costmap_world_model/include/nav2_costmap_world_model/costmap_world_model.hpp
+++ b/nav2_costmap_world_model/include/nav2_costmap_world_model/costmap_world_model.hpp
@@ -26,7 +26,7 @@
 #include "nav2_util/costmap.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
 #include "nav2_msgs/srv/get_costmap.hpp"
-#include "nav2_tasks/map_service_client.hpp"
+#include "tf2_ros/transform_listener.h"
 
 namespace nav2_costmap_world_model
 {

--- a/nav2_costmap_world_model/include/nav2_costmap_world_model/costmap_world_model.hpp
+++ b/nav2_costmap_world_model/include/nav2_costmap_world_model/costmap_world_model.hpp
@@ -18,6 +18,9 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include "costmap_2d/costmap_2d_ros.h"
+#include "costmap_2d/inflation_layer.h"
+#include "costmap_2d/static_layer.h"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_util/costmap.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
@@ -33,26 +36,26 @@ public:
   explicit CostmapWorldModel(const std::string & name);
   CostmapWorldModel();
 
+  void addStaticLayer();
+  void addInflationLayer();
+
 private:
+  void costmap_callback(
+      const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+      const std::shared_ptr<nav2_world_model_msgs::srv::GetCostmap::Request>/*request*/,
+      const std::shared_ptr<nav2_world_model_msgs::srv::GetCostmap::Response> response);
+
   // Server for providing a costmap
   rclcpp::Service<nav2_msgs::srv::GetCostmap>::SharedPtr costmapServer_;
 
   // TODO(orduno): Define a server for scoring trajectories
   // rclcpp::Service<nav2_msgs::srv::ScoreTrajectory>::SharedPtr scoringServer_;
 
-  // TODO(orduno): Define a client for getting the static map
-  // rclcpp::Client<nav2_msgs::srv::GetMap>::SharedPtr mapClient_;
-
-  // TODO(orduno): Alternatively, obtain from a latched topic
-  // rclcpp::Subscription<nav2_msgs::OccupancyGrid>::SharedPtr mapSub_;
-
   // TODO(orduno): Define a task for handling trajectory scoring
   // std::unique_ptr<ScoreTrajectoryClient> scorer;
 
-  // TODO(orduno): std::unique_ptr<LayeredCostmap> layeredCostmap_;
-  std::unique_ptr<nav2_util::Costmap> costmap_;
-
-  nav2_tasks::MapServiceClient map_client_;
+  costmap_2d::LayeredCostmap * layered_costmap_;
+  tf2_ros::Buffer * tf_;
 };
 
 }  // namespace nav2_costmap_world_model

--- a/nav2_costmap_world_model/include/nav2_costmap_world_model/costmap_world_model.hpp
+++ b/nav2_costmap_world_model/include/nav2_costmap_world_model/costmap_world_model.hpp
@@ -18,9 +18,9 @@
 #include <string>
 #include <vector>
 #include <memory>
-#include "costmap_2d/inflation_layer.h"
-#include "costmap_2d/layered_costmap.h"
-#include "costmap_2d/static_layer.h"
+#include "nav2_costmap_2d/inflation_layer.h"
+#include "nav2_costmap_2d/layered_costmap.h"
+#include "nav2_costmap_2d/static_layer.h"
 #include "geometry_msgs/msg/point.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_util/costmap.hpp"
@@ -50,12 +50,12 @@ public:
 private:
   void costmap_callback(
     const std::shared_ptr<rmw_request_id_t>/*request_header*/,
-    const std::shared_ptr<nav2_world_model_msgs::srv::GetCostmap::Request>/*request*/,
-    const std::shared_ptr<nav2_world_model_msgs::srv::GetCostmap::Response> response);
+    const std::shared_ptr<nav2_msgs::srv::GetCostmap::Request>/*request*/,
+    const std::shared_ptr<nav2_msgs::srv::GetCostmap::Response> response);
 
   // Server for providing a costmap
   rclcpp::Service<nav2_msgs::srv::GetCostmap>::SharedPtr costmapServer_;
-  costmap_2d::LayeredCostmap * layered_costmap_;
+  nav2_costmap_2d::LayeredCostmap * layered_costmap_;
   tf2_ros::Buffer * tf_;
 };
 

--- a/nav2_costmap_world_model/package.xml
+++ b/nav2_costmap_world_model/package.xml
@@ -18,7 +18,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>nav2_tasks</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
-  <exec_depend>nav2_tasks</exec_depend>
+  <exec_depend>nav2_costmap_2d</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_costmap_world_model/package.xml
+++ b/nav2_costmap_world_model/package.xml
@@ -10,13 +10,12 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
-  <build_depend>nav2_tasks</build_depend>
-  <build_depend>nav2_tasks</build_depend>
   <build_depend>nav2_util</build_depend>
   <build_depend>nav2_msgs</build_depend>
+  <build_depend>nav2_costmap_2d</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
-  <exec_depend>nav2_tasks</exec_depend>
+  <exec_depend>nav2_util</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>nav2_costmap_2d</exec_depend>
 

--- a/nav2_costmap_world_model/src/costmap_world_model.cpp
+++ b/nav2_costmap_world_model/src/costmap_world_model.cpp
@@ -36,20 +36,10 @@ CostmapWorldModel::CostmapWorldModel(const string & name)
   setFootprint(0, 0);
   layered_costmap_->updateMap(0, 0, 0);
 
-
-  auto costmap_service_callback = [this](
-    const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<nav2_world_model_msgs::srv::GetCostmap::Request> request,
-    const std::shared_ptr<nav2_world_model_msgs::srv::GetCostmap::Response> response) -> void
-    {
-      RCLCPP_INFO(
-        this->get_logger(), "CostmapWorldModel::CostmapWorldModel:Incoming costmap request");
-      costmap_callback(request_header, request, response);
-    };
-
   // Create a service that will use the callback function to handle requests.
-  costmapServer_ = create_service<nav2_msgs::srv::GetCostmap>("GetCostmap",
-      costmap_service_callback);
+  costmapServer_ = create_service<nav2_msgs::srv::GetCostmap>(name + "_GetCostmap",
+    std::bind(&CostmapWorldModel::costmap_callback, this,
+    std::placeholders::_1, std::placeholders::_2. std::placeholders::_3));
 }
 
 void CostmapWorldModel::costmap_callback(
@@ -57,6 +47,9 @@ void CostmapWorldModel::costmap_callback(
   const std::shared_ptr<nav2_world_model_msgs::srv::GetCostmap::Request>/*request*/,
   const std::shared_ptr<nav2_world_model_msgs::srv::GetCostmap::Response> response)
 {
+  RCLCPP_INFO(
+    this->get_logger(), "CostmapWorldModel::CostmapWorldModel:Incoming costmap request");
+
   costmap_2d::Costmap2D * costmap = layered_costmap_->getCostmap();
   rclcpp::Clock clock;
 
@@ -87,17 +80,17 @@ void CostmapWorldModel::setFootprint(double length, double width)
 {
   std::vector<geometry_msgs::msg::Point> polygon;
   geometry_msgs::msg::Point p;
-  p.x = width;
-  p.y = length;
+  p.x = width/2;
+  p.y = length/2;
   polygon.push_back(p);
-  p.x = width;
-  p.y = -length;
+  p.x = width/2;
+  p.y = -length/2;
   polygon.push_back(p);
-  p.x = -width;
-  p.y = -length;
+  p.x = -width/2;
+  p.y = -length/2;
   polygon.push_back(p);
-  p.x = -width;
-  p.y = length;
+  p.x = -width/2;
+  p.y = length/2;
   polygon.push_back(p);
   layered_costmap_->setFootprint(polygon);
 }

--- a/nav2_costmap_world_model/src/costmap_world_model.cpp
+++ b/nav2_costmap_world_model/src/costmap_world_model.cpp
@@ -29,28 +29,28 @@ CostmapWorldModel::CostmapWorldModel(const string & name)
 : Node(name + "_Node")
 {
   // Create layered costmap with static and inflation layer
-  layered_costmap_ = new costmap_2d::LayeredCostmap("frame", false, false);
-  addLayer<costmap_2d::StaticLayer>("static");
-  addLayer<costmap_2d::InflationLayer>("inflation");
+  layered_costmap_ = new nav2_costmap_2d::LayeredCostmap("frame", false, false);
+  addLayer<nav2_costmap_2d::StaticLayer>("static");
+  addLayer<nav2_costmap_2d::InflationLayer>("inflation");
   // TODO(bpwilcox): replace manual footprint to layered_costmap with parameter or from nav2_robot
   setFootprint(0, 0);
   layered_costmap_->updateMap(0, 0, 0);
 
   // Create a service that will use the callback function to handle requests.
   costmapServer_ = create_service<nav2_msgs::srv::GetCostmap>(name + "_GetCostmap",
-    std::bind(&CostmapWorldModel::costmap_callback, this,
-    std::placeholders::_1, std::placeholders::_2. std::placeholders::_3));
+      std::bind(&CostmapWorldModel::costmap_callback, this,
+      std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 }
 
 void CostmapWorldModel::costmap_callback(
   const std::shared_ptr<rmw_request_id_t>/*request_header*/,
-  const std::shared_ptr<nav2_world_model_msgs::srv::GetCostmap::Request>/*request*/,
-  const std::shared_ptr<nav2_world_model_msgs::srv::GetCostmap::Response> response)
+  const std::shared_ptr<nav2_msgs::srv::GetCostmap::Request>/*request*/,
+  const std::shared_ptr<nav2_msgs::srv::GetCostmap::Response> response)
 {
   RCLCPP_INFO(
     this->get_logger(), "CostmapWorldModel::CostmapWorldModel:Incoming costmap request");
 
-  costmap_2d::Costmap2D * costmap = layered_costmap_->getCostmap();
+  nav2_costmap_2d::Costmap2D * costmap = layered_costmap_->getCostmap();
   rclcpp::Clock clock;
 
   response->map.metadata.size_x = costmap->getSizeInCellsX();
@@ -80,17 +80,17 @@ void CostmapWorldModel::setFootprint(double length, double width)
 {
   std::vector<geometry_msgs::msg::Point> polygon;
   geometry_msgs::msg::Point p;
-  p.x = width/2;
-  p.y = length/2;
+  p.x = width / 2;
+  p.y = length / 2;
   polygon.push_back(p);
-  p.x = width/2;
-  p.y = -length/2;
+  p.x = width / 2;
+  p.y = -length / 2;
   polygon.push_back(p);
-  p.x = -width/2;
-  p.y = -length/2;
+  p.x = -width / 2;
+  p.y = -length / 2;
   polygon.push_back(p);
-  p.x = -width/2;
-  p.y = length/2;
+  p.x = -width / 2;
+  p.y = length / 2;
   polygon.push_back(p);
   layered_costmap_->setFootprint(polygon);
 }

--- a/nav2_costmap_world_model/src/costmap_world_model.cpp
+++ b/nav2_costmap_world_model/src/costmap_world_model.cpp
@@ -47,8 +47,7 @@ void CostmapWorldModel::costmap_callback(
   const std::shared_ptr<nav2_msgs::srv::GetCostmap::Request>/*request*/,
   const std::shared_ptr<nav2_msgs::srv::GetCostmap::Response> response)
 {
-  RCLCPP_INFO(
-    this->get_logger(), "CostmapWorldModel::CostmapWorldModel:Incoming costmap request");
+  RCLCPP_INFO(this->get_logger(), "Received costmap request");
 
   nav2_costmap_2d::Costmap2D * costmap = layered_costmap_->getCostmap();
   rclcpp::Clock clock;
@@ -61,6 +60,7 @@ void CostmapWorldModel::costmap_callback(
   response->map.metadata.update_time = now();
 
   tf2::Quaternion quaternion;
+  // TODO(bpwilcox): Grab correct orientation information
   quaternion.setRPY(0.0, 0.0, 0.0);  // set roll, pitch, yaw
   response->map.metadata.origin.position.x = costmap->getOriginX();
   response->map.metadata.origin.position.y = costmap->getOriginY();


### PR DESCRIPTION
The costmap stubbed code has now been replaced with an implementation using the costmap_2d package. In this change, a LayeredCostmap object is created and a static & inflation layer are manually added during the CostmapWorldModel construction. The static layer plugin is responsible for grabbing the static map from the map_server via the map topic.
