### PR TITLE
Dwb fixes to get reliable motion

### DIFF
--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
@@ -94,7 +94,7 @@ public:
     name_ = name;
     costmap_ros_ = costmap_ros;
     nh_ = nh;
-    nh_->get_parameter_or("scale", scale_, 1.0);
+    nh_->get_parameter_or(name + "/scale", scale_, 1.0);
     onInit();
   }
   virtual void onInit() {}

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
@@ -94,7 +94,7 @@ public:
     name_ = name;
     costmap_ros_ = costmap_ros;
     nh_ = nh;
-    nh_->get_parameter_or(name + "/scale", scale_, 1.0);
+    nh_->get_parameter_or(name_ + ".scale", scale_, 1.0);
     onInit();
   }
   virtual void onInit() {}

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
@@ -89,8 +89,9 @@ public:
    * @param parent_namespace The namespace of the planner
    * @param costmap_ros Pointer to the costmap
    */
-  void initialize(const std::shared_ptr<rclcpp::Node> & nh, CostmapROSPtr costmap_ros)
+  void initialize(const std::shared_ptr<rclcpp::Node> & nh, std::string & name, CostmapROSPtr costmap_ros)
   {
+    name_ = name;
     costmap_ros_ = costmap_ros;
     nh_ = nh;
     nh_->get_parameter_or("scale", scale_, 1.0);

--- a/nav2_dwb_controller/dwb_core/src/dwb_core.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_core.cpp
@@ -68,14 +68,14 @@ void loadBackwardsCompatibleParameters(const std::shared_ptr<rclcpp::Node> & nh)
                                                 //   (local) goal, based on wave propagation
   nh->set_parameters({rclcpp::Parameter("critics", critic_names)});
   /* *INDENT-OFF* */
-  nav_2d_utils::moveParameter(nh, "path_distance_bias", "PathAlign/scale", 32.0, false);
-  nav_2d_utils::moveParameter(nh, "goal_distance_bias", "GoalAlign/scale", 24.0, false);
-  nav_2d_utils::moveParameter(nh, "path_distance_bias", "PathDist/scale", 32.0);
-  nav_2d_utils::moveParameter(nh, "goal_distance_bias", "GoalDist/scale", 24.0);
-  nav_2d_utils::moveParameter(nh, "occdist_scale",      "ObstacleFootprint/scale", 0.01);
+  nav_2d_utils::moveParameter(nh, "path_distance_bias", "PathAlign.scale", 32.0, false);
+  nav_2d_utils::moveParameter(nh, "goal_distance_bias", "GoalAlign.scale", 24.0, false);
+  nav_2d_utils::moveParameter(nh, "path_distance_bias", "PathDist.scale", 32.0);
+  nav_2d_utils::moveParameter(nh, "goal_distance_bias", "GoalDist.scale", 24.0);
+  nav_2d_utils::moveParameter(nh, "occdist_scale",      "ObstacleFootprint.scale", 0.01);
 
-  nav_2d_utils::moveParameter(nh, "max_scaling_factor", "ObstacleFootprint/max_scaling_factor", 0.2);  // NOLINT
-  nav_2d_utils::moveParameter(nh, "scaling_speed",      "ObstacleFootprint/scaling_speed", 0.25);
+  nav_2d_utils::moveParameter(nh, "max_scaling_factor", "ObstacleFootprint.max_scaling_factor", 0.2);  // NOLINT
+  nav_2d_utils::moveParameter(nh, "scaling_speed",      "ObstacleFootprint.scaling_speed", 0.25);
   /* *INDENT-ON* */
 }
 

--- a/nav2_dwb_controller/dwb_core/src/dwb_core.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_core.cpp
@@ -95,6 +95,7 @@ void DWBLocalPlanner::initialize(
   costmap_ros_ = costmap_ros;
   nh_->get_parameter_or("prune_plan", prune_plan_, true);
   nh_->get_parameter_or("prune_distance", prune_distance_, 1.0);
+  nh_->get_parameter_or("debug_trajectory_details", debug_trajectory_details_, false);
   pub_.initialize(nh_);
 
   // Plugins

--- a/nav2_dwb_controller/dwb_core/src/dwb_core.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_core.cpp
@@ -153,7 +153,7 @@ void DWBLocalPlanner::loadCritics()
     RCLCPP_INFO(nh_->get_logger(),
       "Using critic \"%s\" (%s)", plugin_name.c_str(), plugin_class.c_str());
     critics_.push_back(plugin);
-    plugin->initialize(nh_, costmap_ros_);
+    plugin->initialize(nh_, plugin_name, costmap_ros_);
   }
 }
 

--- a/nav2_dwb_controller/dwb_core/src/publisher.cpp
+++ b/nav2_dwb_controller/dwb_core/src/publisher.cpp
@@ -116,6 +116,8 @@ void DWBPublisher::publishTrajectories(const dwb_msgs::msg::LocalPlanEvaluation 
       m.color.b = 1;
       m.ns = "ValidTrajectories";
     } else {
+      m.color.r = 0;
+      m.color.g = 0;
       m.color.b = 0;
       m.ns = "InvalidTrajectories";
     }

--- a/nav2_dwb_controller/dwb_critics/src/base_obstacle.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/base_obstacle.cpp
@@ -45,7 +45,7 @@ namespace dwb_critics
 void BaseObstacleCritic::onInit()
 {
   costmap_ = costmap_ros_->getCostmap();
-  nh_->get_parameter_or("sum_scores", sum_scores_, false);
+  nh_->get_parameter_or(name_ + "/sum_scores", sum_scores_, false);
 }
 
 double BaseObstacleCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & traj)

--- a/nav2_dwb_controller/dwb_critics/src/base_obstacle.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/base_obstacle.cpp
@@ -45,7 +45,7 @@ namespace dwb_critics
 void BaseObstacleCritic::onInit()
 {
   costmap_ = costmap_ros_->getCostmap();
-  nh_->get_parameter_or(name_ + "/sum_scores", sum_scores_, false);
+  nh_->get_parameter_or(name_ + ".sum_scores", sum_scores_, false);
 }
 
 double BaseObstacleCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & traj)

--- a/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
@@ -70,7 +70,7 @@ void MapGridCritic::onInit()
   stop_on_failure_ = true;
 
   std::string aggro_str;
-  nh_->get_parameter_or("aggregation_type", aggro_str, std::string("last"));
+  nh_->get_parameter_or(name_ + "/aggregation_type", aggro_str, std::string("last"));
   std::transform(aggro_str.begin(), aggro_str.end(), aggro_str.begin(), ::tolower);
   if (aggro_str == "last") {
     aggregationType_ = ScoreAggregationType::Last;

--- a/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
@@ -70,7 +70,7 @@ void MapGridCritic::onInit()
   stop_on_failure_ = true;
 
   std::string aggro_str;
-  nh_->get_parameter_or(name_ + "/aggregation_type", aggro_str, std::string("last"));
+  nh_->get_parameter_or(name_ + ".aggregation_type", aggro_str, std::string("last"));
   std::transform(aggro_str.begin(), aggro_str.end(), aggro_str.begin(), ::tolower);
   if (aggro_str == "last") {
     aggregationType_ = ScoreAggregationType::Last;

--- a/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
@@ -104,7 +104,7 @@ void OscillationCritic::onInit()
    * If min_trans_vel is set in the namespace, as it used to be used for trajectory generation, complain then use that.
    * Otherwise, set x_only_threshold_ to 0.05
    */
-  nh_->get_parameter_or("x_only_threshold", x_only_threshold_, 0.05);
+  nh_->get_parameter_or(name_+ "/x_only_threshold", x_only_threshold_, 0.05);
   // TODO(crdelsey): How to handle searchParam?
   // std::string resolved_name;
   // if (nh_->hasParam("x_only_threshold"))

--- a/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
@@ -104,7 +104,7 @@ void OscillationCritic::onInit()
    * If min_trans_vel is set in the namespace, as it used to be used for trajectory generation, complain then use that.
    * Otherwise, set x_only_threshold_ to 0.05
    */
-  nh_->get_parameter_or(name_+ "/x_only_threshold", x_only_threshold_, 0.05);
+  nh_->get_parameter_or(name_ + ".x_only_threshold", x_only_threshold_, 0.05);
   // TODO(crdelsey): How to handle searchParam?
   // std::string resolved_name;
   // if (nh_->hasParam("x_only_threshold"))

--- a/nav2_dwb_controller/dwb_critics/src/prefer_forward.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/prefer_forward.cpp
@@ -43,10 +43,10 @@ namespace dwb_critics
 
 void PreferForwardCritic::onInit()
 {
-  nh_->get_parameter_or(name_ + "/penalty", penalty_, 1.0);
-  nh_->get_parameter_or(name_ + "/strafe_x", strafe_x_, 0.1);
-  nh_->get_parameter_or(name_ + "/strafe_theta", strafe_theta_, 0.2);
-  nh_->get_parameter_or(name_ + "/theta_scale", theta_scale_, 10.0);
+  nh_->get_parameter_or(name_ + ".penalty", penalty_, 1.0);
+  nh_->get_parameter_or(name_ + ".strafe_x", strafe_x_, 0.1);
+  nh_->get_parameter_or(name_ + ".strafe_theta", strafe_theta_, 0.2);
+  nh_->get_parameter_or(name_ + ".theta_scale", theta_scale_, 10.0);
 }
 
 double PreferForwardCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & traj)

--- a/nav2_dwb_controller/dwb_critics/src/prefer_forward.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/prefer_forward.cpp
@@ -43,10 +43,10 @@ namespace dwb_critics
 
 void PreferForwardCritic::onInit()
 {
-  nh_->get_parameter_or("penalty", penalty_, 1.0);
-  nh_->get_parameter_or("strafe_x", strafe_x_, 0.1);
-  nh_->get_parameter_or("strafe_theta", strafe_theta_, 0.2);
-  nh_->get_parameter_or("theta_scale", theta_scale_, 10.0);
+  nh_->get_parameter_or(name_ + "/penalty", penalty_, 1.0);
+  nh_->get_parameter_or(name_ + "/strafe_x", strafe_x_, 0.1);
+  nh_->get_parameter_or(name_ + "/strafe_theta", strafe_theta_, 0.2);
+  nh_->get_parameter_or(name_ + "/theta_scale", theta_scale_, 10.0);
 }
 
 double PreferForwardCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & traj)

--- a/nav2_dwb_controller/dwb_critics/src/twirling.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/twirling.cpp
@@ -40,7 +40,7 @@ namespace dwb_critics
 void TwirlingCritic::onInit()
 {
   // Scale is set to 0 by default, so if it was not set otherwise, set to 0
-  nh_->get_parameter_or("scale", scale_, 0.0);
+  nh_->get_parameter_or(name_ + "/scale", scale_, 0.0);
 }
 
 double TwirlingCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & traj)

--- a/nav2_dwb_controller/dwb_critics/src/twirling.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/twirling.cpp
@@ -40,7 +40,7 @@ namespace dwb_critics
 void TwirlingCritic::onInit()
 {
   // Scale is set to 0 by default, so if it was not set otherwise, set to 0
-  nh_->get_parameter_or(name_ + "/scale", scale_, 0.0);
+  nh_->get_parameter_or(name_ + ".scale", scale_, 0.0);
 }
 
 double TwirlingCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & traj)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on |  Ubuntu  |
| Primary platform tested on | gazebo simulation of turtlebot) |

--- 

## Description of contribution in a few bullet points

* Fixes dwb critic parameter naming such that each critic gets a prefix for it's parameters
* Adds back in the `debug_trajectory_details` parameter which had been accidentally deleted.
* Initializes all three color components of an invalid path, such that they always appear black. Sometimes they were showing up yellow, depending on initial conditions of the red and green components.
* Separates parameter prefixes with a `.` instead of a `/` because that is what the ROS2 parameter server seems to expect.
