### PR TITLE
Use the new onInit method from BT library

### DIFF
--- a/nav2_tasks/include/nav2_tasks/back_up_action.hpp
+++ b/nav2_tasks/include/nav2_tasks/back_up_action.hpp
@@ -36,6 +36,8 @@ public:
 
   void onInit() override
   {
+    BtActionNode<BackUpCommand, BackUpResult>::onInit();
+
     // Create the input and output messages
     command_ = std::make_shared<nav2_tasks::BackUpCommand>();
     result_ = std::make_shared<nav2_tasks::BackUpResult>();

--- a/nav2_tasks/include/nav2_tasks/compute_path_to_pose_action.hpp
+++ b/nav2_tasks/include/nav2_tasks/compute_path_to_pose_action.hpp
@@ -37,6 +37,8 @@ public:
 
   void onInit() override
   {
+    BtActionNode<ComputePathToPoseCommand, ComputePathToPoseResult>::onInit();
+
     command_ =
       blackboard()->template get<nav2_tasks::ComputePathToPoseCommand::SharedPtr>("goal");
 

--- a/nav2_tasks/include/nav2_tasks/follow_path_action.hpp
+++ b/nav2_tasks/include/nav2_tasks/follow_path_action.hpp
@@ -36,6 +36,8 @@ public:
 
   void onInit() override
   {
+    BtActionNode<FollowPathCommand, FollowPathResult>::onInit();
+
     // Set up the input and output messages
     command_ = blackboard()->template get<nav2_tasks::ComputePathToPoseResult::SharedPtr>("path");
     result_ = std::make_shared<nav2_tasks::FollowPathResult>();

--- a/nav2_tasks/include/nav2_tasks/navigate_to_pose_action.hpp
+++ b/nav2_tasks/include/nav2_tasks/navigate_to_pose_action.hpp
@@ -32,6 +32,10 @@ public:
   NavigateToPoseAction(const std::string & action_name, const BT::NodeParameters & params)
   : BtActionNode<NavigateToPoseCommand, NavigateToPoseResult>(action_name, params)
   {
+  //}
+
+  //void onInit() override
+  //{
     // Use the position and orientation fields from the XML attributes
     geometry_msgs::msg::Point position;
     bool have_position = getParam<geometry_msgs::msg::Point>("position", position);

--- a/nav2_tasks/include/nav2_tasks/navigate_to_pose_action.hpp
+++ b/nav2_tasks/include/nav2_tasks/navigate_to_pose_action.hpp
@@ -32,10 +32,12 @@ public:
   NavigateToPoseAction(const std::string & action_name, const BT::NodeParameters & params)
   : BtActionNode<NavigateToPoseCommand, NavigateToPoseResult>(action_name, params)
   {
-  //}
+  }
 
-  //void onInit() override
-  //{
+  void onInit() override
+  {
+    BtActionNode<NavigateToPoseCommand, NavigateToPoseResult>::onInit();
+
     // Use the position and orientation fields from the XML attributes
     geometry_msgs::msg::Point position;
     bool have_position = getParam<geometry_msgs::msg::Point>("position", position);

--- a/nav2_tasks/include/nav2_tasks/spin_action.hpp
+++ b/nav2_tasks/include/nav2_tasks/spin_action.hpp
@@ -39,6 +39,8 @@ public:
 
   void onInit() override
   {
+    BtActionNode<SpinCommand, SpinResult>::onInit();
+
     // Create the input and output messages
     command_ = std::make_shared<nav2_tasks::SpinCommand>();
     result_ = std::make_shared<nav2_tasks::SpinResult>();

--- a/nav2_tasks/include/nav2_tasks/stop_action.hpp
+++ b/nav2_tasks/include/nav2_tasks/stop_action.hpp
@@ -35,6 +35,8 @@ public:
 
   void onInit() override
   {
+    BtActionNode<StopCommand, StopResult>::onInit();
+
     // Create the input and output messages
     command_ = std::make_shared<nav2_tasks::StopCommand>();
     result_ = std::make_shared<nav2_tasks::StopResult>();


### PR DESCRIPTION
## Description of contribution in a few bullet points

* At our request, Davide added an onInit function to the BT node base class. We can now use this to initialize BT nodes since the blackboard is available when onInit is called.
* This replaces our own onInit; effectively this "first time" checking in the tick() method is now moved into the library itself.

## Future work that may be required in bullet points

* Since Davide has shared with us a method to use complex constructors for BT nodes instead of the standard two-argument constructor, we can avoid using the blackboard for some data and pass it directly to the node constructors.
* Might want to avoid making the classes derived from BtActionNode have to call BtActionNode::onInit. Could avoid this by renaming our own initialize function. That way, the BtActionNode base class would be called from the BT framework it would in turn call the user's initialization function. 