### PR TITLE
Fixing uninitialized variable in Task Server.

### DIFF
--- a/nav2_tasks/include/nav2_tasks/task_server.hpp
+++ b/nav2_tasks/include/nav2_tasks/task_server.hpp
@@ -35,7 +35,7 @@ class TaskServer : public rclcpp::Node
 {
 public:
   explicit TaskServer(const std::string & name, bool autoStart = true)
-  : Node(name), workerThread_(nullptr)
+  : Node(name), workerThread_(nullptr), commandReceived_(false)
   {
     std::string taskName = getTaskName<CommandMsg, ResultMsg>();
     commandSub_ = create_subscription<CommandMsg>(taskName + "_command",


### PR DESCRIPTION
This problem would cause TaskServer to immediately call the execute
process, even before a command was received. Whether you were
affected by this bug depended on the state of the stack when the
Task Server was constructed.