### PR TITLE
remove my fork used for geometry2 after upstream merge

### DIFF
--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -19,7 +19,3 @@ repositories:
     type: git
     url: https://github.com/bpwilcox/xmlrpcpp.git
     version: master
-  tf2_sensor_msgs:
-    type: git
-    url: https://github.com/stevemacenski/geometry2
-    version: ros2


### PR DESCRIPTION
It builds in the `ros_ws` directory which I believe is part of the daily builds. Should wait a day or two before removing to make sure its reflected. 