### PR TITLE
Make all package.xml files consistently use format 3.

### DIFF
--- a/nav2_amcl/package.xml
+++ b/nav2_amcl/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>nav2_amcl</name>
   <version>0.1.0</version>
   <description>

--- a/nav2_costmap_2d/package.xml
+++ b/nav2_costmap_2d/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format ="3">
   <name>nav2_costmap_2d</name>
   <version>0.1.0</version>

--- a/nav2_dwb_controller/dwb_controller/package.xml
+++ b/nav2_dwb_controller/dwb_controller/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dwb_controller</name>
   <version>0.1.0</version>

--- a/nav2_dwb_controller/nav2_dwb_controller/package.xml
+++ b/nav2_dwb_controller/nav2_dwb_controller/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>nav2_dwb_controller</name>
   <version>0.1.0</version>
   <description>

--- a/nav2_dwb_controller/nav_2d_utils/package.xml
+++ b/nav2_dwb_controller/nav_2d_utils/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>nav_2d_utils</name>
   <version>0.1.0</version>
   <description>A handful of useful utility functions for nav_2d packages.</description>

--- a/nav2_map_server/package.xml
+++ b/nav2_map_server/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>nav2_map_server</name>
   <version>0.1.0</version>
   <description>

--- a/nav2_voxel_grid/package.xml
+++ b/nav2_voxel_grid/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nav2_voxel_grid</name>
   <version>0.1.0</version>

--- a/navigation2/package.xml
+++ b/navigation2/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>navigation2</name>
   <version>0.1.0</version>
   <description>
@@ -29,7 +29,7 @@
   <exec_depend>nav2_tasks</exec_depend>
   <exec_depend>nav2_util</exec_depend>
   <exec_depend>nav2_voxel_grid</exec_depend>
-  
+
   <export>
     <metapackage/>
   </export>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #334 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* Ensures all package.xml files are self-consistent and consistent across the repo.
* Standardizes on version 3 of the package.xml format.
* This fixes some xmllint errors
