### PR TITLE
Remapping fixes for the lastest Turtlebot 3 models

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -21,13 +21,13 @@ def generate_launch_description():
             package='tf2_ros',
             node_executable='static_transform_publisher',
             output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_footprint']),
+            arguments=['0', '0', '0', '0', '0', '0', 'base_footprint', 'base_link']),
 
         launch_ros.actions.Node(
             package='tf2_ros',
             node_executable='static_transform_publisher',
             output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'base_footprint', 'base_scan']),
+            arguments=['0', '0', '0', '0', '0', '0', 'base_footprint', 'base_scan_link']),
 
         launch_ros.actions.Node(
             package='nav2_map_server',
@@ -47,7 +47,6 @@ def generate_launch_description():
             node_executable='amcl',
             node_name='amcl',
             output='screen',
-            remappings=[('scan', 'tb3/scan')],
             parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
@@ -55,7 +54,6 @@ def generate_launch_description():
             node_executable='dwb_controller',
             node_name='FollowPathNode',
             output='screen',
-            remappings=[('/cmd_vel', 'tb3/cmd_vel')],
             parameters=[{ 'prune_plan': False }, {'debug_trajectory_details': True }, { 'use_sim_time': use_sim_time }]),
 
         launch_ros.actions.Node(

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -27,7 +27,7 @@ def generate_launch_description():
             package='tf2_ros',
             node_executable='static_transform_publisher',
             output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'base_footprint', 'base_scan_link']),
+            arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_scan_link']),
 
         launch_ros.actions.Node(
             package='nav2_map_server',


### PR DESCRIPTION
The latest turtlebot 3 and gazebo ros packages have changed the names of the frames they publish, the topics they publish/subscribe on. This updates the default launch file with the latest mappings.

Do not merge to master till you update your turtlebot packages.
---

Here are the current versions I'm running for comparison:
turtlebot3: 3423b19e5e (Friday Oct 26)
turtlebot3_msg: 6813d307f3d921 (Aug 16)
turtlebot3_simulations: 15aee4e4c (Nov 15)
gazebo_ros_pkgs: 73a12b7c9b (Sep 12)

Looking at those dates, it seems it must be the turtlebot3_simulations package only that really matters for this change.