### PR TITLE
Adding time delays to launch script.

### DIFF
--- a/launch/core.launch.py
+++ b/launch/core.launch.py
@@ -13,8 +13,8 @@ def generate_launch_description():
                 ], period = 1.0),
         launch.actions.TimerAction(
             actions = [
-                launch_ros.actions.Node( package='nav2_controller_dwb', node_executable='nav2_controller_dwb', output='screen')
-                #launch_ros.actions.Node( package='nav2_controller_example', node_executable='dwa_controller', output='screen')
+                #launch_ros.actions.Node( package='nav2_controller_dwb', node_executable='nav2_controller_dwb', output='screen')
+                launch_ros.actions.Node( package='nav2_controller_example', node_executable='dwa_controller', output='screen')
                 ], period = 5.0),
         launch.actions.TimerAction(
             actions = [

--- a/launch/core.launch.py
+++ b/launch/core.launch.py
@@ -1,24 +1,39 @@
 import os
 from launch import LaunchDescription
+import launch.actions
 import launch_ros.actions
 
 def generate_launch_description():
     mapFile = os.path.join(os.getenv('TEST_LAUNCH_DIR'), 'test_map.yaml')
 
     return LaunchDescription([
-        launch_ros.actions.Node(
-            package='nav2_map_server', node_executable='map_server', output='screen', arguments=[[mapFile], 'occupancy']),
-        launch_ros.actions.Node(
-            package='nav2_controller_example', node_executable='dwa_controller', output='screen'),
-        launch_ros.actions.Node(
-            package='nav2_simple_navigator', node_executable='simple_navigator', output='screen'),
-        launch_ros.actions.Node(
-            package='nav2_mission_executor', node_executable='mission_executor', output='screen'),
-        launch_ros.actions.Node(
-            package='nav2_costmap_world_model', node_executable='costmap_world_model', output='screen'),
-        launch_ros.actions.Node(
-            package='nav2_dijkstra_planner', node_executable='dijkstra_planner', output='screen'),
-        launch_ros.actions.Node(
-            package='nav2_amcl', node_executable='amcl', output='screen'),
+        launch.actions.TimerAction(
+            actions = [
+                launch_ros.actions.Node( package='nav2_map_server', node_executable='map_server', output='screen', arguments=[[mapFile], 'occupancy'])
+                ], period = 1.0),
+        launch.actions.TimerAction(
+            actions = [
+                launch_ros.actions.Node( package='nav2_controller_dwb', node_executable='nav2_controller_dwb', output='screen')
+                #launch_ros.actions.Node( package='nav2_controller_example', node_executable='dwa_controller', output='screen')
+                ], period = 5.0),
+        launch.actions.TimerAction(
+            actions = [
+                launch_ros.actions.Node( package='nav2_dijkstra_planner', node_executable='dijkstra_planner', output='screen')
+                ], period = 10.0),
+        launch.actions.TimerAction(
+            actions = [
+                launch_ros.actions.Node( package='nav2_simple_navigator', node_executable='simple_navigator', output='screen')
+                ], period = 15.0),
+        launch.actions.TimerAction(
+            actions = [
+                launch_ros.actions.Node( package='nav2_mission_executor', node_executable='mission_executor', output='screen')
+                ], period = 20.0),
+        launch.actions.TimerAction(
+            actions = [
+                launch_ros.actions.Node( package='nav2_costmap_world_model', node_executable='costmap_world_model', output='screen')
+                ], period = 25.0),
+        launch.actions.TimerAction(
+            actions = [
+                launch_ros.actions.Node( package='nav2_amcl', node_executable='amcl', output='screen')
+                ], period = 30.0),
     ])
-

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -13,8 +13,8 @@ repositories:
     version: ros2
   ros2/launch:
     type: git
-    url: https://github.com/ros2/launch.git
-    version: 4ec284ad96534a044e69213db9a335057945d1b9
+    url: https://github.com/crdelsey/launch.git
+    version: TimerActionWorkaround
   xmlrpcpp:
     type: git
     url: https://github.com/bpwilcox/xmlrpcpp.git


### PR DESCRIPTION
To use this updated launch file, you need to update your ros2/launch repo to point to the version specified in the change to the repos file.

We can change the repo back when ros2/launch#144 is fixed.