### PR TITLE
DWB main loop fixes

### DIFF
--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -64,7 +64,8 @@ DwbController::followPath(const nav2_tasks::FollowPathCommand::SharedPtr command
     planner_.setPlan(path);
     RCLCPP_INFO(get_logger(), "Initialized");
 
-    while (true) {
+    rclcpp::Rate loop_rate(10);
+    while (rclcpp::ok()) {
       nav_2d_msgs::msg::Pose2DStamped pose2d;
       if (!getRobotPose(pose2d)) {
         RCLCPP_INFO(get_logger(), "No pose. Stopping robot");
@@ -98,7 +99,7 @@ DwbController::followPath(const nav2_tasks::FollowPathCommand::SharedPtr command
           planner_.setPlan(path);
         }
       }
-      std::this_thread::sleep_for(100ms);
+      loop_rate.sleep();
     }
   } catch (nav_core2::PlannerException & e) {
     RCLCPP_INFO(this->get_logger(), e.what());

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -77,7 +77,7 @@ DwbController::followPath(const nav2_tasks::FollowPathCommand::SharedPtr command
         auto velocity = odom_sub_->getTwist();
         auto cmd_vel_2d = planner_.computeVelocityCommands(pose2d, velocity);
         publishVelocity(cmd_vel_2d);
-        RCLCPP_INFO(get_logger(), "Publishing velocity");
+        RCLCPP_INFO(get_logger(), "Publishing velocity at time %.2f", now().seconds());
 
         // Check if this task has been canceled
         if (task_server_->cancelRequested()) {


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot 3 on Gazebo |

---

## Description of contribution in a few bullet points

* DWB main loop was just using a constant sleep at the end of the loop. Replaced this with a rclcpp::Rate object.
* DWB main loop was while(true). This prevented a clean shutdown. Replaced it with while(rclcpp::ok())
* Printing out a time as part of the publishing velocity message to see the real publishing rate.

---

## Future work that may be required in bullet points

* Optimization of DWB. The real publishing rate always fails to achieve the desired rate, at least with a debug build.