### PR TITLE
Temporary fix to hanging problem in listing parameters in costmap2d

### DIFF
--- a/nav2_dynamic_params/include/nav2_dynamic_params/dynamic_params_client.hpp
+++ b/nav2_dynamic_params/include/nav2_dynamic_params/dynamic_params_client.hpp
@@ -65,7 +65,8 @@ public:
       auto event_sub = node_->create_subscription<rcl_interfaces::msg::ParameterEvent>(
         topic, callback);
       event_subscriptions_.push_back(event_sub);
-      get_param_list(node_namespace);
+      // TODO(bpwilcox): Fix hanging problem for list parameters service call
+      //get_param_list(node_namespace);
     }
   }
 


### PR DESCRIPTION
## Description of contribution
- commented out function call in `DynamicParamsClient `which lists parameters from all available remote nodes
- this fixes hanging issue where apparently the call _client->list_parameters_ will hang on nodes which are being spun in `rclcpp::executors::SingleThreadedExectutor `

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

--- 

## Future work
- resolve issue of listing parameters on nodes run in an `rclcpp::executors::SingleThreadedExectutor`. Not sure if a `rclcpp::executors::MultiThreadedExectutor` works either in my own simple test
<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

---

