### PR TITLE
Fix DWB trajectory visualization

### DIFF
--- a/nav2_dwb_controller/dwb_core/include/dwb_core/publisher.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/publisher.hpp
@@ -37,6 +37,7 @@
 
 #include <vector>
 #include <memory>
+#include <string>
 #include "rclcpp/rclcpp.hpp"
 #include "dwb_core/common_types.hpp"
 #include "dwb_core/trajectory_critic.hpp"
@@ -92,6 +93,12 @@ public:
 protected:
   void publishTrajectories(const dwb_msgs::msg::LocalPlanEvaluation & results);
 
+  void addDeleteMarkers(
+    visualization_msgs::msg::MarkerArray & ma,
+    unsigned startingId,
+    std::string & ns
+  );
+
   // Helper function for publishing other plans
   void publishGenericPlan(
     const nav_2d_msgs::msg::Path2D plan,
@@ -103,7 +110,7 @@ protected:
   bool publish_cost_grid_pc_;
 
   // Previously published marker count for removing markers as needed
-  int prev_marker_count_;
+  unsigned prev_marker_count_;
 
   // Publisher Objects
   std::shared_ptr<rclcpp::Publisher<dwb_msgs::msg::LocalPlanEvaluation>> eval_pub_;

--- a/nav2_dwb_controller/dwb_core/src/publisher.cpp
+++ b/nav2_dwb_controller/dwb_core/src/publisher.cpp
@@ -244,7 +244,7 @@ void DWBPublisher::addDeleteMarkers(
 {
   visualization_msgs::msg::Marker m;
   m.action = m.DELETE;
-  m.ns =  ns;
+  m.ns = ns;
   for (unsigned i = startingId; i < prev_marker_count_; i++) {
     m.id = i;
     ma.markers.push_back(m);

--- a/nav2_dwb_controller/dwb_core/src/publisher.cpp
+++ b/nav2_dwb_controller/dwb_core/src/publisher.cpp
@@ -35,11 +35,16 @@
 #include "dwb_core/publisher.hpp"
 #include <vector>
 #include <memory>
+#include <string>
+#include <algorithm>
 #include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "nav_2d_utils/conversions.hpp"
 //#include <sensor_msgs/point_cloud_conversion.hpp> // NOLINT cpplint doesn't like commented out header file
+
+using std::max;
+using std::string;
 
 namespace dwb_core
 {
@@ -108,18 +113,26 @@ void DWBPublisher::publishTrajectories(const dwb_msgs::msg::LocalPlanEvaluation 
   double best_cost = results.twists[results.best_index].total,
     worst_cost = results.twists[results.worst_index].total;
 
+  unsigned currentValidId = 0;
+  unsigned currentInvalidId = 0;
+  string validNamespace("ValidTrajectories");
+  string invalidNamespace("InvalidTrajectories");
   for (unsigned int i = 0; i < results.twists.size(); i++) {
     const dwb_msgs::msg::TrajectoryScore & twist = results.twists[i];
     if (twist.total >= 0) {
-      m.color.r = 1 - (twist.total - best_cost) / (worst_cost - best_cost);
-      m.color.g = 1 - (twist.total - best_cost) / (worst_cost - best_cost);
-      m.color.b = 1;
-      m.ns = "ValidTrajectories";
+      m.color.r = 1.0 - (twist.total - best_cost) / (worst_cost - best_cost);
+      m.color.g = 1.0 - (twist.total - best_cost) / (worst_cost - best_cost);
+      m.color.b = 1.0;
+      m.ns = validNamespace;
+      m.id = currentValidId;
+      ++currentValidId;
     } else {
       m.color.r = 0;
       m.color.g = 0;
       m.color.b = 0;
-      m.ns = "InvalidTrajectories";
+      m.ns = invalidNamespace;
+      m.id = currentInvalidId;
+      ++currentInvalidId;
     }
     m.points.clear();
     for (unsigned int j = 0; j < twist.traj.poses.size(); ++j) {
@@ -129,15 +142,10 @@ void DWBPublisher::publishTrajectories(const dwb_msgs::msg::LocalPlanEvaluation 
       m.points.push_back(pt);
     }
     ma.markers.push_back(m);
-    m.id += 1;
   }
-  int temp = ma.markers.size();
-  for (int i = temp; i < prev_marker_count_; i++) {
-    m.action = m.DELETE;
-    m.id = i;
-    ma.markers.push_back(m);
-  }
-  prev_marker_count_ = temp;
+  addDeleteMarkers(ma, currentValidId, validNamespace);
+  addDeleteMarkers(ma, currentInvalidId, invalidNamespace);
+  prev_marker_count_ = max(currentValidId, currentInvalidId);
   marker_pub_->publish(ma);
 }
 
@@ -223,6 +231,21 @@ void DWBPublisher::publishGenericPlan(
   if (!flag) {return;}
   nav_msgs::msg::Path path = nav_2d_utils::pathToPath(plan);
   pub.publish(path);
+}
+
+void DWBPublisher::addDeleteMarkers(
+  visualization_msgs::msg::MarkerArray & ma,
+  unsigned startingId,
+  string & ns
+)
+{
+  visualization_msgs::msg::Marker m;
+  m.action = m.DELETE;
+  m.ns =  ns;
+  for (unsigned i = startingId; i < prev_marker_count_; i++) {
+    m.id = i;
+    ma.markers.push_back(m);
+  }
 }
 
 }  // namespace dwb_core

--- a/nav2_dwb_controller/dwb_core/src/publisher.cpp
+++ b/nav2_dwb_controller/dwb_core/src/publisher.cpp
@@ -110,8 +110,8 @@ void DWBPublisher::publishTrajectories(const dwb_msgs::msg::LocalPlanEvaluation 
   m.scale.x = 0.002;
   m.color.a = 1.0;
 
-  double best_cost = results.twists[results.best_index].total,
-    worst_cost = results.twists[results.worst_index].total;
+  double best_cost = results.twists[results.best_index].total;
+  double worst_cost = results.twists[results.worst_index].total;
 
   unsigned currentValidId = 0;
   unsigned currentInvalidId = 0;
@@ -119,10 +119,12 @@ void DWBPublisher::publishTrajectories(const dwb_msgs::msg::LocalPlanEvaluation 
   string invalidNamespace("InvalidTrajectories");
   for (unsigned int i = 0; i < results.twists.size(); i++) {
     const dwb_msgs::msg::TrajectoryScore & twist = results.twists[i];
+    double displayLevel = (twist.total - best_cost) / (worst_cost - best_cost);
     if (twist.total >= 0) {
-      m.color.r = 1.0 - (twist.total - best_cost) / (worst_cost - best_cost);
-      m.color.g = 1.0 - (twist.total - best_cost) / (worst_cost - best_cost);
+      m.color.r = 0;
+      m.color.g = 0;
       m.color.b = 1.0;
+      m.color.a = 1.0 - displayLevel;
       m.ns = validNamespace;
       m.id = currentValidId;
       ++currentValidId;
@@ -130,6 +132,7 @@ void DWBPublisher::publishTrajectories(const dwb_msgs::msg::LocalPlanEvaluation 
       m.color.r = 0;
       m.color.g = 0;
       m.color.b = 0;
+      m.color.a = 1.0;
       m.ns = invalidNamespace;
       m.id = currentInvalidId;
       ++currentInvalidId;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #447  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 on Gazebo |

---

## Description of contribution in a few bullet points

* Code now ensures all markers are properly deleted. The trajectory markers are divided into two namespaces, one for valid trajectories and the other for invalid. Marker IDs are independent in the two namespaces, so both namespaces need to be cleaned up separately.
* Changed the valid trajectory color scheme to be solid blue for good trajectories, fading away for poor trajectories.

---

## Future work that may be required in bullet points

* The color scheme might need tweaking to better see what's going on. It seems trajectory scores right now are all clustered around the really good score and it is hard to see any difference. However, I think the scores themselves need to be investigated further before tweaking the display.
---