### PR TITLE
Cleaner way to disable unused param warning.

### DIFF
--- a/nav2_dwb_controller/costmap_queue/include/costmap_queue/costmap_queue.hpp
+++ b/nav2_dwb_controller/costmap_queue/include/costmap_queue/costmap_queue.hpp
@@ -140,10 +140,7 @@ public:
    * @param cell The cell to check
    * @return True, unless overriden
    */
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wunused-parameter"
-  virtual bool validCellToQueue(const CellData & cell) {return true;}
-  #pragma GCC diagnostic pop
+  virtual bool validCellToQueue(const CellData & /*cell*/) {return true;}
   /**
    * @brief convenience typedef for a pointer
    */


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  NA  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* Since originally writing these pragmas, I've learned a better way of disabling the unused parameter warning from @orduno This change just cleans up the code a smidge.
