### PR TITLE
Tb3 latest remappings

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -21,13 +21,13 @@ def generate_launch_description():
             package='tf2_ros',
             node_executable='static_transform_publisher',
             output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_footprint']),
+            arguments=['0', '0', '0', '0', '0', '0', 'base_footprint', 'base_link']),
 
         launch_ros.actions.Node(
             package='tf2_ros',
             node_executable='static_transform_publisher',
             output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'base_footprint', 'base_scan']),
+            arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_scan_link']),
 
         launch_ros.actions.Node(
             package='nav2_map_server',
@@ -47,7 +47,6 @@ def generate_launch_description():
             node_executable='amcl',
             node_name='amcl',
             output='screen',
-            remappings=[('scan', 'tb3/scan')],
             parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
@@ -55,7 +54,6 @@ def generate_launch_description():
             node_executable='dwb_controller',
             node_name='FollowPathNode',
             output='screen',
-            remappings=[('/cmd_vel', 'tb3/cmd_vel')],
             parameters=[{ 'prune_plan': False }, {'debug_trajectory_details': True }, { 'use_sim_time': use_sim_time }]),
 
         launch_ros.actions.Node(

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -27,7 +27,7 @@ def generate_launch_description():
             package='tf2_ros',
             node_executable='static_transform_publisher',
             output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_scan_link']),
+            arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_scan']),
 
         launch_ros.actions.Node(
             package='nav2_map_server',


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |gazebo simulation of TB3 |

---

## Description of contribution in a few bullet points

* Updates the bringup launch file to be compatible with the latest Turtlebot 3 topic and frame names.
* This should be compatible with turtlebot3_simulations  ROBOTIS-GIT/turtlebot3_simulations@41db458a5 or newer. In other words, newer than Nov 18, 2018.