### PR TITLE
Robot velocity should be set to zero after primitive is cancelled

### DIFF
--- a/nav2_motion_primitives/include/nav2_motion_primitives/motion_primitive.hpp
+++ b/nav2_motion_primitives/include/nav2_motion_primitives/motion_primitive.hpp
@@ -103,7 +103,8 @@ protected:
       if (task_server_->cancelRequested()) {
         RCLCPP_INFO(node_->get_logger(), "%s cancelled", taskName_.c_str());
         task_server_->setCanceled();
-        return nav2_tasks::TaskStatus::CANCELED;
+        status = nav2_tasks::TaskStatus::CANCELED;
+        break;
       }
 
       // Log a message every second


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#491 ) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | ( gazebo simulation of turtlebot) |

---

## Description of contribution in a few bullet points

* Fixed a bug with motion primitive base class. After a primitive is cancelled, velocity should be set to zero.
