### PR TITLE
Cleanup of some time math and conversions between type.

### DIFF
--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -332,7 +332,7 @@ void StaticLayer::updateCosts(nav2_costmap_2d::Costmap2D & master_grid, int min_
     // Might even be in a different frame
     geometry_msgs::msg::TransformStamped transform;
     try {
-      transform = tf_->lookupTransform(map_frame_, global_frame_, tf2_ros::fromMsg(rclcpp::Time()));
+      transform = tf_->lookupTransform(map_frame_, global_frame_, tf2::TimePointZero);
     } catch (tf2::TransformException ex) {
       RCLCPP_ERROR(rclcpp::get_logger("nav2_costmap_2d"), "%s", ex.what());
       return;


### PR DESCRIPTION
This change makes use of the rclcpp Time and duration classes to simplify time conversion. The time conversions can be done with one step instead of multiple.

I'm not sure if it is strictly necessary, however, I think the result is a bit easier to understand