### PR TITLE
Fix costmap queue expansion

### DIFF
--- a/nav2_dwb_controller/costmap_queue/src/costmap_queue.cpp
+++ b/nav2_dwb_controller/costmap_queue/src/costmap_queue.cpp
@@ -85,6 +85,7 @@ CellData CostmapQueue::getNextCell()
 {
   // get the highest priority cell and pop it off the priority queue
   CellData current_cell = front();
+  pop();
 
   unsigned int index = current_cell.index_;
   unsigned int mx = current_cell.x_;
@@ -107,8 +108,6 @@ CellData CostmapQueue::getNextCell()
     enqueueCell(index + size_x, mx, my + 1, sx, sy);
   }
 
-  // pop once we have our cell info
-  pop();
   return current_cell;
 }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #451  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot 3 on Gazebo |

---

## Description of contribution in a few bullet points

* Fix costmap queue. The getNextCell function pulls off the head of the queue, but also enqueues adjacent cells. The previous implementation would reference the head of the, add adjacent cells, and then pop the head. Unfortunately, under certain circumstances, the newly enqueued cells would become the new head of the queue and get popped instead of the cell that was just processed. This change fixes that problem