### PR TITLE
Update the first of the split launch scripts

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_1st_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_1st_launch.py
@@ -4,23 +4,21 @@ import launch.actions
 import launch_ros.actions
 
 def generate_launch_description():
-    map_file = launch.substitutions.LaunchConfiguration('map')
-    map_type = launch.substitutions.LaunchConfiguration('map_type', default='occupancy')
+    map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             'map', description='Full path to map file to load'),
         launch.actions.DeclareLaunchArgument(
-            'map_type', default_value='occupancy', description='Type of map to load'),
-        launch.actions.DeclareLaunchArgument(
             'use_sim_time', default_value='false', description='Use simulation (Gazebo) clock if true'),
 
         launch_ros.actions.Node(
             package='nav2_map_server',
             node_executable='map_server',
+            node_name='map_server',
             output='screen',
-            arguments=[map_file, map_type]),
+            parameters=[{ 'use_sim_time': use_sim_time}, { 'yaml_filename': map_yaml_file }]),
 
         launch_ros.actions.Node(
             package='nav2_amcl',

--- a/nav2_map_server/src/map_server.cpp
+++ b/nav2_map_server/src/map_server.cpp
@@ -84,8 +84,8 @@ void MapServer::getParameters()
   try {
     map_type_ = doc_["map_type"].as<std::string>();
   } catch (YAML::Exception) {
-    std::string msg = "'" + yaml_filename_ + "' does not contain a map_type tag or it is invalid";
-    throw std::runtime_error(msg);
+    // Default to occupancy grid if not specified in the YAML file
+    map_type_ = "occupancy";
   }
 }
 


### PR DESCRIPTION
The map server now takes YAML filename via node parameter. I missed this new file on my previous map server PR. Also, the map type should be optional and default to "occupancy." 