### PR TITLE
Small fixes in build_all.sh

### DIFF
--- a/tools/build_all.sh
+++ b/tools/build_all.sh
@@ -60,14 +60,13 @@ fi
 
 # Build our ROS 2 dependencies
 cd $CWD/navstack_dependencies_ws
-export ROSDISTRO_INDEX_URL'https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml'
+export ROSDISTRO_INDEX_URL='https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml'
 rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO --skip-keys "catkin"
 (. $ROS2_SETUP_FILE &&
  colcon build --symlink-install)
 
 # Build our code
 cd $CWD/navigation2_ws
-export ROSDISTRO_INDEX_URL'https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml'
 rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO
 (. $ROS2_SETUP_FILE && . $CWD/navstack_dependencies_ws/install/setup.bash &&
  colcon build --symlink-install)


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Primary platform tested on | N/A |

--- 

## Description of contribution in a few bullet points

* Remove duplicate export statement
* Update the export statement so it has correct syntax.  Here is the
help from `bash`:

```
       export [-fn] [name[=word]] ...
       export -p
              The supplied names are marked for automatic export to the  envi‐
              ronment  of subsequently executed commands.  If the -f option is
              given, the names refer to functions.  If no names are given,  or
              if  the  -p  option is supplied, a list of names of all exported
              variables is printed.  The -n option causes the export  property
              to be removed from each name.  If a variable name is followed by
              =word, the value of the variable is set to word.  export returns
              an exit status of 0 unless an invalid option is encountered, one
              of the names is not a valid shell variable name, or -f  is  sup‐
              plied with a name that is not a function.
```


