### PR TITLE
Changing calls to now() to always use a node reference instead of instantiating a clock object

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -925,8 +925,7 @@ void
 AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
 {
   std::string laser_scan_frame_id = strutils::stripLeadingSlash(laser_scan->header.frame_id);
-  rclcpp::Clock ros_clock(RCL_ROS_TIME);
-  last_laser_received_ts_ = ros_clock.now();
+  last_laser_received_ts_ = now();
   if (map_ == NULL) {
     return;
   }

--- a/nav2_controller/dwb_core/include/dwb_core/dwb_core.h
+++ b/nav2_controller/dwb_core/include/dwb_core/dwb_core.h
@@ -196,13 +196,14 @@ protected:
    * @brief Load the critic parameters from the namespace
    * @param name The namespace of this planner.
    */
-  void loadCritics(const std::shared_ptr<rclcpp::Node> & private_nh);
+  void loadCritics();
 
   std::vector<std::string> default_critic_namespaces_;
 
   CostmapROSPtr costmap_ros_;
   TFBufferPtr tf_;
   DWBPublisher pub_;
+  std::shared_ptr<rclcpp::Node> nh_;
 };
 
 }  // namespace dwb_core

--- a/nav2_controller/dwb_core/include/dwb_core/publisher.h
+++ b/nav2_controller/dwb_core/include/dwb_core/publisher.h
@@ -112,6 +112,8 @@ protected:
   std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::Path>> local_pub_;
   std::shared_ptr<rclcpp::Publisher<visualization_msgs::msg::MarkerArray>> marker_pub_;
   std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud>> cost_grid_pc_pub_;
+
+  std::shared_ptr<rclcpp::Node> nh_;
 };
 
 }  // namespace dwb_core

--- a/nav2_controller/dwb_core/src/publisher.cpp
+++ b/nav2_controller/dwb_core/src/publisher.cpp
@@ -46,36 +46,37 @@ namespace dwb_core
 
 void DWBPublisher::initialize(const std::shared_ptr<rclcpp::Node> & nh)
 {
+  nh_ = nh;
   // Load Publishers
-  nh->get_parameter_or("publish_evaluation", publish_evaluation_, true);
+  nh_->get_parameter_or("publish_evaluation", publish_evaluation_, true);
   if (publish_evaluation_) {
-    eval_pub_ = nh->create_publisher<dwb_msgs::msg::LocalPlanEvaluation>("evaluation", 1);
+    eval_pub_ = nh_->create_publisher<dwb_msgs::msg::LocalPlanEvaluation>("evaluation", 1);
   }
 
-  nh->get_parameter_or("publish_global_plan", publish_global_plan_, true);
+  nh_->get_parameter_or("publish_global_plan", publish_global_plan_, true);
   if (publish_global_plan_) {
-    global_pub_ = nh->create_publisher<nav_msgs::msg::Path>("global_plan", 1);
+    global_pub_ = nh_->create_publisher<nav_msgs::msg::Path>("global_plan", 1);
   }
 
-  nh->get_parameter_or("publish_transformed_plan", publish_transformed_, true);
+  nh_->get_parameter_or("publish_transformed_plan", publish_transformed_, true);
   if (publish_transformed_) {
-    transformed_pub_ = nh->create_publisher<nav_msgs::msg::Path>("transformed_global_plan", 1);
+    transformed_pub_ = nh_->create_publisher<nav_msgs::msg::Path>("transformed_global_plan", 1);
   }
 
-  nh->get_parameter_or("publish_local_plan", publish_local_plan_, true);
+  nh_->get_parameter_or("publish_local_plan", publish_local_plan_, true);
   if (publish_local_plan_) {
-    local_pub_ = nh->create_publisher<nav_msgs::msg::Path>("local_plan", 1);
+    local_pub_ = nh_->create_publisher<nav_msgs::msg::Path>("local_plan", 1);
   }
 
-  nh->get_parameter_or("publish_trajectories", publish_trajectories_, true);
+  nh_->get_parameter_or("publish_trajectories", publish_trajectories_, true);
   if (publish_trajectories_) {
-    marker_pub_ = nh->create_publisher<visualization_msgs::msg::MarkerArray>("marker", 1);
+    marker_pub_ = nh_->create_publisher<visualization_msgs::msg::MarkerArray>("marker", 1);
   }
   prev_marker_count_ = 0;
 
-  nh->get_parameter_or("publish_cost_grid_pc", publish_cost_grid_pc_, false);
+  nh_->get_parameter_or("publish_cost_grid_pc", publish_cost_grid_pc_, false);
   if (publish_cost_grid_pc_) {
-    cost_grid_pc_pub_ = nh->create_publisher<sensor_msgs::msg::PointCloud>("cost_cloud", 1);
+    cost_grid_pc_pub_ = nh_->create_publisher<sensor_msgs::msg::PointCloud>("cost_cloud", 1);
   }
 }
 
@@ -157,7 +158,7 @@ void DWBPublisher::publishCostGrid(
 
   sensor_msgs::msg::PointCloud cost_grid_pc;
   cost_grid_pc.header.frame_id = costmap_ros->getGlobalFrameID();
-  cost_grid_pc.header.stamp = rclcpp::Clock().now();
+  cost_grid_pc.header.stamp = nh_->now();
 
   nav2_costmap_2d::Costmap2D * costmap = costmap_ros->getCostmap();
   double x_coord, y_coord;

--- a/nav2_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_controller/dwb_critics/src/oscillation.cpp
@@ -144,7 +144,7 @@ void OscillationCritic::debrief(const nav_2d_msgs::msg::Twist2D & cmd_vel)
 {
   if (setOscillationFlags(cmd_vel)) {
     prev_stationary_pose_ = pose_;
-    prev_reset_time_ = rclcpp::Clock().now();
+    prev_reset_time_ = nh_->now();
   }
 
   // if we've got restrictions... check if we can reset any oscillation flags
@@ -173,7 +173,7 @@ bool OscillationCritic::resetAvailable()
     }
   }
   if (oscillation_reset_time_ >= nav2_util::durationFromSeconds(0.0)) {
-    auto t_diff = (rclcpp::Clock().now() - prev_reset_time_);
+    auto t_diff = (nh_->now() - prev_reset_time_);
     if (t_diff > oscillation_reset_time_) {
       return true;
     }

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.h
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.h
@@ -282,6 +282,8 @@ private:
   std::vector<geometry_msgs::msg::Point> unpadded_footprint_;
   std::vector<geometry_msgs::msg::Point> padded_footprint_;
   float footprint_padding_;
+
+  rclcpp::Node::SharedPtr private_nh_;
 };
 // class Costmap2DROS
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.h
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.h
@@ -70,7 +70,7 @@ public:
    * @param  sensor_frame The frame of the origin of the sensor, can be left blank to be read from the messages
    * @param  tf_tolerance The amount of time to wait for a transform to be available when setting a new global frame
    */
-  ObservationBuffer(std::string topic_name, double observation_keep_time,
+  ObservationBuffer(rclcpp::Node::SharedPtr nh, std::string topic_name, double observation_keep_time,
       double expected_update_rate,
       double min_obstacle_height, double max_obstacle_height, double obstacle_range,
       double raytrace_range, tf2_ros::Buffer & tf2_buffer, std::string global_frame,
@@ -140,7 +140,7 @@ private:
   tf2_ros::Buffer & tf2_buffer_;
   const rclcpp::Duration observation_keep_time_;
   const rclcpp::Duration expected_update_rate_;
-  rclcpp::Clock clock_;
+  rclcpp::Node::SharedPtr nh_;
   rclcpp::Time last_updated_;
   std::string global_frame_;
   std::string sensor_frame_;

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -46,9 +46,6 @@ using nav2_costmap_2d::NO_INFORMATION;
 using nav2_costmap_2d::LETHAL_OBSTACLE;
 using nav2_costmap_2d::FREE_SPACE;
 
-using nav2_costmap_2d::ObservationBuffer;
-using nav2_costmap_2d::Observation;
-
 namespace nav2_costmap_2d
 {
 

--- a/nav2_map_server/src/map_reps/occ_grid_server.cpp
+++ b/nav2_map_server/src/map_reps/occ_grid_server.cpp
@@ -279,10 +279,9 @@ void OccGridServer::LoadMapFromFile(const std::string & map_name_)
 
   SDL_FreeSurface(img);
 
-  rclcpp::Clock clock;
-  map_msg_.info.map_load_time = clock.now();
+  map_msg_.info.map_load_time = node_->now();
   map_msg_.header.frame_id = frame_id_;
-  map_msg_.header.stamp = clock.now();
+  map_msg_.header.stamp = node_->now();
 
   RCLCPP_INFO(rclcpp::get_logger("map_server"), "Read a %d X %d map @ %.3lf m/cell",
     map_msg_.info.width,


### PR DESCRIPTION
To properly work with simulation_time, all calls to now() to get the current time need to be called on the node.

In several places in the code, where a node reference is not readily available, we use the pattern of creating a Clock() and calling now() on it. This is wrong. This pattern always returns wall time, even if the simulator is running.

Resolves #165 