### PR TITLE
fixing costmap_2d_ros logic operator bug

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -268,7 +268,7 @@ void Costmap2DROS::readFootprintFromConfig()
   dynamic_param_client_->get_event_param("footprint", footprint); 
   dynamic_param_client_->get_event_param("robot_radius", robot_radius); 
 
-  if (!dynamic_param_client_->is_in_event("footprint") ||
+  if (!dynamic_param_client_->is_in_event("footprint") &&
     !dynamic_param_client_->is_in_event("robot_radius"))
     {
       return;


### PR DESCRIPTION
Bug Fix: The robot footprint was never being updated when setting the "footprint" or "robot_radius" parameters during run-time, thus it remained at its initial value. This bug was due to an incorrect logical operator checking whether the dynamic parameter was part of the parameter event.

I mistakenly had used the wrong logical operator (OR instead of AND), preventing the footprint to be updated dynamically.