### PR TITLE
Wire bt params

### DIFF
--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp
@@ -17,10 +17,11 @@
 
 #include <string>
 #include "rclcpp/rclcpp.hpp"
+#include "nav2_tasks/navigate_to_pose_task.hpp"
 #include "behavior_tree_core/behavior_tree.h"
 #include "behavior_tree_core/bt_factory.h"
 #include "behavior_tree_core/xml_parsing.h"
-#include "nav2_tasks/navigate_to_pose_task.hpp"
+#include "Blackboard/blackboard_local.h"
 
 namespace nav2_bt_navigator
 {
@@ -32,6 +33,7 @@ public:
   NavigateToPoseBehaviorTree() = delete;
 
   nav2_tasks::TaskStatus run(
+    BT::Blackboard::Ptr & blackboard,
     const std::string & behavior_tree_xml,
     std::function<bool()> cancelRequested,
     std::chrono::milliseconds tree_tick_timeout = std::chrono::milliseconds(100));

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -28,7 +28,7 @@ namespace nav2_bt_navigator
 {
 
 BtNavigator::BtNavigator()
-: nav2_tasks::NavigateToPoseTaskServer("NavigateToPose"),
+: nav2_tasks::NavigateToPoseTaskServer("NavigateToPoseNode"),
   robot_(this)
 {
 }

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+#include <memory>
+#include <set>
 #include <sstream>
 #include "nav2_bt_navigator/bt_navigator.hpp"
 #include "nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp"
+#include "nav2_tasks/compute_path_to_pose_task.hpp"
+#include "nav2_tasks/bt_conversions.hpp"
+#include "Blackboard/blackboard_local.h"
 
 using nav2_tasks::TaskStatus;
 
@@ -22,7 +28,7 @@ namespace nav2_bt_navigator
 {
 
 BtNavigator::BtNavigator()
-: nav2_tasks::NavigateToPoseTaskServer("NavigateToPoseNode"),
+: nav2_tasks::NavigateToPoseTaskServer("NavigateToPose"),
   robot_(this)
 {
 }
@@ -34,49 +40,45 @@ BtNavigator::execute(const nav2_tasks::NavigateToPoseCommand::SharedPtr command)
     command->pose.position.x, command->pose.position.y);
 
   // Get the current pose from the robot
-  geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr current;
+  auto current = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
 
   if (!robot_.getCurrentPose(current)) {
     RCLCPP_ERROR(get_logger(), "Current robot pose is not available.");
     return TaskStatus::FAILED;
   }
 
-  // Get a reference to the command pose for convenience
-  geometry_msgs::msg::Pose & goal = command->pose;
+  // Create the blackboard that will be shared by all of the nodes in the tree
+  BT::Blackboard::Ptr blackboard = BT::Blackboard::create<BT::BlackboardLocal>();
 
-  // Compose the args for the ComputePathToPose action
-  std::stringstream args;
-  args << "start_position=\"" <<
-    current->pose.pose.position.x << ";" << current->pose.pose.position.y << ";" <<
-    current->pose.pose.position.z << "\" " <<
-    "start_orientation=\"" <<
-    current->pose.pose.orientation.x << ";" << current->pose.pose.orientation.y << ";" <<
-    current->pose.pose.orientation.z << ";" << current->pose.pose.orientation.w << "\"" <<
-    "goal_position=\"" <<
-    goal.position.x << ";" << goal.position.y << ";" << goal.position.z << "\" " <<
-    "goal_orientation=\"" <<
-    goal.orientation.x << ";" << goal.orientation.y << ";" <<
-    goal.orientation.z << ";" << goal.orientation.w << "\"";
+  // Put together the PathEndPoints message for the ComputePathToPose
+  auto endpoints = std::make_shared<nav2_tasks::ComputePathToPoseCommand>();
+  endpoints->start = current->pose.pose;
+  endpoints->goal = command->pose;
+  endpoints->tolerance = 0.3;
 
-  // Put it all together, trying to make the XML somewhat readable here
-  std::stringstream command_ss;
-  command_ss <<
+  // The path returned from ComputePath and sent to FollowPath
+  auto path = std::make_shared<nav2_tasks::ComputePathToPoseResult>();
+
+  // Set the shared data (commands/results)
+  blackboard->set<nav2_tasks::ComputePathToPoseCommand::SharedPtr>("endpoints", endpoints);
+  blackboard->set<nav2_tasks::ComputePathToPoseResult::SharedPtr>("path", path);
+
+  std::string xml_text =
     R"(
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <SequenceStar name="root">
-      <ComputePathToPose )" << args.str() <<
-    R"(/>
-      <FollowPath />
+      <ComputePathToPose endpoints="${endpoints}" path="${path}"/>
+      <FollowPath path="${path}"/>
     </SequenceStar>
   </BehaviorTree>
 </root>)";
 
-  RCLCPP_INFO(get_logger(), "Behavior tree XML: %s", command_ss.str().c_str());
+  RCLCPP_INFO(get_logger(), "Behavior tree XML: %s", xml_text.c_str());
 
   // Create and run the behavior tree
   NavigateToPoseBehaviorTree bt(shared_from_this());
-  TaskStatus result = bt.run(command_ss.str(), std::bind(&BtNavigator::cancelRequested, this));
+  TaskStatus result = bt.run(blackboard, xml_text, std::bind(&BtNavigator::cancelRequested, this));
 
   RCLCPP_INFO(get_logger(), "Completed navigation: result: %d", result);
   return result;

--- a/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
+++ b/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
@@ -17,10 +17,10 @@
 #include <memory>
 #include <string>
 #include <set>
-#include "behavior_tree_core/xml_parsing.h"
-#include "Blackboard/blackboard_local.h"
 #include "nav2_tasks/compute_path_to_pose_action.hpp"
 #include "nav2_tasks/follow_path_action.hpp"
+#include "behavior_tree_core/xml_parsing.h"
+#include "Blackboard/blackboard_local.h"
 
 using namespace std::chrono_literals;
 
@@ -37,13 +37,11 @@ NavigateToPoseBehaviorTree::NavigateToPoseBehaviorTree(rclcpp::Node::SharedPtr n
 
 nav2_tasks::TaskStatus
 NavigateToPoseBehaviorTree::run(
+  BT::Blackboard::Ptr & blackboard,
   const std::string & behavior_tree_xml,
   std::function<bool()> cancelRequested,
   std::chrono::milliseconds tree_tick_timeout)
 {
-  // Create the blackboard that will be shared by all of the nodes in the tree
-  BT::Blackboard::Ptr blackboard = BT::Blackboard::create<BT::BlackboardLocal>();
-
   // Set a couple values that all of the action nodes expect/require
   blackboard->set<rclcpp::Node::SharedPtr>("node", node_);
   blackboard->set<std::chrono::milliseconds>("node_loop_timeout", std::chrono::milliseconds(100));

--- a/nav2_simple_navigator/src/simple_navigator.cpp
+++ b/nav2_simple_navigator/src/simple_navigator.cpp
@@ -65,7 +65,7 @@ SimpleNavigator::execute(const nav2_tasks::NavigateToPoseCommand::SharedPtr comm
     command->pose.position.x, command->pose.position.y);
 
   // Get the current pose from the robot
-  geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr current_pose;
+  auto current_pose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
 
   if (!robot_.getCurrentPose(current_pose)) {
     // TODO(mhpanah): use either last known pose, current pose from odom, wait, or try again.

--- a/nav2_tasks/include/nav2_tasks/bt_action_node.hpp
+++ b/nav2_tasks/include/nav2_tasks/bt_action_node.hpp
@@ -33,12 +33,12 @@ class BtActionNode : public BT::ActionNode
 {
 public:
   explicit BtActionNode(const std::string & action_name)
-  : BT::ActionNode(action_name), task_client_(nullptr)
+  : BT::ActionNode(action_name), task_client_(nullptr), initialized_(false)
   {
   }
 
   BtActionNode(const std::string & action_name, const BT::NodeParameters & params)
-  : BT::ActionNode(action_name, params), task_client_(nullptr)
+  : BT::ActionNode(action_name, params), task_client_(nullptr), initialized_(false)
   {
   }
 
@@ -48,9 +48,18 @@ public:
   {
   }
 
+  // Derived classes can override this method to perform some initialization such
+  // as getting values from the shared blackboard. A BT node can't get values
+  // from the blackboard in the constructor since the BT library doesn't set
+  // the blackboard until *after* the tree is build
+  virtual void init() {}
+
   BT::NodeStatus tick() override
   {
-    if (task_client_ == nullptr) {
+    // The first time we're ticked, there's some setup to do. This is because
+    // The blackboard isn't set yet in the BT node constructor; the tree gets
+    // created and *then* the blackboard is set.
+    if (!initialized_) {
       // Get the required items from the blackboard
       node_ = blackboard()->template get<rclcpp::Node::SharedPtr>("node");
       node_loop_timeout_ =
@@ -58,6 +67,10 @@ public:
 
       // Now that we have the ROS node to use, create the task client for this action
       task_client_ = std::make_unique<nav2_tasks::TaskClient<CommandMsg, ResultMsg>>(node_);
+
+      // Give the derived class a chance to do some initialization
+      init();
+      initialized_ = true;
     }
 
     task_client_->sendCommand(command_);
@@ -117,6 +130,8 @@ protected:
   // Allow for signaling receipt of the cancel message
   std::mutex cancel_mutex_;
   std::condition_variable cv_cancel_;
+
+  bool initialized_;
 };
 
 }  // namespace nav2_tasks

--- a/nav2_tasks/include/nav2_tasks/bt_conversions.hpp
+++ b/nav2_tasks/include/nav2_tasks/bt_conversions.hpp
@@ -43,14 +43,12 @@ inline std::chrono::milliseconds convertFromString(const std::string & /*key*/)
 template<>
 inline nav2_msgs::msg::Path::SharedPtr convertFromString(const std::string & /*key*/)
 {
-  printf("template convert Path froms string\n");
   return nullptr;
 }
 
 template<>
 inline nav2_msgs::msg::PathEndPoints::SharedPtr convertFromString(const std::string & /*key*/)
 {
-  printf("template convert PathEndPoints froms string\n");
   return nullptr;
 }
 

--- a/nav2_tasks/include/nav2_tasks/bt_conversions.hpp
+++ b/nav2_tasks/include/nav2_tasks/bt_conversions.hpp
@@ -19,11 +19,13 @@
 #include "behavior_tree_core/behavior_tree.h"
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
+#include "nav2_msgs/msg/path.hpp"
+#include "nav2_msgs/msg/path_end_points.hpp"
 
 namespace BT
 {
 
-// The next two conversion functions are required to be defined by the BT library,
+// The following four conversion functions are required to be defined by the BT library,
 // but are not actually called. TODO(mjeronimo): See if we can avoid these.
 
 template<>
@@ -37,6 +39,22 @@ inline std::chrono::milliseconds convertFromString(const std::string & /*key*/)
 {
   return std::chrono::milliseconds(0);
 }
+
+template<>
+inline nav2_msgs::msg::Path::SharedPtr convertFromString(const std::string & /*key*/)
+{
+  printf("template convert Path froms string\n");
+  return nullptr;
+}
+
+template<>
+inline nav2_msgs::msg::PathEndPoints::SharedPtr convertFromString(const std::string & /*key*/)
+{
+  printf("template convert PathEndPoints froms string\n");
+  return nullptr;
+}
+
+// These are needed to be able to set parameters for these types in the BT XML
 
 template<>
 inline geometry_msgs::msg::Point convertFromString(const std::string & key)

--- a/nav2_tasks/include/nav2_tasks/compute_path_to_pose_action.hpp
+++ b/nav2_tasks/include/nav2_tasks/compute_path_to_pose_action.hpp
@@ -30,56 +30,17 @@ class ComputePathToPoseAction
   : public BtActionNode<ComputePathToPoseCommand, ComputePathToPoseResult>
 {
 public:
-  ComputePathToPoseAction(const std::string & action_name, const BT::NodeParameters & params)
-  : BtActionNode<ComputePathToPoseCommand, ComputePathToPoseResult>(action_name, params)
+  ComputePathToPoseAction(const std::string & action_name)
+  : BtActionNode<ComputePathToPoseCommand, ComputePathToPoseResult>(action_name)
   {
-    // Get the starting pose information from the XML attributes
-
-    geometry_msgs::msg::Point start_position;
-    bool have_start_position =
-      getParam<geometry_msgs::msg::Point>("start_position", start_position);
-
-    geometry_msgs::msg::Quaternion start_orientation;
-    bool have_start_orientation =
-      getParam<geometry_msgs::msg::Quaternion>("start_orientation", start_orientation);
-
-    if (!have_start_position || !have_start_orientation) {
-      RCLCPP_ERROR(node_->get_logger(),
-        "ComputePathToPoseAction: starting position or orientation not provided");
-    }
-
-    // Get the ending pose information from the XML attributes
-
-    geometry_msgs::msg::Point goal_position;
-    bool have_goal_position = getParam<geometry_msgs::msg::Point>("goal_position", goal_position);
-
-    geometry_msgs::msg::Quaternion goal_orientation;
-    bool have_goal_orientation =
-      getParam<geometry_msgs::msg::Quaternion>("goal_orientation", goal_orientation);
-
-    if (!have_goal_position || !have_goal_orientation) {
-      RCLCPP_ERROR(node_->get_logger(),
-        "ComputePathToPoseAction: goal position or orientation not provided");
-    }
-
-    // Create the command message for this task
-    command_ = std::make_shared<nav2_tasks::ComputePathToPoseCommand>();
-    command_->start.position = start_position;
-    command_->start.orientation = start_orientation;
-    command_->goal.position = goal_position;
-    command_->goal.orientation = goal_orientation;
-
-    // Create the result message
-    result_ = std::make_shared<nav2_tasks::ComputePathToPoseResult>();
   }
 
-  // Any BT node that accepts parameters must provide a requiredNodeParameters method
-  static const BT::NodeParameters & requiredNodeParameters()
+  void init() override
   {
-    static BT::NodeParameters params = {
-      {"start_position", "0;0;0"}, {"start_orientation", "0;0;0;0"},
-      {"goal_position", "0;0;0"}, {"goal_orientation", "0;0;0;0"}};
-    return params;
+    command_ =
+      blackboard()->template get<nav2_tasks::ComputePathToPoseCommand::SharedPtr>("endpoints");
+
+    result_ = blackboard()->template get<nav2_tasks::ComputePathToPoseResult::SharedPtr>("path");
   }
 };
 

--- a/nav2_tasks/include/nav2_tasks/costmap_service_client.hpp
+++ b/nav2_tasks/include/nav2_tasks/costmap_service_client.hpp
@@ -25,7 +25,7 @@ class CostmapServiceClient : public ServiceClient<nav2_msgs::srv::GetCostmap>
 {
 public:
   CostmapServiceClient()
-  : ServiceClient<nav2_msgs::srv::GetCostmap>("GetCostmap")
+  : ServiceClient<nav2_msgs::srv::GetCostmap>("WorldModel_GetCostmap")
   {
   }
 


### PR DESCRIPTION
## Description of contribution in a few bullet points

* In this PR, the BT navigator code is now using the shared blackboard to communicate the input to the global planner and the output of the global planner (which is then the input for the local planner). This change requires that the blackboard be created before the run method (and passed to it) so that the variables can be put on the blackboard before the tree is built
* The BtNode base class now has an init() method that derive classes can override to read values off of the blackboard. This typically is used to set the input and output parameters for the task.

## Future work that may be required in bullet points

* The next PR will be to factor out the common code in the bt_navigator and mission_executor that executes the behavior tree. There is already a BehaviorTreeEngine class for this. Just need to update the two files to use it.
* After that, I'll address running the global planner in parallel with the local planner (Issue #48). It should simply involve describing another behavior tree to do to replace the simple BT that is currently used (two sequential nodes).
* The tolerance value is still hardcoded. This will be addressed in a subsequent PR for both the simple navigator and the BT navigator (Issue #164)