### PR TITLE
Replace manual layered costmap with costmap2dROS object

### DIFF
--- a/nav2_world_model/include/nav2_world_model/world_model.hpp
+++ b/nav2_world_model/include/nav2_world_model/world_model.hpp
@@ -18,10 +18,7 @@
 #include <string>
 #include <vector>
 #include <memory>
-#include "nav2_costmap_2d/inflation_layer.hpp"
-#include "nav2_costmap_2d/layered_costmap.hpp"
-#include "nav2_costmap_2d/static_layer.hpp"
-#include "geometry_msgs/msg/point.hpp"
+#include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_util/costmap.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
@@ -34,30 +31,21 @@ namespace nav2_world_model
 class WorldModel : public rclcpp::Node
 {
 public:
-  explicit WorldModel(const std::string & name);
-  WorldModel();
-
-  template<class LayerT>
-  void addLayer(std::string layer_name)
-  {
-    auto layer = std::make_shared<LayerT>();
-    layered_costmap_->addPlugin(layer);
-    layer->initialize(layered_costmap_, layer_name, tf_, node_);
-  }
-
-  void setFootprint(double length, double width);
+  WorldModel(rclcpp::executor::Executor & executor, const std::string & name);
+  explicit WorldModel(rclcpp::executor::Executor & executor);
 
 private:
   void costmap_callback(
-    const std::shared_ptr<rmw_request_id_t>/*request_header*/,
-    const std::shared_ptr<nav2_msgs::srv::GetCostmap::Request>/*request*/,
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<nav2_msgs::srv::GetCostmap::Request> request,
     const std::shared_ptr<nav2_msgs::srv::GetCostmap::Response> response);
 
   // Server for providing a costmap
   rclcpp::Service<nav2_msgs::srv::GetCostmap>::SharedPtr costmapServer_;
-  nav2_costmap_2d::LayeredCostmap * layered_costmap_;
-  tf2_ros::Buffer * tf_;
-  rclcpp::Node::SharedPtr node_;
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
+  nav2_costmap_2d::Costmap2D * costmap_;
+  tf2_ros::Buffer tfBuffer_;
+  tf2_ros::TransformListener tfListener_;
 };
 
 }  // namespace nav2_world_model

--- a/nav2_world_model/src/main.cpp
+++ b/nav2_world_model/src/main.cpp
@@ -19,7 +19,10 @@
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<nav2_world_model::WorldModel>());
+  rclcpp::executors::SingleThreadedExecutor exec;
+  auto world_model_node = std::make_shared<nav2_world_model::WorldModel>(exec);
+  exec.add_node(world_model_node);
+  exec.spin();
   rclcpp::shutdown();
 
   return 0;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #252  |
| Primary OS tested on | Ubuntu 16.04 |
| Primary platform tested on | NUC |

--- 

## Description of contribution
- replaces the manual creation of the `layeredcostmap_` with the `costmap2DROS` node object
--- 

## Future work 
- Grab correct orientation information from costmap to put in service map metadata (currently a TODO)


---

