### PR TITLE
Put local and global costmaps into separate namespaces

### DIFF
--- a/nav2_bringup/README.md
+++ b/nav2_bringup/README.md
@@ -2,7 +2,7 @@
 
 The `nav2_bringup` package is an example bringup system for navigation2 applications.
 
-Notes: (December 2018, Crystal Release) 
+Notes: (December 2018, Crystal Release)
 * We recommend doing this on a Ubuntu 18.04 installation. We’re currently having build issues on 16.04. (see https://github.com/ros-planning/navigation2/issues/353)
 * This stack and ROS2 are still in heavy development and there are some bugs and stability issues being worked on, so please do not try this on a robot without taking *heavy* safety precautions. THE ROBOT MAY CRASH!
 * It is recommended to start with simulation using Gazebo before proceeding to run on a physical robot
@@ -43,12 +43,17 @@ Run the rest of the Navigation2 bringup
 
 `ros2 launch nav2_bringup nav2_bringup_2nd_launch.py use_sim_time:=True`
 
-Set the World Model node to use simulation time
+Set the World Model and the two costmap nodes to use simulation time
 
-`ros2 param set /world_model use_sim_time True`
+```
+ros2 param set /world_model use_sim_time True
+ros2 param set /global_costmap/global_costmap use_sim_time True
+ros2 param set /local_costmap/local_costmap use_sim_time True
+```
 
 Notes:
 * Setting use_sim_time has to be done dynamically after the nodes are up due to this bug:https://github.com/ros2/rclcpp/issues/595
+* Sim time needs to be set in every namespace individually.
 * Sometimes setting use_sim_time a second time is required for all the nodes to get updated
 * IF you continue to see WARN messages like the ones below, retry setting the use_sim_time parameter
 ```
@@ -91,7 +96,7 @@ Pre-requisites:
 * You've completed bringup of your robot successfully following the 2-step process above
 * You know your transforms are being published correctly and AMCL can localize
 
-Follow directions above *except* 
+Follow directions above *except*
 * Instead of running the `nav2_bringup_1st_launch.py` then the `nav2_bringup_2nd_launch.py`
 * You can do it in one step like this:
 ```
@@ -100,7 +105,7 @@ ros2 launch nav2_bringup nav2_bringup_launch.py map:=<full/path/to/map.yaml>
 If running in simulation:
 ```
 ros2 launch nav2_bringup nav2_bringup_launch.py map:=<full/path/to/map.yaml> use_sim_time:=True
-ros2 param set /world_model use_sim_time True
+ros2 param set /world_model use_sim_time True; ros2 param set /global_costmap/global_costmap use_sim_time True; ros2 param set /local_costmap/local_costmap use_sim_time True
 ```
 
 ## Future Work

--- a/nav2_bringup/config/nav2_default_view.rviz
+++ b/nav2_bringup/config/nav2_default_view.rviz
@@ -8,7 +8,8 @@ Panels:
         - /RobotModel1/Status1
         - /TF1/Frames1
         - /TF1/Tree1
-        - /Gobal Planner1/Global Costmap1
+        - /Global Planner1
+        - /Global Planner1/Global Costmap1
       Splitter Ratio: 0.5833333134651184
     Tree Height: 574
   - Class: rviz_common/Selection
@@ -230,7 +231,7 @@ Visualization Manager:
           Unreliable: false
           Value: false
       Enabled: true
-      Name: Gobal Planner
+      Name: Global Planner
     - Class: rviz_common/Group
       Displays:
         - Alpha: 0.699999988

--- a/nav2_bringup/config/nav2_default_view.rviz
+++ b/nav2_bringup/config/nav2_default_view.rviz
@@ -197,7 +197,7 @@ Visualization Manager:
           Queue Size: 10
           Topic: /endpoints
           Unreliable: false
-          Value: true
+          Value: false
         - Alpha: 1
           Buffer Length: 1
           Class: rviz_default_plugins/Path

--- a/nav2_bringup/config/nav2_default_view.rviz
+++ b/nav2_bringup/config/nav2_default_view.rviz
@@ -8,11 +8,9 @@ Panels:
         - /RobotModel1/Status1
         - /TF1/Frames1
         - /TF1/Tree1
-        - /LaserScan1/Status1
-        - /Gobal Planner1
-        - /Local Planner1
-      Splitter Ratio: 0.583333313
-    Tree Height: 584
+        - /Gobal Planner1/Global Costmap1
+      Splitter Ratio: 0.5833333134651184
+    Tree Height: 574
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -77,14 +75,10 @@ Visualization Manager:
           Value: true
         base_scan:
           Value: false
-        left_wheel:
-          Value: false
         map:
           Value: true
         odom:
           Value: true
-        right_wheel:
-          Value: false
       Marker Scale: 1
       Name: TF
       Show Arrows: true
@@ -93,14 +87,8 @@ Visualization Manager:
       Tree:
         map:
           odom:
-            base_link:
-              base_footprint:
-                base_scan:
-                  {}
-              left_wheel:
-                {}
-              right_wheel:
-                {}
+            base_footprint:
+              {}
       Update Interval: 0
       Value: true
     - Alpha: 1
@@ -128,7 +116,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.00999999978
       Style: Flat Squares
-      Topic: /tb3/scan
+      Topic: /scan
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -173,16 +161,6 @@ Visualization Manager:
       Unreliable: false
       Use Timestamp: false
       Value: true
-    - Alpha: 0.200000003
-      Class: rviz_default_plugins/Map
-      Color Scheme: costmap
-      Draw Behind: false
-      Enabled: true
-      Name: Costmap
-      Topic: /costmap
-      Unreliable: false
-      Use Timestamp: false
-      Value: true
     - Alpha: 1
       Arrow Length: 0.0199999996
       Axes Length: 0.300000012
@@ -205,21 +183,21 @@ Visualization Manager:
           Class: rviz_default_plugins/Map
           Color Scheme: map
           Draw Behind: true
-          Enabled: true
+          Enabled: false
           Name: Global Costmap
           Topic: /global_costmap/costmap
           Unreliable: false
           Use Timestamp: false
-          Value: true
+          Value: false
         - Class: rviz_default_plugins/Marker
-          Enabled: false
+          Enabled: true
           Name: PathEndPoints
           Namespaces:
             {}
           Queue Size: 10
           Topic: /endpoints
           Unreliable: false
-          Value: false
+          Value: true
         - Alpha: 1
           Buffer Length: 1
           Class: rviz_default_plugins/Path
@@ -243,13 +221,21 @@ Visualization Manager:
           Topic: /global_plan
           Unreliable: false
           Value: true
+        - Alpha: 1
+          Class: rviz_default_plugins/Polygon
+          Color: 25; 255; 0
+          Enabled: false
+          Name: Polygon
+          Topic: /global_costmap/footprint
+          Unreliable: false
+          Value: false
       Enabled: true
       Name: Gobal Planner
     - Class: rviz_common/Group
       Displays:
         - Alpha: 0.699999988
           Class: rviz_default_plugins/Map
-          Color Scheme: map
+          Color Scheme: costmap
           Draw Behind: false
           Enabled: true
           Name: Local Costmap
@@ -287,6 +273,14 @@ Visualization Manager:
             {}
           Queue Size: 10
           Topic: /marker
+          Unreliable: false
+          Value: true
+        - Alpha: 1
+          Class: rviz_default_plugins/Polygon
+          Color: 25; 255; 0
+          Enabled: true
+          Name: Polygon
+          Topic: /local_costmap/footprint
           Unreliable: false
           Value: true
       Enabled: true

--- a/nav2_bringup/launch/nav2_bringup_2nd_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_2nd_launch.py
@@ -5,6 +5,8 @@ import launch_ros.actions
 
 def generate_launch_description():
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
+    params_file = launch.substitutions.LaunchConfiguration('params', default=
+        [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -22,7 +24,7 @@ def generate_launch_description():
             node_executable='dwb_controller',
             node_name='FollowPathNode',
             output='screen',
-            parameters=[{ 'prune_plan': False }, {'debug_trajectory_details': True }, { 'use_sim_time': use_sim_time }]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_navfn_planner',

--- a/nav2_bringup/launch/nav2_bringup_2nd_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_2nd_launch.py
@@ -15,14 +15,12 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='nav2_world_model',
             node_executable='world_model',
-            node_name='world_model',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='dwb_controller',
             node_executable='dwb_controller',
-            node_name='FollowPathNode',
             output='screen',
             parameters=[params_file]),
 
@@ -31,20 +29,20 @@ def generate_launch_description():
             node_executable='navfn_planner',
             node_name='navfn_planner',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_simple_navigator',
             node_executable='simple_navigator',
             node_name='simple_navigator',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_mission_executor',
             node_executable='mission_executor',
             node_name='mission_executor',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
     ])

--- a/nav2_bringup/launch/nav2_bringup_2nd_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_2nd_launch.py
@@ -29,20 +29,20 @@ def generate_launch_description():
             node_executable='navfn_planner',
             node_name='navfn_planner',
             output='screen',
-            parameters=[params_file]),
+            parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
             package='nav2_simple_navigator',
             node_executable='simple_navigator',
             node_name='simple_navigator',
             output='screen',
-            parameters=[params_file]),
+            parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
             package='nav2_mission_executor',
             node_executable='mission_executor',
             node_name='mission_executor',
             output='screen',
-            parameters=[params_file]),
+            parameters=[{ 'use_sim_time': use_sim_time}]),
 
     ])

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -2,12 +2,55 @@ import os
 from launch import LaunchDescription
 import launch.actions
 import launch_ros.actions
+from typing import Dict
+from typing import List
+from typing import Text
+import yaml
+import tempfile
+
+class RewrittenYaml(launch.Substitution):
+    """
+    Substitution that modifies the given Yaml file.
+    """
+
+    def __init__(self, source_file: launch.SomeSubstitutionsType, rewrites: Dict) -> None:
+        super().__init__()
+
+        from launch.utilities import normalize_to_list_of_substitutions  # import here to avoid loop
+        self.__source_file = normalize_to_list_of_substitutions(source_file)
+        self.__rewrites = rewrites
+
+    @property
+    def name(self) -> List[launch.Substitution]:
+        """Getter for name."""
+        return self.__source_file
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return ''
+
+    def perform(self, context: launch.LaunchContext) -> Text:
+        yaml_filename = launch.utilities.perform_substitutions(context, self.name)
+        rewritten_yaml = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        resolved_rewrites = self.resolve_rewrites(context)
+        data = yaml.load(open(yaml_filename, 'r'))
+        self.substitute_values(data, resolved_rewrites)
+        yaml.dump(data, rewritten_yaml)
+        rewritten_yaml.close()
+        return rewritten_yaml.name
+
+    def resolve_rewrites(self, context):
+        return self.__rewrites
+
+    def substitute_values(self, yaml, rewrites):
+        return
 
 def generate_launch_description():
     map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default=
         [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
+    final_params = RewrittenYaml(params_file, {'use_sim_time': False})
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -32,45 +75,45 @@ def generate_launch_description():
             node_executable='map_server',
             node_name='map_server',
             output='screen',
-            parameters=[params_file, { 'yaml_filename': map_yaml_file }]),
+            parameters=[final_params, { 'yaml_filename': map_yaml_file }]),
 
         launch_ros.actions.Node(
             package='nav2_world_model',
             node_executable='world_model',
             output='screen',
-            parameters=[params_file]),
+            parameters=[final_params]),
 
         launch_ros.actions.Node(
             package='nav2_amcl',
             node_executable='amcl',
             node_name='amcl',
             output='screen',
-            parameters=[params_file]),
+            parameters=[final_params]),
 
         launch_ros.actions.Node(
             package='dwb_controller',
             node_executable='dwb_controller',
             output='screen',
-            parameters=[params_file]),
+            parameters=[final_params]),
 
         launch_ros.actions.Node(
             package='nav2_navfn_planner',
             node_executable='navfn_planner',
             node_name='navfn_planner',
             output='screen',
-            parameters=[params_file]),
+            parameters=[final_params]),
 
         launch_ros.actions.Node(
             package='nav2_simple_navigator',
             node_executable='simple_navigator',
             node_name='simple_navigator',
             output='screen',
-            parameters=[params_file]),
+            parameters=[final_params]),
 
         launch_ros.actions.Node(
             package='nav2_mission_executor',
             node_executable='mission_executor',
             node_name='mission_executor',
             output='screen',
-            parameters=[params_file]),
+            parameters=[final_params]),
     ])

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -6,7 +6,8 @@ import launch_ros.actions
 def generate_launch_description():
     map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
-    params_file = launch.substitutions.LaunchConfiguration('params', default='nav2_params.yaml')
+    params_file = launch.substitutions.LaunchConfiguration('params', default=
+        [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
     launch_dir = os.path.dirname(os.path.abspath(__file__))
 
     return LaunchDescription([
@@ -54,7 +55,7 @@ def generate_launch_description():
             node_executable='dwb_controller',
             output='screen',
             remappings=[('occ_grid', '/occ_grid')],
-            parameters=[os.path.join(launch_dir, 'dwb_controller_config.yaml')]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_navfn_planner',

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -32,7 +32,7 @@ def generate_launch_description():
             node_executable='map_server',
             node_name='map_server',
             output='screen',
-            parameters=[params_file, { 'yaml_filename': map_yaml_file }]),
+            parameters=[{ 'use_sim_time': use_sim_time}, { 'yaml_filename': map_yaml_file }]),
 
         launch_ros.actions.Node(
             package='nav2_world_model',
@@ -45,7 +45,7 @@ def generate_launch_description():
             node_executable='amcl',
             node_name='amcl',
             output='screen',
-            parameters=[params_file]),
+            parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
             package='dwb_controller',
@@ -58,19 +58,19 @@ def generate_launch_description():
             node_executable='navfn_planner',
             node_name='navfn_planner',
             output='screen',
-            parameters=[params_file]),
+            parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
             package='nav2_simple_navigator',
             node_executable='simple_navigator',
             node_name='simple_navigator',
             output='screen',
-            parameters=[params_file]),
+            parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
             package='nav2_mission_executor',
             node_executable='mission_executor',
             node_name='mission_executor',
             output='screen',
-            parameters=[params_file]),
+            parameters=[{ 'use_sim_time': use_sim_time}]),
     ])

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -8,7 +8,6 @@ def generate_launch_description():
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default=
         [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
-    launch_dir = os.path.dirname(os.path.abspath(__file__))
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -33,21 +32,20 @@ def generate_launch_description():
             node_executable='map_server',
             node_name='map_server',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}, { 'yaml_filename': map_yaml_file }]),
+            parameters=[params_file, { 'yaml_filename': map_yaml_file }]),
 
         launch_ros.actions.Node(
             package='nav2_world_model',
             node_executable='world_model',
-            node_name='world_model',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_amcl',
             node_executable='amcl',
             node_name='amcl',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='dwb_controller',
@@ -60,19 +58,19 @@ def generate_launch_description():
             node_executable='navfn_planner',
             node_name='navfn_planner',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_simple_navigator',
             node_executable='simple_navigator',
             node_name='simple_navigator',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_mission_executor',
             node_executable='mission_executor',
             node_name='mission_executor',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
     ])

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -7,6 +7,7 @@ def generate_launch_description():
     map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default='nav2_params.yaml')
+    launch_dir = os.path.dirname(os.path.abspath(__file__))
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -38,6 +39,7 @@ def generate_launch_description():
             node_executable='world_model',
             node_name='world_model',
             output='screen',
+            remappings=[('occ_grid', '/occ_grid')],
             parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
@@ -50,9 +52,9 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='dwb_controller',
             node_executable='dwb_controller',
-            node_name='FollowPathNode',
             output='screen',
-            parameters=[{ 'prune_plan': False }, {'debug_trajectory_details': True }, { 'use_sim_time': use_sim_time }]),
+            remappings=[('occ_grid', '/occ_grid')],
+            parameters=[os.path.join(launch_dir, 'dwb_controller_config.yaml')]),
 
         launch_ros.actions.Node(
             package='nav2_navfn_planner',

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -1,19 +1,56 @@
 import os
-import yaml
-import tempfile
 from launch import LaunchDescription
 import launch.actions
 import launch_ros.actions
 from typing import Dict
 from typing import List
 from typing import Text
+import yaml
+import tempfile
+
+class RewrittenYaml(launch.Substitution):
+    """
+    Substitution that modifies the given Yaml file.
+    """
+
+    def __init__(self, source_file: launch.SomeSubstitutionsType, rewrites: Dict) -> None:
+        super().__init__()
+
+        from launch.utilities import normalize_to_list_of_substitutions  # import here to avoid loop
+        self.__source_file = normalize_to_list_of_substitutions(source_file)
+        self.__rewrites = rewrites
+
+    @property
+    def name(self) -> List[launch.Substitution]:
+        """Getter for name."""
+        return self.__source_file
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return ''
+
+    def perform(self, context: launch.LaunchContext) -> Text:
+        yaml_filename = launch.utilities.perform_substitutions(context, self.name)
+        rewritten_yaml = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        resolved_rewrites = self.resolve_rewrites(context)
+        data = yaml.load(open(yaml_filename, 'r'))
+        self.substitute_values(data, resolved_rewrites)
+        yaml.dump(data, rewritten_yaml)
+        rewritten_yaml.close()
+        return rewritten_yaml.name
+
+    def resolve_rewrites(self, context):
+        return self.__rewrites
+
+    def substitute_values(self, yaml, rewrites):
+        return
 
 def generate_launch_description():
     map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default=
         [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
-    final_params = RewrittenYaml(params_file, {'use_sim_time': use_sim_time })
+    final_params = RewrittenYaml(params_file, {'use_sim_time': False})
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -80,82 +117,3 @@ def generate_launch_description():
             output='screen',
             parameters=[final_params]),
     ])
-
-class DictItemReference:
-  def __init__(self, dictionary, key):
-    self.dictionary = dictionary
-    self.dictKey = key
-
-  def key(self):
-      return self.dictKey
-
-  def setValue(self, value):
-      self.dictionary[self.dictKey] = value
-
-class RewrittenYaml(launch.Substitution):
-  """
-  Substitution that modifies the given Yaml file, given a dictionary of keys and substitutions
-
-  The dictionary is something along the lines of {'use_sim_time': substition_value }
-  and this would take every key matching 'use_sim_time' in the given Yaml file and
-  replace it with the substitution value.
-
-  The resulting yaml data is written to a temporary
-  """
-
-  def __init__(self, source_file: launch.SomeSubstitutionsType, rewrites: Dict) -> None:
-    super().__init__()
-
-    from launch.utilities import normalize_to_list_of_substitutions
-    self.__source_file = normalize_to_list_of_substitutions(source_file)
-    self.__rewrites = {}
-    for key in rewrites:
-        self.__rewrites[key] = normalize_to_list_of_substitutions(rewrites[key])
-
-  @property
-  def name(self) -> List[launch.Substitution]:
-    """Getter for name."""
-    return self.__source_file
-
-  def describe(self) -> Text:
-    """Return a description of this substitution as a string."""
-    return 'RewrittenYaml'
-
-  def perform(self, context: launch.LaunchContext) -> Text:
-    # resolve name of input Yaml file
-    original_yaml_filename = launch.utilities.perform_substitutions(context, self.name)
-    # create temporary file for output
-    rewritten_yaml = tempfile.NamedTemporaryFile(mode='w', delete=False)
-    # resolve all substitions in the rewrites dict
-    resolved_rewrites = self.resolve_rewrites(context)
-    data = yaml.load(open(original_yaml_filename, 'r'))
-    self.substitute_values(data, resolved_rewrites)
-    yaml.dump(data, rewritten_yaml)
-    rewritten_yaml.close()
-    return rewritten_yaml.name
-
-  # The rewrite dictionary consists of key - value pairs. The key is a plain
-  # string. The value is a launch.substitution. This function resolves the
-  # substitions.
-  def resolve_rewrites(self, context):
-    resolved = {}
-    for key in self.__rewrites:
-      resolved[key] = launch.utilities.perform_substitutions(context, self.__rewrites[key])
-    return resolved
-
-  # Modifies the input yaml data with the values specified in rewrite dictionary
-  def substitute_values(self, yaml, rewrites):
-    for key in self.getYamlKeys(yaml):
-      if key.key() in rewrites:
-        key.setValue(rewrites[key.key()])
-
-  # create a generator to allow iterating through all keys in the yaml file
-  # only iterates through dictionaries. Doesn't iterate through lists.
-  def getYamlKeys(self, yamlData):
-    try:
-      for key in yamlData.keys():
-        for k in self.getYamlKeys(yamlData[key]):
-          yield k
-        yield DictItemReference(yamlData, key)
-    except AttributeError:
-      return

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -2,55 +2,12 @@ import os
 from launch import LaunchDescription
 import launch.actions
 import launch_ros.actions
-from typing import Dict
-from typing import List
-from typing import Text
-import yaml
-import tempfile
-
-class RewrittenYaml(launch.Substitution):
-    """
-    Substitution that modifies the given Yaml file.
-    """
-
-    def __init__(self, source_file: launch.SomeSubstitutionsType, rewrites: Dict) -> None:
-        super().__init__()
-
-        from launch.utilities import normalize_to_list_of_substitutions  # import here to avoid loop
-        self.__source_file = normalize_to_list_of_substitutions(source_file)
-        self.__rewrites = rewrites
-
-    @property
-    def name(self) -> List[launch.Substitution]:
-        """Getter for name."""
-        return self.__source_file
-
-    def describe(self) -> Text:
-        """Return a description of this substitution as a string."""
-        return ''
-
-    def perform(self, context: launch.LaunchContext) -> Text:
-        yaml_filename = launch.utilities.perform_substitutions(context, self.name)
-        rewritten_yaml = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        resolved_rewrites = self.resolve_rewrites(context)
-        data = yaml.load(open(yaml_filename, 'r'))
-        self.substitute_values(data, resolved_rewrites)
-        yaml.dump(data, rewritten_yaml)
-        rewritten_yaml.close()
-        return rewritten_yaml.name
-
-    def resolve_rewrites(self, context):
-        return self.__rewrites
-
-    def substitute_values(self, yaml, rewrites):
-        return
 
 def generate_launch_description():
     map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default=
         [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
-    final_params = RewrittenYaml(params_file, {'use_sim_time': False})
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -75,45 +32,45 @@ def generate_launch_description():
             node_executable='map_server',
             node_name='map_server',
             output='screen',
-            parameters=[final_params, { 'yaml_filename': map_yaml_file }]),
+            parameters=[params_file, { 'yaml_filename': map_yaml_file }]),
 
         launch_ros.actions.Node(
             package='nav2_world_model',
             node_executable='world_model',
             output='screen',
-            parameters=[final_params]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_amcl',
             node_executable='amcl',
             node_name='amcl',
             output='screen',
-            parameters=[final_params]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='dwb_controller',
             node_executable='dwb_controller',
             output='screen',
-            parameters=[final_params]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_navfn_planner',
             node_executable='navfn_planner',
             node_name='navfn_planner',
             output='screen',
-            parameters=[final_params]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_simple_navigator',
             node_executable='simple_navigator',
             node_name='simple_navigator',
             output='screen',
-            parameters=[final_params]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_mission_executor',
             node_executable='mission_executor',
             node_name='mission_executor',
             output='screen',
-            parameters=[final_params]),
+            parameters=[params_file]),
     ])

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -40,7 +40,6 @@ def generate_launch_description():
             node_executable='world_model',
             node_name='world_model',
             output='screen',
-            remappings=[('occ_grid', '/occ_grid')],
             parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
@@ -54,7 +53,6 @@ def generate_launch_description():
             package='dwb_controller',
             node_executable='dwb_controller',
             output='screen',
-            remappings=[('occ_grid', '/occ_grid')],
             parameters=[params_file]),
 
         launch_ros.actions.Node(

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -1,56 +1,19 @@
 import os
+import yaml
+import tempfile
 from launch import LaunchDescription
 import launch.actions
 import launch_ros.actions
 from typing import Dict
 from typing import List
 from typing import Text
-import yaml
-import tempfile
-
-class RewrittenYaml(launch.Substitution):
-    """
-    Substitution that modifies the given Yaml file.
-    """
-
-    def __init__(self, source_file: launch.SomeSubstitutionsType, rewrites: Dict) -> None:
-        super().__init__()
-
-        from launch.utilities import normalize_to_list_of_substitutions  # import here to avoid loop
-        self.__source_file = normalize_to_list_of_substitutions(source_file)
-        self.__rewrites = rewrites
-
-    @property
-    def name(self) -> List[launch.Substitution]:
-        """Getter for name."""
-        return self.__source_file
-
-    def describe(self) -> Text:
-        """Return a description of this substitution as a string."""
-        return ''
-
-    def perform(self, context: launch.LaunchContext) -> Text:
-        yaml_filename = launch.utilities.perform_substitutions(context, self.name)
-        rewritten_yaml = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        resolved_rewrites = self.resolve_rewrites(context)
-        data = yaml.load(open(yaml_filename, 'r'))
-        self.substitute_values(data, resolved_rewrites)
-        yaml.dump(data, rewritten_yaml)
-        rewritten_yaml.close()
-        return rewritten_yaml.name
-
-    def resolve_rewrites(self, context):
-        return self.__rewrites
-
-    def substitute_values(self, yaml, rewrites):
-        return
 
 def generate_launch_description():
     map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default=
         [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
-    final_params = RewrittenYaml(params_file, {'use_sim_time': False})
+    final_params = RewrittenYaml(params_file, {'use_sim_time': use_sim_time })
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -117,3 +80,82 @@ def generate_launch_description():
             output='screen',
             parameters=[final_params]),
     ])
+
+class DictItemReference:
+  def __init__(self, dictionary, key):
+    self.dictionary = dictionary
+    self.dictKey = key
+
+  def key(self):
+      return self.dictKey
+
+  def setValue(self, value):
+      self.dictionary[self.dictKey] = value
+
+class RewrittenYaml(launch.Substitution):
+  """
+  Substitution that modifies the given Yaml file, given a dictionary of keys and substitutions
+
+  The dictionary is something along the lines of {'use_sim_time': substition_value }
+  and this would take every key matching 'use_sim_time' in the given Yaml file and
+  replace it with the substitution value.
+
+  The resulting yaml data is written to a temporary
+  """
+
+  def __init__(self, source_file: launch.SomeSubstitutionsType, rewrites: Dict) -> None:
+    super().__init__()
+
+    from launch.utilities import normalize_to_list_of_substitutions
+    self.__source_file = normalize_to_list_of_substitutions(source_file)
+    self.__rewrites = {}
+    for key in rewrites:
+        self.__rewrites[key] = normalize_to_list_of_substitutions(rewrites[key])
+
+  @property
+  def name(self) -> List[launch.Substitution]:
+    """Getter for name."""
+    return self.__source_file
+
+  def describe(self) -> Text:
+    """Return a description of this substitution as a string."""
+    return 'RewrittenYaml'
+
+  def perform(self, context: launch.LaunchContext) -> Text:
+    # resolve name of input Yaml file
+    original_yaml_filename = launch.utilities.perform_substitutions(context, self.name)
+    # create temporary file for output
+    rewritten_yaml = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    # resolve all substitions in the rewrites dict
+    resolved_rewrites = self.resolve_rewrites(context)
+    data = yaml.load(open(original_yaml_filename, 'r'))
+    self.substitute_values(data, resolved_rewrites)
+    yaml.dump(data, rewritten_yaml)
+    rewritten_yaml.close()
+    return rewritten_yaml.name
+
+  # The rewrite dictionary consists of key - value pairs. The key is a plain
+  # string. The value is a launch.substitution. This function resolves the
+  # substitions.
+  def resolve_rewrites(self, context):
+    resolved = {}
+    for key in self.__rewrites:
+      resolved[key] = launch.utilities.perform_substitutions(context, self.__rewrites[key])
+    return resolved
+
+  # Modifies the input yaml data with the values specified in rewrite dictionary
+  def substitute_values(self, yaml, rewrites):
+    for key in self.getYamlKeys(yaml):
+      if key.key() in rewrites:
+        key.setValue(rewrites[key.key()])
+
+  # create a generator to allow iterating through all keys in the yaml file
+  # only iterates through dictionaries. Doesn't iterate through lists.
+  def getYamlKeys(self, yamlData):
+    try:
+      for key in yamlData.keys():
+        for k in self.getYamlKeys(yamlData[key]):
+          yield k
+        yield DictItemReference(yamlData, key)
+    except AttributeError:
+      return

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -1,3 +1,27 @@
 map_server:
     ros__parameters:
         yaml_filename: "test_map.yaml"
+DwbController:
+  ros__parameters:
+    debug_trajectory_details: True
+    min_vel_x: -0.26
+    min_vel_y: 0.0
+    max_vel_x: 0.26
+    max_vel_y: 0.0
+    max_vel_theta: 1.0
+    min_speed_xy: 0.0
+    max_speed_xy: 0.26
+    min_speed_theta: 0.0
+    acc_lim_x: 2.5
+    acc_lim_y: 0.0
+    acc_lim_theta: 3.2
+    decel_lim_x: -2.5
+    decel_lim_y: 0.0
+    decel_lim_theta: -3.2
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      always_send_full_costmap: True
+      scan:
+        topic: /scan
+

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -1,6 +1,7 @@
 map_server:
-    ros__parameters:
-        yaml_filename: "test_map.yaml"
+  ros__parameters:
+    yaml_filename: "test_map.yaml"
+    use_sim_time: True
 DwbController:
   ros__parameters:
     debug_trajectory_details: True
@@ -18,8 +19,31 @@ DwbController:
     decel_lim_x: -2.5
     decel_lim_y: 0.0
     decel_lim_theta: -3.2
+    use_sim_time: True
 local_costmap:
   local_costmap:
     ros__parameters:
       always_send_full_costmap: True
-
+      use_sim_time: True
+WorldModel_Node:
+  ros__parameters:
+    use_sim_time: True
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      use_sim_time: True
+amcl:
+  ros__parameters:
+    use_sim_time: True
+navfn_planner:
+  ros__parameters:
+    use_sim_time: True
+simple_navigator:
+  ros__parameters:
+    use_sim_time: True
+BtNavigator:
+  ros__parameters:
+    use_sim_time: True
+mission_executor:
+  ros__parameters:
+    use_sim_time: True

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -22,6 +22,4 @@ local_costmap:
   local_costmap:
     ros__parameters:
       always_send_full_costmap: True
-      scan:
-        topic: /scan
 

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -1,7 +1,6 @@
 map_server:
   ros__parameters:
     yaml_filename: "test_map.yaml"
-    use_sim_time: True
 DwbController:
   ros__parameters:
     debug_trajectory_details: True
@@ -19,31 +18,11 @@ DwbController:
     decel_lim_x: -2.5
     decel_lim_y: 0.0
     decel_lim_theta: -3.2
-    use_sim_time: True
 local_costmap:
   local_costmap:
     ros__parameters:
       always_send_full_costmap: True
-      use_sim_time: True
-WorldModel_Node:
-  ros__parameters:
-    use_sim_time: True
 global_costmap:
   global_costmap:
     ros__parameters:
-      use_sim_time: True
-amcl:
-  ros__parameters:
-    use_sim_time: True
-navfn_planner:
-  ros__parameters:
-    use_sim_time: True
-simple_navigator:
-  ros__parameters:
-    use_sim_time: True
-BtNavigator:
-  ros__parameters:
-    use_sim_time: True
-mission_executor:
-  ros__parameters:
-    use_sim_time: True
+      always_send_full_costmap: True

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -70,7 +70,7 @@ void StaticLayer::onInitialize()
   node_->set_parameter_if_not_set(name_ + "." + "enabled",true);
 
   std::string map_topic;
-  node_->get_parameter_or<std::string>("map_topic", map_topic, std::string("occ_grid"));
+  node_->get_parameter_or<std::string>("map_topic", map_topic, std::string("/occ_grid"));
   node_->get_parameter_or<bool>("first_map_only", first_map_only_, false);
   node_->get_parameter_or<bool>("subscribe_to_updates", subscribe_to_updates_, false);
 

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -52,7 +52,7 @@ namespace nav2_costmap_2d
 {
 
 Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
-  : Node(name),
+  : Node(name, name),
   layered_costmap_(NULL),
   name_(name),
   tf_(tf),


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  Gazebo Turtlebot 3 |

---

## Description of contribution in a few bullet points

* Costmaps now put themselves into a namespace that is the same as the node name assigned in code.
* Updates the RVIZ default config to map the new topic names, so both global and local costmap topics can be displayed independently.
* Adds a nav2_params.yaml file to the launch directory and sets a couple of parameters on the DwbController node and the local_costmap node.

## Future Work

* Due to the way parameter events work, each namespace in use needs to have the `use_sim_time` variable set to switch the nodes in that namespace. Since this change causes us to have 3 namespaces (`root`, `global_costmap`, and `local_costmap`), we need to set it in each. Here is the command line I use

```
ros2 param set /gazebo use_sim_time true ; ros2 param set /global_costmap/world_model use_sim_time true ; ros2 param set /local_costmap/local_costmap use_sim_time true
```
