### PR TITLE
Fix robot class to use cmd_vel topic

### DIFF
--- a/nav2_robot/src/robot.cpp
+++ b/nav2_robot/src/robot.cpp
@@ -31,7 +31,7 @@ Robot::Robot(rclcpp::Node::SharedPtr & node)
   odom_sub_ = node_->create_subscription<nav_msgs::msg::Odometry>(
     "odom", std::bind(&Robot::onOdomReceived, this, std::placeholders::_1));
 
-  vel_pub_ = node_->create_publisher<geometry_msgs::msg::Twist>("/cmdVelocity", 1);
+  vel_pub_ = node_->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", 1);
 }
 
 void


### PR DESCRIPTION
One line change to fix robot class. Instead of "cmdVelocity" it is fixed to "cmd_vel" which is the standard.