### PR TITLE
Remove the old message filters dependency.

### DIFF
--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -1,8 +1,4 @@
 repositories:
-  ros2_message_filters:
-    type: git
-    url: https://github.com/intel/ros2_message_filters.git
-    version: master
   behavior_tree_core:
     type: git
     url: https://github.com/mjeronimo/BehaviorTree.CPP


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Resolves #274 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 in gazebo |

---

## Description of contribution in a few bullet points

* Removes message filters from the additional ROS 2 dependencies. It is part of base ROS 2 now.

