### PR TITLE
Remove the fake placeholder Oregon robotics e-mail address

### DIFF
--- a/nav2_controller/nav2_controller/package.xml
+++ b/nav2_controller/nav2_controller/package.xml
@@ -6,7 +6,7 @@
   <description>
     ROS2 controller (DWB) metapackage
   </description>
-  <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
+  <maintainer email="carl.r.delsey@intel.com">Carl Delsey</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <license>Apache License 2.0</license>
 

--- a/navigation2/package.xml
+++ b/navigation2/package.xml
@@ -6,7 +6,6 @@
   <description>
     ROS2 Navigation Stack
   </description>
-  <maintainer email="oregon.robotics.team@intel.com">Oregon Robotics Team</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <license>Apache License 2.0</license>
 


### PR DESCRIPTION
We previously included a fictitious e-mail address in the maintainer field in package.xml files. Instead of pursuing the idea of having a team e-mail address, we'll use only individual addresses.  