### PR TITLE
Remove unneeded depends from nav2_bringup

### DIFF
--- a/nav2_bringup/CMakeLists.txt
+++ b/nav2_bringup/CMakeLists.txt
@@ -10,14 +10,5 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
-find_package(rclcpp REQUIRED)
 find_package(ament_cmake REQUIRED)
-find_package(builtin_interfaces REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
-find_package(navigation2 REQUIRED)
-
-ament_export_dependencies(rosidl_default_runtime)
-
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
-
-ament_package()

--- a/nav2_bringup/CMakeLists.txt
+++ b/nav2_bringup/CMakeLists.txt
@@ -11,4 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(navigation2 REQUIRED)
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/nav2_bringup/package.xml
+++ b/nav2_bringup/package.xml
@@ -9,27 +9,9 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
-  <build_depend>rclcpp</build_depend>
-  <build_depend>navigation2</build_depend>
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>rosidl_default_generators</build_depend>
-  <build_depend>launch_ros</build_depend>
-
-  <exec_depend>launch_ros</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
+  
+<exec_depend>launch_ros</exec_depend>
   <exec_depend>navigation2</exec_depend>
-
-  <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch</test_depend>
-  <test_depend>launch_testing</test_depend>
-
-  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_bringup/package.xml
+++ b/nav2_bringup/package.xml
@@ -9,9 +9,21 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  
-<exec_depend>launch_ros</exec_depend>
+
+  <build_depend>rclcpp</build_depend>  
+  <build_depend>navigation2</build_depend>
+  <build_depend>launch_ros</build_depend>
+
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
   <exec_depend>navigation2</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_testing</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_bringup/package.xml
+++ b/nav2_bringup/package.xml
@@ -10,12 +10,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>rclcpp</build_depend>  
   <build_depend>navigation2</build_depend>
   <build_depend>launch_ros</build_depend>
 
   <exec_depend>launch_ros</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
   <exec_depend>navigation2</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #477 Update Exported Dependencies|
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | NA - made sure the launch files are still installed and working |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

---
Removes extra dependencies from nav2_bringup CMakeLists and package.xml

