### PR TITLE
Fixing small bug within AMCL: checking for the last laser message

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -629,6 +629,13 @@ void AmclNode::updatePoseFromServer()
 void
 AmclNode::checkLaserReceived()
 {
+  if (last_laser_received_ts_.nanoseconds() == 0) {
+    RCLCPP_WARN(
+      get_logger(), "No laser scan received (and thus no pose updates have been published)."
+      " Verify that data is being published on the %s topic.", scan_topic_);
+    return;
+  }
+
   rclcpp::Duration d = this->now() - last_laser_received_ts_;
   if (d.nanoseconds() * 1e-9 > laser_check_interval_.count()) {
     RCLCPP_WARN(

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -631,7 +631,7 @@ AmclNode::checkLaserReceived()
 {
   if (last_laser_received_ts_.nanoseconds() == 0) {
     RCLCPP_WARN(
-      get_logger(), "No laser scan received (and thus no pose updates have been published)."
+      get_logger(), "Laser scan has not been received (and thus no pose updates have been published)."
       " Verify that data is being published on the %s topic.", scan_topic_);
     return;
   }


### PR DESCRIPTION
Need to handle situation when amcl node is loaded but laser messages are not yet available.