### PR TITLE
Disabling transform timeout

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -61,6 +61,11 @@ using nav2_util::Laser;
 using nav2_util::LaserData;
 
 using namespace std::chrono_literals;
+
+// TODO(crdelsey): This timeout value can probably be entirely removed when
+// message filter support is re-enabled. The default timeout to the transform
+// call is 0 anyhow, so this no longer serves a purpose. A value other than 0
+// causes the node to hang when use_sim_time is active.
 static const auto TRANSFORM_TIMEOUT = 0ns;
 
 static const char scan_topic_[] = "scan";

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -61,7 +61,7 @@ using nav2_util::Laser;
 using nav2_util::LaserData;
 
 using namespace std::chrono_literals;
-static const auto TRANSFORM_TIMEOUT = 1s;
+static const auto TRANSFORM_TIMEOUT = 0ns;
 
 static const char scan_topic_[] = "scan";
 


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |   |
| Primary OS tested on | Ubuntu 18.04 |
| Primary platform tested on | gazebo simulation  turtlebot |

--- 

## Description of contribution in a few bullet points

* Disabling transform timeout in AMCL. The current ROS2 transform code deadlocks when there is a transform timeout and use_sim_time is active. The timeout clock can't advance because the transform code is in a tight loop, preventing the node from spinning and servicing clock messages. 
* It seems it doesn't matter much that AMCL fails to process the laser scans due to missing transform, because occasionally the transform is available, and we can get a fix.

--- 

## Future work that may be required in bullet points

Fix AMCL by re-introducing message filters, or finding some other wait to ensure a transform is available when there is laser scan data to process. #171 