### PR TITLE
Fixing several linter failures

### DIFF
--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -79,7 +79,7 @@ if(BUILD_TESTING)
   # remove the line when a copyright and license is present in all source files
   set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
-  
+
   find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   add_subdirectory(test)

--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -76,7 +76,6 @@ install(TARGETS ${executable_name} ${library_name}
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
-  # remove the line when a copyright and license is present in all source files
   set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 

--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -74,10 +74,14 @@ install(TARGETS ${executable_name} ${library_name}
 )
 
 if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # remove the line when a copyright and license is present in all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+  
   find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
   add_subdirectory(test)
 endif()
 

--- a/nav2_amcl/package.xml
+++ b/nav2_amcl/package.xml
@@ -36,14 +36,9 @@
   <build_depend>nav2_util</build_depend>
   <build_depend>nav2_tasks</build_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_amcl/test/integration/test_localization_launch.py
+++ b/nav2_amcl/test/integration/test_localization_launch.py
@@ -16,21 +16,21 @@
 
 import os
 import sys
+
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing import LaunchTestService
-from launch.substitutions import ThisLaunchFileDir
 
 
 def main(argv=sys.argv[1:]):
     launchFile = os.path.join(os.getenv('TEST_LAUNCH_DIR'), 'localization_node.launch.py')
     testExecutable = os.getenv('TEST_EXECUTABLE')
-    ld = LaunchDescription([
-        IncludeLaunchDescription(PythonLaunchDescriptionSource( [launchFile] )),
-        ])
+    ld = LaunchDescription(
+        [IncludeLaunchDescription(PythonLaunchDescriptionSource([launchFile]))]
+    )
     test1_action = ExecuteProcess(
         cmd=[testExecutable],
         name='test_localization_node',
@@ -46,4 +46,3 @@ def main(argv=sys.argv[1:]):
 
 if __name__ == '__main__':
     sys.exit(main())
-

--- a/nav2_amcl/test/test_launch_files/localization_node.launch.py
+++ b/nav2_amcl/test/test_launch_files/localization_node.launch.py
@@ -15,13 +15,20 @@
 # limitations under the License.
 
 import os
+
 from launch import LaunchDescription
 import launch_ros.actions
 
+
 def generate_launch_description():
     mapFile = os.path.join(os.getenv('TEST_LAUNCH_DIR'), '../maps/test_map.yaml')
-    run_amcl = launch_ros.actions.Node(package='nav2_amcl', node_executable='amcl', output='screen')
-    run_map_server = launch_ros.actions.Node(package='nav2_map_server', node_executable='map_server', output='screen',
-                    arguments = [ [mapFile] , 'occupancy'])
+    run_amcl = launch_ros.actions.Node(
+        package='nav2_amcl',
+        node_executable='amcl',
+        output='screen')
+    run_map_server = launch_ros.actions.Node(
+        package='nav2_map_server',
+        node_executable='map_server',
+        output='screen',
+        arguments=[[mapFile], 'occupancy'])
     return LaunchDescription([run_amcl, run_map_server])
-

--- a/nav2_controller/costmap_queue/CMakeLists.txt
+++ b/nav2_controller/costmap_queue/CMakeLists.txt
@@ -38,6 +38,9 @@ ament_target_dependencies(${PROJECT_NAME}
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # remove the line when a copyright and license is present in all source files
+  set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)

--- a/nav2_controller/costmap_queue/CMakeLists.txt
+++ b/nav2_controller/costmap_queue/CMakeLists.txt
@@ -39,7 +39,6 @@ ament_target_dependencies(${PROJECT_NAME}
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
-  # remove the line when a copyright and license is present in all source files
   set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 

--- a/nav2_controller/costmap_queue/package.xml
+++ b/nav2_controller/costmap_queue/package.xml
@@ -12,12 +12,7 @@
   <depend>nav2_costmap_2d</depend>
   <depend>rclcpp</depend>
 
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/nav2_controller/costmap_queue/src/limited_costmap_queue.cpp
+++ b/nav2_controller/costmap_queue/src/limited_costmap_queue.cpp
@@ -37,7 +37,9 @@
 namespace costmap_queue
 {
 
-LimitedCostmapQueue::LimitedCostmapQueue(nav2_costmap_2d::Costmap2D & costmap, const int distance_limit)
+LimitedCostmapQueue::LimitedCostmapQueue(
+  nav2_costmap_2d::Costmap2D & costmap,
+  const int distance_limit)
 : CostmapQueue(costmap)
 {
   max_distance_ = distance_limit;

--- a/nav2_controller/costmap_queue/test/utest.cpp
+++ b/nav2_controller/costmap_queue/test/utest.cpp
@@ -107,7 +107,7 @@ TEST(CostmapQueue, crossQueue)
       double dd = hypot(xs[i] - static_cast<float>(cell.x_), ys[i] - static_cast<float>(cell.y_));
       min_d = std::min(min_d, dd);
     }
-    EXPECT_EQ(cell.distance_, min_d);
+    EXPECT_NEAR(cell.distance_, min_d, 0.00001);
     count++;
   }
   EXPECT_EQ(count, 25);

--- a/nav2_controller/dwb_core/CMakeLists.txt
+++ b/nav2_controller/dwb_core/CMakeLists.txt
@@ -60,6 +60,9 @@ install(DIRECTORY include/
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # remove the line when a copyright and license is present in all source files
+  set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/nav2_controller/dwb_core/CMakeLists.txt
+++ b/nav2_controller/dwb_core/CMakeLists.txt
@@ -61,7 +61,6 @@ install(DIRECTORY include/
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
-  # remove the line when a copyright and license is present in all source files
   set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/nav2_controller/dwb_core/package.xml
+++ b/nav2_controller/dwb_core/package.xml
@@ -31,12 +31,7 @@
   <exec_depend>nav_2d_utils</exec_depend>
   <exec_depend>pluginlib</exec_depend>
 
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/nav2_controller/dwb_critics/CMakeLists.txt
+++ b/nav2_controller/dwb_critics/CMakeLists.txt
@@ -73,7 +73,6 @@ install(FILES default_critics.xml
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
-  # remove the line when a copyright and license is present in all source files
   set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/nav2_controller/dwb_critics/CMakeLists.txt
+++ b/nav2_controller/dwb_critics/CMakeLists.txt
@@ -72,6 +72,9 @@ install(FILES default_critics.xml
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # remove the line when a copyright and license is present in all source files
+  set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/nav2_controller/dwb_critics/package.xml
+++ b/nav2_controller/dwb_critics/package.xml
@@ -21,12 +21,7 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
 
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 
   <export>

--- a/nav2_controller/dwb_critics/src/base_obstacle.cpp
+++ b/nav2_controller/dwb_critics/src/base_obstacle.cpp
@@ -75,7 +75,8 @@ double BaseObstacleCritic::scorePose(const geometry_msgs::msg::Pose2D & pose)
 
 bool BaseObstacleCritic::isValidCost(const unsigned char cost)
 {
-  return cost != nav2_costmap_2d::LETHAL_OBSTACLE && cost != nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE &&
+  return cost != nav2_costmap_2d::LETHAL_OBSTACLE &&
+         cost != nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE &&
          cost != nav2_costmap_2d::NO_INFORMATION;
 }
 

--- a/nav2_controller/dwb_critics/src/map_grid.cpp
+++ b/nav2_controller/dwb_critics/src/map_grid.cpp
@@ -50,7 +50,8 @@ namespace dwb_critics
 bool MapGridCritic::MapGridQueue::validCellToQueue(const costmap_queue::CellData & cell)
 {
   unsigned char cost = costmap_.getCost(cell.x_, cell.y_);
-  if (cost == nav2_costmap_2d::LETHAL_OBSTACLE || cost == nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE ||
+  if (cost == nav2_costmap_2d::LETHAL_OBSTACLE ||
+    cost == nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE ||
     cost == nav2_costmap_2d::NO_INFORMATION)
   {
     parent_.setAsObstacle(cell.index_);

--- a/nav2_controller/dwb_plugins/CMakeLists.txt
+++ b/nav2_controller/dwb_plugins/CMakeLists.txt
@@ -45,6 +45,9 @@ ament_target_dependencies(standard_traj_generator ${dependencies})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # remove the line when a copyright and license is present in all source files
+  set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)

--- a/nav2_controller/dwb_plugins/CMakeLists.txt
+++ b/nav2_controller/dwb_plugins/CMakeLists.txt
@@ -46,7 +46,6 @@ ament_target_dependencies(standard_traj_generator ${dependencies})
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
-  # remove the line when a copyright and license is present in all source files
   set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 

--- a/nav2_controller/dwb_plugins/package.xml
+++ b/nav2_controller/dwb_plugins/package.xml
@@ -20,12 +20,7 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
 
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/nav2_controller/nav2_controller_dwb/src/dwb_controller.cpp
+++ b/nav2_controller/nav2_controller_dwb/src/dwb_controller.cpp
@@ -46,7 +46,8 @@ DwbController::execute(const nav2_tasks::FollowPathCommand::SharedPtr command)
     cm_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>("local_costmap", tfBuffer_);
     auto nh = shared_from_this();
     odom_sub_ = std::make_shared<nav_2d_utils::OdomSubscriber>(*this);
-    vel_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("/mobile_base/commands/velocity", 1);
+    vel_pub_ =
+      this->create_publisher<geometry_msgs::msg::Twist>("/mobile_base/commands/velocity", 1);
     planner_.initialize(nh, shared_ptr<tf2_ros::Buffer>(&tfBuffer_), cm_);
     planner_.setPlan(path);
     RCLCPP_INFO(get_logger(), "Initialized");

--- a/nav2_controller/nav2_controller_example/include/nav2_controller_example/dwa_controller.hpp
+++ b/nav2_controller/nav2_controller_example/include/nav2_controller_example/dwa_controller.hpp
@@ -15,6 +15,7 @@
 #ifndef NAV2_CONTROLLER_EXAMPLE__DWA_CONTROLLER_HPP_
 #define NAV2_CONTROLLER_EXAMPLE__DWA_CONTROLLER_HPP_
 
+#include <memory>
 #include <string>
 #include "nav2_tasks/follow_path_task.hpp"
 #include "geometry_msgs/msg/twist.hpp"

--- a/nav2_controller/nav_2d_utils/CMakeLists.txt
+++ b/nav2_controller/nav_2d_utils/CMakeLists.txt
@@ -59,7 +59,6 @@ install(DIRECTORY include/
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
-  # remove the line when a copyright and license is present in all source files
   set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/nav2_controller/nav_2d_utils/CMakeLists.txt
+++ b/nav2_controller/nav_2d_utils/CMakeLists.txt
@@ -58,6 +58,9 @@ install(DIRECTORY include/
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # remove the line when a copyright and license is present in all source files
+  set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/nav2_controller/nav_2d_utils/package.xml
+++ b/nav2_controller/nav_2d_utils/package.xml
@@ -20,12 +20,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>nav2_msgs</depend>
 
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 
   <export>

--- a/nav2_dijkstra_planner/package.xml
+++ b/nav2_dijkstra_planner/package.xml
@@ -22,12 +22,7 @@
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
 
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -75,7 +75,6 @@ install(DIRECTORY include/
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
-  # remove the line when a copyright and license is present in all source files
   set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 

--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -74,6 +74,9 @@ install(DIRECTORY include/
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # remove the line when a copyright and license is present in all source files
+  set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_pytest REQUIRED)

--- a/nav2_map_server/package.xml
+++ b/nav2_map_server/package.xml
@@ -20,16 +20,11 @@
   <depend>sdl-image</depend>
   <depend>rviz_yaml_cpp_vendor</depend>
 
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
-	
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/nav2_util/package.xml
+++ b/nav2_util/package.xml
@@ -18,11 +18,7 @@
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
 
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 
   <export>


### PR DESCRIPTION
This fixes linter failures in all the controller packages, nav2_amcl and nav2_map_server.

This also fixes the way we remove the copyright linter from those packages and resolves #149 
