### PR TITLE
Move tolerance to param

### DIFF
--- a/nav2_astar_planner/include/nav2_astar_planner/astar_planner.hpp
+++ b/nav2_astar_planner/include/nav2_astar_planner/astar_planner.hpp
@@ -29,6 +29,9 @@ public:
 
   nav2_tasks::TaskStatus execute(
     const nav2_tasks::ComputePathToPoseCommand::SharedPtr command) override;
+
+private:
+  double tolerance_;
 };
 
 }  // namespace nav2_astar_planner

--- a/nav2_astar_planner/src/astar_planner.cpp
+++ b/nav2_astar_planner/src/astar_planner.cpp
@@ -44,7 +44,7 @@ AStarPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr comm
     "(%.2f, %.2f) with tolerance %.2f",
     command->start.position.x, command->start.position.y,
     command->goal.position.x, command->goal.position.y,
-	tolerance_);
+    tolerance_);
 
   unsigned int seed = std::time(nullptr);
 

--- a/nav2_astar_planner/src/astar_planner.cpp
+++ b/nav2_astar_planner/src/astar_planner.cpp
@@ -40,8 +40,8 @@ AStarPlanner::~AStarPlanner()
 TaskStatus
 AStarPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr command)
 {
-  RCLCPP_INFO(get_logger(), "Attempting to a find path from (%.2f, %.2f) to "
-    "(%.2f, %.2f) with tolerance %.2f",
+  RCLCPP_INFO(get_logger(),
+    "Attempting to a find path from (%.2f, %.2f) to (%.2f, %.2f) with tolerance %.2f",
     command->start.position.x, command->start.position.y,
     command->goal.position.x, command->goal.position.y,
     tolerance_);

--- a/nav2_astar_planner/src/astar_planner.cpp
+++ b/nav2_astar_planner/src/astar_planner.cpp
@@ -58,7 +58,7 @@ AStarPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr comm
 
     // Before we loop again to do more work, check if we've been canceled
     if (cancelRequested()) {
-      RCLCPP_INFO(get_logger(), "Cancelled global planning task");
+      RCLCPP_INFO(get_logger(), "Canceled global planning task");
       setCanceled();
       return TaskStatus::CANCELED;
     }

--- a/nav2_astar_planner/src/astar_planner.cpp
+++ b/nav2_astar_planner/src/astar_planner.cpp
@@ -28,6 +28,8 @@ AStarPlanner::AStarPlanner()
 : nav2_tasks::ComputePathToPoseTaskServer("ComputePathToPoseNode")
 {
   RCLCPP_INFO(get_logger(), "Initializing");
+
+  get_parameter_or_set("tolerance", tolerance_, 1.0);
 }
 
 AStarPlanner::~AStarPlanner()
@@ -39,10 +41,10 @@ TaskStatus
 AStarPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr command)
 {
   RCLCPP_INFO(get_logger(), "Attempting to a find path from (%.2f, %.2f) to "
-    "(%.2f, %.2f) with tolerance %.2f.",
+    "(%.2f, %.2f) with tolerance %.2f",
     command->start.position.x, command->start.position.y,
     command->goal.position.x, command->goal.position.y,
-    command->tolerance);
+	tolerance_);
 
   unsigned int seed = std::time(nullptr);
 
@@ -56,7 +58,7 @@ AStarPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr comm
 
     // Before we loop again to do more work, check if we've been canceled
     if (cancelRequested()) {
-      RCLCPP_INFO(get_logger(), "Canceled global planning task.");
+      RCLCPP_INFO(get_logger(), "Cancelled global planning task");
       setCanceled();
       return TaskStatus::CANCELED;
     }

--- a/nav2_bringup/launch/system_test.yaml
+++ b/nav2_bringup/launch/system_test.yaml
@@ -1,0 +1,3 @@
+ComputePathToPoseNode:
+    ros__parameters:
+        tolerance: 1.0

--- a/nav2_dijkstra_planner/include/nav2_dijkstra_planner/dijkstra_planner.hpp
+++ b/nav2_dijkstra_planner/include/nav2_dijkstra_planner/dijkstra_planner.hpp
@@ -116,7 +116,7 @@ private:
   bool allow_unknown_;
 
   // Amount the planner can relax the space constraint
-  double default_tolerance_;
+  double tolerance_;
 };
 
 }  // namespace nav2_dijkstra_planner

--- a/nav2_dijkstra_planner/src/dijkstra_planner.cpp
+++ b/nav2_dijkstra_planner/src/dijkstra_planner.cpp
@@ -74,8 +74,9 @@ DijkstraPlanner::~DijkstraPlanner()
 TaskStatus
 DijkstraPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr command)
 {
-  RCLCPP_INFO(get_logger(), "DijkstraPlanner: Attempting to a find path from (%.2f, %.2f) to "
-    "(%.2f, %.2f).",command->start.position.x, command->start.position.y,
+  RCLCPP_INFO(get_logger(),
+    "DijkstraPlanner: Attempting to a find path from (%.2f, %.2f) to (%.2f, %.2f)",
+    command->start.position.x, command->start.position.y,
     command->goal.position.x, command->goal.position.y);
 
   nav2_tasks::ComputePathToPoseResult result;

--- a/nav2_dijkstra_planner/src/dijkstra_planner.cpp
+++ b/nav2_dijkstra_planner/src/dijkstra_planner.cpp
@@ -47,10 +47,11 @@ namespace nav2_dijkstra_planner
 DijkstraPlanner::DijkstraPlanner()
 : nav2_tasks::ComputePathToPoseTaskServer("ComputePathToPoseNode", false),
   global_frame_("map"),
-  allow_unknown_(true),
-  default_tolerance_(1.0)
+  allow_unknown_(true)
 {
   RCLCPP_INFO(get_logger(), "Initializing DijkstraPlanner...");
+
+  get_parameter_or_set("tolerance", tolerance_, 1.0);
 
   // TODO(orduno): Enable parameter server and get costmap service name from there
 
@@ -88,7 +89,7 @@ DijkstraPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr c
     planner_ = std::make_unique<NavFn>(costmap_.metadata.size_x, costmap_.metadata.size_y);
 
     // Make the plan for the provided goal pose
-    bool foundPath = makePlan(command->start, command->goal, command->tolerance, result);
+    bool foundPath = makePlan(command->start, command->goal, tolerance_, result);
 
     // TODO(orduno): should check for cancel within the makePlan() method?
     if (cancelRequested()) {
@@ -342,7 +343,7 @@ DijkstraPlanner::getPointPotential(const geometry_msgs::msg::Point & world_point
 bool
 DijkstraPlanner::validPointPotential(const geometry_msgs::msg::Point & world_point)
 {
-  return validPointPotential(world_point, default_tolerance_);
+  return validPointPotential(world_point, tolerance_);
 }
 
 bool

--- a/nav2_dijkstra_planner/src/dijkstra_planner.cpp
+++ b/nav2_dijkstra_planner/src/dijkstra_planner.cpp
@@ -49,7 +49,7 @@ DijkstraPlanner::DijkstraPlanner()
   global_frame_("map"),
   allow_unknown_(true)
 {
-  RCLCPP_INFO(get_logger(), "Initializing DijkstraPlanner...");
+  RCLCPP_INFO(get_logger(), "Initializing");
 
   get_parameter_or_set("tolerance", tolerance_, 1.0);
 
@@ -68,22 +68,23 @@ DijkstraPlanner::DijkstraPlanner()
 
 DijkstraPlanner::~DijkstraPlanner()
 {
-  RCLCPP_INFO(get_logger(), "Shutting down DijkstraPlanner");
+  RCLCPP_INFO(get_logger(), "Shutting down");
 }
 
 TaskStatus
 DijkstraPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr command)
 {
   RCLCPP_INFO(get_logger(),
-    "DijkstraPlanner: Attempting to a find path from (%.2f, %.2f) to (%.2f, %.2f)",
+    "Attempting to a find path from (%.2f, %.2f) to (%.2f, %.2f) with tolerance %.2f",
     command->start.position.x, command->start.position.y,
-    command->goal.position.x, command->goal.position.y);
+    command->goal.position.x, command->goal.position.y,
+    tolerance_);
 
   nav2_tasks::ComputePathToPoseResult result;
   try {
     // Get an updated costmap
     getCostmap(costmap_);
-    RCLCPP_DEBUG(get_logger(), "DijkstraPlanner: Costmap size: %d,%d",
+    RCLCPP_DEBUG(get_logger(), "Costmap size: %d,%d",
       costmap_.metadata.size_x, costmap_.metadata.size_y);
 
     // Create a planner based on the new costmap size
@@ -94,22 +95,21 @@ DijkstraPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr c
 
     // TODO(orduno): should check for cancel within the makePlan() method?
     if (cancelRequested()) {
-      RCLCPP_INFO(get_logger(), "DijkstraPlanner: Cancelled global planning task.");
+      RCLCPP_INFO(get_logger(), "Canceled global planning task");
       setCanceled();
       return TaskStatus::CANCELED;
     }
 
     if (!foundPath) {
-      RCLCPP_WARN(get_logger(), "DijkstraPlanner: Planning algorithm failed to generate a valid"
+      RCLCPP_WARN(get_logger(), "Planning algorithm failed to generate a valid"
         " path to (%.2f, %.2f)", command->goal.position.x, command->goal.position.y);
       return TaskStatus::FAILED;
     }
 
-    RCLCPP_INFO(get_logger(),
-      "DijkstraPlanner: Found valid path of size %u", result.poses.size());
+    RCLCPP_INFO(get_logger(), "Found valid path of size %u", result.poses.size());
 
     // Publish the plan for visualization purposes
-    RCLCPP_INFO(get_logger(), "DijkstraPlanner: Publishing the valid path.");
+    RCLCPP_INFO(get_logger(), "Publishing the valid path");
     publishPlan(result);
     publishEndpoints(command);
 
@@ -121,14 +121,14 @@ DijkstraPlanner::execute(const nav2_tasks::ComputePathToPoseCommand::SharedPtr c
     // Return success, which causes the result message to be sent to the client
     return TaskStatus::SUCCEEDED;
   } catch (std::exception & ex) {
-    RCLCPP_WARN(get_logger(), "DijkstraPlanner: Plan calculation to (%.2f, %.2f) failed: \"%s\"",
+    RCLCPP_WARN(get_logger(), "Plan calculation to (%.2f, %.2f) failed: \"%s\"",
       command->goal.position.x, command->goal.position.y, ex.what());
 
     // TODO(orduno): provide information about fail error to parent task,
     //               for example: couldn't get costmap update
     return TaskStatus::FAILED;
   } catch (...) {
-    RCLCPP_WARN(get_logger(), "DijkstraPlanner: Plan calculation failed");
+    RCLCPP_WARN(get_logger(), "Plan calculation failed");
 
     // TODO(orduno): provide information about the failure to the parent task,
     //               for example: couldn't get costmap update
@@ -150,14 +150,14 @@ DijkstraPlanner::makePlan(
   double wx = start.position.x;
   double wy = start.position.y;
 
-  RCLCPP_INFO(get_logger(), "DijkstraPlanner: Making plan from (%.2f,%.2f) to (%.2f,%.2f)",
+  RCLCPP_INFO(get_logger(), "Making plan from (%.2f,%.2f) to (%.2f,%.2f)",
     start.position.x, start.position.y, goal.position.x, goal.position.y);
 
   unsigned int mx, my;
   if (!worldToMap(wx, wy, mx, my)) {
     RCLCPP_WARN(
       get_logger(),
-      "DijkstraPlanner: Cannot create a plan: the robot's start position is off the global"
+      "Cannot create a plan: the robot's start position is off the global"
       " costmap. Planning will always fail, are you sure"
       " the robot has been properly localized?");
     return false;
@@ -183,7 +183,7 @@ DijkstraPlanner::makePlan(
       std::cout << "tolerance: " << tolerance << std::endl;
       RCLCPP_WARN(
         get_logger(),
-        "DijkstraPlanner: The goal sent to the planner is off the global costmap."
+        "The goal sent to the planner is off the global costmap."
         " Planning will always fail to this goal.");
       return false;
     }
@@ -234,7 +234,7 @@ DijkstraPlanner::makePlan(
     } else {
       RCLCPP_ERROR(
         get_logger(),
-        "DijkstraPlanner: Failed to create a plan from potential when a legal"
+        "Failed to create a plan from potential when a legal"
         " potential was found. This shouldn't happen.");
     }
   }

--- a/nav2_msgs/msg/PathEndPoints.msg
+++ b/nav2_msgs/msg/PathEndPoints.msg
@@ -5,7 +5,3 @@ geometry_msgs/Pose start
 
 # The final pose of the goal
 geometry_msgs/Pose goal
-
-# If the goal is obstructed, how many meters the planner can
-# relax the constraint in x and y before failing.
-float32 tolerance

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -252,7 +252,6 @@ bool PlannerTester::defaultPlannerTest(
     endpoints->start.position.y = 1.0;
     endpoints->goal.position.x = 9.0;
     endpoints->goal.position.y = 9.0;
-    endpoints->tolerance = 2.0;
 
   } else {
     RCLCPP_INFO(this->get_logger(), "PlannerTester::defaultPlannerTest:"
@@ -264,7 +263,6 @@ bool PlannerTester::defaultPlannerTest(
     endpoints->start.position.y = 10.0;
     endpoints->goal.position.x = 10.0;
     endpoints->goal.position.y = 390.0;
-    endpoints->tolerance = 2.0;
   }
 
   bool pathIsCollisionFree = plannerTest(endpoints, path);
@@ -330,8 +328,6 @@ bool PlannerTester::defaultPlannerRandomTests(const unsigned int number_tests)
     endpoints->start.position.y = start.second;
     endpoints->goal.position.x = goal.first;
     endpoints->goal.position.y = goal.second;
-
-    endpoints->tolerance = 2.0;
 
     // TODO(orduno): Tweak criteria for defining if a path goes into obstacles.
     //               Current Dijkstra planner will sometimes produce paths that cut corners


### PR DESCRIPTION
Per the team discussion, move the tolerance value out of the PathEndPoints message to become a parameter of the global planners. Fixes #164. 