### PR TITLE
Use new ros2 branch of the BehaviorTree.CPP library

### DIFF
--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   behavior_tree_core:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: 5904431
+    version: ros2
   angles:
     type: git
     url: https://github.com/ros/angles.git


### PR DESCRIPTION
## Description of contribution in a few bullet points

* Use the newly-created 'ros2' branch of the BehaviorTree.CPP library