### PR TITLE
Planner hook fix

### DIFF
--- a/nav2_smart_planner/include/nav2_smart_planner/smart_planner.hpp
+++ b/nav2_smart_planner/include/nav2_smart_planner/smart_planner.hpp
@@ -59,9 +59,9 @@ private:
     const geometry_msgs::msg::Pose & goal,
     nav2_msgs::msg::Path & plan);
 
-  // Remove artifacts at the end of the path. -- originated from planning on a discretized world
+  // Remove artifacts at the end of the path - originated from planning on a discretized world
   void smoothApproachToGoal(
-    const geometry_msgs::msg::Pose & goal
+    const geometry_msgs::msg::Pose & goal,
     nav2_msgs::msg::Path & plan);
 
   // Compute the potential, or navigation cost, at a given point in the world

--- a/nav2_smart_planner/include/nav2_smart_planner/smart_planner.hpp
+++ b/nav2_smart_planner/include/nav2_smart_planner/smart_planner.hpp
@@ -59,6 +59,11 @@ private:
     const geometry_msgs::msg::Pose & goal,
     nav2_msgs::msg::Path & plan);
 
+  // Remove artifacts at the end of the path. -- originated from planning on a discretized world
+  void smoothApproachToGoal(
+    const geometry_msgs::msg::Pose & goal
+    nav2_msgs::msg::Path & plan);
+
   // Compute the potential, or navigation cost, at a given point in the world
   // - must call computePotential first
   double getPointPotential(const geometry_msgs::msg::Point & world_point);

--- a/nav2_smart_planner/src/smart_planner.cpp
+++ b/nav2_smart_planner/src/smart_planner.cpp
@@ -203,16 +203,10 @@ SmartPlanner::makePlan(
   wy = goal.position.y;
 
   if (!worldToMap(wx, wy, mx, my)) {
-    if (tolerance <= 0.0) {
-      std::cout << "tolerance: " << tolerance << std::endl;
-      RCLCPP_WARN(
-        get_logger(),
-        "SmartPlanner: The goal sent to the planner is off the global costmap."
-        " Planning will always fail to this goal.");
-      return false;
-    }
-    mx = 0;
-    my = 0;
+    RCLCPP_WARN(get_logger(),
+      "SmartPlanner: The goal sent to the planner is off the global costmap."
+      " Planning will always fail to this goal.");
+    return false;
   }
 
   int map_goal[2];
@@ -271,19 +265,21 @@ SmartPlanner::makePlan(
 
 void
 SmartPlanner::smoothApproachToGoal(
-  const geometry_msgs::msg::Pose & best_pose,
+  const geometry_msgs::msg::Pose & goal,
   nav2_msgs::msg::Path & plan)
 {
-  // For now we only check the last two poses of the plan
+  // Replace the last pose of the computed path if it's actually further away
+  // to the second to last pose than the goal pose.
+
   auto second_to_last_pose = plan.poses.end()[-2];
   auto last_pose = plan.poses.back();
   if (
     squared_distance(last_pose, second_to_last_pose) >
-    squared_distance(best_pose, second_to_last_pose)
+    squared_distance(goal, second_to_last_pose)
   ) {
-    plan.poses.back() = best_pose;
+    plan.poses.back() = goal;
   } else {
-    geometry_msgs::msg::Pose goal_copy = best_pose;
+    geometry_msgs::msg::Pose goal_copy = goal;
     plan.poses.push_back(goal_copy);
   }
 }


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #304 |
| Primary OS tested on | (Ubuntu) |
| Primary platform tested on | (gazebo turtlebot) |

--- 

## Description of contribution in a few bullet points

The artifact observed at the end of the path is originated from rounding errors when translating the goal and start poses from world continuous space to the discretized map representation.

The figure below shows an example. To the left we have a path generated with a 'hook' artifact on one end, to the right is a path (connecting the same start and end poses) but without artifact.

![both](https://user-images.githubusercontent.com/39749557/48510078-b3937280-e807-11e8-8bbf-33b46fb867e9.png)

