### PR TITLE
Inflate obstacles by default.

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -87,11 +87,11 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
   std::vector<std::string> plugin_names;
   std::vector<std::string> plugin_types;
   get_parameter_or_set("plugin_names", plugin_names,
-    {"static_layer", "inflation_layer", "obstacle_layer"});
+    {"static_layer", "obstacle_layer", "inflation_layer"});
   get_parameter_or_set("plugin_types", plugin_types,
     {"nav2_costmap_2d::StaticLayer",
-      "nav2_costmap_2d::InflationLayer",
-      "nav2_costmap_2d::ObstacleLayer"});
+      "nav2_costmap_2d::ObstacleLayer",
+      "nav2_costmap_2d::InflationLayer"});
 
   get_parameter_or<std::string>("global_frame", global_frame_, std::string("map"));
   get_parameter_or<std::string>("robot_base_frame", robot_base_frame_, std::string("base_link"));


### PR DESCRIPTION
It seems the Costmap plugins run in order, so if you want the obstacles to
be inflated, then obstacle needs to come before inflation in the
list.

This changes the default ordering for that to happen, because that
seems to be the preferred default behavior

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |   |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | TB3 in Gazebo |

