### PR TITLE
Fix loading of stopped goal checker.

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
@@ -34,7 +34,8 @@ add_library(simple_goal_checker SHARED src/simple_goal_checker.cpp)
 ament_target_dependencies(simple_goal_checker ${dependencies})
 
 add_library(stopped_goal_checker SHARED src/stopped_goal_checker.cpp)
-ament_target_dependencies(stopped_goal_checker simple_goal_checker ${dependencies})
+target_link_libraries(stopped_goal_checker simple_goal_checker)
+ament_target_dependencies(stopped_goal_checker ${dependencies})
 
 add_library(standard_traj_generator SHARED
             src/standard_traj_generator.cpp


### PR DESCRIPTION
The `stopped_goal_checker` library was not getting the dependency on the `libsimple_goal_checker.so` set by the `ament_target_dependencies` call. That call is only appropriate for external package dependencies. Dependencies that internal to the same package need to be specified using standard cmake.

The symptom of this bug was that plugin lib failed to load `libstopped_goal_checker.so`

I wasn't able to properly test that this plug in stops the robot at the end due to the current defect in AMCL localization. There is a commit ( 91f47ec ) on the integtation-debug2 branch where I've enabled this by default, but I'm not sure if we want to put this on master. I figure on master, we should just set this parameter through the launch file