### PR TITLE
Core to node

### DIFF
--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -27,13 +27,12 @@ include_directories(
   include
 )
 
-set(executable_name amcl)
+set(library_name amcl)
+set(executable_name ${library_name}_node)
 
 add_executable(${executable_name}
   src/main.cpp
 )
-
-set(library_name ${executable_name}_core)
 
 add_library(${library_name}
   src/amcl_node.cpp

--- a/nav2_bringup/launch/core.launch.py
+++ b/nav2_bringup/launch/core.launch.py
@@ -9,30 +9,30 @@ def generate_launch_description():
     return LaunchDescription([
         launch.actions.TimerAction(
             actions = [
-                launch_ros.actions.Node( package='nav2_map_server', node_executable='map_server', output='screen', arguments=[[mapFile], 'occupancy'])
+                launch_ros.actions.Node( package='nav2_map_server', node_executable='map_server_node', output='screen', arguments=[[mapFile], 'occupancy'])
                 ], period = 1.0),
         launch.actions.TimerAction(
             actions = [
-                launch_ros.actions.Node( package='nav2_controller_dwb', node_executable='nav2_controller_dwb', output='screen')
+                launch_ros.actions.Node( package='nav2_controller_dwb', node_executable='nav2_controller_dwb_node', output='screen')
                 ], period = 5.0),
         launch.actions.TimerAction(
             actions = [
-                launch_ros.actions.Node( package='nav2_smart_planner', node_executable='smart_planner', output='screen')
+                launch_ros.actions.Node( package='nav2_smart_planner', node_executable='smart_planner_node', output='screen')
                 ], period = 10.0),
         launch.actions.TimerAction(
             actions = [
-                launch_ros.actions.Node( package='nav2_simple_navigator', node_executable='simple_navigator', output='screen')
+                launch_ros.actions.Node( package='nav2_simple_navigator', node_executable='simple_navigator_node', output='screen')
                 ], period = 15.0),
         launch.actions.TimerAction(
             actions = [
-                launch_ros.actions.Node( package='nav2_mission_executor', node_executable='mission_executor', output='screen')
+                launch_ros.actions.Node( package='nav2_mission_executor', node_executable='mission_executor_node', output='screen')
                 ], period = 20.0),
         launch.actions.TimerAction(
             actions = [
-                launch_ros.actions.Node( package='nav2_costmap_world_model', node_executable='costmap_world_model', output='screen')
+                launch_ros.actions.Node( package='nav2_costmap_world_model', node_executable='costmap_world_model_node', output='screen')
                 ], period = 25.0),
         launch.actions.TimerAction(
             actions = [
-                launch_ros.actions.Node( package='nav2_amcl', node_executable='amcl', output='screen')
+                launch_ros.actions.Node( package='nav2_amcl', node_executable='amcl_node', output='screen')
                 ], period = 30.0),
     ])

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -22,13 +22,12 @@ include_directories(
   include
 )
 
-set(executable_name bt_navigator)
+set(library_name bt_navigator)
+set(executable_name ${library_name}_node)
 
 add_executable(${executable_name}
   src/main.cpp
 )
-
-set(library_name ${executable_name}_core)
 
 add_library(${library_name}
   src/bt_navigator.cpp

--- a/nav2_dwb_controller/dwb_controller/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_controller/CMakeLists.txt
@@ -24,13 +24,12 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
 )
 
-set(executable_name dwb_controller)
+set(library_name dwb_controller)
+set(executable_name ${library_name}_node)
 
 add_executable(${executable_name}
   src/main.cpp
 )
-
-set(library_name ${executable_name}_core)
 
 add_library(${library_name}
   src/dwb_controller.cpp

--- a/nav2_dynamic_params/CMakeLists.txt
+++ b/nav2_dynamic_params/CMakeLists.txt
@@ -21,7 +21,10 @@ set(dependencies
   rclcpp
 )
 
-add_library(nav2_dynamic_params
+set(library_name nav2_dynamic_params)
+set(executable_name ${library_name}_node)
+
+add_library(${library_name}
   src/dynamic_params_validator.cpp
 )
 
@@ -29,8 +32,9 @@ ament_target_dependencies(nav2_dynamic_params
   ${dependencies}
 )
 
-add_executable(example_nav2_dynamic_params
+add_executable(example_${executable_name}
   src/example_dynamic_params.cpp
+}
 )
 
 ament_target_dependencies(example_nav2_dynamic_params

--- a/nav2_dynamic_params/CMakeLists.txt
+++ b/nav2_dynamic_params/CMakeLists.txt
@@ -28,24 +28,23 @@ add_library(${library_name}
   src/dynamic_params_validator.cpp
 )
 
-ament_target_dependencies(nav2_dynamic_params
+ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
 add_executable(example_${executable_name}
   src/example_dynamic_params.cpp
-}
 )
 
-ament_target_dependencies(example_nav2_dynamic_params
+ament_target_dependencies(example_${executable_name}
   ${dependencies}
 )
 
-target_link_libraries(example_nav2_dynamic_params
+target_link_libraries(example_${executable_name}
   nav2_dynamic_params
 )
 
-install(TARGETS nav2_dynamic_params example_nav2_dynamic_params
+install(TARGETS ${library_name} example_${executable_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
@@ -66,6 +65,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(nav2_dynamic_params)
+ament_export_libraries(${library_name})
 
 ament_package()

--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -25,13 +25,12 @@ include_directories(
   ${SDL_IMAGE_INCLUDE_DIRS}
 )
 
-set(executable_name map_server)
+set(library_name map_server)
+set(executable_name ${library_name}_node)
 
 add_executable(${executable_name}
   src/main.cpp
 )
-
-set(library_name ${executable_name}_core)
 
 add_library(${library_name}
   src/map_representations/occ_grid_server.cpp

--- a/nav2_mission_executor/CMakeLists.txt
+++ b/nav2_mission_executor/CMakeLists.txt
@@ -21,13 +21,12 @@ include_directories(
   include
 )
 
-set(executable_name mission_executor)
+set(library_name mission_executor)
+set(executable_name ${library_name}_node)
 
 add_executable(${executable_name}
   src/main.cpp
 )
-
-set(library_name ${executable_name}_core)
 
 add_library(${library_name}
   src/mission_executor.cpp

--- a/nav2_simple_navigator/CMakeLists.txt
+++ b/nav2_simple_navigator/CMakeLists.txt
@@ -21,13 +21,12 @@ include_directories(
   include
 )
 
-set(executable_name simple_navigator)
+set(library_name simple_navigator)
+set(executable_name ${library_name}_node)
 
 add_executable(${executable_name}
   src/main.cpp
 )
-
-set(library_name ${executable_name}_core)
 
 add_library(${library_name}
   src/simple_navigator.cpp

--- a/nav2_world_model/CMakeLists.txt
+++ b/nav2_world_model/CMakeLists.txt
@@ -20,13 +20,12 @@ include_directories(
   include
 )
 
-set(executable_name world_model)
+set(library_name world_model)
+set(executable_name ${library_name}_node)
 
 add_executable(${executable_name}
   src/main.cpp
 )
-
-set(library_name ${executable_name}_core)
 
 add_library(${library_name}
   src/world_model.cpp


### PR DESCRIPTION
Moving all the library `_core`s to name, and nodes to `_node` as used in all the DWB controller, move_base, and general ROS cmakelists templates. 

Has no functional difference, but homologates the codebase to follow convention.