### PR TITLE
Add dependencies based on package build failures.

### DIFF
--- a/nav2_dwb_controller/nav_2d_msgs/package.xml
+++ b/nav2_dwb_controller/nav_2d_msgs/package.xml
@@ -7,11 +7,13 @@
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
   <license>BSD</license>
 
+  <build_export_depend>rosidl_default_runtime</build_export_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>rosidl_default_runtime</depend>
+  <depend>rosidl_default_generators</depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/nav2_dynamic_params/package.xml
+++ b/nav2_dynamic_params/package.xml
@@ -15,6 +15,8 @@
 
   <depend>rclcpp</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 

--- a/nav2_map_server/package.xml
+++ b/nav2_map_server/package.xml
@@ -17,6 +17,7 @@
   <depend>rclcpp</depend>
   <depend>sdl</depend>
   <depend>sdl-image</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_robot/package.xml
+++ b/nav2_robot/package.xml
@@ -20,6 +20,8 @@
   <exec_depend>urdf</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 

--- a/nav2_tasks/package.xml
+++ b/nav2_tasks/package.xml
@@ -12,6 +12,7 @@
 
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>behaviortree_cpp</build_depend>
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -21,6 +22,7 @@
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>behaviortree_cpp</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>

--- a/nav2_util/package.xml
+++ b/nav2_util/package.xml
@@ -10,13 +10,19 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>nav2_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_ros</build_depend>
 
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>tf2</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Packaging failures on build.ros2.org |
| Primary OS tested on | none |
| Robotic platform tested on | none |

---

## Description of contribution in a few bullet points

* Added some dependencies based on cursory CMakeLists.txt examination and failing builds on build.ros2.org
  * http://build.ros2.org/job/Cbin_uB64__nav2_map_server__ubuntu_bionic_amd64__binary/4/
  * http://build.ros2.org/job/Cbin_uB64__nav2_robot__ubuntu_bionic_amd64__binary/4/
  * http://build.ros2.org/job/Cbin_uB64__nav2_tasks__ubuntu_bionic_amd64__binary/4/
  * http://build.ros2.org/job/Cbin_uB64__nav2_util__ubuntu_bionic_amd64__binary/4/
  * http://build.ros2.org/job/Cbin_uB64__nav2_dynamic_params__ubuntu_bionic_amd64__binary/3/

---

## Future work that may be required in bullet points

* Review dependencies for these and other packages and make sure they're referenced in each appropriate package.xml
---

It appears that there are some packages required in CMakeLists.txt that
aren't declared in package.xml manifests.

I haven't tested these changes at all and they are based on an extremely
cursory glance at failed builds on build.ros2.org and the CMakeLists.txt of packages whose binary jobs are currently failing so I would suggest at least a moderately scrupulous review.

I used my ownership powers on ros-planning somewhat dubiously to push a branch directly to this repository to make it as straightforward as possible for a package maintainer to pick up where I left off. 