### PR TITLE
Integration launch files

### DIFF
--- a/nav2_bringup/README.md
+++ b/nav2_bringup/README.md
@@ -2,6 +2,24 @@
 
 The `nav2_bringup` package is an example bringup system for navigation2 applications.
 
+## Launch Navigation2 in simulation with Gazebo
+ - Launch Gazebo and Rviz2
+ 
+```
+ros2 launch nav2_bringup gazebo_rviz2_launch.py world:=<full/path/to/gazebo.world>
+```
+ - Launch Navigation2
+ 
+```
+ros2 launch nav2_bringup nav2_bringup_launch.py map:=<full/path/to/map.yaml use_sim_time:=True 
+```
+ - Set 'use\_sim\_time' parameter for static transforms
+* This is due to a bug in static\_transform\_publisher - [https://github.com/ros2/geometry2/issues/80](https://github.com/ros2/geometry2/issues/80)
+
+```
+ros2 param set /static_transform_publisher use_sim_time True
+```
+
 ## system_test.rviz
 
 There is an rviz configuration for testing base navigation2 systems.

--- a/nav2_bringup/launch/gazebo_rviz2_launch.py
+++ b/nav2_bringup/launch/gazebo_rviz2_launch.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from launch import LaunchDescription
+from launch.substitutions import EnvironmentVariable
+import launch.actions
+import launch_ros.actions
+
+def generate_launch_description():
+    world = launch.substitutions.LaunchConfiguration('world')
+
+    return LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'world', description='Full path to world file to load'),
+        
+        launch.actions.ExecuteProcess(
+            cmd=['gazebo', '--verbose', '-s', 'libgazebo_ros_init.so', world],
+            output='screen'),
+
+        launch_ros.actions.Node(package='rviz2', node_executable='rviz2', output='screen')
+    ])

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -59,9 +59,9 @@ def generate_launch_description():
             parameters=[{ 'prune_plan': False }, {'debug_trajectory_details': True }, { 'use_sim_time': use_sim_time }]),
 
         launch_ros.actions.Node(
-            package='nav2_dijkstra_planner',
-            node_executable='dijkstra_planner',
-            node_name='dijkstra_planner',
+            package='nav2_smart_planner',
+            node_executable='smart_planner_node',
+            node_name='smart_planner',
             output='screen',
             parameters=[{ 'use_sim_time': use_sim_time}]),
 

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -1,0 +1,82 @@
+import os
+from launch import LaunchDescription
+import launch.actions
+import launch_ros.actions
+
+def generate_launch_description():
+    map_file = launch.substitutions.LaunchConfiguration('map')
+    map_type = launch.substitutions.LaunchConfiguration('map_type', default='occupancy')
+    use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
+    params_file = launch.substitutions.LaunchConfiguration('params', default='nav2_params.yaml')
+
+    return LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'map', description='Full path to map file to load'),
+        launch.actions.DeclareLaunchArgument(
+            'map_type', default_value='occupancy', description='Type of map to load'),
+        launch.actions.DeclareLaunchArgument(
+            'use_sim_time', default_value='false', description='Use simulation (Gazebo) clock if true'),
+
+        launch_ros.actions.Node(
+            package='tf2_ros',
+            node_executable='static_transform_publisher',
+            output='screen',
+            arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_footprint']),
+
+        launch_ros.actions.Node(
+            package='tf2_ros',
+            node_executable='static_transform_publisher',
+            output='screen',
+            arguments=['0', '0', '0', '0', '0', '0', 'base_footprint', 'base_scan']),
+
+        launch_ros.actions.Node(
+            package='nav2_map_server',
+            node_executable='map_server',
+            output='screen',
+            arguments=[map_file, map_type]),
+
+        launch_ros.actions.Node(
+            package='nav2_world_model',
+            node_executable='world_model',
+            node_name='world_model',
+            output='screen',
+            parameters=[{ 'use_sim_time': use_sim_time}]),
+
+        launch_ros.actions.Node(
+            package='nav2_amcl',
+            node_executable='amcl',
+            node_name='amcl',
+            output='screen',
+            remappings=[('scan', 'tb3/scan')],
+            parameters=[{ 'use_sim_time': use_sim_time}]),
+
+        launch_ros.actions.Node(
+            package='dwb_controller',
+            node_executable='dwb_controller',
+            node_name='FollowPathNode',
+            output='screen',
+            remappings=[('/cmd_vel', 'tb3/cmd_vel')],
+            parameters=[{ 'prune_plan': False }, {'debug_trajectory_details': True }, { 'use_sim_time': use_sim_time }]),
+
+        launch_ros.actions.Node(
+            package='nav2_dijkstra_planner',
+            node_executable='dijkstra_planner',
+            node_name='dijkstra_planner',
+            output='screen',
+            parameters=[{ 'use_sim_time': use_sim_time}]),
+
+        launch_ros.actions.Node(
+            package='nav2_simple_navigator',
+            node_executable='simple_navigator',
+            node_name='simple_navigator',
+            output='screen',
+            parameters=[{ 'use_sim_time': use_sim_time}]),
+
+        launch_ros.actions.Node(
+            package='nav2_mission_executor',
+            node_executable='mission_executor',
+            node_name='mission_executor',
+            output='screen',
+            parameters=[{ 'use_sim_time': use_sim_time}]),
+
+    ])

--- a/nav2_world_model/src/world_model.cpp
+++ b/nav2_world_model/src/world_model.cpp
@@ -39,7 +39,7 @@ WorldModel::WorldModel(const string & name)
   layered_costmap_->updateMap(0, 0, 0);
 
   // Create a service that will use the callback function to handle requests.
-  costmapServer_ = create_service<nav2_msgs::srv::GetCostmap>(name + "_GetCostmap",
+  costmapServer_ = create_service<nav2_msgs::srv::GetCostmap>("GetCostmap",
       std::bind(&WorldModel::costmap_callback, this,
       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu 18.04 |
| Primary platform tested on | Turtlebot3 |

--- 

## Description of contribution in a few bullet points

With this change, the entire stack can more easily be run with two launch files.

* Added nav2_bringup_launch.py for launching the stack
* Added gazebo_rviz2_launch.py for launching Gazebo and RVIZ2 easily
* Fixed a bug where "GetCostmap" service was called "WorldModel_GetCostmap". This was causing the stack to hang
* Updated the nav2_bringup readme for running the new launch files
--- 

## Future work that may be required in bullet points
* Could change the parameters to be read in from a YAML file instead. I tried this but for some nodes it caused them to crash, I don't know why yet, so I decided to submit this as-is for now and we can enhance it later
<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

---

<!-- OPTIONAL --> 

