### PR TITLE
Don't use metapackage, since it is not recommended in ROS2

### DIFF
--- a/navigation2/package.xml
+++ b/navigation2/package.xml
@@ -31,7 +31,7 @@
   <exec_depend>nav2_voxel_grid</exec_depend>
   
   <export>
-    <metapackage/>
+    <build_type>ament_cmake</build_type>  
   </export>
 
 </package>


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #334 |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (N/A) |

---

## Description of contribution in a few bullet points

Fix the warning below.  The discussion [https://github.com/ros2/ros2/issues/408](https://github.com/ros2/ros2/issues/408) describes the recommended way for fixing it in ROS2. 
```
WARNING: Metapackage "navigation2" must buildtool_depend on catkin.
WARNING: Metapackage "navigation2" should not have other dependencies besides a buildtool_depend on catkin and run_depends.
```
Note that this is just a warning, so techically it is not a failing issue, but it helps keep the output clean.
