### PR TITLE
Fix Travis build - remove gazebo_ros_pkgs dependency

### DIFF
--- a/nav2_system_tests/CMakeLists.txt
+++ b/nav2_system_tests/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(nav_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(gazebo_ros_pkgs REQUIRED)
 find_package(nav2_amcl REQUIRED)
 find_package(rclpy REQUIRED)
 
@@ -33,7 +32,6 @@ set(dependencies
   nav_msgs
   visualization_msgs
   nav2_amcl
-  gazebo_ros_pkgs
   geometry_msgs
   std_msgs
   rclpy

--- a/nav2_system_tests/package.xml
+++ b/nav2_system_tests/package.xml
@@ -21,7 +21,6 @@
   <build_depend>launch_testing</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>gazebo_ros_pkgs</build_depend>
   <build_depend>launch_ros</build_depend>
   <build_depend>launch_testing</build_depend>
 
@@ -37,7 +36,6 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nav2_amcl</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>gazebo_ros_pkgs</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch_testing</exec_depend>
 

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -7,7 +7,3 @@ repositories:
     type: git
     url: https://github.com/ros/angles.git
     version: ros2
-  gazebo_ros_pkgs:
-    type: git
-    url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-    version: ros2


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info
Removes gazebo_ros_pkgs from the dependencies for nav2_system_tests. They should still build fine but won't run without those packages installed. This should hopefully fix the build and we can find another solution later.