### PR TITLE
Update behavior tree cpp

### DIFF
--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(std_msgs REQUIRED)
 find_package(nav2_tasks REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav2_robot REQUIRED)
-find_package(behavior_tree_core REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
 
 include_directories(
   include
@@ -41,7 +41,7 @@ set(dependencies
   nav2_tasks
   nav2_msgs
   nav2_robot
-  behavior_tree_core
+  behaviortree_cpp
 )
 
 ament_target_dependencies(${executable_name}

--- a/nav2_bt_navigator/behavior_trees/parallel.xml
+++ b/nav2_bt_navigator/behavior_trees/parallel.xml
@@ -19,7 +19,7 @@
   <BehaviorTree ID="MainTree">
     <SequenceStar name="root">
       <ComputePathToPose endpoints="${endpoints}" path="${path}"/>
-      <Parallel threshold="1">
+      <ParallelNode threshold="1">
         <FollowPath path="${path}"/>
         <Sequence>
           <RateController hz="2">
@@ -27,7 +27,7 @@
           </RateController>
           <UpdatePath/>
         </Sequence>
-      </Parallel>
+      </ParallelNode>
     </SequenceStar>
   </BehaviorTree>
 </root>

--- a/nav2_bt_navigator/behavior_trees/parallel.xml
+++ b/nav2_bt_navigator/behavior_trees/parallel.xml
@@ -19,7 +19,7 @@
   <BehaviorTree ID="MainTree">
     <SequenceStar name="root">
       <ComputePathToPose endpoints="${endpoints}" path="${path}"/>
-      <Parallel threshold_M="1">
+      <Parallel threshold="1">
         <FollowPath path="${path}"/>
         <Sequence>
           <RateController hz="2">

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -20,7 +20,7 @@
 #include "nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp"
 #include "nav2_tasks/compute_path_to_pose_task.hpp"
 #include "nav2_tasks/bt_conversions.hpp"
-#include "Blackboard/blackboard_local.h"
+#include "behaviortree_cpp/blackboard/blackboard_local.h"
 
 using nav2_tasks::TaskStatus;
 

--- a/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
+++ b/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
@@ -38,9 +38,6 @@ NavigateToPoseBehaviorTree::NavigateToPoseBehaviorTree(rclcpp::Node::SharedPtr n
   factory_.registerSimpleAction("UpdatePath",
     std::bind(&NavigateToPoseBehaviorTree::updatePath, this, std::placeholders::_1));
 
-  // The parallel node is not yet registered in the BehaviorTree.CPP library
-  factory_.registerNodeType<BT::ParallelNode>("Parallel");
-
   follow_path_task_client_ = std::make_unique<nav2_tasks::FollowPathTaskClient>(node);
 }
 

--- a/nav2_mission_executor/CMakeLists.txt
+++ b/nav2_mission_executor/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(nav2_tasks REQUIRED)
 find_package(nav2_msgs REQUIRED)
-find_package(behavior_tree_core REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
 
 include_directories(
   include
@@ -39,7 +39,7 @@ set(dependencies
   std_msgs
   nav2_tasks
   nav2_msgs
-  behavior_tree_core
+  behaviortree_cpp
 )
 
 ament_target_dependencies(${executable_name}

--- a/nav2_tasks/CMakeLists.txt
+++ b/nav2_tasks/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(std_msgs REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
-find_package(behavior_tree_core REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
 
 include_directories(
   include
@@ -32,7 +32,7 @@ set(dependencies
   rclcpp
   geometry_msgs
   nav2_msgs
-  behavior_tree_core
+  behaviortree_cpp
 )
 
 ament_target_dependencies(${library_name}

--- a/nav2_tasks/include/nav2_tasks/behavior_tree_engine.hpp
+++ b/nav2_tasks/include/nav2_tasks/behavior_tree_engine.hpp
@@ -17,10 +17,10 @@
 
 #include <string>
 #include "rclcpp/rclcpp.hpp"
-#include "behavior_tree_core/behavior_tree.h"
-#include "behavior_tree_core/bt_factory.h"
-#include "behavior_tree_core/xml_parsing.h"
-#include "Blackboard/blackboard_local.h"
+#include "behaviortree_cpp/behavior_tree.h"
+#include "behaviortree_cpp/bt_factory.h"
+#include "behaviortree_cpp/xml_parsing.h"
+#include "behaviortree_cpp/blackboard/blackboard_local.h"
 #include "nav2_tasks/task_status.hpp"
 
 namespace nav2_tasks

--- a/nav2_tasks/include/nav2_tasks/bt_action_node.hpp
+++ b/nav2_tasks/include/nav2_tasks/bt_action_node.hpp
@@ -22,8 +22,8 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_tasks/task_client.hpp"
-#include "behavior_tree_core/action_node.h"
-#include "behavior_tree_core/bt_factory.h"
+#include "behaviortree_cpp/action_node.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 namespace nav2_tasks
 {

--- a/nav2_tasks/include/nav2_tasks/bt_conversions.hpp
+++ b/nav2_tasks/include/nav2_tasks/bt_conversions.hpp
@@ -16,7 +16,8 @@
 #define NAV2_TASKS__BT_CONVERSIONS_HPP_
 
 #include <string>
-#include "behavior_tree_core/behavior_tree.h"
+#include "behaviortree_cpp/behavior_tree.h"
+#include "behaviortree_cpp/blackboard/blackboard.h"
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "nav2_msgs/msg/path.hpp"
@@ -29,25 +30,25 @@ namespace BT
 // but are not actually called. TODO(mjeronimo): See if we can avoid these.
 
 template<>
-inline rclcpp::Node::SharedPtr convertFromString(const std::string & /*key*/)
+inline rclcpp::Node::SharedPtr convertFromString(const StringView & /*key*/)
 {
   return nullptr;
 }
 
 template<>
-inline std::chrono::milliseconds convertFromString(const std::string & /*key*/)
+inline std::chrono::milliseconds convertFromString(const StringView & /*key*/)
 {
   return std::chrono::milliseconds(0);
 }
 
 template<>
-inline nav2_msgs::msg::Path::SharedPtr convertFromString(const std::string & /*key*/)
+inline nav2_msgs::msg::Path::SharedPtr convertFromString(const StringView & /*key*/)
 {
   return nullptr;
 }
 
 template<>
-inline nav2_msgs::msg::PathEndPoints::SharedPtr convertFromString(const std::string & /*key*/)
+inline nav2_msgs::msg::PathEndPoints::SharedPtr convertFromString(const StringView & /*key*/)
 {
   return nullptr;
 }
@@ -55,7 +56,7 @@ inline nav2_msgs::msg::PathEndPoints::SharedPtr convertFromString(const std::str
 // These are needed to be able to set parameters for these types in the BT XML
 
 template<>
-inline geometry_msgs::msg::Point convertFromString(const std::string & key)
+inline geometry_msgs::msg::Point convertFromString(const StringView & key)
 {
   // three real numbers separated by semicolons
   auto parts = BT::splitString(key, ';');
@@ -71,7 +72,7 @@ inline geometry_msgs::msg::Point convertFromString(const std::string & key)
 }
 
 template<>
-inline geometry_msgs::msg::Quaternion convertFromString(const std::string & key)
+inline geometry_msgs::msg::Quaternion convertFromString(const StringView & key)
 {
   // three real numbers separated by semicolons
   auto parts = BT::splitString(key, ';');

--- a/nav2_tasks/include/nav2_tasks/rate_controller_node.hpp
+++ b/nav2_tasks/include/nav2_tasks/rate_controller_node.hpp
@@ -17,7 +17,7 @@
 
 #include <string>
 #include <chrono>
-#include "behavior_tree_core/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 
 namespace nav2_tasks
 {

--- a/nav2_tasks/src/behavior_tree_engine.cpp
+++ b/nav2_tasks/src/behavior_tree_engine.cpp
@@ -16,7 +16,7 @@
 
 #include <string>
 #include "geometry_msgs/msg/pose2_d.hpp"
-#include "Blackboard/blackboard_local.h"
+#include "behaviortree_cpp/blackboard/blackboard_local.h"
 #include "nav2_tasks/navigate_to_pose_action.hpp"
 #include "nav2_tasks/compute_path_to_pose_action.hpp"
 #include "nav2_tasks/follow_path_action.hpp"

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -1,8 +1,8 @@
 repositories:
   behavior_tree_core:
     type: git
-    url: https://github.com/mjeronimo/BehaviorTree.CPP
-    version: bt-12-4-2018
+    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+    version: 5904431
   angles:
     type: git
     url: https://github.com/ros/angles.git

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   behavior_tree_core:
     type: git
     url: https://github.com/mjeronimo/BehaviorTree.CPP
-    version: bt-10-21
+    version: bt-12-4-2018
   angles:
     type: git
     url: https://github.com/ros/angles.git

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   behavior_tree_core:
     type: git
     url: https://github.com/mjeronimo/BehaviorTree.CPP
-    version: master
+    version: bt-10-21
   angles:
     type: git
     url: https://github.com/ros/angles.git


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu 18.04 |
| Primary platform tested on | NUC, HP Envy |

--- 

## Description of contribution in a few bullet points

* Update the BehaviorTree.CPP library to the latest version. This version fixes a few issues
    - M_PI macro undefined on Ubuntu 18.04
    - New ParallelNode constructor added so that it can be registered with the bt_factory 
    - ParallelNode is registered in the library so that it can be used in XML
--- 

## Future work that may be required in bullet points

* What remains is to provide a PR to the BehaviorTree repo for the colcon-enabled CMakeLists.txt
* Work with @SteveMacenski to understand how we can incorporate this library into our official build 

