### PR TITLE
get namespace from node for get_event_param() variant

### DIFF
--- a/nav2_dynamic_params/include/nav2_dynamic_params/dynamic_params_client.hpp
+++ b/nav2_dynamic_params/include/nav2_dynamic_params/dynamic_params_client.hpp
@@ -66,7 +66,7 @@ public:
         topic, callback);
       event_subscriptions_.push_back(event_sub);
       // TODO(bpwilcox): Fix hanging problem for list parameters service call
-      //get_param_list(node_namespace);
+      // get_param_list(node_namespace);
     }
   }
 
@@ -182,7 +182,7 @@ public:
   template<class T>
   bool get_event_param(const std::string & param_name, T & new_value)
   {
-    return get_event_param<T>("", param_name, new_value);
+    return get_event_param<T>(node_->get_namespace(), param_name, new_value);
   }
 
   // retreive parameter or assign default value if not set
@@ -203,7 +203,7 @@ public:
   template<class T>
   bool get_event_param_or(const std::string & param_name, T & new_value, const T & default_value)
   {
-    return get_event_param_or<T>("", param_name, new_value, default_value);
+    return get_event_param_or<T>(node_->get_namespace(), param_name, new_value, default_value);
   }
 
   // A check to filter whether parameter name is part of the lastest event


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu 16.04 |


---

## Description of contribution
- The `get_event_param` call would assume the root namespace if not specified, which would lookup the incorrect parameter name in the internal parameter map for nodes with namespaces. This PR fixes this to grab the namespace of the member node if not specified otherwise in the function call

