### PR TITLE
Add angles back to ros2_dependencies to fix master build

### DIFF
--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -11,3 +11,7 @@ repositories:
     type: git
     url: https://github.com/mjeronimo/BehaviorTree.CPP
     version: master
+  angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2


### PR DESCRIPTION
currently the Travis build of master is failing. I can reproduce this on my system by building the dockerfile locally. 

Error:
--- stderr: dwb_plugins
/ros2_ws/navigation2_ws/src/navigation2/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp:38:10: fatal error: angles/angles.h: No such file or directory
 #include "angles/angles.h"
          ^~~~~~~~~~~~~~~~~