### PR TITLE
Port costmap2d buffer + tf_sensor_msgs local port 

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(visualization_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_sensor_msgs REQUIRED)
 find_package(xmlrpcpp REQUIRED)
 find_package(laser_geometry REQUIRED)
 find_package(pluginlib REQUIRED)
@@ -30,13 +31,11 @@ find_package(message_filters REQUIRED)
 find_package(nav2_util REQUIRED)
 
 # TODO(bpwilcox): port remaining packages
-#find_package(tf2_sensor_msgs REQUIRED)
 #find_package(dynamic_reconfigure REQUIRED)
 #find_package(voxel_grid REQUIRED)
 
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 find_package(Eigen3 REQUIRED)
-#find_package(Boost REQUIRED COMPONENTS system thread)
 
 include_directories(
   include
@@ -63,8 +62,7 @@ add_library(nav2_costmap_2d SHARED
   src/costmap_math.cpp
   src/footprint.cpp
   src/costmap_layer.cpp
-  #	TODO(bpwilcox): need tf2_sensor_msgs ported
-  # src/observation_buffer.cpp
+  src/observation_buffer.cpp
 )
 
 set(dependencies
@@ -77,6 +75,7 @@ set(dependencies
   xmlrpcpp
   pluginlib
   tf2_geometry_msgs
+  tf2_sensor_msgs
   message_filters
   nav2_util
 )
@@ -87,12 +86,12 @@ ament_target_dependencies(nav2_costmap_2d
 
 add_library(layers SHARED
   plugins/inflation_layer.cpp
-
-  # TODO(bpwilcox): port additional plugin layers
   plugins/static_layer.cpp
   #plugins/obstacle_layer.cpp
+  src/observation_buffer.cpp
+
+  # TODO(bpwilcox): port additional plugin layers
   #plugins/voxel_layer.cpp
-  #src/observation_buffer.cpp
 )
 ament_target_dependencies(layers
   ${dependencies}

--- a/nav2_costmap_2d/include/nav2_costmap_2d/observation.h
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/observation.h
@@ -50,7 +50,7 @@ public:
    * @brief  Creates an empty observation
    */
   Observation()
-    : cloud_(new sensor_msgs::PointCloud2()), obstacle_range_(0.0), raytrace_range_(0.0)
+    : cloud_(new sensor_msgs::msg::PointCloud2()), obstacle_range_(0.0), raytrace_range_(0.0)
   {
   }
 
@@ -68,7 +68,7 @@ public:
    */
   Observation(geometry_msgs::msg::Point & origin, const sensor_msgs::msg::PointCloud2 & cloud,
       double obstacle_range, double raytrace_range)
-    : origin_(origin), cloud_(new sensor_msgs::PointCloud2(cloud)),
+    : origin_(origin), cloud_(new sensor_msgs::msg::PointCloud2(cloud)),
     obstacle_range_(obstacle_range), raytrace_range_(raytrace_range)
   {
   }
@@ -78,7 +78,7 @@ public:
    * @param obs The observation to copy
    */
   Observation(const Observation & obs)
-    : origin_(obs.origin_), cloud_(new sensor_msgs::PointCloud2(*(obs.cloud_))),
+    : origin_(obs.origin_), cloud_(new sensor_msgs::msg::PointCloud2(*(obs.cloud_))),
     obstacle_range_(obs.obstacle_range_), raytrace_range_(obs.raytrace_range_)
   {
   }
@@ -89,7 +89,7 @@ public:
    * @param obstacle_range The range out to which an observation should be able to insert obstacles
    */
   Observation(const sensor_msgs::msg::PointCloud2 & cloud, double obstacle_range)
-    : cloud_(new sensor_msgs::PointCloud2(cloud)), obstacle_range_(obstacle_range),
+    : cloud_(new sensor_msgs::msg::PointCloud2(cloud)), obstacle_range_(obstacle_range),
     raytrace_range_(0.0)
   {
   }

--- a/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.h
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.h
@@ -40,12 +40,13 @@
 #include <vector>
 #include <list>
 #include <string>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include "rclcpp/time.hpp"
 #include <nav2_costmap_2d/observation.h>
 #include <tf2_ros/buffer.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
-
 
 namespace nav2_costmap_2d
 {

--- a/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.h
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.h
@@ -38,23 +38,24 @@
 #ifndef NAV2_COSTMAP_2D__OBSTACLE_LAYER_H_
 #define NAV2_COSTMAP_2D__OBSTACLE_LAYER_H_
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <nav2_costmap_2d/costmap_layer.h>
 #include <nav2_costmap_2d/layered_costmap.h>
 #include <nav2_costmap_2d/observation_buffer.h>
+#include <nav2_costmap_2d/footprint.h>
 
-#include <nav_msgs/OccupancyGrid.h>
-
-#include <sensor_msgs/LaserScan.h>
 #include <laser_geometry/laser_geometry.h>
-#include <sensor_msgs/PointCloud.h>
-#include <sensor_msgs/PointCloud2.h>
-#include <sensor_msgs/point_cloud_conversion.h>
 #include <tf2_ros/message_filter.h>
 #include <message_filters/subscriber.h>
-#include <dynamic_reconfigure/server.h>
-#include <nav2_costmap_2d/ObstaclePluginConfig.h>
-#include <nav2_costmap_2d/footprint.h>
+
+//#include <nav2_costmap_2d/ObstaclePluginConfig.h>
+//#include <dynamic_reconfigure/server.h>
+
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <sensor_msgs/msg/point_cloud.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud_conversion.h>
 
 namespace nav2_costmap_2d
 {
@@ -85,7 +86,7 @@ public:
    * @param message The message returned from a message notifier
    * @param buffer A pointer to the observation buffer to update
    */
-  void laserScanCallback(const sensor_msgs::LaserScanConstPtr & message,
+  void laserScanCallback(const sensor_msgs::msg::LaserScanConstPtr & message,
       const std::shared_ptr<nav2_costmap_2d::ObservationBuffer> & buffer);
 
   /**
@@ -93,7 +94,7 @@ public:
    * @param message The message returned from a message notifier
    * @param buffer A pointer to the observation buffer to update
    */
-  void laserScanValidInfCallback(const sensor_msgs::LaserScanConstPtr & message,
+  void laserScanValidInfCallback(const sensor_msgs::msg::LaserScanConstPtr & message,
       const std::shared_ptr<ObservationBuffer> & buffer);
 
   /**
@@ -101,7 +102,7 @@ public:
    * @param message The message returned from a message notifier
    * @param buffer A pointer to the observation buffer to update
    */
-  void pointCloudCallback(const sensor_msgs::PointCloudConstPtr & message,
+  void pointCloudCallback(const sensor_msgs::msg::PointCloudConstPtr & message,
       const std::shared_ptr<nav2_costmap_2d::ObservationBuffer> & buffer);
 
   /**
@@ -109,7 +110,7 @@ public:
    * @param message The message returned from a message notifier
    * @param buffer A pointer to the observation buffer to update
    */
-  void pointCloud2Callback(const sensor_msgs::PointCloud2ConstPtr & message,
+  void pointCloud2Callback(const sensor_msgs::msg::PointCloud2ConstPtr & message,
       const std::shared_ptr<nav2_costmap_2d::ObservationBuffer> & buffer);
 
   // for testing purposes
@@ -173,12 +174,13 @@ protected:
   std::vector<nav2_costmap_2d::Observation> static_clearing_observations_, static_marking_observations_;
 
   bool rolling_window_;
-  dynamic_reconfigure::Server<nav2_costmap_2d::ObstaclePluginConfig> * dsrv_;
 
   int combination_method_;
 
-private:
-  void reconfigureCB(nav2_costmap_2d::ObstaclePluginConfig & config, uint32_t level);
+  // TODO(SteveMacenski): Replace dynamic_reconfigure functionality
+  // dynamic_reconfigure::Server<nav2_costmap_2d::ObstaclePluginConfig> * dsrv_;
+// private:
+  // void reconfigureCB(nav2_costmap_2d::ObstaclePluginConfig & config, uint32_t level);
 };
 
 }  // namespace nav2_costmap_2d

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -22,4 +22,4 @@ repositories:
   tf2_sensor_msgs:
     type: git
     url: https://github.com/stevemacenski/geometry2
-    version: bouncy
+    version: ros2

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/bpwilcox/xmlrpcpp.git
     version: master
+  tf2_sensor_msgs:
+    type: git
+    url: https://github.com/stevemacenski/geometry2
+    version: bouncy


### PR DESCRIPTION
tf2_sensor_msgs once merged into geometry2 should move back to their fork rather than mine which is identical except for this commit.

Deals with #132 as well as ports correctly the observation_buffer. This deals with elements needed to fully port obstacle layer