### PR TITLE
Fixing last_publish_ time to be RCL_ROS_TIME by default.

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -64,6 +64,7 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
   map_update_thread_(NULL),
   plugin_loader_("nav2_costmap_2d", "nav2_costmap_2d::Layer"),
   publisher_(NULL),
+  last_publish_(0, 0, RCL_ROS_TIME),
   publish_cycle_(1,0),
   footprint_padding_(0.0)
 {


### PR DESCRIPTION
## Basic Info
## Description of contribution in a few bullet points

* There was a bug in #307 that would cause the mapUpdateLoop to throw an exception on the intial pass when it compared `last_publish_` to `now()`. The time from `now()` is RCL_ROS_TIME as expected, but the default time for `last_publish_` was `RCL_SYSTEM_TIME`. This fix makes sure the initial version of last_publish is `RCL_ROS_TIME`