### PR TITLE
Make node libraries SHARED objects instead of static link libraries.

### DIFF
--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -35,7 +35,7 @@ add_executable(${executable_name}
 
 set(library_name ${executable_name}_core)
 
-add_library(${library_name}
+add_library(${library_name} SHARED
   src/amcl_node.cpp
 )
 

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -30,7 +30,7 @@ add_executable(${executable_name}
 
 set(library_name ${executable_name}_core)
 
-add_library(${library_name}
+add_library(${library_name} SHARED
   src/bt_navigator.cpp
   src/navigate_to_pose_behavior_tree.cpp
 )

--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   #add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/nav2_dynamic_params/CMakeLists.txt
+++ b/nav2_dynamic_params/CMakeLists.txt
@@ -21,7 +21,7 @@ set(dependencies
   rclcpp
 )
 
-add_library(nav2_dynamic_params
+add_library(nav2_dynamic_params SHARED
   src/dynamic_params_validator.cpp
 )
 

--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -33,7 +33,7 @@ add_executable(${executable_name}
 
 set(library_name ${executable_name}_core)
 
-add_library(${library_name}
+add_library(${library_name} SHARED
   src/map_representations/occ_grid_server.cpp
   src/map_representations/map_factory.cpp
   src/map_server_ros.cpp

--- a/nav2_mission_executor/CMakeLists.txt
+++ b/nav2_mission_executor/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -29,7 +29,7 @@ add_executable(${executable_name}
 
 set(library_name ${executable_name}_core)
 
-add_library(${library_name}
+add_library(${library_name} SHARED
   src/mission_executor.cpp
   src/execute_mission_behavior_tree.cpp
 )

--- a/nav2_robot/CMakeLists.txt
+++ b/nav2_robot/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -20,7 +20,7 @@ include_directories(
   include
 )
 
-add_library(nav2_robot STATIC
+add_library(nav2_robot SHARED
   src/robot.cpp
 )
 

--- a/nav2_simple_navigator/CMakeLists.txt
+++ b/nav2_simple_navigator/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -29,7 +29,7 @@ add_executable(${executable_name}
 
 set(library_name ${executable_name}_core)
 
-add_library(${library_name}
+add_library(${library_name} SHARED
   src/simple_navigator.cpp
 )
 

--- a/nav2_smart_planner/CMakeLists.txt
+++ b/nav2_smart_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -36,8 +36,7 @@ set(dependencies
   nav_msgs
 )
 
-# Library
-add_library(${library_name}
+add_library(${library_name} SHARED
   src/smart_planner.cpp
   src/navfn.cpp
 )
@@ -46,7 +45,6 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
-# Executable
 add_executable(${executable_name}
   src/main.cpp
 )

--- a/nav2_tasks/CMakeLists.txt
+++ b/nav2_tasks/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -24,7 +24,7 @@ include_directories(
 
 set(library_name ${PROJECT_NAME})
 
-add_library(${library_name}
+add_library(${library_name} SHARED
   src/behavior_tree_engine.cpp
 )
 

--- a/nav2_util/CMakeLists.txt
+++ b/nav2_util/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/nav2_voxel_grid/CMakeLists.txt
+++ b/nav2_voxel_grid/CMakeLists.txt
@@ -16,7 +16,9 @@ find_package(rclcpp REQUIRED)
 include_directories(
   include)
 
-add_library(voxel_grid src/voxel_grid.cpp)
+add_library(voxel_grid SHARED
+  src/voxel_grid.cpp
+)
 
 set(dependencies
   rclcpp

--- a/nav2_world_model/CMakeLists.txt
+++ b/nav2_world_model/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -28,7 +28,7 @@ add_executable(${executable_name}
 
 set(library_name ${executable_name}_core)
 
-add_library(${library_name}
+add_library(${library_name} SHARED
   src/world_model.cpp
 )
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Action item from weekly Navigation WG meeting |
| Primary OS tested on | Ubuntu 16.04 |
| Primary platform tested on | Gazebo 9 |
--- 

## Description of contribution in a few bullet points

* Use position-independent code (-fPIC) for code that's in shared libraries.
* Make other non-node libraries SHARED as well since they could be used by nodes
  in node libraries and this code also needs to be position independent.
