### PR TITLE
Remove static tf publishers from bringup launch file

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -16,18 +16,6 @@ def generate_launch_description():
             'use_sim_time', default_value='false', description='Use simulation (Gazebo) clock if true'),
 
         launch_ros.actions.Node(
-            package='tf2_ros',
-            node_executable='static_transform_publisher',
-            output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'base_footprint', 'base_link']),
-
-        launch_ros.actions.Node(
-            package='tf2_ros',
-            node_executable='static_transform_publisher',
-            output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_scan']),
-
-        launch_ros.actions.Node(
             package='nav2_map_server',
             node_executable='map_server',
             node_name='map_server',


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info
Removes the static transform publishers from the nav2_bringup_launch.py file.

These were a work-around since we didn't have a fully working tf tree. We now have one available (turtlebot3) and documented as an example in the bringup README. 

We've already removed this from the "bringup_1st" launch file also, so this was an oversight.



