### PR TITLE
Add Dynamic params tests

### DIFF
--- a/nav2_dynamic_params/CMakeLists.txt
+++ b/nav2_dynamic_params/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -fPIC)
+  add_compile_options(-Wall -Wextra -Wpedantic -fPIC -Wno-sign-compare)
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -69,7 +69,6 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
-  # TODO(bpwilcox): Port/Add unit and component tests
   add_subdirectory(test)
 endif()
 

--- a/nav2_dynamic_params/CMakeLists.txt
+++ b/nav2_dynamic_params/CMakeLists.txt
@@ -70,7 +70,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   # TODO(bpwilcox): Port/Add unit and component tests
-  #add_subdirectory(test)
+  add_subdirectory(test)
 endif()
 
 ament_export_include_directories(include)

--- a/nav2_dynamic_params/include/nav2_dynamic_params/dynamic_params_client.hpp
+++ b/nav2_dynamic_params/include/nav2_dynamic_params/dynamic_params_client.hpp
@@ -233,6 +233,15 @@ protected:
       user_callback_();
     }
   }
+  // Variant of is_in_event to also check the node path of last event
+  bool is_in_event(const std::string & path, const std::string & name)
+  {
+    auto full_path = path;
+    if (*full_path.begin() != '/') {
+      full_path = '/' + full_path;
+    }
+    return full_path == last_event_->node && is_in_event(name);
+  }
 
 private:
   std::vector<rclcpp::Parameter> get_params_from_node(

--- a/nav2_dynamic_params/include/nav2_dynamic_params/dynamic_params_client.hpp
+++ b/nav2_dynamic_params/include/nav2_dynamic_params/dynamic_params_client.hpp
@@ -76,10 +76,9 @@ public:
     if (*full_path.begin() != '/') {
       full_path = '/' + full_path;
     }
-
+    RCLCPP_INFO(node_->get_logger(), "adding parameters from: %s", full_path.c_str());
     init_as_not_set(full_path, param_names);
     std::vector<rclcpp::Parameter> params;
-
     if (full_path == join_path(node_->get_namespace(), node_->get_name())) {
       if (param_names.size() < 1) {
         auto param_list = node_->list_parameters({}, 1);
@@ -94,6 +93,7 @@ public:
           auto param_list = client->list_parameters({}, 1);
           params = client->get_parameters(param_list.names);
         } else {
+          RCLCPP_INFO(node_->get_logger(), "get parameters...");
           params = client->get_parameters(param_names);
         }
       } else {

--- a/nav2_dynamic_params/test/CMakeLists.txt
+++ b/nav2_dynamic_params/test/CMakeLists.txt
@@ -5,3 +5,11 @@ ament_target_dependencies(test_dynamic_params_validator ${dependencies})
 target_link_libraries(test_dynamic_params_validator
   nav2_dynamic_params
 )
+
+ament_add_gtest(test_dynamic_params_client test_dynamic_params_client.cpp)
+
+ament_target_dependencies(test_dynamic_params_client ${dependencies})
+
+target_link_libraries(test_dynamic_params_client
+  nav2_dynamic_params
+)

--- a/nav2_dynamic_params/test/CMakeLists.txt
+++ b/nav2_dynamic_params/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+ament_add_gtest(test_dynamic_params_validator test_dynamic_params_validator.cpp)
+
+ament_target_dependencies(test_dynamic_params_validator ${dependencies})
+
+target_link_libraries(test_dynamic_params_validator
+  nav2_dynamic_params
+)

--- a/nav2_dynamic_params/test/CMakeLists.txt
+++ b/nav2_dynamic_params/test/CMakeLists.txt
@@ -1,3 +1,17 @@
+add_executable(test_dynamic_params_helper test_dynamic_params_helper.cpp)
+
+ament_target_dependencies(test_dynamic_params_helper ${dependencies})
+
+target_link_libraries(test_dynamic_params_helper
+  nav2_dynamic_params
+)
+
+install(TARGETS test_dynamic_params_helper
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
 ament_add_gtest(test_dynamic_params_validator test_dynamic_params_validator.cpp)
 
 ament_target_dependencies(test_dynamic_params_validator ${dependencies})
@@ -6,10 +20,18 @@ target_link_libraries(test_dynamic_params_validator
   nav2_dynamic_params
 )
 
-ament_add_gtest(test_dynamic_params_client test_dynamic_params_client.cpp)
+ament_add_gtest_executable(test_dynamic_params_client_exec test_dynamic_params_client.cpp)
 
-ament_target_dependencies(test_dynamic_params_client ${dependencies})
+ament_target_dependencies(test_dynamic_params_client_exec ${dependencies})
 
-target_link_libraries(test_dynamic_params_client
+target_link_libraries(test_dynamic_params_client_exec
   nav2_dynamic_params
+)
+
+ament_add_test(test_dynamic_params_client
+  GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/dynamic_params_test.launch.py"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  ENV
+    TEST_EXECUTABLE=$<TARGET_FILE:test_dynamic_params_client_exec>
 )

--- a/nav2_dynamic_params/test/dynamic_params_test.launch.py
+++ b/nav2_dynamic_params/test/dynamic_params_test.launch.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+from launch import LaunchDescription
+import launch_ros.actions
+from launch import LaunchService
+from launch.actions import ExecuteProcess
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing import LaunchTestService
+
+def generate_launch_description():
+    return LaunchDescription([
+        launch_ros.actions.Node(
+            package='nav2_dynamic_params',
+            node_executable='test_dynamic_params_helper',
+            output='screen')
+    ])
+
+def main(argv=sys.argv[1:]):
+    testExecutable = os.getenv('TEST_EXECUTABLE')
+    ld = generate_launch_description()
+
+    test1_action = ExecuteProcess(
+        cmd=[testExecutable],
+        name='test_dynamic_params_client',
+    )
+
+    ld.add_action(test1_action)
+    lts = LaunchTestService()
+    lts.add_test_action(ld, test1_action)
+    ls = LaunchService(argv=argv)
+    ls.include_launch_description(ld)
+    return lts.run(ls)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/nav2_dynamic_params/test/dynamic_params_test.launch.py
+++ b/nav2_dynamic_params/test/dynamic_params_test.launch.py
@@ -18,12 +18,11 @@ import os
 import sys
 
 from launch import LaunchDescription
-import launch_ros.actions
 from launch import LaunchService
 from launch.actions import ExecuteProcess
-from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+import launch_ros.actions
 from launch_testing import LaunchTestService
+
 
 def generate_launch_description():
     return LaunchDescription([
@@ -32,6 +31,7 @@ def generate_launch_description():
             node_executable='test_dynamic_params_helper',
             output='screen')
     ])
+
 
 def main(argv=sys.argv[1:]):
     testExecutable = os.getenv('TEST_EXECUTABLE')

--- a/nav2_dynamic_params/test/test_dynamic_params_client.cpp
+++ b/nav2_dynamic_params/test/test_dynamic_params_client.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "nav2_dynamic_params/dynamic_params_client.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+
+RclCppFixture g_rclcppfixture;
+
+class ClientTest : public ::testing::Test
+{
+public:
+  ClientTest()
+  {
+    node_ = rclcpp::Node::make_shared("dynamic_param_client_test");
+    params_client_ = std::make_unique<nav2_dynamic_params::DynamicParamsClient>(node_);
+  }
+
+protected:
+  std::unique_ptr<nav2_dynamic_params::DynamicParamsClient> params_client_;
+  rclcpp::Node::SharedPtr node_;
+};
+
+TEST_F(ClientTest, testAddParameters)
+{
+  //auto node_A = rclcpp::Node::make_shared("node_A");
+  //auto node_B = rclcpp::Node::make_shared("node_B", "namespace");
+  //std::map<std::string, rclcpp::Parameter> params;
+
+  //params["/node_A/foo"] = rclcpp::Parameter("foo", 1.0);
+  //params["/namespace/node_B/bar"] = rclcpp::Parameter("bar", 1);
+  //params["/namespace/node_B/foobar"] = rclcpp::Parameter("foobar", 1);
+  //node_A->set_parameters({params["/node_A/foo"]});
+  //node_B->set_parameters({params["/namespace/node_B/bar"]});
+
+  //node_B->set_parameters({rclcpp::Parameter("foobar", 1)});
+  
+/*   rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node_A);
+  exec.add_node(node_B);
+  exec.spin(); */
+  //node_B->set_parameters({rclcpp::Parameter("foobar", 1)});
+  node_->set_parameters({rclcpp::Parameter("baz", 1)});
+
+  params_client_->add_parameters({"baz"});
+  //params_client_->add_parameters("node_A", {"foo"});
+  //params_client_->add_parameters("namespace", "node_B", {"bar"});
+  //params_client_->add_parameters_on_node("namespace", "node_B");
+
+  auto dynamic_param_map = params_client_->get_param_map();
+  EXPECT_EQ(1, dynamic_param_map.count("/baz"));
+}
+
+/* 
+TEST_F(ClientTest, testGetParameters)
+{
+
+}
+
+TEST_F(ClientTest, testDifferentNamespaces)
+{
+
+}
+
+TEST_F(ClientTest, testDuplicateParams)
+{
+
+} */
+
+// Define a user event callback
+/* void event_callback()
+{
+  RCLCPP_INFO(rclcpp::get_logger("example_dynamic_params"), "\nEvent Callback!");
+
+  if (dynamic_params_client->is_in_event("foo")) {
+    RCLCPP_INFO(rclcpp::get_logger("example_dynamic_params"), "'foo' is in this event!");
+  }
+
+  double foo;
+  dynamic_params_client->get_event_param("foo", foo);
+  RCLCPP_INFO(rclcpp::get_logger("example_dynamic_params"), "foo: %f", foo);
+
+  int bar_B;
+  dynamic_params_client->get_event_param_or("bar", bar_B, 2);
+  RCLCPP_INFO(rclcpp::get_logger("example_dynamic_params"), "bar_B: %d", bar_B);
+
+  int bar_C;
+  dynamic_params_client->get_event_param_or("some_namespace", "bar", bar_C, 3);
+  RCLCPP_INFO(rclcpp::get_logger("example_dynamic_params"), "bar_C: %d", bar_C);
+
+  std::string baz;
+  dynamic_params_client->get_event_param_or("some_namespace/baz", baz, std::string("default"));
+  RCLCPP_INFO(rclcpp::get_logger("example_dynamic_params"), "baz: %s", baz.c_str());
+
+  // Parameter not set on server
+  double foobar;
+  dynamic_params_client->get_event_param_or("foobar", foobar, 5.5);
+  RCLCPP_INFO(rclcpp::get_logger("example_dynamic_params"), "foobar: %f", foobar);
+}
+
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("example_dynamic_params_client", "some_other_namespace");
+
+  // Add Dynamic Reconfigure Client
+  dynamic_params_client = new nav2_dynamic_params::DynamicParamsClient(node);
+  // Add parameters by node. Note that there are different ways to add parameters
+  // The namespace must be provided, if applicable
+  dynamic_params_client->add_parameters("example_node_A", {"foo"});
+  // If node is not available for service, then none of its parameters will be registered
+  dynamic_params_client->add_parameters_on_node("example_node_B");
+  dynamic_params_client->add_parameters("some_namespace", "example_node_C", {"baz", "bar"});
+  // without node path, adding only parameters will grab parameters from member node
+  dynamic_params_client->add_parameters({"foobaz"});
+
+  dynamic_params_client->set_callback(std::bind(event_callback));
+
+  // Check list of parameters
+  auto list = dynamic_params_client->get_param_names();
+  std::stringstream ss;
+  for (auto & param_name : list) {
+    ss << "\n" << param_name;
+  }
+
+  RCLCPP_INFO(node->get_logger(), ss.str().c_str());
+
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+
+  delete dynamic_params_client;
+  return 0;
+}
+ */

--- a/nav2_dynamic_params/test/test_dynamic_params_client.cpp
+++ b/nav2_dynamic_params/test/test_dynamic_params_client.cpp
@@ -65,32 +65,28 @@ protected:
   bool callback_result_ = false;
 };
 
-
-TEST_F(ClientTest, testAddParameters)
+TEST_F(ClientTest, testAddParamsOtherNodes)
 {
   node_->set_parameters({rclcpp::Parameter("baz", 1)});
 
   dynamic_params_client_->add_parameters();
+  dynamic_params_client_->add_parameters_on_node("test_namespace", "test_node");
+  dynamic_params_client_->add_parameters("test_namespace", "test_node", {"foobar"});
+  dynamic_params_client_->add_parameters("test_node", {"foo"});
   dynamic_params_client_->add_parameters({"foobar"});
 
   auto dynamic_param_map = dynamic_params_client_->get_param_map();
   EXPECT_EQ(1, dynamic_param_map.count("/dynamic_param_client_test/baz"));
   EXPECT_EQ(1, dynamic_param_map.count("/dynamic_param_client_test/foobar"));
-}
-
-
-TEST_F(ClientTest, testAddParamsOtherNodes)
-{
-  dynamic_params_client_->add_parameters_on_node("test_namespace", "test_node");
-  dynamic_params_client_->add_parameters("test_namespace", "test_node", {"foobar"});
-  dynamic_params_client_->add_parameters("test_node", {"foo"});
-
-  auto dynamic_param_map = dynamic_params_client_->get_param_map();
   EXPECT_EQ(1, dynamic_param_map.count("/test_node/foo"));
   EXPECT_EQ(1, dynamic_param_map.count("/test_namespace/test_node/bar"));
   EXPECT_EQ(1, dynamic_param_map.count("/test_namespace/test_node/foobar"));
-}
 
+  // Verify that parameters not added to other namespaces/nodes
+  EXPECT_EQ(0, dynamic_param_map.count("/dynamic_param_client_test/bar"));
+  EXPECT_EQ(0, dynamic_param_map.count("/test_namespace/dynamic_param_client_test/baz"));
+  EXPECT_EQ(0, dynamic_param_map.count("/test_node/bar"));
+}
 
 TEST_F(ClientTest, testGetParams)
 {

--- a/nav2_dynamic_params/test/test_dynamic_params_client.cpp
+++ b/nav2_dynamic_params/test/test_dynamic_params_client.cpp
@@ -33,7 +33,7 @@ RclCppFixture g_rclcppfixture;
 class DynamicParamsClientTest : public nav2_dynamic_params::DynamicParamsClient
 {
 public:
-  DynamicParamsClientTest(rclcpp::Node::SharedPtr node)
+  explicit DynamicParamsClientTest(rclcpp::Node::SharedPtr node)
   : DynamicParamsClient(node)
   {}
 
@@ -66,20 +66,19 @@ protected:
 };
 
 
-
 TEST_F(ClientTest, testAddParameters)
 {
   node_->set_parameters({rclcpp::Parameter("baz", 1)});
 
   dynamic_params_client_->add_parameters();
   dynamic_params_client_->add_parameters({"foobar"});
-  
+
   auto dynamic_param_map = dynamic_params_client_->get_param_map();
   EXPECT_EQ(1, dynamic_param_map.count("/dynamic_param_client_test/baz"));
   EXPECT_EQ(1, dynamic_param_map.count("/dynamic_param_client_test/foobar"));
 }
 
- 
+
 TEST_F(ClientTest, testAddParamsOtherNodes)
 {
   dynamic_params_client_->add_parameters_on_node("test_namespace", "test_node");
@@ -89,7 +88,7 @@ TEST_F(ClientTest, testAddParamsOtherNodes)
   auto dynamic_param_map = dynamic_params_client_->get_param_map();
   EXPECT_EQ(1, dynamic_param_map.count("/test_node/foo"));
   EXPECT_EQ(1, dynamic_param_map.count("/test_namespace/test_node/bar"));
-  EXPECT_EQ(1, dynamic_param_map.count("/test_namespace/test_node/foobar"));  
+  EXPECT_EQ(1, dynamic_param_map.count("/test_namespace/test_node/foobar"));
 }
 
 
@@ -117,7 +116,8 @@ TEST_F(ClientTest, testGetParams)
   EXPECT_EQ(1.0, foo);
   EXPECT_EQ(1, bar);
 
-  auto result  = dynamic_params_client_->get_event_param_or<std::string>("test_namespace/test_node", "foobar", foobar, "test");
+  auto result = dynamic_params_client_->get_event_param_or<std::string>(
+    "test_namespace/test_node", "foobar", foobar, "test");
   EXPECT_EQ(false, result);
   result = dynamic_params_client_->get_event_param_or("foobaz", foobaz, 7.0);
   EXPECT_EQ(true, result);
@@ -125,51 +125,74 @@ TEST_F(ClientTest, testGetParams)
   EXPECT_EQ(false, result);
   EXPECT_EQ("test", foobar);
   EXPECT_EQ(5.0, foobaz);
-  
 }
 
 TEST_F(ClientTest, testEventCallbacks)
 {
   dynamic_params_client_->add_parameters({"baz"});
   dynamic_params_client_->add_parameters("test_node", {"foo"});
+  dynamic_params_client_->add_parameters("test_namespace", "test_node", {"bar"});
 
-  std::function<void()> callback = [this]()-> void
+  auto param_client_A = std::make_shared<rclcpp::SyncParametersClient>(node_, "/test_node");
+  auto param_client_B = std::make_shared<rclcpp::SyncParametersClient>(
+    node_, "/test_namespace/test_node");
+
+  std::function<void()> callback = [this]() -> void
     {
       callback_result_ = true;
     };
 
   dynamic_params_client_->set_callback(callback, false);
-  
-  node_->set_parameters({rclcpp::Parameter("baz", 2)});
 
-  while(!callback_result_)
-  {
+  // Directly call into event callback
+  dynamic_params_client_->call_test_event(
+    "/dynamic_param_client_test", rclcpp::Parameter("baz", 2), true);
+  node_->set_parameters({rclcpp::Parameter("baz", 2)});
+  while (!callback_result_) {
     rclcpp::spin_some(node_);
   }
-  // Directly call into event callback
-  //dynamic_params_client_->call_test_event("/dynamic_param_client_test", rclcpp::Parameter("baz", 2), true);
 
   EXPECT_EQ(true, callback_result_);
   int baz;
   dynamic_params_client_->get_event_param("baz", baz);
   EXPECT_EQ(2, baz);
-
-  auto param_client_A = std::make_shared<rclcpp::SyncParametersClient>(node_, "/test_node");
-  auto param_client_B = std::make_shared<rclcpp::SyncParametersClient>(node_, "/test_namespace/test_node");
-
   callback_result_ = false;
-  
-  // Directly call into event callback
-  //dynamic_params_client_->call_test_event("/test_node", rclcpp::Parameter("foo", 3.0), false);
 
+  // Directly call into event callback
+  dynamic_params_client_->call_test_event("/test_node", rclcpp::Parameter("foo", 3.0), false);
   param_client_A->set_parameters({rclcpp::Parameter("foo", 3.0)});
-  while(!callback_result_)
-  {
+  while (!callback_result_) {
     rclcpp::spin_some(node_);
   }
-  
+
   EXPECT_EQ(true, callback_result_);
   double foo;
   dynamic_params_client_->get_event_param("test_node", "foo", foo);
   EXPECT_EQ(3.0, foo);
+  callback_result_ = false;
+
+  // Directly call into event callback
+  /* dynamic_params_client_->call_test_event(
+    "/test_namespace/test_node", rclcpp::Parameter("bar", 5), false); */
+  param_client_B->set_parameters({rclcpp::Parameter("bar", 5)});
+  while (!callback_result_) {
+    rclcpp::spin_some(node_);
+  }
+
+  EXPECT_EQ(true, callback_result_);
+  int bar;
+  dynamic_params_client_->get_event_param("test_namespace", "test_node", "bar", bar);
+  EXPECT_EQ(5, bar);
+  callback_result_ = false;
+
+  // Check that 'bar' is in the last event
+  EXPECT_EQ(true, dynamic_params_client_->is_in_event("test_namespace", "test_node", "bar"));
+  EXPECT_EQ(false, dynamic_params_client_->is_in_event("foo"));
+
+  // If data type unexpectedly changes, callback should be skipped
+  dynamic_params_client_->call_test_event(
+    "/dynamic_param_client_test", rclcpp::Parameter("bar", "hello"), false);
+  EXPECT_EQ(false, callback_result_);
+  dynamic_params_client_->get_event_param("baz", baz);
+  EXPECT_EQ(2, baz);
 }

--- a/nav2_dynamic_params/test/test_dynamic_params_client.cpp
+++ b/nav2_dynamic_params/test/test_dynamic_params_client.cpp
@@ -145,8 +145,8 @@ TEST_F(ClientTest, testEventCallbacks)
   dynamic_params_client_->set_callback(callback, false);
 
   // Directly call into event callback
-  dynamic_params_client_->call_test_event(
-    "/dynamic_param_client_test", rclcpp::Parameter("baz", 2), true);
+  /* dynamic_params_client_->call_test_event(
+    "/dynamic_param_client_test", rclcpp::Parameter("baz", 2), true); */
   node_->set_parameters({rclcpp::Parameter("baz", 2)});
   while (!callback_result_) {
     rclcpp::spin_some(node_);
@@ -159,7 +159,7 @@ TEST_F(ClientTest, testEventCallbacks)
   callback_result_ = false;
 
   // Directly call into event callback
-  dynamic_params_client_->call_test_event("/test_node", rclcpp::Parameter("foo", 3.0), false);
+  // dynamic_params_client_->call_test_event("/test_node", rclcpp::Parameter("foo", 3.0), false);
   param_client_A->set_parameters({rclcpp::Parameter("foo", 3.0)});
   while (!callback_result_) {
     rclcpp::spin_some(node_);
@@ -185,7 +185,7 @@ TEST_F(ClientTest, testEventCallbacks)
   EXPECT_EQ(5, bar);
   callback_result_ = false;
 
-  // Check that 'bar' is in the last event
+  // Check that parameter is in the last event
   EXPECT_EQ(true, dynamic_params_client_->is_in_event("test_namespace", "test_node", "bar"));
   EXPECT_EQ(false, dynamic_params_client_->is_in_event("foo"));
 

--- a/nav2_dynamic_params/test/test_dynamic_params_helper.cpp
+++ b/nav2_dynamic_params/test/test_dynamic_params_helper.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "nav2_dynamic_params/dynamic_params_client.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node_A = rclcpp::Node::make_shared("test_node");
+  auto node_B = rclcpp::Node::make_shared("test_node", "test_namespace");
+
+  node_A->set_parameters({rclcpp::Parameter("foo", 1.0)});
+  node_B->set_parameters({rclcpp::Parameter("bar", 1)});
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node_A);
+  exec.add_node(node_B);
+  exec.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/nav2_dynamic_params/test/test_dynamic_params_validator.cpp
+++ b/nav2_dynamic_params/test/test_dynamic_params_validator.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <sstream>
+#include <vector>
+#include "gtest/gtest.h"
+#include "nav2_dynamic_params/dynamic_params_validator.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using rcl_interfaces::msg::SetParametersResult;
+using namespace std::chrono_literals;
+
+namespace nav2_dynamic_params
+{
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+
+RclCppFixture g_rclcppfixture;
+
+// Define a custom validation callback
+SetParametersResult custom_validation_callback(const std::vector<rclcpp::Parameter> & parameters)
+{
+  auto result = SetParametersResult();
+  result.successful = true;
+
+  for (const auto & parameter : parameters) {
+    // Filter for parameter "foo"
+    if (parameter.get_name() == "custom_param") {
+      auto value = parameter.get_value<double>();
+      // Reject any set requests between 10 & 20
+      if (value > 10.0 && value < 20.0) {
+        RCLCPP_INFO(rclcpp::get_logger("example_dynamic_params"),
+          "Parameter Change Denied::Failing Custom Validation: %s",
+          parameter.get_name().c_str());
+        result.successful = false;
+        return result;
+      }
+    }
+  }
+  return result;
+}
+
+class ValidatorTest : public ::testing::Test
+{
+public:
+  ValidatorTest()
+  {
+    node_ = rclcpp::Node::make_shared("dynamic_param_validator_test");
+    param_validator_ = std::make_unique<DynamicParamsValidator>(node_);
+  }
+
+protected:
+  std::unique_ptr<DynamicParamsValidator> param_validator_;
+  rclcpp::Node::SharedPtr node_;
+};
+
+TEST_F(ValidatorTest, testValidType)
+{
+  param_validator_->add_param("double", rclcpp::ParameterType::PARAMETER_DOUBLE);
+  param_validator_->add_param("int", rclcpp::ParameterType::PARAMETER_INTEGER);
+  param_validator_->add_param("string", rclcpp::ParameterType::PARAMETER_STRING);
+  param_validator_->add_param("bool", rclcpp::ParameterType::PARAMETER_BOOL);
+  param_validator_->add_param("double_array", rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY);
+  param_validator_->add_param("int_array", rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY);
+  param_validator_->add_param("string_array", rclcpp::ParameterType::PARAMETER_STRING_ARRAY);
+  param_validator_->add_param("bool_array", rclcpp::ParameterType::PARAMETER_BOOL_ARRAY);
+
+  // Set valid type values
+  auto valid_results = node_->set_parameters({
+    rclcpp::Parameter("double", 1.0),
+    rclcpp::Parameter("int", 1),
+    rclcpp::Parameter("string", "test"),
+    rclcpp::Parameter("bool", true),
+    rclcpp::Parameter("double_array", {1.0, 2.0}),
+    rclcpp::Parameter("int_array", {1, 2}),
+    rclcpp::Parameter("string_array", {"test_1", "test_2"}),
+    rclcpp::Parameter("bool_array", {true, false}),
+  });
+
+  // Set invalid type values
+  auto invalid_results = node_->set_parameters({
+    rclcpp::Parameter("double", 1),
+    rclcpp::Parameter("int", 1.0),
+    rclcpp::Parameter("string", 1),
+    rclcpp::Parameter("bool", 1),
+    rclcpp::Parameter("double_array", 1),
+    rclcpp::Parameter("int_array", 1),
+    rclcpp::Parameter("string_array", 1),
+    rclcpp::Parameter("bool_array", 1),
+  });
+
+  for (auto result : valid_results) {
+    EXPECT_EQ(true, result.successful);
+  }
+  for (auto result : invalid_results) {
+    EXPECT_EQ(false, result.successful);
+  }
+}
+
+TEST_F(ValidatorTest, testValidRange)
+{
+  param_validator_->add_param("double_bound", rclcpp::ParameterType::PARAMETER_DOUBLE, {0.0, 10.0});
+  param_validator_->add_param("double_low_bound", rclcpp::ParameterType::PARAMETER_DOUBLE, {0.0, 10.0}, 0);
+  param_validator_->add_param("double_high_bound", rclcpp::ParameterType::PARAMETER_DOUBLE, {0.0, 10.0}, 1);
+
+  param_validator_->add_param("int_bound", rclcpp::ParameterType::PARAMETER_INTEGER, {0, 10});
+  param_validator_->add_param("int_low_bound", rclcpp::ParameterType::PARAMETER_INTEGER, {0, 10}, 0);
+  param_validator_->add_param("int_high_bound", rclcpp::ParameterType::PARAMETER_INTEGER, {0, 10}, 1);
+
+  param_validator_->add_param("string_invalid_bound", rclcpp::ParameterType::PARAMETER_STRING, {0, 10});
+
+  auto valid_results = node_->set_parameters({
+    rclcpp::Parameter("double_bound", 5.0),
+    rclcpp::Parameter("double_low_bound", -100.0),
+    rclcpp::Parameter("double_high_bound", 100.0),
+    rclcpp::Parameter("int_bound", 5),
+    rclcpp::Parameter("int_low_bound", -100),
+    rclcpp::Parameter("int_high_bound", 100),
+  });
+
+  // Set invalid type values
+  auto invalid_results = node_->set_parameters({
+    rclcpp::Parameter("double_bound", 11.0),
+    rclcpp::Parameter("double_low_bound", 11.0),
+    rclcpp::Parameter("double_high_bound", -1.0),
+    rclcpp::Parameter("int_bound", 11),
+    rclcpp::Parameter("int_low_bound", 11),
+    rclcpp::Parameter("int_high_bound", -1),
+    rclcpp::Parameter("string_invalid_bound", "test"),
+  });
+
+  for (auto result : valid_results) {
+    EXPECT_EQ(true, result.successful);
+  }
+  for (auto result : invalid_results) {
+    EXPECT_EQ(false, result.successful);
+  }
+}
+
+TEST_F(ValidatorTest, testStaticParams)
+{
+  param_validator_->add_param("static_param", rclcpp::ParameterType::PARAMETER_DOUBLE);
+  param_validator_->add_param("non_static_param", rclcpp::ParameterType::PARAMETER_DOUBLE);
+
+  param_validator_->add_static_params({"static_param"});
+  
+  auto invalid_result = node_->set_parameters({rclcpp::Parameter("static_param", 1.0)});
+  auto valid_result = node_->set_parameters({rclcpp::Parameter("non_static_param", 1.0)})
+
+  EXPECT_EQ(false, invalid_result.successful);
+  EXPECT_EQ(true, valid_result.successful);
+}
+
+
+TEST_F(ValidatorTest, testCustomValidation)
+{
+  param_validator_->add_param("param", rclcpp::ParameterType::PARAMETER_DOUBLE);
+  param_validator_->add_param("custom_param", rclcpp::ParameterType::PARAMETER_DOUBLE);
+
+  param_validator_->set_validation_callback(
+    std::bind(custom_validation_callback, std::placeholders::_1));
+
+  auto invalid_result = node_->set_parameters({rclcpp::Parameter("param", 15.0)});
+  auto invalid_result_custom = node_->set_parameters({rclcpp::Parameter("custom_param", 15.0)})
+  auto valid_result = node_->set_parameters({rclcpp::Parameter("custom_param", 10.0)})
+
+  EXPECT_EQ(false, invalid_result.successful);
+  EXPECT_EQ(false, invalid_result_custom.successful);
+  EXPECT_EQ(true, valid_result.successful);   
+}
+
+}  // namespace nav2_dynamic_params


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #251  |
| Primary OS tested on | Ubuntu 18.04 |


## Description of contribution 
- Added gtests for `DynamicParamsValidator` and `DynamicParamsClient`
- added interfaces to `is_in_event` to scope by node path
- changed event callback to class member function instead of lambda function
- added `get_param_from_node` function to fix hanging bug with `SyncParameterClient` which was occasionaly hanging when listing or getting parameters, now uses `AsyncParameterClient` with a timeout and a variable number of re-attempts

