### PR TITLE
DWB fixes

### DIFF
--- a/nav2_controller/costmap_queue/CMakeLists.txt
+++ b/nav2_controller/costmap_queue/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/nav2_controller/costmap_queue/CMakeLists.txt
+++ b/nav2_controller/costmap_queue/CMakeLists.txt
@@ -7,7 +7,9 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  # fPIC option is required so this library can be added to shared libraries.
+  add_compile_options(-fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/nav2_controller/dwb_core/CMakeLists.txt
+++ b/nav2_controller/dwb_core/CMakeLists.txt
@@ -39,7 +39,7 @@ set(dependencies
   nav_2d_utils
 )
 
-add_library(dwb_core
+add_library(dwb_core SHARED
   src/dwb_core.cpp
   src/publisher.cpp
   src/illegal_trajectory_tracker.cpp

--- a/nav2_controller/dwb_critics/CMakeLists.txt
+++ b/nav2_controller/dwb_critics/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories(
   include
 )
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
     src/alignment_util.cpp
     src/map_grid.cpp
     src/goal_dist.cpp

--- a/nav2_controller/dwb_critics/include/dwb_critics/oscillation.h
+++ b/nav2_controller/dwb_critics/include/dwb_critics/oscillation.h
@@ -79,6 +79,8 @@ namespace dwb_critics
 class OscillationCritic : public dwb_core::TrajectoryCritic
 {
 public:
+  OscillationCritic()
+  : oscillation_reset_time_(0) {}
   void onInit() override;
   bool prepare(
     const geometry_msgs::msg::Pose2D & pose, const nav_2d_msgs::msg::Twist2D & vel,
@@ -141,7 +143,7 @@ private:
 
   CommandTrend x_trend_, y_trend_, theta_trend_;
   double oscillation_reset_dist_, oscillation_reset_angle_, x_only_threshold_;
-  double oscillation_reset_time_;
+  rclcpp::Duration oscillation_reset_time_;
 
   // Cached square parameter
   double oscillation_reset_dist_sq_;

--- a/nav2_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_controller/dwb_critics/src/oscillation.cpp
@@ -33,9 +33,11 @@
  */
 
 #include "dwb_critics/oscillation.h"
+#include <chrono>
 #include <cmath>
 #include <string>
 #include <vector>
+#include "nav2_util/duration_conversions.h"
 #include "nav_2d_utils/parameters.h"
 #include "dwb_core/exceptions.h"
 #include "pluginlib/class_list_macros.hpp"
@@ -44,6 +46,7 @@ PLUGINLIB_EXPORT_CLASS(dwb_critics::OscillationCritic, dwb_core::TrajectoryCriti
 
 namespace dwb_critics
 {
+
 
 OscillationCritic::CommandTrend::CommandTrend()
 {
@@ -91,7 +94,8 @@ void OscillationCritic::onInit()
   oscillation_reset_dist_ = nav_2d_utils::searchAndGetParam(nh_, "oscillation_reset_dist", 0.05);
   oscillation_reset_dist_sq_ = oscillation_reset_dist_ * oscillation_reset_dist_;
   oscillation_reset_angle_ = nav_2d_utils::searchAndGetParam(nh_, "oscillation_reset_angle", 0.2);
-  oscillation_reset_time_ = nav_2d_utils::searchAndGetParam(nh_, "oscillation_reset_time", -1.0);
+  oscillation_reset_time_ = nav2_util::durationFromSeconds(
+    nav_2d_utils::searchAndGetParam(nh_, "oscillation_reset_time", -1.0));
 
   /**
    * Historical Parameter Loading
@@ -168,9 +172,9 @@ bool OscillationCritic::resetAvailable()
       return true;
     }
   }
-  if (oscillation_reset_time_ >= 0.0) {
+  if (oscillation_reset_time_ >= nav2_util::durationFromSeconds(0.0)) {
     auto t_diff = (rclcpp::Clock().now() - prev_reset_time_);
-    if (t_diff > rclcpp::Duration(oscillation_reset_time_)) {
+    if (t_diff > oscillation_reset_time_) {
       return true;
     }
   }

--- a/nav2_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -38,6 +38,7 @@
 #include "nav_2d_utils/parameters.h"
 #include "pluginlib/class_list_macros.hpp"
 #include "dwb_core/exceptions.h"
+#include "nav2_util/duration_conversions.h"
 
 namespace dwb_plugins
 {
@@ -83,7 +84,7 @@ dwb_msgs::msg::Trajectory2D LimitedAccelGenerator::generateTrajectory(
 {
   dwb_msgs::msg::Trajectory2D traj;
   traj.velocity = cmd_vel;
-  traj.duration = rclcpp::Duration(sim_time_);
+  traj.duration = nav2_util::durationFromSeconds(sim_time_);
   geometry_msgs::msg::Pose2D pose = start_pose;
 
   std::vector<double> steps = getTimeSteps(cmd_vel);

--- a/nav2_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -41,6 +41,7 @@
 #include "nav_2d_utils/parameters.h"
 #include "pluginlib/class_list_macros.hpp"
 #include "dwb_core/exceptions.h"
+#include "nav2_util/duration_conversions.h"
 
 using nav_2d_utils::loadParameterWithDeprecation;
 
@@ -142,7 +143,7 @@ dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
 {
   dwb_msgs::msg::Trajectory2D traj;
   traj.velocity = cmd_vel;
-  traj.duration = rclcpp::Duration(sim_time_);
+  traj.duration = nav2_util::durationFromSeconds(sim_time_);
   //  simulate the trajectory
   geometry_msgs::msg::Pose2D pose = start_pose;
   nav_2d_msgs::msg::Twist2D vel = start_vel;

--- a/nav2_controller/nav2_controller_dwb/include/nav2_controller_dwb/dwb_controller.hpp
+++ b/nav2_controller/nav2_controller_dwb/include/nav2_controller_dwb/dwb_controller.hpp
@@ -45,7 +45,6 @@ protected:
   std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::Twist>> vel_pub_;
   tf2_ros::Buffer tfBuffer_;
   tf2_ros::TransformListener tfListener_;
-
 };
 
 }  // namespace nav2_controller_dwb

--- a/nav2_controller/nav2_controller_dwb/include/nav2_controller_dwb/dwb_controller.hpp
+++ b/nav2_controller/nav2_controller_dwb/include/nav2_controller_dwb/dwb_controller.hpp
@@ -43,6 +43,9 @@ protected:
   dwb_core::DWBLocalPlanner planner_;
   std::shared_ptr<nav_2d_utils::OdomSubscriber> odom_sub_;
   std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::Twist>> vel_pub_;
+  tf2_ros::Buffer tfBuffer_;
+  tf2_ros::TransformListener tfListener_;
+
 };
 
 }  // namespace nav2_controller_dwb

--- a/nav2_controller/nav_2d_utils/CMakeLists.txt
+++ b/nav2_controller/nav_2d_utils/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(nav2_msgs REQUIRED)
 
 set(dependencies
   geometry_msgs
@@ -25,18 +26,23 @@ set(dependencies
   rclcpp
   tf2
   tf2_geometry_msgs
+  nav2_msgs
 )
 
 include_directories(
     include
 )
 
-add_library(conversions src/conversions.cpp)
+add_library(conversions SHARED
+  src/conversions.cpp)
+
 ament_target_dependencies(conversions
   ${dependencies}
 )
 
-add_library(path_ops src/path_ops.cpp)
+add_library(path_ops SHARED
+  src/path_ops.cpp)
+
 ament_target_dependencies(path_ops
   ${dependencies}
 )

--- a/nav2_controller/nav_2d_utils/include/nav_2d_utils/conversions.h
+++ b/nav2_controller/nav_2d_utils/include/nav_2d_utils/conversions.h
@@ -45,12 +45,14 @@
 #include "nav_msgs/msg/path.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/convert.h"
+#include "nav2_msgs/msg/path.hpp"
 
 namespace nav_2d_utils
 {
 geometry_msgs::msg::Twist twist2Dto3D(const nav_2d_msgs::msg::Twist2D & cmd_vel_2d);
 // nav_2d_msgs::msg::Pose2DStamped stampedPoseToPose2D(const tf2::Stamped<tf2::Pose>& pose);
 nav_2d_msgs::msg::Pose2DStamped poseStampedToPose2D(const geometry_msgs::msg::PoseStamped & pose);
+geometry_msgs::msg::Pose2D poseToPose2D(const geometry_msgs::msg::Pose & pose);
 geometry_msgs::msg::Pose pose2DToPose(const geometry_msgs::msg::Pose2D & pose2d);
 geometry_msgs::msg::PoseStamped pose2DToPoseStamped(
   const nav_2d_msgs::msg::Pose2DStamped & pose2d);
@@ -58,8 +60,7 @@ geometry_msgs::msg::PoseStamped pose2DToPoseStamped(
   const geometry_msgs::msg::Pose2D & pose2d,
   const std::string & frame, const rclcpp::Time & stamp);
 nav_msgs::msg::Path posesToPath(const std::vector<geometry_msgs::msg::PoseStamped> & poses);
-nav_2d_msgs::msg::Path2D posesToPath2D(
-  const std::vector<geometry_msgs::msg::PoseStamped> & poses);
+nav_2d_msgs::msg::Path2D pathToPath2D(const nav2_msgs::msg::Path & path);
 nav_msgs::msg::Path poses2DToPath(
   const std::vector<geometry_msgs::msg::Pose2D> & poses,
   const std::string & frame, const rclcpp::Time & stamp);

--- a/nav2_controller/nav_2d_utils/package.xml
+++ b/nav2_controller/nav_2d_utils/package.xml
@@ -18,6 +18,7 @@
   <depend>roscpp</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>nav2_msgs</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>

--- a/nav2_controller/nav_2d_utils/src/conversions.cpp
+++ b/nav2_controller/nav_2d_utils/src/conversions.cpp
@@ -73,6 +73,15 @@ nav_2d_msgs::msg::Pose2DStamped poseStampedToPose2D(const geometry_msgs::msg::Po
   return pose2d;
 }
 
+geometry_msgs::msg::Pose2D poseToPose2D(const geometry_msgs::msg::Pose & pose)
+{
+  geometry_msgs::msg::Pose2D pose2d;
+  pose2d.x = pose.position.x;
+  pose2d.y = pose.position.y;
+  pose2d.theta = tf2::getYaw(pose.orientation);
+  return pose2d;
+}
+
 geometry_msgs::msg::Pose pose2DToPose(const geometry_msgs::msg::Pose2D & pose2d)
 {
   geometry_msgs::msg::Pose pose;
@@ -123,21 +132,14 @@ nav_msgs::msg::Path posesToPath(const std::vector<geometry_msgs::msg::PoseStampe
   return path;
 }
 
-nav_2d_msgs::msg::Path2D posesToPath2D(const std::vector<geometry_msgs::msg::PoseStamped> & poses)
+nav_2d_msgs::msg::Path2D pathToPath2D(const nav2_msgs::msg::Path & path)
 {
-  nav_2d_msgs::msg::Path2D path;
-  if (poses.empty()) {
-    return path;
+  nav_2d_msgs::msg::Path2D path2d;
+  path2d.header = path.header;
+  for (auto & pose : path.poses) {
+    path2d.poses.push_back(poseToPose2D(pose));
   }
-  nav_2d_msgs::msg::Pose2DStamped pose;
-  path.poses.resize(poses.size());
-  path.header.frame_id = poses[0].header.frame_id;
-  path.header.stamp = poses[0].header.stamp;
-  for (unsigned int i = 0; i < poses.size(); i++) {
-    pose = poseStampedToPose2D(poses[i]);
-    path.poses[i] = pose.pose;
-  }
-  return path;
+  return path2d;
 }
 
 

--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -27,10 +27,11 @@ find_package(xmlrpcpp REQUIRED)
 find_package(laser_geometry REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(message_filters REQUIRED)
+find_package(nav2_util REQUIRED)
 
 # TODO(bpwilcox): port remaining packages
 #find_package(tf2_sensor_msgs REQUIRED)
-#find_package(dynamic_reconfigure REQUIRED) 
+#find_package(dynamic_reconfigure REQUIRED)
 #find_package(voxel_grid REQUIRED)
 
 remove_definitions(-DDISABLE_LIBUSB-1.0)
@@ -61,9 +62,9 @@ add_library(nav2_costmap_2d
   src/costmap_2d_publisher.cpp
   src/costmap_math.cpp
   src/footprint.cpp
-  src/costmap_layer.cpp	
+  src/costmap_layer.cpp
   #	TODO(bpwilcox): need tf2_sensor_msgs ported
-  # src/observation_buffer.cpp  
+  # src/observation_buffer.cpp
 )
 
 set(dependencies
@@ -77,6 +78,7 @@ set(dependencies
   pluginlib
   tf2_geometry_msgs
   message_filters
+  nav2_util
 )
 
 ament_target_dependencies(nav2_costmap_2d

--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -53,7 +53,7 @@ add_definitions(${EIGEN3_DEFINITIONS})
 #	DEPENDENCIES std_msgs geometry_msgs map_msgs
 #)
 
-add_library(nav2_costmap_2d
+add_library(nav2_costmap_2d SHARED
   src/array_parser.cpp
   src/costmap_2d.cpp
   src/layer.cpp
@@ -85,7 +85,7 @@ ament_target_dependencies(nav2_costmap_2d
   ${dependencies}
 )
 
-add_library(layers
+add_library(layers SHARED
   plugins/inflation_layer.cpp
 
   # TODO(bpwilcox): port additional plugin layers

--- a/nav2_costmap_2d/package.xml
+++ b/nav2_costmap_2d/package.xml
@@ -37,6 +37,7 @@
   <depend>pluginlib</depend>
   <depend>libpcl-all-dev</depend>
   <depend>message_filters</depend>
+  <depend>nav2_util</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -43,6 +43,7 @@
 #include <algorithm>
 #include <vector>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include "nav2_util/duration_conversions.h"
 
 using namespace std;
 
@@ -107,7 +108,7 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
         tf2::durationFromSec(0.1), &tf_error))
   {
     rclcpp::spin_some(private_nh);
-    if (last_error + rclcpp::Duration(5.0) < clock.now()) {
+    if (last_error + nav2_util::durationFromSeconds(5.0) < clock.now()) {
       RCLCPP_WARN(rclcpp::get_logger(
             "nav2_costmap_2d"),
           "Timed out waiting for transform from %s to %s to become available before running costmap, tf error: %s",

--- a/nav2_tasks/include/nav2_tasks/task_client.hpp
+++ b/nav2_tasks/include/nav2_tasks/task_client.hpp
@@ -84,7 +84,7 @@ public:
       rclcpp::spin_some(node_->get_node_base_interface());
 
       auto t1 = std::chrono::high_resolution_clock::now();
-      auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
+      auto elapsedTime = t1 - t0;
 
       if (elapsedTime > timeout) {
         return false;

--- a/nav2_util/CMakeLists.txt
+++ b/nav2_util/CMakeLists.txt
@@ -82,7 +82,7 @@ install(TARGETS
   LIBRARY DESTINATION lib)
 
 install(DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/
 )
 
 if(BUILD_TESTING)

--- a/nav2_util/include/nav2_util/duration_conversions.h
+++ b/nav2_util/include/nav2_util/duration_conversions.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_UTIL__DURATION_CONVERSIONS_H_
+#define NAV2_UTIL__DURATION_CONVERSIONS_H_
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace nav2_util
+{
+  // TODO(crdelsey): This functionality should be part of the RCLCPP Duration
+  // interface. Once that gets integrated, this function can be removed.
+  inline rclcpp::Duration durationFromSeconds(double seconds)
+  {
+    return rclcpp::Duration(static_cast<long>(seconds * 1e9));  // convert to ns
+  }
+}
+
+#endif  // NAV2_UTIL__DURATION_CONVERSIONS_H_


### PR DESCRIPTION
This commit
* adds in the missing conversion from the Task path parameter to the version the DWB code uses
* fixes a bunch of time conversions because the RCLCPP Duration constructors take nanoseconds by default
* makes the dwb_critics library shared so the critics can load as a plugin.

With these changes, DWB starts to do stuff. We need to resolve getting the current pose reliably still, in order to get a fully operational system test.