### PR TITLE
Add return paths from the DWB controller stop the robot

### DIFF
--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -78,6 +78,7 @@ DwbController::followPath(const nav2_tasks::FollowPathCommand::SharedPtr command
         if (task_server_->cancelRequested()) {
           RCLCPP_INFO(this->get_logger(), "execute: task has been canceled");
           task_server_->setCanceled();
+          publishZeroVelocity();
           return TaskStatus::CANCELED;
         }
       }
@@ -85,11 +86,13 @@ DwbController::followPath(const nav2_tasks::FollowPathCommand::SharedPtr command
     }
   } catch (nav_core2::PlannerException & e) {
     RCLCPP_INFO(this->get_logger(), e.what());
+    publishZeroVelocity();
     return TaskStatus::FAILED;
   }
 
   nav2_tasks::FollowPathResult result;
   task_server_->setResult(result);
+  publishZeroVelocity();
 
   return TaskStatus::SUCCEEDED;
 }


### PR DESCRIPTION
## Description of contribution in a few bullet points

* The DWB controller will now stop the robot upon any return from the execution of the FollowPath command - success, failure, or cancelation. 