### PR TITLE
Address issue #164, hardcoded endpoint tolerance in the simple navigator

### DIFF
--- a/nav2_astar_planner/src/astar_planner.cpp
+++ b/nav2_astar_planner/src/astar_planner.cpp
@@ -37,8 +37,9 @@ TaskStatus
 AStarPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr command)
 {
   RCLCPP_INFO(get_logger(), "AStarPlanner: Attempting to a find path from (%.2f, %.2f) to "
-    "(%.2f, %.2f).",command->start.position.x, command->start.position.y,
-    command->goal.position.x, command->goal.position.y);
+    "(%.2f, %.2f), with tolerance: %.2f.",
+    command->start.position.x, command->start.position.y,
+    command->goal.pose.position.x, command->goal.pose.position.y, command->goal.tolerance);
 
   // Spin here for a bit to fake out some processing time
   for (int i = 0; i < 10; i++) {
@@ -60,8 +61,9 @@ AStarPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr comm
   }
 
   // We've successfully completed the task, so return the result
-  RCLCPP_INFO(get_logger(), "AStarPlanner: Successfully navigated to (%.2f, %.2f) with tolerance %.2f",
-    command->goal.position.x, command->goal.position.y, command->tolerance);
+  RCLCPP_INFO(get_logger(),
+    "AStarPlanner: Successfully navigated to (%.2f, %.2f) with tolerance %.2f",
+    command->goal.pose.position.x, command->goal.pose.position.y, command->goal.tolerance);
 
   nav2_tasks::ComputePathToPoseResult result;
   setResult(result);

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -58,7 +58,8 @@ BtNavigator::execute(const nav2_tasks::NavigateToPoseCommand::SharedPtr command)
   auto endpoints = std::make_shared<nav2_tasks::ComputePathToPoseCommand>();
   // TODO(mjeronimo): get the starting pose from Localization (fake it out for now)
   endpoints->start = command->pose;
-  endpoints->goal = command->pose;
+  endpoints->goal.pose = command->pose;
+  endpoints->goal.tolerance = command->tolerance;
 
   RCLCPP_INFO(get_logger(), "BtNavigator: Getting a path from the planner.");
   auto path = std::make_shared<nav2_tasks::ComputePathToPoseResult>();

--- a/nav2_mission_executor/src/mission_executor.cpp
+++ b/nav2_mission_executor/src/mission_executor.cpp
@@ -64,11 +64,18 @@ MissionExecutor::execute(const nav2_tasks::ExecuteMissionCommand::SharedPtr comm
   RCLCPP_INFO(get_logger(), "MissionExecutor: Executing task: %s from %f",
     command->mission_plan.c_str(), command->header.stamp);
 
-  // TODO(mjeronimo): Validate the mission plan for syntax and semantics
+  // TODO(mjeronimo): Normally, we'll get the goal pose from the task in the mission plan.
+  // For now, we're using the one received from rviz via the move_base_simple/goal topic.
+  // Since the pose from the move_base_simple/goal topic doesn't include the tolerance,
+  // we'll add that here. In the future we can modify the rviz plug-in to also provide
+  // the tolerance value. In the case of the mission plan, the tolerance will be available
+  // as an attribute of the NavigateToPose action.
 
-  // TODO(mjeronimo): Get the goal pose from the task in the mission plan. For now, we're
-  // using the one received from rviz via the move_base_simple/goal topic.
-  navTaskClient_->sendCommand(goal_pose_);
+  auto nav_command = std::make_shared<nav2_tasks::NavigateToPoseCommand>();
+  nav_command->pose = goal_pose_->pose;
+  nav_command->tolerance = 2.0;
+
+  navTaskClient_->sendCommand(nav_command);
 
   auto navResult = std::make_shared<nav2_tasks::NavigateToPoseResult>();
 

--- a/nav2_msgs/CMakeLists.txt
+++ b/nav2_msgs/CMakeLists.txt
@@ -21,6 +21,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/CostmapMetaData.msg"
   "msg/Path.msg"
   "msg/PathEndPoints.msg"
+  "msg/PoseWithToleranceStamped.msg"
   "msg/MissionPlan.msg"
   "msg/TaskStatus.msg"
   "srv/GetCostmap.srv"

--- a/nav2_msgs/msg/PathEndPoints.msg
+++ b/nav2_msgs/msg/PathEndPoints.msg
@@ -1,11 +1,7 @@
 std_msgs/Header header
 
-# The start pose for the plan
+# The starting pose of the path
 geometry_msgs/Pose start
 
-# The final pose of the goal
-geometry_msgs/Pose goal
-
-# If the goal is obstructed, how many meters the planner can
-# relax the constraint in x and y before failing.
-float32 tolerance
+# The ending pose of the path
+nav2_msgs/PoseWithToleranceStamped goal

--- a/nav2_msgs/msg/PoseWithToleranceStamped.msg
+++ b/nav2_msgs/msg/PoseWithToleranceStamped.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+geometry_msgs/Pose pose
+float32 tolerance

--- a/nav2_simple_navigator/src/simple_navigator.cpp
+++ b/nav2_simple_navigator/src/simple_navigator.cpp
@@ -64,10 +64,9 @@ SimpleNavigator::execute(const nav2_tasks::NavigateToPoseCommand::SharedPtr comm
   if (robot_.getCurrentPose(current_pose)) {
     RCLCPP_DEBUG(get_logger(), "got robot pose");
     endpoints->start = current_pose->pose.pose;
-    endpoints->goal = command->pose;
-    endpoints->tolerance = 2.0;
+    endpoints->goal = *command;
   } else {
-    //TODO(mhpanah): use either last known pose, current pose from odom, wait, or try again.
+    // TODO(mhpanah): use either last known pose, current pose from odom, wait, or try again.
     RCLCPP_WARN(get_logger(), "Current Robot Pose is not available.");
     return TaskStatus::FAILED;
   }

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -247,9 +247,9 @@ bool PlannerTester::defaultPlannerTest(
 
     endpoints->start.position.x = 1.0;
     endpoints->start.position.y = 1.0;
-    endpoints->goal.position.x = 9.0;
-    endpoints->goal.position.y = 9.0;
-    endpoints->tolerance = 2.0;
+    endpoints->goal.pose.position.x = 9.0;
+    endpoints->goal.pose.position.y = 9.0;
+    endpoints->goal.tolerance = 2.0;
 
   } else {
     RCLCPP_INFO(this->get_logger(), "PlannerTester::defaultPlannerTest:"
@@ -259,9 +259,9 @@ bool PlannerTester::defaultPlannerTest(
     //  Planner will do coordinate transformation to map internally
     endpoints->start.position.x = 390.0;
     endpoints->start.position.y = 10.0;
-    endpoints->goal.position.x = 10.0;
-    endpoints->goal.position.y = 390.0;
-    endpoints->tolerance = 2.0;
+    endpoints->goal.pose.position.x = 10.0;
+    endpoints->goal.pose.position.y = 390.0;
+    endpoints->goal.tolerance = 2.0;
   }
 
   bool pathIsCollisionFree = plannerTest(endpoints, path);
@@ -325,10 +325,9 @@ bool PlannerTester::defaultPlannerRandomTests(const unsigned int number_tests)
     auto goal = generate_random();
     endpoints->start.position.x = start.first;
     endpoints->start.position.y = start.second;
-    endpoints->goal.position.x = goal.first;
-    endpoints->goal.position.y = goal.second;
-
-    endpoints->tolerance = 2.0;
+    endpoints->goal.pose.position.x = goal.first;
+    endpoints->goal.pose.position.y = goal.second;
+    endpoints->goal.tolerance = 2.0;
 
     // TODO(orduno): Tweak criteria for defining if a path goes into obstacles.
     //               Current Dijkstra planner will sometimes produce paths that cut corners
@@ -339,7 +338,7 @@ bool PlannerTester::defaultPlannerRandomTests(const unsigned int number_tests)
       RCLCPP_INFO(this->get_logger(), "PlannerTester::defaultPlannerRandomTests:"
         " failed or found a collision with start at %0.2f, %0.2f and end at %0.2f, %0.2f",
         endpoints->start.position.x, endpoints->start.position.y,
-        endpoints->goal.position.x, endpoints->goal.position.y);
+        endpoints->goal.pose.position.x, endpoints->goal.pose.position.y);
       all_tests_OK = false;
       ++num_fail;
     }

--- a/nav2_tasks/include/nav2_tasks/navigate_to_pose_task.hpp
+++ b/nav2_tasks/include/nav2_tasks/navigate_to_pose_task.hpp
@@ -17,13 +17,13 @@
 
 #include "nav2_tasks/task_client.hpp"
 #include "nav2_tasks/task_server.hpp"
-#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav2_msgs/msg/pose_with_tolerance_stamped.hpp"
 #include "std_msgs/msg/empty.hpp"
 
 namespace nav2_tasks
 {
 
-using NavigateToPoseCommand = geometry_msgs::msg::PoseStamped;
+using NavigateToPoseCommand = nav2_msgs::msg::PoseWithToleranceStamped;
 using NavigateToPoseResult = std_msgs::msg::Empty;
 
 using NavigateToPoseTaskClient = TaskClient<NavigateToPoseCommand, NavigateToPoseResult>;


### PR DESCRIPTION
Instead, the tolerance should be provided to the navigator(s) along with the goal pose. The intention being that the command would be: "navigate to this specified goal pose within this specified tolerance." This PR adds a new message, **PoseWithToleranceStamped**, to hold a pose with an associated tolerance. This is now used as the command message to NavigateToPose. I've also updated the command message to ComputePathToPose (**PathEndPoints**) to use this new message type.