### PR TITLE
Declaring use of hypot function.

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d.h
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d.h
@@ -38,6 +38,7 @@
 #ifndef nav2_costmap_2d_nav2_costmap_2d_H_
 #define nav2_costmap_2d_nav2_costmap_2d_H_
 
+#include <cmath>
 #include <vector>
 #include <queue>
 #include <mutex>
@@ -381,7 +382,7 @@ protected:
     unsigned int offset = y0 * size_x_ + x0;
 
     // we need to chose how much to scale our dominant dimension, based on the maximum length of the line
-    double dist = hypot(dx, dy);
+    double dist = std::hypot(dx, dy);
     double scale = (dist == 0.0) ? 1.0 : std::min(1.0, max_length / dist);
 
     // if x is dominant

--- a/nav2_costmap_2d/test/costmap_tester.cpp
+++ b/nav2_costmap_2d/test/costmap_tester.cpp
@@ -47,7 +47,7 @@ class CostmapTester : public testing::Test {
     CostmapTester(tf2_ros::Buffer& tf);
     void checkConsistentCosts();
     void compareCellToNeighbors(nav2_costmap_2d::Costmap2D& costmap, unsigned int x, unsigned int y);
-    void compareCells(nav2_costmap_2d::Costmap2D& costmap, 
+    void compareCells(nav2_costmap_2d::Costmap2D& costmap,
         unsigned int x, unsigned int y, unsigned int nx, unsigned int ny);
     virtual void TestBody(){}
 

--- a/nav2_costmap_2d/test/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/inflation_tests.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2013, Willow Garage, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Willow Garage, Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -50,16 +50,16 @@ std::vector<Point> setRadii(LayeredCostmap& layers, double length, double width,
   std::vector<Point> polygon;
   Point p;
   p.x = width;
-  p.y = length; 
+  p.y = length;
   polygon.push_back(p);
   p.x = width;
-  p.y = -length; 
+  p.y = -length;
   polygon.push_back(p);
   p.x = -width;
-  p.y = -length; 
+  p.y = -length;
   polygon.push_back(p);
   p.x = -width;
-  p.y = length; 
+  p.y = length;
   polygon.push_back(p);
   layers.setFootprint(polygon);
 
@@ -87,7 +87,7 @@ void validatePointInflation(unsigned int mx, unsigned int my, Costmap2D* costmap
         seen[cell.index_] = true;
         unsigned int dx = (cell.x_ > cell.src_x_) ? cell.x_ - cell.src_x_ : cell.src_x_ - cell.x_;
         unsigned int dy = (cell.y_ > cell.src_y_) ? cell.y_ - cell.src_y_ : cell.src_y_ - cell.y_;
-        double dist = hypot(dx, dy);
+        double dist = std::hypot(dx, dy);
 
         unsigned char expected_cost = ilayer->computeCost(dist);
         ASSERT_TRUE(costmap->getCost(cell.x_, cell.y_) >= expected_cost);
@@ -136,7 +136,7 @@ TEST(costmap, testAdjacentToObstacleCanStillMove){
   //               circumscribed radius = 3.1
   std::vector<Point> polygon = setRadii(layers, 2.1, 2.3, 4.1);
 
-  ObstacleLayer* olayer = addObstacleLayer(layers, tf);  
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
   InflationLayer* ilayer = addInflationLayer(layers, tf);
   layers.setFootprint(polygon);
 
@@ -162,7 +162,7 @@ TEST(costmap, testInflationShouldNotCreateUnknowns){
   //               circumscribed radius = 3.1
   std::vector<Point> polygon = setRadii(layers, 2.1, 2.3, 4.1);
 
-  ObstacleLayer* olayer = addObstacleLayer(layers, tf);  
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
   InflationLayer* ilayer = addInflationLayer(layers, tf);
   layers.setFootprint(polygon);
 
@@ -187,7 +187,7 @@ TEST(costmap, testCostFunctionCorrectness){
   //               circumscribed radius = 8.0
   std::vector<Point> polygon = setRadii(layers, 5.0, 6.25, 10.5);
 
-  ObstacleLayer* olayer = addObstacleLayer(layers, tf);  
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
   InflationLayer* ilayer = addInflationLayer(layers, tf);
   layers.setFootprint(polygon);
 
@@ -284,7 +284,7 @@ TEST(costmap, testInflation){
   std::vector<Point> polygon = setRadii(layers, 1, 1, 1);
 
   addStaticLayer(layers, tf);
-  ObstacleLayer* olayer = addObstacleLayer(layers, tf);  
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
   InflationLayer* ilayer = addInflationLayer(layers, tf);
   layers.setFootprint(polygon);
 
@@ -310,7 +310,7 @@ TEST(costmap, testInflation){
   // It and its 2 neighbors makes 3 obstacles
   ASSERT_EQ(countValues(*costmap, LETHAL_OBSTACLE) + countValues(*costmap, INSCRIBED_INFLATED_OBSTACLE), (unsigned int)51);
 
-  // @todo Rewrite 
+  // @todo Rewrite
   // Add an obstacle at <2,0> which will inflate and refresh to of the other inflated cells
   addObservation(olayer, 2, 0);
   layers.updateMap(0,0,0);
@@ -348,7 +348,7 @@ TEST(costmap, testInflation2){
   std::vector<Point> polygon = setRadii(layers, 1, 1, 1);
 
   addStaticLayer(layers, tf);
-  ObstacleLayer* olayer = addObstacleLayer(layers, tf);  
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
   InflationLayer* ilayer = addInflationLayer(layers, tf);
   layers.setFootprint(polygon);
 
@@ -360,7 +360,7 @@ TEST(costmap, testInflation2){
 
   Costmap2D* costmap = layers.getCostmap();
   //printMap(*costmap);
-  ASSERT_EQ(costmap->getCost(2, 3), nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE);  
+  ASSERT_EQ(costmap->getCost(2, 3), nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE);
   ASSERT_EQ(costmap->getCost(3, 3), nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE);
 }
 
@@ -375,7 +375,7 @@ TEST(costmap, testInflation3){
   // 1 2 3
   std::vector<Point> polygon = setRadii(layers, 1, 1.75, 3);
 
-  ObstacleLayer* olayer = addObstacleLayer(layers, tf);  
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
   InflationLayer* ilayer = addInflationLayer(layers, tf);
   layers.setFootprint(polygon);
 


### PR DESCRIPTION
For some reason, on Ubuntu 18.04, cmath functions are no longer
being added to the global namespace by default. To fix this, the
cmath header needs to be added and the hypot function scoped.

This should fix the CI build.