### PR TITLE
Fix dwb_plugin test build

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
@@ -54,12 +54,12 @@ if(BUILD_TESTING)
   ament_add_gtest(vtest test/velocity_iterator_test.cpp)
 
   #find_package(rostest REQUIRED)
-  add_executable(goal_checker test/goal_checker.cpp)
-  target_link_libraries(goal_checker simple_goal_checker stopped_goal_checker ${GTEST_LIBRARIES})
+  ament_add_gtest_executable(goal_checker test/goal_checker.cpp)
+  target_link_libraries(goal_checker simple_goal_checker stopped_goal_checker)
   #add_rostest(test/goal_checker.launch DEPENDENCIES goal_checker)
 
-  add_executable(twist_gen_test test/twist_gen.cpp)
-  target_link_libraries(twist_gen_test standard_traj_generator ${GTEST_LIBRARIES})
+  ament_add_gtest_executable(twist_gen_test test/twist_gen.cpp)
+  target_link_libraries(twist_gen_test standard_traj_generator)
   #add_rostest(test/twist_gen.launch DEPENDENCIES twist_gen_test)
 
 endif()

--- a/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
@@ -51,17 +51,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
-  ament_add_gtest(vtest test/velocity_iterator_test.cpp)
-
-  #find_package(rostest REQUIRED)
-  ament_add_gtest_executable(goal_checker test/goal_checker.cpp)
-  target_link_libraries(goal_checker simple_goal_checker stopped_goal_checker)
-  #add_rostest(test/goal_checker.launch DEPENDENCIES goal_checker)
-
-  ament_add_gtest_executable(twist_gen_test test/twist_gen.cpp)
-  target_link_libraries(twist_gen_test standard_traj_generator)
-  #add_rostest(test/twist_gen.launch DEPENDENCIES twist_gen_test)
-
+  add_subdirectory(test)
 endif()
 
 install(TARGETS simple_goal_checker stopped_goal_checker standard_traj_generator

--- a/nav2_dwb_controller/dwb_plugins/test/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+ament_add_gtest(vtest velocity_iterator_test.cpp)
+
+ament_add_gtest(goal_checker goal_checker.cpp)
+target_link_libraries(goal_checker simple_goal_checker stopped_goal_checker)
+
+# Re-enable when DWB reads kinematic parameters
+# ament_add_gtest(twist_gen_test twist_gen.cpp)
+# target_link_libraries(twist_gen_test standard_traj_generator)

--- a/nav2_dwb_controller/dwb_plugins/test/goal_checker.launch
+++ b/nav2_dwb_controller/dwb_plugins/test/goal_checker.launch
@@ -1,3 +1,0 @@
-<launch>
-  <test test-name="goal_checker" pkg="dwb_plugins" type="goal_checker" />
-</launch>

--- a/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
@@ -55,7 +55,7 @@ void checkLimits(
   double exp_max_xy = -1.0,
   double exp_min_xy = -1.0, double exp_min_speed_theta = -1.0)
 {
-  ASSERT_GT(twists.size(), 0);
+  ASSERT_GT(twists.size(), 0u);
   nav_2d_msgs::msg::Twist2D first = twists[0];
 
   double min_x = first.x, max_x = first.x, min_y = first.y, max_y = first.y;
@@ -98,7 +98,7 @@ TEST(VelocityIterator, standard_gen)
   StandardTrajectoryGenerator gen;
   gen.initialize(nh);
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
-  EXPECT_EQ(twists.size(), 1926);
+  EXPECT_EQ(twists.size(), 1926u);
   checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, 0.55, 0.1, 0.4);
 }
 
@@ -111,7 +111,7 @@ TEST(VelocityIterator, max_xy)
 
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
   // Expect more twists since max_speed_xy is now beyond feasible limits
-  EXPECT_EQ(twists.size(), 2010);
+  EXPECT_EQ(twists.size(), 2010u);
   checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1));
 }
 
@@ -123,7 +123,7 @@ TEST(VelocityIterator, min_xy)
   gen.initialize(nh);
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
   // Expect even more since theres no min_speed_xy
-  EXPECT_EQ(twists.size(), 2015);
+  EXPECT_EQ(twists.size(), 2015u);
   checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0);
 }
 
@@ -135,7 +135,7 @@ TEST(VelocityIterator, min_theta)
   gen.initialize(nh);
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
   // Expect even more since theres no min_speed_xy
-  EXPECT_EQ(twists.size(), 2015);
+  EXPECT_EQ(twists.size(), 2015u);
   checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0);
 }
 
@@ -149,7 +149,7 @@ TEST(VelocityIterator, no_limits)
   gen.initialize(nh);
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
   // vx_samples * vtheta_samples * vy_samples + added zero theta samples - (0,0,0)
-  EXPECT_EQ(twists.size(), 20 * 20 * 5 + 100 - 1);
+  EXPECT_EQ(twists.size(), 20u * 20u * 5u + 100u - 1u);
   checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1), 0.0, 0.0);
 }
 
@@ -166,7 +166,7 @@ TEST(VelocityIterator, no_limits_samples)
   StandardTrajectoryGenerator gen;
   gen.initialize(nh);
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
-  EXPECT_EQ(twists.size(), x_samples * y_samples * theta_samples - 1);
+  EXPECT_EQ(twists.size(), static_cast<unsigned>(x_samples * y_samples * theta_samples - 1));
   checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1), 0.0, 0.0);
 }
 
@@ -195,7 +195,7 @@ TEST(VelocityIterator, dwa_gen)
   gen.initialize(nh);
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
   // Same as no-limits since everything is within our velocity limits
-  EXPECT_EQ(twists.size(), 20 * 20 * 5 + 100 - 1);
+  EXPECT_EQ(twists.size(), 20u * 20u * 5u + 100u - 1u);
   checkLimits(twists, 0.0, 0.125, -0.1, 0.1, -0.16, 0.16, hypot(0.125, 0.1), 0.0, 0.1);
 }
 
@@ -206,7 +206,7 @@ TEST(VelocityIterator, dwa_gen_no_param)
   dwb_plugins::LimitedAccelGenerator gen;
   gen.initialize(nh);
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
-  EXPECT_EQ(twists.size(), 20 * 20 * 5 + 100 - 1);
+  EXPECT_EQ(twists.size(), 20u * 20u * 5u + 100u - 1u);
   checkLimits(twists, 0.0, 0.125, -0.1, 0.1, -0.16, 0.16, hypot(0.125, 0.1), 0.0, 0.1);
 }
 
@@ -222,7 +222,7 @@ TEST(VelocityIterator, nonzero)
   initial.y = -0.08;
   initial.theta = 0.05;
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(initial);
-  EXPECT_EQ(twists.size(), 2519);
+  EXPECT_EQ(twists.size(), 2519u);
   checkLimits(twists, 0.0, 0.225, -0.1, 0.045, -0.11000000000000003, 0.21,
     0.24622144504490268, 0.0, 0.1);
 }
@@ -362,7 +362,7 @@ TEST(TrajectoryGenerator, accel)
   dwb_msgs::msg::Trajectory2D res = gen.generateTrajectory(origin, zero, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.duration), 5.0);
-  ASSERT_EQ(res.poses.size(), 5);
+  ASSERT_EQ(res.poses.size(), 5u);
   matchPose(res.poses[0], origin);
   matchPose(res.poses[1], 0.1, 0, 0);
   matchPose(res.poses[2], 0.3, 0, 0);
@@ -386,7 +386,7 @@ TEST(TrajectoryGenerator, dwa)
   dwb_msgs::msg::Trajectory2D res = gen.generateTrajectory(origin, zero, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.duration), 5.0);
-  ASSERT_EQ(res.poses.size(), 5);
+  ASSERT_EQ(res.poses.size(), 5u);
   matchPose(res.poses[0], origin);
   matchPose(res.poses[1], 0.3, 0, 0);
   matchPose(res.poses[2], 0.6, 0, 0);

--- a/nav2_dwb_controller/dwb_plugins/test/twist_gen.launch
+++ b/nav2_dwb_controller/dwb_plugins/test/twist_gen.launch
@@ -1,3 +1,0 @@
-<launch>
-  <test test-name="twist_gen_test" pkg="dwb_plugins" type="twist_gen_test" />
-</launch>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Resolves #353. Resolves #365 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  NA  |

---

## Description of contribution in a few bullet points

* Fixed build failures that sometimes occurred in dwb_plugins tests. They are now built as gtest executables instead of just executables.
* The tests no longer require rostest. They are just standard gtest executables and can be launched without a launch file or other support.
* Enabled the goal_checker test so it will be run by `colcon test`

---

## Future work that may be required in bullet points

* Need to re-enable the `twist_gen_test` however it is dependent on getting kinematic parameters as node parameters. Right now they are hard coded.

---

