### PR TITLE
removing rosdep cache for new initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV ROSDISTRO_INDEX_URL 'https://raw.githubusercontent.com/ros2/rosdistro/ros2/i
 
 # update latest package versions
 RUN apt-get update
+RUN rm -rf /etc/ros/rosdep/sources.list.d/20-default.list
 
 # install ROS2 dependencies
 RUN apt install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN if [ "$http_proxy" == "" ]; \
 
 ENV ROS1_DISTRO melodic
 ENV ROS2_DISTRO bouncy
+ENV ROSDISTRO_INDEX_URL 'https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml'
 
 # update latest package versions
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN if [ "$http_proxy" == "" ]; \
 
 ENV ROS1_DISTRO melodic
 ENV ROS2_DISTRO bouncy
-ENV ROSDISTRO_INDEX_URL 'https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml'
 
 # update latest package versions
 RUN apt-get update


### PR DESCRIPTION
A couple of things changed, rosdistro2 has been homologated with its upstream + container may have been updated and didn't remove the rosdep initialization cache