### PR TITLE
System fixes to Costmap 2D

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -70,19 +70,6 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
 {
   node_ = std::shared_ptr<rclcpp::Node>(this, [](rclcpp::Node *) {});
 
-  // Set Parameters if not set
-  set_parameter_if_not_set("transform_tolerance",0.3);
-  set_parameter_if_not_set("update_frequency", 5.0);
-  set_parameter_if_not_set("publish_frequency", 1.0);
-  set_parameter_if_not_set("width", 10);
-  set_parameter_if_not_set("height", 10);
-  set_parameter_if_not_set("resolution", 0.1);
-  set_parameter_if_not_set("origin_x", 0.0);
-  set_parameter_if_not_set("origin_y", 0.0);
-  set_parameter_if_not_set("footprint", "[]");
-  set_parameter_if_not_set("footprint_padding", 0.01);
-  set_parameter_if_not_set("robot_radius", 0.1);
-
   std::vector<std::string> plugin_names;
   std::vector<std::string> plugin_types; 
   get_parameter_or_set("plugin_names", plugin_names, {"static_layer","inflation_layer", "obstacle_layer"});
@@ -176,6 +163,20 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
     {"transform_tolerance", "update_frequency", "publish_frequency", "width", "height",
     "resolution", "origin_x", "origin_y", "footprint_padding", "robot_radius", "footprint"});
   dynamic_param_client_->set_callback(std::bind(&Costmap2DROS::reconfigureCB, this));
+
+  // Set these parameters *after* the dynamic params stuff is set up
+  // so that the reconfigure callback is called
+  set_parameter_if_not_set("transform_tolerance",0.3);
+  set_parameter_if_not_set("update_frequency", 5.0);
+  set_parameter_if_not_set("publish_frequency", 1.0);
+  set_parameter_if_not_set("width", 10);
+  set_parameter_if_not_set("height", 10);
+  set_parameter_if_not_set("resolution", 0.1);
+  set_parameter_if_not_set("origin_x", 0.0);
+  set_parameter_if_not_set("origin_y", 0.0);
+  set_parameter_if_not_set("footprint", "[]");
+  set_parameter_if_not_set("footprint_padding", 0.01);
+  set_parameter_if_not_set("robot_radius", 0.1);
 }
 
 void Costmap2DROS::setUnpaddedRobotFootprintPolygon(

--- a/nav2_robot/src/robot.cpp
+++ b/nav2_robot/src/robot.cpp
@@ -40,6 +40,7 @@ Robot::onPoseReceived(const geometry_msgs::msg::PoseWithCovarianceStamped::Share
   // TODO(mjeronimo): serialize access
   current_pose_ = msg;
   if (!initial_pose_received_) {
+    RCLCPP_INFO(node_->get_logger(), "Received initial pose");
     initial_pose_received_ = true;
   }
 }

--- a/nav2_tasks/include/nav2_tasks/navigate_to_pose_task.hpp
+++ b/nav2_tasks/include/nav2_tasks/navigate_to_pose_task.hpp
@@ -53,6 +53,7 @@ protected:
   std::unique_ptr<nav2_tasks::NavigateToPoseTaskClient> self_client_;
   void onGoalPoseReceived(const geometry_msgs::msg::PoseStamped::SharedPtr pose)
   {
+    RCLCPP_INFO(node_->get_logger(), "Received move_base_simple/goal");
     self_client_->sendCommand(pose);
   }
 };


### PR DESCRIPTION
This is to improve system stability and ease of traceability
* This cherry-picks a commit from the integration-debug2 branch made by mjeronimo which moves the parameter setting to the end of the Costmap 2D constructor
* This adds 2 INFO messages for the /initialpose and /move_base_simple/goal topics for ease of traceability
 * Adds a 'wait_for_tf' parameter with a default of false to Costmap 2D constructor to bypass waiting for the transform to be there. At a future date, we could deprecate this entirely since we think it makes the system less stable. By making it controlled by a parameter, we make it possible for a user to enable it if they have a use case requiring it
