### PR TITLE
Dockerfile change  to copy navigation2 source code from the current repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ notifications:
       - matthew.k.hansen@intel.com
 
 before_install:
+  - if [ "${TRAVIS_REPO_SLUG}" != "ros-planning/navigation2" ]; then echo "Travis CI is supported only in ros-planning/navigation2" && exit 1; fi
   - docker build -t nav2:latest --build-arg PULLREQ=$TRAVIS_PULL_REQUEST .
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,21 +63,9 @@ WORKDIR /ros2_ws
 RUN wget -nv https://ci.ros2.org/view/packaging/job/packaging_linux/lastSuccessfulBuild/artifact/ws/ros2-package-linux-x86_64.tar.bz2
 RUN tar -xjf ros2-package-linux-x86_64.tar.bz2
 
-# clone navigation2 repo
+# Copy navigation2 repo
 WORKDIR /ros2_ws/navigation2_ws/src
-RUN git clone https://github.com/ros-planning/navigation2.git
-
-# change to correct branch if $BRANCH is not = master
-WORKDIR /ros2_ws/navigation2_ws/src/navigation2
-ARG PULLREQ=false
-RUN echo "pullreq is $PULLREQ"
-RUN if [ "$PULLREQ" == "false" ]; \
-    then \
-      echo "No pull request number given - defaulting to master branch"; \
-    else \
-      git fetch origin pull/$PULLREQ/head:pr_branch; \
-      git checkout pr_branch; \
-    fi
+COPY ./ navigation2/
 
 # Download dependencies
 RUN echo "Downloading the ROS 2 navstack dependencies workspace"


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (N/A) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (N/A) |

---

## Description of contribution in a few bullet points

Fixing the logic on how source code gets into the docker image.  The previous version always was cloning from `ros-panning/navigation2` that is unexpected for:
- Local build
- Travis build in a forked repo

I hit this problem when was testing a fix for `colcon test` of one of the packages.  I was confident the fix was right, it worked locally, but Travis build was failing.  After some time I saw the code in this file that is ignoring all the changes, but gets source code from the master of ros-planning/navigation2.

@mkhansen-intel 