### PR TITLE
Remove costmap movement callback

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -258,24 +258,21 @@ private:
 
   void reconfigureCB();
 
-  void movementCB();
-
   void mapUpdateLoop(double frequency);
   bool map_update_thread_shutdown_;
-  bool stop_updates_, initialized_, stopped_, robot_stopped_;
+  bool stop_updates_, initialized_, stopped_;
   std::thread * map_update_thread_;  ///< @brief A thread for updating the map
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Time last_publish_;
   rclcpp::Duration publish_cycle_;
   pluginlib::ClassLoader<Layer> plugin_loader_;
-  geometry_msgs::msg::PoseStamped old_pose_;
   Costmap2DPublisher * publisher_;
 
   nav2_dynamic_params::DynamicParamsValidator * param_validator_;
   nav2_dynamic_params::DynamicParamsClient * dynamic_param_client_;
 
   std::recursive_mutex configuration_mutex_;
-  
+
   rclcpp::Node::SharedPtr node_;
   rclcpp::SyncParametersClient::SharedPtr parameters_client_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr footprint_pub_;

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -170,7 +170,7 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
 
   // Create a timer to check if the robot is moving
   robot_stopped_ = false;
-  timer_ = create_wall_timer(100ms, std::bind(&Costmap2DROS::movementCB, this));
+  //timer_ = create_wall_timer(100ms, std::bind(&Costmap2DROS::movementCB, this));
 
   // Create Parameter Validator
   param_validator_ = new nav2_dynamic_params::DynamicParamsValidator(node_);


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu 18.04 |
| Primary platform tested on | Gazebo Turtlebot 3 |

--- 

## Description of contribution in a few bullet points

* Removes the costmap_2d_ros movement callback. This call back would check every 1/10s to see if the robot had moved, and would set a flag. Nobody used the flag, so this removes the flag and the callback.
* Also accidentally cleans up trailing whitespace in the associated files.

--- 

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->


