### PR TITLE
Fix costmap publishing loop

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -46,6 +46,7 @@
 #include <geometry_msgs/msg/polygon_stamped.h>
 #include <pluginlib/class_loader.hpp>
 #include <tf2/transform_datatypes.h>
+#include <chrono>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #include "tf2/utils.h"
@@ -243,8 +244,8 @@ private:
   bool stop_updates_, initialized_, stopped_;
   std::thread * map_update_thread_;  ///< @brief A thread for updating the map
   rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Time last_publish_;
-  rclcpp::Duration publish_cycle_;
+  std::chrono::time_point<std::chrono::steady_clock> last_publish_;
+  std::chrono::nanoseconds publish_cycle_;
   pluginlib::ClassLoader<Layer> plugin_loader_;
   Costmap2DPublisher * publisher_;
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -46,7 +46,6 @@
 #include <geometry_msgs/msg/polygon_stamped.h>
 #include <pluginlib/class_loader.hpp>
 #include <tf2/transform_datatypes.h>
-#include <chrono>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #include "tf2/utils.h"

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -244,8 +244,8 @@ private:
   bool stop_updates_, initialized_, stopped_;
   std::thread * map_update_thread_;  ///< @brief A thread for updating the map
   rclcpp::TimerBase::SharedPtr timer_;
-  std::chrono::time_point<std::chrono::steady_clock> last_publish_;
-  std::chrono::nanoseconds publish_cycle_;
+  rclcpp::Time last_publish_;
+  rclcpp::Duration publish_cycle_;
   pluginlib::ClassLoader<Layer> plugin_loader_;
   Costmap2DPublisher * publisher_;
 

--- a/nav2_costmap_2d/src/costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_publisher.cpp
@@ -125,10 +125,10 @@ void Costmap2DPublisher::prepareGrid()
 
 void Costmap2DPublisher::publishCostmap()
 {
- if(node_->count_subscribers(topic_name_))
+ if(node_->count_subscribers(topic_name_) == 0)
  {
     // No subscribers, so why do any work?
-    return;   
+    return;
  }
 
   float resolution = costmap_->getResolution();

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -320,7 +320,8 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
       publisher_->updateBounds(x0, xn, y0, yn);
 
       auto current_time = now();
-      if (last_publish_ + publish_cycle_ < current_time) {
+      if ((last_publish_ + publish_cycle_ < current_time) ||  // publish_cycle_ is due
+          (current_time < last_publish_)) {  // time has moved backwards, probably due to a switch to sim_time // NOLINT
         publisher_->publishCostmap();
         last_publish_ = current_time;
       }

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -113,7 +113,7 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
   bool rolling_window, track_unknown_space, always_send_full_costmap;
   get_parameter_or<bool>("rolling_window", rolling_window, false);
   get_parameter_or<bool>("track_unknown_space", track_unknown_space, false);
-  get_parameter_or<bool>("always_send_full_costmap", always_send_full_costmap, false);
+  get_parameter_or<bool>("always_send_full_costmap", always_send_full_costmap, true);
 
   layered_costmap_ = new LayeredCostmap(global_frame_, rolling_window, track_unknown_space);
 
@@ -322,7 +322,7 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
       layered_costmap_->getBounds(&x0, &xn, &y0, &yn);
       publisher_->updateBounds(x0, xn, y0, yn);
 
-      rclcpp::Time now = this->now();
+      rclcpp::Time now = rclcpp::Clock(RCL_SYSTEM_TIME).now();
 
       if (last_publish_.nanoseconds() + publish_cycle_.nanoseconds() < now.nanoseconds()) {
       //if (last_publish_ + publish_cycle_ < now) {

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -46,6 +46,11 @@
 #include "nav2_util/duration_conversions.hpp"
 
 using namespace std;
+using namespace std::chrono_literals;
+using std::chrono::steady_clock;
+using std::chrono::high_resolution_clock;
+using std::chrono::duration;
+using std::chrono::nanoseconds;
 
 namespace nav2_costmap_2d
 {
@@ -61,10 +66,9 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
   initialized_(true),
   stopped_(false),
   map_update_thread_(NULL),
-  last_publish_(0),
   plugin_loader_("nav2_costmap_2d", "nav2_costmap_2d::Layer"),
   publisher_(NULL),
-  publish_cycle_(1),
+  publish_cycle_(1s),
   footprint_padding_(0.0)
 {
   node_ = std::shared_ptr<rclcpp::Node>(this, [](rclcpp::Node *) {});
@@ -113,7 +117,7 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
   bool rolling_window, track_unknown_space, always_send_full_costmap;
   get_parameter_or<bool>("rolling_window", rolling_window, false);
   get_parameter_or<bool>("track_unknown_space", track_unknown_space, false);
-  get_parameter_or<bool>("always_send_full_costmap", always_send_full_costmap, true);
+  get_parameter_or<bool>("always_send_full_costmap", always_send_full_costmap, false);
 
   layered_costmap_ = new LayeredCostmap(global_frame_, rolling_window, track_unknown_space);
 
@@ -218,9 +222,10 @@ void Costmap2DROS::reconfigureCB()
   dynamic_param_client_->get_event_param("publish_frequency", map_publish_frequency);
 
   if (map_publish_frequency > 0)
-    publish_cycle_ = nav2_util::durationFromSeconds(1 / map_publish_frequency);
+    publish_cycle_ = std::chrono::duration_cast<nanoseconds>(
+      duration<double>(1 / map_publish_frequency));
   else
-    publish_cycle_ = nav2_util::durationFromSeconds(-1);
+    publish_cycle_ = -1ns;
 
   // find size parameters
   double resolution, origin_x, origin_y;
@@ -308,24 +313,19 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
   }
   rclcpp::Rate r(frequency);
   while (rclcpp::ok() && !map_update_thread_shutdown_) {
-    struct timeval start, end;
-    double start_t, end_t, t_diff;
-    gettimeofday(&start, NULL);
+    auto start = high_resolution_clock::now();
     updateMap();
-    gettimeofday(&end, NULL);
-    start_t = start.tv_sec + double(start.tv_usec) / 1e6;
-    end_t = end.tv_sec + double(end.tv_usec) / 1e6;
-    t_diff = end_t - start_t;
-    RCLCPP_DEBUG(get_logger(), "Map update time: %.9f", t_diff);
-    if (publish_cycle_.nanoseconds() > 0 && layered_costmap_->isInitialized()) {
+    auto end = high_resolution_clock::now();
+    duration<double> diff = end - start;
+    RCLCPP_DEBUG(get_logger(), "Map update time: %.9f", diff.count());
+    if (publish_cycle_ > 0ns && layered_costmap_->isInitialized()) {
       unsigned int x0, y0, xn, yn;
       layered_costmap_->getBounds(&x0, &xn, &y0, &yn);
       publisher_->updateBounds(x0, xn, y0, yn);
 
-      rclcpp::Time now = rclcpp::Clock(RCL_SYSTEM_TIME).now();
+      auto now = steady_clock::now();
 
-      if (last_publish_.nanoseconds() + publish_cycle_.nanoseconds() < now.nanoseconds()) {
-      //if (last_publish_ + publish_cycle_ < now) {
+      if (last_publish_ + publish_cycle_ < now) {
         publisher_->publishCostmap();
         last_publish_ = now;
       }

--- a/nav2_util/CMakeLists.txt
+++ b/nav2_util/CMakeLists.txt
@@ -98,6 +98,9 @@ if(BUILD_TESTING)
   set(ament_cmake_copyright_FOUND TRUE)
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  add_subdirectory(test)
 endif()
 
 ament_export_include_directories(include)

--- a/nav2_util/include/nav2_util/execution_timer.hpp
+++ b/nav2_util/include/nav2_util/execution_timer.hpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_UTIL__EXECUTION_TIMER_HPP_
+#define NAV2_UTIL__EXECUTION_TIMER_HPP_
+
+#include <chrono>
+
+namespace nav2_util
+{
+
+/// @brief Measures execution time of code between calls to start and end
+class ExecutionTimer
+{
+public:
+  using Clock = std::chrono::high_resolution_clock;
+  using nanoseconds = std::chrono::nanoseconds;
+
+  /// @brief Call just prior to code you want to measure
+  void start() {start_ = Clock::now();}
+
+  /// @brief Call just after the code you want to measure
+  void end() {end_ = Clock::now();}
+
+  /// @brief Extract the measured time as an integral std::chrono::duration object
+  nanoseconds elapsed_time() {return end_ - start_;}
+
+  /// @brief Extract the measured time as a floating point number of seconds.
+  double elapsed_time_in_seconds()
+  {
+    return std::chrono::duration<double>(end_ - start_).count();
+  }
+
+protected:
+  Clock::time_point start_;
+  Clock::time_point end_;
+};
+
+}  // namespace nav2_util
+
+#endif  // NAV2_UTIL__EXECUTION_TIMER_HPP_

--- a/nav2_util/test/CMakeLists.txt
+++ b/nav2_util/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+ament_add_gtest(test_execution_timer test_execution_timer.cpp)

--- a/nav2_util/test/test_execution_timer.cpp
+++ b/nav2_util/test/test_execution_timer.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_util/execution_timer.hpp"
+#include <chrono>
+#include <thread>
+#include "gtest/gtest.h"
+
+using nav2_util::ExecutionTimer;
+using std::this_thread::sleep_for;
+using namespace std::chrono_literals;
+
+TEST(ExecutionTimer, BasicDelay)
+{
+  ExecutionTimer t;
+  t.start();
+  sleep_for(10ns);
+  t.end();
+  ASSERT_GE(t.elapsed_time(), 10ns);
+  ASSERT_GE(t.elapsed_time_in_seconds(), 1e-8);
+}


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |   |
| Primary OS tested on | Ubuntu |
| Primary platform tested on | gazebo simulation of Turtlebot |

--- 

## Description of contribution in a few bullet points

* The code to determine when to publish a new costmap was using ROS time. This caused the costmap to never get published if we changed to sim_time after the `last_publish_` value had been set. I changed it use std::chrono time instead. This way, the costmap always gets published at a regular interval, even if the simulation is paused, which IMHO is desirable.
* Fixed a bug in the logic that checks whether there are subscribers to the costmap topic before publishing. The logic was reversed.
