### PR TITLE
Enable obstacle_layer marking/clearing observations

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -21,6 +21,8 @@ DwbController:
 local_costmap:
   local_costmap:
     ros__parameters:
+      obstacle_layer:
+        enabled: False
       always_send_full_costmap: True
       observation_sources: scan
       scan:
@@ -30,6 +32,8 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
+      obstacle_layer:
+        enabled: False
       always_send_full_costmap: True
       observation_sources: scan
       scan:

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -22,7 +22,17 @@ local_costmap:
   local_costmap:
     ros__parameters:
       always_send_full_costmap: True
+      observation_sources: scan
+      scan:
+        topic: /scan
+        max_obstacle_height: 2.0
+        clearing: True
 global_costmap:
   global_costmap:
     ros__parameters:
       always_send_full_costmap: True
+      observation_sources: scan
+      scan:
+        topic: /scan
+        max_obstacle_height: 2.0
+        clearing: True

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -110,7 +110,7 @@ void ObstacleLayer::onInitialize()
     node_->get_parameter_or(source + "." + "min_obstacle_height", min_obstacle_height, 0.0);
     node_->get_parameter_or(source + "." + "max_obstacle_height", max_obstacle_height, 0.0);
     node_->get_parameter_or(source + "." + "inf_is_valid", inf_is_valid, false);
-    node_->get_parameter_or(source + "." + "marking", marking, false);
+    node_->get_parameter_or(source + "." + "marking", marking, true);
     node_->get_parameter_or(source + "." + "clearing", clearing, false);
 
     if (!(data_type == "PointCloud2" || data_type == "LaserScan")) {
@@ -120,15 +120,13 @@ void ObstacleLayer::onInitialize()
               "Only topics that use point cloud2s or laser scans are currently supported");
     }
 
-    std::string raytrace_range_param_name, obstacle_range_param_name;
-
     // get the obstacle range for the sensor
     double obstacle_range;
     node_->get_parameter_or(source + "." + "obstacle_range", obstacle_range, 2.5);
 
     // get the raytrace range for the sensor
     double raytrace_range;
-    node_->get_parameter_or(source + "." + "raytrace_range", obstacle_range, 3.0);
+    node_->get_parameter_or(source + "." + "raytrace_range", raytrace_range, 3.0);
 
     RCLCPP_DEBUG(node_->get_logger(),
       "Creating an observation buffer for source %s, topic %s, frame %s",


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Turtlebot3 Gazebo |

---

## Description of contribution in a few bullet points
- sets default for observation_layer sensor marking observations to True
- adds clearing observation parameter set to True for scan sensor
- fixes `raytrace_range` assignment bug/error
- with above changes, obstacles can be detected and cleared in real time 
---

## Future work that may be required in bullet points
- Though obstacles were detected, sometimes the local planner failed to find a valid path even though global planner would create a valid path. Should further test to see why this would be the case given a valid costmap.
