### PR TITLE
Default to a valid laser scan message type.

### DIFF
--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -94,12 +94,12 @@ void ObstacleLayer::onInitialize()
     double observation_keep_time, expected_update_rate, min_obstacle_height, max_obstacle_height;
     std::string topic, sensor_frame, data_type;
     bool inf_is_valid, clearing, marking;
-  
+
     node_->get_parameter_or(source + "." + "topic", topic, source);
     node_->get_parameter_or(source + "." + "sensor_frame", sensor_frame, std::string(""));
     node_->get_parameter_or(source + "." + "observation_persistence", observation_keep_time, 0.0);
     node_->get_parameter_or(source + "." + "expected_update_rate", expected_update_rate, 0.0);
-    node_->get_parameter_or(source + "." + "data_type", data_type, std::string("PointCloud"));
+    node_->get_parameter_or(source + "." + "data_type", data_type, std::string("LaserScan"));
     node_->get_parameter_or(source + "." + "min_obstacle_height", min_obstacle_height, 0.0);
     node_->get_parameter_or(source + "." + "max_obstacle_height", max_obstacle_height, 0.0);
     node_->get_parameter_or(source + "." + "inf_is_valid", inf_is_valid, false);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  Gazebo Turtlebot 3|

---

## Description of contribution in a few bullet points

* The obstacle layer listens to laser scan messages and accepts two types: PointCloud2 or LaserScan. The type gets specified in a parameter, however, the default value for that parameter is PointCloud, which is invalid. This change makes the default value a valid type. I've chosen the type provided by Turtlebot 3 which is LaserScan
---

## Future work that may be required in bullet points

* Add obstacle layer parameters to the launch file. I've got a change for that locally.
* Add message filters back to obstacle layer.
