### PR TITLE
Remove bt_conversions work around (now fixed)

### DIFF
--- a/nav2_tasks/include/nav2_tasks/bt_conversions.hpp
+++ b/nav2_tasks/include/nav2_tasks/bt_conversions.hpp
@@ -15,46 +15,15 @@
 #ifndef NAV2_TASKS__BT_CONVERSIONS_HPP_
 #define NAV2_TASKS__BT_CONVERSIONS_HPP_
 
-#include <string>
 #include "behaviortree_cpp/behavior_tree.h"
-#include "behaviortree_cpp/blackboard/blackboard.h"
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
-#include "geometry_msgs/msg/pose_stamped.hpp"
-#include "nav2_msgs/msg/path.hpp"
 
 namespace BT
 {
 
-// The following four conversion functions are required to be defined by the BT library,
-// but are not actually called. TODO(mjeronimo): See if we can avoid these.
-
-template<>
-inline rclcpp::Node::SharedPtr convertFromString(const StringView & /*key*/)
-{
-  return nullptr;
-}
-
-template<>
-inline std::chrono::milliseconds convertFromString(const StringView & /*key*/)
-{
-  return std::chrono::milliseconds(0);
-}
-
-template<>
-inline nav2_msgs::msg::Path::SharedPtr convertFromString(const StringView & /*key*/)
-{
-  return nullptr;
-}
-
-template<>
-inline geometry_msgs::msg::PoseStamped::SharedPtr convertFromString(const StringView & /*key*/)
-{
-  return nullptr;
-}
-
-
-// These are needed to be able to set parameters for these types in the BT XML
+// The follow templates are needed to be able to use these types as parameters
+// in the BT XML files
 
 template<>
 inline geometry_msgs::msg::Point convertFromString(const StringView & key)


### PR DESCRIPTION
## Description of contribution in a few bullet points

Previously, the BT Library required (incorrectly) that any item used on the blackboard must also have a function for reading it from a string. This should have only been required for items that were used as parameters (not items on the blackboard). Davide has fixed this and the fix is present in the ros2 branch of the library that we're using, rendering this code unnecessary.
