### PR TITLE
Amcl use map topic

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -166,7 +166,7 @@ AmclNode::AmclNode()
         std::bind(&AmclNode::mapReceived, this, std::placeholders::_1));
     RCLCPP_INFO(get_logger(), "Subscribed to map topic.");
   } else {
-    requestMap(); // FIXME: This seems to hang indefinitely
+    requestMap(); // TODO:(mkhansen) This seems to hang indefinitely - see issue #330
   }
   m_force_update = false;
 
@@ -1068,7 +1068,7 @@ void
 AmclNode::initAmclParams()
 {
   // Grab params off the param server
-  get_parameter_or_set("use_map_topic_", use_map_topic_, true); // FIXME: when false AMCL hangs in constructor
+  get_parameter_or_set("use_map_topic_", use_map_topic_, true); // When false AMCL hangs in constructor (issue #330)
   get_parameter_or_set("first_map_only_", first_map_only_, true);
   double save_pose_rate;
   get_parameter_or_set("save_pose_rate", save_pose_rate, 0.5);

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1063,8 +1063,8 @@ void
 AmclNode::initAmclParams()
 {
   // Grab params off the param server
-  get_parameter_or_set("use_map_topic_", use_map_topic_, false);
-  get_parameter_or_set("first_map_only_", first_map_only_, false);
+  get_parameter_or_set("use_map_topic_", use_map_topic_, true);
+  get_parameter_or_set("first_map_only_", first_map_only_, true);
   double save_pose_rate;
   get_parameter_or_set("save_pose_rate", save_pose_rate, 0.5);
   save_pose_period = tf2::durationFromSec(1.0 / save_pose_rate);

--- a/nav2_amcl/src/amcl_node.hpp
+++ b/nav2_amcl/src/amcl_node.hpp
@@ -238,6 +238,7 @@ private:
   double init_cov_[3];
 
   bool tf_broadcast_;
+  int scan_error_count_ = 0;
 };
 
 #endif  // AMCL_NODE_HPP_


### PR DESCRIPTION
This is a change to the default behavior of AMCL to subscribe to the map topic instead of trying to use the service to get the map. Currently getting the map through the service seems to hang. Not sure why that is. 

This change is needed to get the robot to move.

I also changed a couple of messages from INFO to DEBUG and changed the ERROR message for the laser scan transform to only report when 20 successive fails occur. This reduces the spew of ERRORS to the screen since this happens a lot (100's of times per second sometimes). This at least helps with debugging what's happening, it may or may not also free up some cycles for other work to get done. 
