### PR TITLE
Refactor map saver

### DIFF
--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -52,6 +52,7 @@ set(map_server_dependencies
   nav_msgs
   yaml_cpp_vendor
   std_msgs
+  tf2
 )
 
 set(map_saver_dependencies
@@ -73,6 +74,10 @@ ament_target_dependencies(${library_name}
 )
 
 target_link_libraries(${map_server_executable}
+  ${library_name}
+)
+
+target_link_libraries(${map_saver_executable}
   ${library_name}
 )
 

--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -44,6 +44,7 @@ set(library_name ${map_server_executable}_core)
 add_library(${library_name} SHARED
   src/occ_grid_loader.cpp
   src/map_server.cpp
+  src/map_generator.cpp
 )
 
 set(map_server_dependencies

--- a/nav2_map_server/include/nav2_map_server/map_generator.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_generator.hpp
@@ -25,7 +25,7 @@ namespace nav2_map_server
 class MapGenerator : public rclcpp::Node
 {
 public:
-  MapGenerator(const std::string& mapname, int threshold_occupied, int threshold_free);
+  MapGenerator(const std::string & mapname, int threshold_occupied, int threshold_free);
 
   void mapCallback(const nav_msgs::msg::OccupancyGrid::SharedPtr map);
 

--- a/nav2_map_server/include/nav2_map_server/map_generator.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_generator.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_MAP_SERVER__MAP_GENERATOR_HPP_
+#define NAV2_MAP_SERVER__MAP_GENERATOR_HPP_
+
+#include <string>
+#include "rclcpp/rclcpp.hpp"
+#include "nav_msgs/srv/get_map.hpp"
+
+namespace nav2_map_server
+{
+
+class MapGenerator : public rclcpp::Node
+{
+public:
+  MapGenerator(const std::string& mapname, int threshold_occupied, int threshold_free);
+
+  void mapCallback(const nav_msgs::msg::OccupancyGrid::SharedPtr map);
+
+  bool saved_map_;
+
+private:
+  std::string mapname_;
+  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::ConstSharedPtr map_sub_;
+  int threshold_occupied_;
+  int threshold_free_;
+};
+
+}  // namespace nav2_map_server
+
+#endif  // NAV2_MAP_SERVER__MAP_GENERATOR_HPP_

--- a/nav2_map_server/src/map_generator.cpp
+++ b/nav2_map_server/src/map_generator.cpp
@@ -1,0 +1,118 @@
+/*
+ * map_saver
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <ORGANIZATION> nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nav2_map_server/map_generator.hpp"
+
+#include <cstdio>
+#include <string>
+#include <memory>
+#include "rclcpp/rclcpp.hpp"
+#include "nav_msgs/srv/get_map.hpp"
+#include "nav_msgs/msg/occupancy_grid.h"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2/LinearMath/Matrix3x3.h"
+
+namespace nav2_map_server
+{
+
+/**
+ * @brief Map generation node.
+ */
+MapGenerator::MapGenerator(const std::string& mapname, int threshold_occupied, int threshold_free)
+: Node("map_saver"),
+        saved_map_(false),
+        mapname_(mapname),
+        threshold_occupied_(threshold_occupied),
+        threshold_free_(threshold_free)
+{
+  RCLCPP_INFO(get_logger(), "Waiting for the map");
+  map_sub_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
+             "map", std::bind(&MapGenerator::mapCallback, this, std::placeholders::_1));
+}
+
+void MapGenerator::mapCallback(const nav_msgs::msg::OccupancyGrid::SharedPtr map)
+{
+  rclcpp::Logger logger = this->get_logger();
+  RCLCPP_INFO(logger, "Received a %d X %d map @ %.3f m/pix",
+              map->info.width,
+              map->info.height,
+              map->info.resolution);
+
+
+  std::string mapdatafile = mapname_ + ".pgm";
+  RCLCPP_INFO(logger, "Writing map occupancy data to %s", mapdatafile.c_str());
+  FILE* out = fopen(mapdatafile.c_str(), "w");
+  if (!out)
+  {
+  RCLCPP_ERROR(logger, "Couldn't save map file to %s", mapdatafile.c_str());
+  return;
+  }
+
+  fprintf(out, "P5\n# CREATOR: map_saver.cpp %.3f m/pix\n%d %d\n255\n",
+          map->info.resolution, map->info.width, map->info.height);
+  for(unsigned int y = 0; y < map->info.height; y++) {
+    for(unsigned int x = 0; x < map->info.width; x++) {
+      unsigned int i = x + (map->info.height - y - 1) * map->info.width;
+      if (map->data[i] >= 0 && map->data[i] <= threshold_free_) {  // [0,free)
+        fputc(254, out);
+      } else if (map->data[i] >= threshold_occupied_) {  // (occ,255]
+        fputc(000, out);
+      } else {  // occ [0.25,0.65]
+        fputc(205, out);
+      }
+    }
+  }
+
+  fclose(out);
+
+  std::string mapmetadatafile = mapname_ + ".yaml";
+  RCLCPP_INFO(logger, "Writing map occupancy data to %s", mapmetadatafile.c_str());
+  FILE* yaml = fopen(mapmetadatafile.c_str(), "w");
+
+  geometry_msgs::msg::Quaternion orientation = map->info.origin.orientation;
+  tf2::Matrix3x3 mat(tf2::Quaternion(orientation.x,
+                                     orientation.y,
+                                     orientation.z,
+                                     orientation.w));
+  double yaw, pitch, roll;
+  mat.getEulerYPR(yaw, pitch, roll);
+
+  fprintf(yaml, "image: %s\nresolution: %f\norigin: [%f, %f, %f]\n",
+          mapdatafile.c_str(), map->info.resolution,
+          map->info.origin.position.x, map->info.origin.position.y, yaw);
+  fprintf(yaml, "negate: 0\noccupied_thresh: 0.65\nfree_thresh: 0.196\n\n");
+
+  fclose(yaml);
+
+  RCLCPP_INFO(logger, "Done\n");
+  saved_map_ = true;
+}
+
+}  // namespace nav2_map_server

--- a/nav2_map_server/src/map_saver.cpp
+++ b/nav2_map_server/src/map_saver.cpp
@@ -32,98 +32,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
-#include <memory>
 #include "rclcpp/rclcpp.hpp"
-#include "nav_msgs/srv/get_map.hpp"
-#include "nav_msgs/msg/occupancy_grid.h"
-#include "tf2/LinearMath/Matrix3x3.h"
-#include "tf2/LinearMath/Quaternion.h"
-
-
-/**
- * @brief Map generation node.
- */
-class MapGenerator : public rclcpp::Node
-{
-public:
-  MapGenerator(const std::string & mapname, int threshold_occupied, int threshold_free)
-  : Node("map_saver"),
-    mapname_(mapname),
-    saved_map_(false),
-    threshold_occupied_(threshold_occupied),
-    threshold_free_(threshold_free)
-  {
-    RCLCPP_INFO(get_logger(), "Waiting for the map");
-    map_sub_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
-      "map", std::bind(&MapGenerator::mapCallback, this, std::placeholders::_1));
-  }
-
-  void mapCallback(const nav_msgs::msg::OccupancyGrid::SharedPtr map)
-  {
-    rclcpp::Logger logger = get_logger();
-    RCLCPP_INFO(logger, "Received a %d X %d map @ %.3f m/pix",
-      map->info.width,
-      map->info.height,
-      map->info.resolution);
-
-
-    std::string mapdatafile = mapname_ + ".pgm";
-    RCLCPP_INFO(logger, "Writing map occupancy data to %s", mapdatafile.c_str());
-    FILE * out = fopen(mapdatafile.c_str(), "w");
-    if (!out) {
-      RCLCPP_ERROR(logger, "Couldn't save map file to %s", mapdatafile.c_str());
-      return;
-    }
-
-    fprintf(out, "P5\n# CREATOR: map_saver.cpp %.3f m/pix\n%d %d\n255\n",
-      map->info.resolution, map->info.width, map->info.height);
-    for (unsigned int y = 0; y < map->info.height; y++) {
-      for (unsigned int x = 0; x < map->info.width; x++) {
-        unsigned int i = x + (map->info.height - y - 1) * map->info.width;
-        if (map->data[i] >= 0 && map->data[i] <= threshold_free_) {    // [0,free)
-          fputc(254, out);
-        } else if (map->data[i] >= threshold_occupied_) {    // (occ,255]
-          fputc(000, out);
-        } else {    // occ [0.25,0.65]
-          fputc(205, out);
-        }
-      }
-    }
-
-    fclose(out);
-
-
-    std::string mapmetadatafile = mapname_ + ".yaml";
-    RCLCPP_INFO(logger, "Writing map occupancy data to %s", mapmetadatafile.c_str());
-    FILE * yaml = fopen(mapmetadatafile.c_str(), "w");
-
-    geometry_msgs::msg::Quaternion orientation = map->info.origin.orientation;
-    tf2::Matrix3x3 mat(tf2::Quaternion(
-        orientation.x,
-        orientation.y,
-        orientation.z,
-        orientation.w
-    ));
-    double yaw, pitch, roll;
-    mat.getEulerYPR(yaw, pitch, roll);
-
-    fprintf(yaml, "image: %s\nresolution: %f\norigin: [%f, %f, %f]\n",
-      mapdatafile.c_str(), map->info.resolution,
-      map->info.origin.position.x, map->info.origin.position.y, yaw);
-    fprintf(yaml, "negate: 0\noccupied_thresh: 0.65\nfree_thresh: 0.196\n\n");
-
-    fclose(yaml);
-
-    RCLCPP_INFO(logger, "Done\n");
-    saved_map_ = true;
-  }
-
-  std::string mapname_;
-  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::ConstSharedPtr map_sub_;
-  bool saved_map_;
-  int threshold_occupied_;
-  int threshold_free_;
-};
+#include "nav2_map_server/map_generator.hpp"
 
 #define USAGE "Usage: \n" \
   "  map_saver -h\n" \
@@ -185,7 +95,7 @@ int main(int argc, char ** argv)
     return 1;
   }
 
-  auto map_gen = std::make_shared<MapGenerator>(mapname, threshold_occupied, threshold_free);
+  auto map_gen = std::make_shared<nav2_map_server::MapGenerator>(mapname, threshold_occupied, threshold_free);
 
   while (!map_gen->saved_map_ && rclcpp::ok()) {
     rclcpp::spin_some(map_gen);

--- a/nav2_map_server/src/map_saver.cpp
+++ b/nav2_map_server/src/map_saver.cpp
@@ -32,6 +32,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <memory>
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_map_server/map_generator.hpp"
 
@@ -95,7 +96,8 @@ int main(int argc, char ** argv)
     return 1;
   }
 
-  auto map_gen = std::make_shared<nav2_map_server::MapGenerator>(mapname, threshold_occupied, threshold_free);
+  auto map_gen = std::make_shared<nav2_map_server::MapGenerator>(mapname, threshold_occupied,
+      threshold_free);
 
   while (!map_gen->saved_map_ && rclcpp::ok()) {
     rclcpp::spin_some(map_gen);


### PR DESCRIPTION

## Description of contribution in a few bullet points
Follow on PR to #462 - Port Map Saver
Refactors the MapGenerator class out of map_saver.cpp into map_generator.cpp

## Future work that may be required in bullet points
There's still a bug to fix where the wrong values for occupied threshold and free threshold are written to the yaml file - that will have to be a separate PR - I'll file an issue for it