### PR TITLE
Ignoring pedantic to fix compilation error

### DIFF
--- a/nav2_motion_primitives/src/spin.cpp
+++ b/nav2_motion_primitives/src/spin.cpp
@@ -20,7 +20,9 @@
 #include <memory>
 
 #include "nav2_motion_primitives/spin.hpp"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "tf2/utils.h"
+#pragma GCC diagnostic pop
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (NA) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (HP Desktop) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

---
Master fails to compile due to ```tf2/impl/utils.h:114:2: error: extra ‘;’ [-Werror=pedantic]
 };```