### PR TITLE
Amcl  workaround for lack of message_filters

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -63,9 +63,7 @@ using nav2_util::LaserData;
 using namespace std::chrono_literals;
 
 // TODO(crdelsey): This timeout value can probably be entirely removed when
-// message filter support is re-enabled. The default timeout to the transform
-// call is 0 anyhow, so this no longer serves a purpose. A value other than 0
-// causes the node to hang when use_sim_time is active.
+// message filter support is re-enabled. See issue #339
 static const auto TRANSFORM_TIMEOUT = 1s;
 
 static const char scan_topic_[] = "scan";

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -66,7 +66,7 @@ using namespace std::chrono_literals;
 // message filter support is re-enabled. The default timeout to the transform
 // call is 0 anyhow, so this no longer serves a purpose. A value other than 0
 // causes the node to hang when use_sim_time is active.
-static const auto TRANSFORM_TIMEOUT = 0ns;
+static const auto TRANSFORM_TIMEOUT = 1s;
 
 static const char scan_topic_[] = "scan";
 
@@ -101,7 +101,7 @@ AmclNode::AmclNode()
   updatePoseFromServer();
 
   tfb_.reset(new tf2_ros::TransformBroadcaster(node_));
-  tf_.reset(new tf2_ros::Buffer(get_clock()));
+  tf_.reset(new tf2_ros::Buffer(simtime_clock));
   tfl_.reset(new tf2_ros::TransformListener(*tf_));
 
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;

--- a/nav2_amcl/src/amcl_node.hpp
+++ b/nav2_amcl/src/amcl_node.hpp
@@ -241,4 +241,6 @@ private:
   int scan_error_count_ = 0;
 };
 
+extern std::shared_ptr<rclcpp::Clock> simtime_clock;
+
 #endif  // AMCL_NODE_HPP_

--- a/nav2_amcl/src/main.cpp
+++ b/nav2_amcl/src/main.cpp
@@ -36,11 +36,19 @@
 #include "rclcpp/rclcpp.hpp"
 #include "amcl_node.hpp"
 
+std::shared_ptr<rclcpp::Clock> simtime_clock;
+
 int
 main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<AmclNode>());
+  rclcpp::executors::MultiThreadedExecutor exec;
+  auto clockNode = rclcpp::Node::make_shared("amcl_clock_node");
+  simtime_clock = clockNode->get_clock();
+  auto amclNode = std::make_shared<AmclNode>();
+  exec.add_node(clockNode);
+  exec.add_node(amclNode);
+  exec.spin();
   rclcpp::shutdown();
 
   return 0;

--- a/nav2_amcl/src/main.cpp
+++ b/nav2_amcl/src/main.cpp
@@ -42,6 +42,17 @@ int
 main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
+
+  // TODO(crdelsey): This is workaround for Issue #339
+  // Depending on a persons particular setup, most of the time when a laser
+  // scan message is received, the transform for it is not available yet. With
+  // the previous implementation, AMCL would discard that data. On some machines
+  // we could go for thousands of scans without a successful transform resulting
+  // in basically an unusable system. Lacking message filters, the fix for this
+  // is to enable transform timeouts, however, at the moment, transform timeouts
+  // hang when use_sim_time is active. This workaround creates a seperate node
+  // for the sole purpose of provide a clock that can keep updating when the
+  // transform code is in a tight loop waiting for transform data or the timeout.
   rclcpp::executors::MultiThreadedExecutor exec;
   auto clockNode = rclcpp::Node::make_shared("amcl_clock_node");
   simtime_clock = clockNode->get_clock();
@@ -49,6 +60,7 @@ main(int argc, char ** argv)
   exec.add_node(clockNode);
   exec.add_node(amclNode);
   exec.spin();
+
   rclcpp::shutdown();
 
   return 0;


### PR DESCRIPTION
This change addresses #339 and should be removed when message filters are available again (Issue #171)

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |#171, #339  |
| Primary OS tested on | Ubuntu) |
| Primary platform tested on | Gazebo turtlebot 3 |

--- 

## Description of contribution in a few bullet points

* Adds a separate node that can be spun independently of the amcl node, for the sole purpose of allowing the clock to advance when waiting for a transform timeout.
* Adds a transform timeout to AMCL transform calls so they don't fail as often as the sometimes do currently.


