### PR TITLE
List/Get parameters from node instead of SyncParameterClient if using own node

### DIFF
--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -110,10 +110,10 @@ void InflationLayer::reconfigureCB()
   bool inflate_unknown;
   bool enabled;
 
-  node_->get_parameter_or(name_ + "." + "inflation_radius", inflation_radius, 0.55);
-  node_->get_parameter_or(name_ + "." + "cost_scaling_factor", cost_scaling_factor, 10.0);
-  node_->get_parameter_or(name_ + "." + "inflate_unknown", inflate_unknown, false);
-  node_->get_parameter_or(name_ + "." + "enabled", enabled, true);
+  dynamic_param_client_->get_event_param_or(name_ + "." + "inflation_radius", inflation_radius, 0.55);
+  dynamic_param_client_->get_event_param_or(name_ + "." + "cost_scaling_factor", cost_scaling_factor, 10.0);
+  dynamic_param_client_->get_event_param_or(name_ + "." + "inflate_unknown", inflate_unknown, false);
+  dynamic_param_client_->get_event_param_or(name_ + "." + "enabled", enabled, true);
 
   setInflationParameters(inflation_radius, cost_scaling_factor);
 

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -256,10 +256,10 @@ void ObstacleLayer::reconfigureCB()
 {
   RCLCPP_DEBUG(node_->get_logger(), "ObstacleLayer:: Event Callback");
 
-  node_->get_parameter(name_ + "." + "enabled", enabled_); 
-  node_->get_parameter(name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_); 
-  node_->get_parameter(name_ + "." + "max_obstacle_height", max_obstacle_height_); 
-  node_->get_parameter(name_ + "." + "combination_method", combination_method_); 
+  dynamic_param_client_->get_event_param(name_ + "." + "enabled", enabled_); 
+  dynamic_param_client_->get_event_param(name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_); 
+  dynamic_param_client_->get_event_param(name_ + "." + "max_obstacle_height", max_obstacle_height_); 
+  dynamic_param_client_->get_event_param(name_ + "." + "combination_method", combination_method_); 
 }
 
 void ObstacleLayer::laserScanCallback(sensor_msgs::msg::LaserScan::ConstSharedPtr message,

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -131,7 +131,7 @@ void StaticLayer::reconfigureCB()
   RCLCPP_DEBUG(node_->get_logger(), "StaticLayer:: Event Callback");
 
   bool enabled = true;
-  node_->get_parameter_or(name_ + "." + "enabled", enabled, true); 
+  dynamic_param_client_->get_event_param_or(name_ + "." + "enabled", enabled, true); 
 
   if (enabled != enabled_)
   {

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -102,16 +102,16 @@ void VoxelLayer::reconfigureCB()
 {
   RCLCPP_DEBUG(node_->get_logger(), "VoxelLayer:: Event Callback");
 
-  node_->get_parameter(name_ + "." + "enabled", enabled_);
-  node_->get_parameter(name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_);
-  node_->get_parameter(name_ + "." + "max_obstacle_height", max_obstacle_height_);
-  node_->get_parameter(name_ + "." + "z_voxels", size_z_);
-  node_->get_parameter(name_ + "." + "origin_z", origin_z_);
-  node_->get_parameter(name_ + "." + "z_resolution", z_resolution_);
-  node_->get_parameter(name_ + "." + "unknown_threshold", unknown_threshold_);
+  dynamic_param_client_->get_event_param(name_ + "." + "enabled", enabled_);
+  dynamic_param_client_->get_event_param(name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_);
+  dynamic_param_client_->get_event_param(name_ + "." + "max_obstacle_height", max_obstacle_height_);
+  dynamic_param_client_->get_event_param(name_ + "." + "z_voxels", size_z_);
+  dynamic_param_client_->get_event_param(name_ + "." + "origin_z", origin_z_);
+  dynamic_param_client_->get_event_param(name_ + "." + "z_resolution", z_resolution_);
+  dynamic_param_client_->get_event_param(name_ + "." + "unknown_threshold", unknown_threshold_);
   unknown_threshold_ += (VOXEL_BITS - size_z_);
-  node_->get_parameter(name_ + "." + "mark_threshold", mark_threshold_);
-  node_->get_parameter(name_ + "." + "combination_method", combination_method_);
+  dynamic_param_client_->get_event_param(name_ + "." + "mark_threshold", mark_threshold_);
+  dynamic_param_client_->get_event_param(name_ + "." + "combination_method", combination_method_);
   matchSize();
 }
 

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -204,7 +204,7 @@ void Costmap2DROS::reconfigureCB()
 {
   RCLCPP_DEBUG(node_->get_logger(), "Costmap2DROS:: Event Callback");
 
-  get_parameter("transform_tolerance", transform_tolerance_);
+  dynamic_param_client_->get_event_param("transform_tolerance", transform_tolerance_);
 
   if (map_update_thread_ != NULL)
   {
@@ -214,10 +214,10 @@ void Costmap2DROS::reconfigureCB()
   }
   map_update_thread_shutdown_ = false;
   double map_update_frequency = 1.0;
-  get_parameter("update_frequency", map_update_frequency);
+  dynamic_param_client_->get_event_param("update_frequency", map_update_frequency);
 
   double map_publish_frequency = 5.0;
-  get_parameter("publish_frequency", map_publish_frequency);
+  dynamic_param_client_->get_event_param("publish_frequency", map_publish_frequency);
 
   if (map_publish_frequency > 0)
     publish_cycle_ = nav2_util::durationFromSeconds(1 / map_publish_frequency);
@@ -228,11 +228,11 @@ void Costmap2DROS::reconfigureCB()
   double resolution, origin_x, origin_y;
   int map_width_meters, map_height_meters;
 
-  get_parameter("width", map_width_meters);
-  get_parameter("height", map_height_meters);
-  get_parameter("resolution", resolution);
-  get_parameter("origin_x", origin_x);
-  get_parameter("origin_y", origin_y);
+  dynamic_param_client_->get_event_param("width", map_width_meters);
+  dynamic_param_client_->get_event_param("height", map_height_meters);
+  dynamic_param_client_->get_event_param("resolution", resolution);
+  dynamic_param_client_->get_event_param("origin_x", origin_x);
+  dynamic_param_client_->get_event_param("origin_y", origin_y);
 
   if (!layered_costmap_->isSizeLocked())
   {
@@ -243,7 +243,7 @@ void Costmap2DROS::reconfigureCB()
   // If the padding has changed, call setUnpaddedRobotFootprint() to
   // re-apply the padding.
   float footprint_padding;
-  node_->get_parameter("footprint_padding", footprint_padding);
+  dynamic_param_client_->get_event_param("footprint_padding", footprint_padding);
 
   if (footprint_padding_ != footprint_padding)
   {
@@ -265,8 +265,8 @@ void Costmap2DROS::readFootprintFromConfig()
 
   std::string footprint;
   double robot_radius;
-  get_parameter("footprint", footprint);
-  get_parameter("robot_radius", robot_radius);
+  dynamic_param_client_->get_event_param("footprint", footprint);
+  dynamic_param_client_->get_event_param("robot_radius", robot_radius);
 
   if (footprint != "" && footprint != "[]")
   {

--- a/nav2_dynamic_params/include/nav2_dynamic_params/dynamic_params_client.hpp
+++ b/nav2_dynamic_params/include/nav2_dynamic_params/dynamic_params_client.hpp
@@ -66,7 +66,7 @@ public:
         topic, callback);
       event_subscriptions_.push_back(event_sub);
       // TODO(bpwilcox): Fix hanging problem for list parameters service call
-      //get_param_list(node_namespace);
+      // get_param_list(node_namespace);
     }
   }
 
@@ -90,24 +90,36 @@ public:
     if (*full_path.begin() != '/') {
       full_path = '/' + full_path;
     }
-    auto client = std::make_shared<rclcpp::SyncParametersClient>(node_, full_path);
+
     std::vector<rclcpp::Parameter> params;
-    if (client->wait_for_service(100ms)) {
+
+    if (full_path == join_path(node_->get_namespace(), node_->get_name())) {
       if (param_names.size() < 1) {
-        auto param_list = client->list_parameters({}, 1);
-        params = client->get_parameters(param_list.names);
+        auto param_list = node_->list_parameters({}, 1);
+        params = node_->get_parameters(param_list.names);
       } else {
-        params = client->get_parameters(param_names);
+        params = node_->get_parameters(param_names);
       }
     } else {
-      RCLCPP_WARN(node_->get_logger(),
-        "Node '%s' not available for service, inserting params as NOT SET", full_path.c_str());
-      // Set param_names as PARAMETER_NOT_SET
-      for (const auto & name : param_names) {
-        auto param = rclcpp::Parameter(name, rclcpp::ParameterValue());
-        params.push_back(param);
+      auto client = std::make_shared<rclcpp::SyncParametersClient>(node_, full_path);
+      if (client->wait_for_service(100ms)) {
+        if (param_names.size() < 1) {
+          auto param_list = client->list_parameters({}, 1);
+          params = client->get_parameters(param_list.names);
+        } else {
+          params = client->get_parameters(param_names);
+        }
+      } else {
+        RCLCPP_WARN(node_->get_logger(),
+          "Node '%s' not available for service, inserting params as NOT SET", full_path.c_str());
+        // Set param_names as PARAMETER_NOT_SET
+        for (const auto & name : param_names) {
+          auto param = rclcpp::Parameter(name, rclcpp::ParameterValue());
+          params.push_back(param);
+        }
       }
     }
+
     std::string node_namespace = split_path(full_path).first;
     add_namespace_event_subscriber(node_namespace);
     for (const auto & param : params) {


### PR DESCRIPTION

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #352  |
| Primary OS tested on | Ubuntu 16.04 |

---

## Description of contribution
- Addresses potential issue of race condition in creating a SyncParameterClient inside of the DynamicParamsClient when adding a new parameter from its own node in the constructor
- reverts the `get_parameter` calls in the reconfigureCB() back to `get_event_param`

## Future work
- Since the dynamic reconfigureCB() are now grabbing parameters from DynamicParamsClient again, they are sensitive to duplicate parameter names in the same namespace. This should be resolved by #394. Will also be resolved with closing of issue #337 

