### PR TITLE
Disable dynamic parameters to allow stable costmap startup.

### DIFF
--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -110,10 +110,10 @@ void InflationLayer::reconfigureCB()
   bool inflate_unknown;
   bool enabled;
 
-  dynamic_param_client_->get_event_param_or(name_ + "." + "inflation_radius", inflation_radius, 0.55);
-  dynamic_param_client_->get_event_param_or(name_ + "." + "cost_scaling_factor", cost_scaling_factor, 10.0);
-  dynamic_param_client_->get_event_param_or(name_ + "." + "inflate_unknown", inflate_unknown, false);
-  dynamic_param_client_->get_event_param_or(name_ + "." + "enabled", enabled, true);
+  node_->get_parameter_or(name_ + "." + "inflation_radius", inflation_radius, 0.55);
+  node_->get_parameter_or(name_ + "." + "cost_scaling_factor", cost_scaling_factor, 10.0);
+  node_->get_parameter_or(name_ + "." + "inflate_unknown", inflate_unknown, false);
+  node_->get_parameter_or(name_ + "." + "enabled", enabled, true);
 
   setInflationParameters(inflation_radius, cost_scaling_factor);
 

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -256,10 +256,10 @@ void ObstacleLayer::reconfigureCB()
 {
   RCLCPP_DEBUG(node_->get_logger(), "ObstacleLayer:: Event Callback");
 
-  dynamic_param_client_->get_event_param(name_ + "." + "enabled", enabled_); 
-  dynamic_param_client_->get_event_param(name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_); 
-  dynamic_param_client_->get_event_param(name_ + "." + "max_obstacle_height", max_obstacle_height_); 
-  dynamic_param_client_->get_event_param(name_ + "." + "combination_method", combination_method_); 
+  node_->get_parameter(name_ + "." + "enabled", enabled_); 
+  node_->get_parameter(name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_); 
+  node_->get_parameter(name_ + "." + "max_obstacle_height", max_obstacle_height_); 
+  node_->get_parameter(name_ + "." + "combination_method", combination_method_); 
 }
 
 void ObstacleLayer::laserScanCallback(sensor_msgs::msg::LaserScan::ConstSharedPtr message,

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -131,7 +131,7 @@ void StaticLayer::reconfigureCB()
   RCLCPP_DEBUG(node_->get_logger(), "StaticLayer:: Event Callback");
 
   bool enabled = true;
-  dynamic_param_client_->get_event_param_or(name_ + "." + "enabled", enabled, true); 
+  node_->get_parameter_or(name_ + "." + "enabled", enabled, true); 
 
   if (enabled != enabled_)
   {

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -54,15 +54,15 @@ void VoxelLayer::onInitialize()
 {
   ObstacleLayer::onInitialize();
 
-  node_->set_parameter_if_not_set(name_ + "." + "enabled", true); 
-  node_->set_parameter_if_not_set(name_ + "." + "footprint_clearing_enabled", true); 
-  node_->set_parameter_if_not_set(name_ + "." + "max_obstacle_height", 2.0); 
-  node_->set_parameter_if_not_set(name_ + "." + "z_voxels", 10); 
-  node_->set_parameter_if_not_set(name_ + "." + "origin_z", 0.0); 
-  node_->set_parameter_if_not_set(name_ + "." + "z_resolution", 0.2); 
+  node_->set_parameter_if_not_set(name_ + "." + "enabled", true);
+  node_->set_parameter_if_not_set(name_ + "." + "footprint_clearing_enabled", true);
+  node_->set_parameter_if_not_set(name_ + "." + "max_obstacle_height", 2.0);
+  node_->set_parameter_if_not_set(name_ + "." + "z_voxels", 10);
+  node_->set_parameter_if_not_set(name_ + "." + "origin_z", 0.0);
+  node_->set_parameter_if_not_set(name_ + "." + "z_resolution", 0.2);
   node_->set_parameter_if_not_set(name_ + "." + "unknown_threshold", 15);
-  node_->set_parameter_if_not_set(name_ + "." + "mark_threshold", 0); 
-  node_->set_parameter_if_not_set(name_ + "." + "combination_method", 1); 
+  node_->set_parameter_if_not_set(name_ + "." + "mark_threshold", 0);
+  node_->set_parameter_if_not_set(name_ + "." + "combination_method", 1);
 
   node_->get_parameter_or<bool>("publish_voxel_map", publish_voxel_, false);
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
@@ -102,16 +102,16 @@ void VoxelLayer::reconfigureCB()
 {
   RCLCPP_DEBUG(node_->get_logger(), "VoxelLayer:: Event Callback");
 
-  dynamic_param_client_->get_event_param(name_ + "." + "enabled", enabled_); 
-  dynamic_param_client_->get_event_param(name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_); 
-  dynamic_param_client_->get_event_param(name_ + "." + "max_obstacle_height", max_obstacle_height_); 
-  dynamic_param_client_->get_event_param(name_ + "." + "z_voxels", size_z_); 
-  dynamic_param_client_->get_event_param(name_ + "." + "origin_z", origin_z_); 
-  dynamic_param_client_->get_event_param(name_ + "." + "z_resolution", z_resolution_); 
-  dynamic_param_client_->get_event_param(name_ + "." + "unknown_threshold", unknown_threshold_);
+  node_->get_parameter(name_ + "." + "enabled", enabled_);
+  node_->get_parameter(name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_);
+  node_->get_parameter(name_ + "." + "max_obstacle_height", max_obstacle_height_);
+  node_->get_parameter(name_ + "." + "z_voxels", size_z_);
+  node_->get_parameter(name_ + "." + "origin_z", origin_z_);
+  node_->get_parameter(name_ + "." + "z_resolution", z_resolution_);
+  node_->get_parameter(name_ + "." + "unknown_threshold", unknown_threshold_);
   unknown_threshold_ += (VOXEL_BITS - size_z_);
-  dynamic_param_client_->get_event_param(name_ + "." + "mark_threshold", mark_threshold_); 
-  dynamic_param_client_->get_event_param(name_ + "." + "combination_method", combination_method_); 
+  node_->get_parameter(name_ + "." + "mark_threshold", mark_threshold_);
+  node_->get_parameter(name_ + "." + "combination_method", combination_method_);
   matchSize();
 }
 

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -204,7 +204,7 @@ void Costmap2DROS::reconfigureCB()
 {
   RCLCPP_DEBUG(node_->get_logger(), "Costmap2DROS:: Event Callback");
 
-  dynamic_param_client_->get_event_param("transform_tolerance", transform_tolerance_);
+  get_parameter("transform_tolerance", transform_tolerance_);
 
   if (map_update_thread_ != NULL)
   {
@@ -214,10 +214,10 @@ void Costmap2DROS::reconfigureCB()
   }
   map_update_thread_shutdown_ = false;
   double map_update_frequency = 1.0;
-  dynamic_param_client_->get_event_param("update_frequency", map_update_frequency);
+  get_parameter("update_frequency", map_update_frequency);
 
   double map_publish_frequency = 5.0;
-  dynamic_param_client_->get_event_param("publish_frequency", map_publish_frequency);
+  get_parameter("publish_frequency", map_publish_frequency);
 
   if (map_publish_frequency > 0)
     publish_cycle_ = nav2_util::durationFromSeconds(1 / map_publish_frequency);
@@ -228,11 +228,11 @@ void Costmap2DROS::reconfigureCB()
   double resolution, origin_x, origin_y;
   int map_width_meters, map_height_meters;
 
-  dynamic_param_client_->get_event_param("width", map_width_meters); 
-  dynamic_param_client_->get_event_param("height", map_height_meters);
-  dynamic_param_client_->get_event_param("resolution", resolution);
-  dynamic_param_client_->get_event_param("origin_x", origin_x);
-  dynamic_param_client_->get_event_param("origin_y", origin_y); 
+  get_parameter("width", map_width_meters);
+  get_parameter("height", map_height_meters);
+  get_parameter("resolution", resolution);
+  get_parameter("origin_x", origin_x);
+  get_parameter("origin_y", origin_y);
 
   if (!layered_costmap_->isSizeLocked())
   {
@@ -243,7 +243,7 @@ void Costmap2DROS::reconfigureCB()
   // If the padding has changed, call setUnpaddedRobotFootprint() to
   // re-apply the padding.
   float footprint_padding;
-  dynamic_param_client_->get_event_param("footprint_padding", footprint_padding);
+  node_->get_parameter("footprint_padding", footprint_padding);
 
   if (footprint_padding_ != footprint_padding)
   {
@@ -265,14 +265,8 @@ void Costmap2DROS::readFootprintFromConfig()
 
   std::string footprint;
   double robot_radius;
-  dynamic_param_client_->get_event_param("footprint", footprint); 
-  dynamic_param_client_->get_event_param("robot_radius", robot_radius); 
-
-  if (!dynamic_param_client_->is_in_event("footprint") &&
-    !dynamic_param_client_->is_in_event("robot_radius"))
-    {
-      return;
-    }
+  get_parameter("footprint", footprint);
+  get_parameter("robot_radius", robot_radius);
 
   if (footprint != "" && footprint != "[]")
   {


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo simulation of TB 3  |

---

## Description of contribution in a few bullet points

* This change effectively disables dynamic reconfigure in costmap and forces it to get parameters directly off the node.
* This is needed due to race conditions in dynamic parameter client due to the use of a seperate SyncParametersClient. When working with parameters on the same node, this has issues when run in a blocking thread.