### PR TITLE
Fix nav2_motion_primitives version to match other packages

### DIFF
--- a/nav2_motion_primitives/package.xml
+++ b/nav2_motion_primitives/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nav2_motion_primitives</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>TODO</description>
   <maintainer email="carlos.a.orduno@intel.com">Carlos Orduno</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Resolves #431 |
| Primary OS tested on |  |
| Robotic platform tested on | |

---

## Description of contribution in a few bullet points

* Bumps nav2_motion_primitives version to 0.1.1 to match others. Required for bloom release.

