### PR TITLE
Renaming getCurrentVelocity and getCurrentPose to address #163

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ before_install:
 script:
   - docker run --name nav2_bash --rm -d -i -t nav2:latest bash -l
   - docker exec nav2_bash bash -c '. /ros2_ws/navigation2_ws/install/setup.bash &&
-      colcon test --packages-skip nav2_tasks'
+      colcon test --ctest-args " -V" --packages-skip nav2_tasks'
   - docker exec nav2_bash bash -c "colcon test-result --verbose"

--- a/nav2_robot/include/nav2_robot/robot.hpp
+++ b/nav2_robot/include/nav2_robot/robot.hpp
@@ -31,8 +31,11 @@ public:
   explicit Robot(rclcpp::Node::SharedPtr & node);
   Robot() = delete;
 
-  bool getCurrentPose(geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr & robot_pose);
-  bool getCurrentVelocity(nav_msgs::msg::Odometry::SharedPtr & robot_velocity);
+  bool getGlobalLocalizerPose(
+    geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr & robot_pose);
+  bool getCurrentPose(
+    geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr & robot_pose);
+  bool getOdometry(nav_msgs::msg::Odometry::SharedPtr & robot_odom);
   std::string getName();
   void sendVelocity(geometry_msgs::msg::Twist twist);
 
@@ -52,8 +55,8 @@ protected:
   // The current pose as received from the Pose subscription
   geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr current_pose_;
 
-  // The current velocity as received from the Odometry subscription
-  nav_msgs::msg::Odometry::SharedPtr current_velocity_;
+  // The odometry as received from the Odometry subscription
+  nav_msgs::msg::Odometry::SharedPtr current_odom_;
 
   // Whether the subscriptions have been received
   bool initial_pose_received_;

--- a/nav2_robot/src/robot.cpp
+++ b/nav2_robot/src/robot.cpp
@@ -72,10 +72,7 @@ bool
 Robot::getCurrentPose(
   geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr & robot_pose)
 {
-  if (!getGlobalLocalizerPose(robot_pose)) {
-    return false;
-  }
-  return true;
+  return getGlobalLocalizerPose(robot_pose);
 }
 
 bool

--- a/nav2_robot/src/robot.cpp
+++ b/nav2_robot/src/robot.cpp
@@ -47,14 +47,15 @@ Robot::onPoseReceived(const geometry_msgs::msg::PoseWithCovarianceStamped::Share
 void
 Robot::onOdomReceived(const nav_msgs::msg::Odometry::SharedPtr msg)
 {
-  current_velocity_ = msg;
+  current_odom_ = msg;
   if (!initial_odom_received_) {
     initial_odom_received_ = true;
   }
 }
 
 bool
-Robot::getCurrentPose(geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr & robot_pose)
+Robot::getGlobalLocalizerPose(
+  geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr & robot_pose)
 {
   if (!initial_pose_received_) {
     RCLCPP_WARN(node_->get_logger(),
@@ -66,8 +67,19 @@ Robot::getCurrentPose(geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr &
   return true;
 }
 
+// TODO(mhpanah): We should get current pose from transforms.
 bool
-Robot::getCurrentVelocity(nav_msgs::msg::Odometry::SharedPtr & robot_velocity)
+Robot::getCurrentPose(
+  geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr & robot_pose)
+{
+  if (!getGlobalLocalizerPose(robot_pose)) {
+    return false;
+  }
+  return true;
+}
+
+bool
+Robot::getOdometry(nav_msgs::msg::Odometry::SharedPtr & robot_odom)
 {
   if (!initial_odom_received_) {
     RCLCPP_WARN(node_->get_logger(),
@@ -75,7 +87,7 @@ Robot::getCurrentVelocity(nav_msgs::msg::Odometry::SharedPtr & robot_velocity)
     return false;
   }
 
-  robot_velocity = current_velocity_;
+  robot_odom = current_odom_;
   return true;
 }
 

--- a/nav2_robot/test/test_robot_class.cpp
+++ b/nav2_robot/test/test_robot_class.cpp
@@ -141,11 +141,11 @@ TEST_F(TestRobotClass, getPoseTest)
   EXPECT_EQ(*currentPose, testPose_);
 }
 
-TEST_F(TestRobotClass, getVelocityTest)
+TEST_F(TestRobotClass, getOdometryTest)
 {
   auto currentOdom = std::make_shared<nav_msgs::msg::Odometry>();
   rclcpp::Rate r(10);
-  while (!(robot_->getCurrentVelocity(currentOdom))) {
+  while (!(robot_->getOdometry(currentOdom))) {
     publishOdom();
     rclcpp::spin_some(node_);
     r.sleep();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#163) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (HP Desktop) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
Addressing first TODO items of issue #163.

- Renamed `getCurrentVelocity` to `getOdometry` which contains both odometry pose and twist.
- Renamed `getCurrentPose` to `getGlobalLocalizerPose`.  This way we know this is the estimated pose from the localizer and not the odometry.

---
## Future work that may be required in bullet points
- Do the remaining of the TODO's.
