### PR TITLE
Removing the validCellToQueue optimization from MapGridQueue.

### DIFF
--- a/nav2_dwb_controller/dwb_critics/include/dwb_critics/map_grid.hpp
+++ b/nav2_dwb_controller/dwb_critics/include/dwb_critics/map_grid.hpp
@@ -109,7 +109,6 @@ protected:
 public:
     MapGridQueue(nav2_costmap_2d::Costmap2D & costmap, MapGridCritic & parent)
     : costmap_queue::CostmapQueue(costmap, true), parent_(parent) {}
-    bool validCellToQueue(const costmap_queue::CellData & cell) override;
 
 protected:
     MapGridCritic & parent_;

--- a/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
@@ -46,21 +46,6 @@ using costmap_queue::CellData;
 namespace dwb_critics
 {
 
-// Customization of the CostmapQueue validCellToQueue method
-bool MapGridCritic::MapGridQueue::validCellToQueue(const costmap_queue::CellData & cell)
-{
-  unsigned char cost = costmap_.getCost(cell.x_, cell.y_);
-  if (cost == nav2_costmap_2d::LETHAL_OBSTACLE ||
-    cost == nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE ||
-    cost == nav2_costmap_2d::NO_INFORMATION)
-  {
-    parent_.setAsObstacle(cell.index_);
-    return false;
-  }
-
-  return true;
-}
-
 void MapGridCritic::onInit()
 {
   costmap_ = costmap_ros_->getCostmap();


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #451  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot 3 in Gazebo |

---

## Description of contribution in a few bullet points

The costmap_queue concept as implemented is incompatible with not
queuing some cells. The costmap_queue expands adjacent cells as
the least cost cell is pulled from the queue. For it to work
properly, the newly added cells must have a cost that is greater
than or equal to the current cell.

This requirement is violated in map grid when there are obstacles.
The cells in the shadow of the obstacle have a lower cost than those
outside the shadow, but they don't get expanded till a cell outside
the shadow is expanded. See the second image in #451 to see what I mean 
about a shadow behind obstacles.

If a lower cost cell is added, the costmap_queue iterator does not
go backwards, so those lower cost cells never get pulled from the
queue. If the queue iterator were instead "fixed" to go backwards,
it would no longer guarantee cells were pulled from the queue in
order of cost, violating the fundamental concept of that structure.

A possible fix would be to fully expand the map grid before
trying to pull any cells from the queue. I need to explore that
possibility for performance issues.
---

## Future work that may be required in bullet points

* Remove MapGridCritic as a base class of GoalDistCritic. GoalDistCritic scores paths based on the distance from the goal. This can be cheaply computed for each point. We don't need all the complexity of building a map of cell distances from the goal.
* Determine performance impact to PathDistCritic of removing this optimization. Determine if there is another way to approach the problem.