### PR TITLE
Disable unstable system test in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ script:
   - docker exec nav2_bash bash -c '. /ros2_ws/navigation2_ws/install/setup.bash &&
       colcon test --packages-skip nav2_system_tests'
   - docker exec nav2_bash bash -c "colcon test-result --verbose"
-  - docker exec nav2_bash bash -c ". install/setup.bash && cd build/nav2_system_tests; ./ctest_retry.bash 3"
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then


### PR DESCRIPTION
The system test is failing far more often than the 1% predicted. This is causing PRs and the master branch to show they are failing even though the fault is not part of that change.

This change disables the system test until it can be made more stable