### PR TITLE
Ignore Eclipse project files and python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ install
 
 # Visual Studio Code files
 .vscode
+
+# Eclipse project files
+.cproject
+.project
+.pydevproject
+
+# Python artifacts
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
Updates the .gitignore file to ignore the Eclipse project files and Python artifacts files and cache.