### PR TITLE
Improve output in initial_ros_setup.sh

### DIFF
--- a/tools/initial_ros_setup.sh
+++ b/tools/initial_ros_setup.sh
@@ -75,6 +75,8 @@ checkpoint() {
   if [ ! -f ${CHECKPOINT_FILE_NAME} ]; then
     $1
     touch ${CHECKPOINT_FILE_NAME}
+  else
+    echo "${CHECKPOINT_FILE_NAME} exists. Skipping $1"
   fi
 }
 


### PR DESCRIPTION
Print a message that a function is skipped if a checkpoint file exists.

Hit this when was trying to repair a broken enlistment.  When I run `inital_ros_setup.sh` I got the error below and it was not immediately clear why the other steps are missing. 

```
$ ./initial_ros_setup.sh 
<...>
Are you sure you want to continue? [yN]
y

./initial_ros_setup.sh: line 102: /home/user/nav2/navigation2_ws/src/navigation2/tools/build_all.sh: No such file or directory
```

Adding printing in the `else` portion of `checkpoint` provides a clue of what's happening:
```
$ ./initial_ros_setup.sh 
<...>
Are you sure you want to continue? [yN]
y

.INITIAL_SETUP_download_navstack exists. Skipping download_navstack
.INITIAL_SETUP_download_ros2_dependencies exists. Skipping download_ros2_dependencies
.INITIAL_SETUP_download_ros2 exists. Skipping download_ros2
./initial_ros_setup.sh: line 102: /home/user/nav2/navigation2_ws/src/navigation2/tools/build_all.sh: No such file or directory
```