### PR TITLE
Ignore Visual Studio Code files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,10 @@
 *.out
 *.app
 
-#colcon output
+# Colcon output
 build
 log
 install
 
+# Visual Studio Code files
+.vscode


### PR DESCRIPTION
## Description of contribution in a few bullet points
* Using Visual Studio Code, I've been opening just the directories that I'm interested in, avoiding the output directories - install, build, and log - because VS Code can't track this many files. In this configuration, when debugging various modules, the VS Code app will put .vscode files around the source hierarchy, in each source directory being debugged. This causes the directories to be highlighted in the editor indicating that files have been added to the directory. With this addition to .gitignore, these files will be ignored and the VS Code editor will more accurately reflect any changes to the workspace.