### PR TITLE
Workaround for logger exception

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_1st_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_1st_launch.py
@@ -6,6 +6,8 @@ import launch_ros.actions
 def generate_launch_description():
     map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
+    params_file = launch.substitutions.LaunchConfiguration('params', default=
+        [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -23,8 +25,7 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='nav2_amcl',
             node_executable='amcl',
-            node_name='amcl',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
     ])

--- a/nav2_bringup/launch/nav2_bringup_2nd_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_2nd_launch.py
@@ -27,22 +27,19 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='nav2_navfn_planner',
             node_executable='navfn_planner',
-            node_name='navfn_planner',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_simple_navigator',
             node_executable='simple_navigator',
-            node_name='simple_navigator',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_mission_executor',
             node_executable='mission_executor',
-            node_name='mission_executor',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
     ])

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -31,9 +31,8 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='nav2_amcl',
             node_executable='amcl',
-            node_name='amcl',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='dwb_controller',
@@ -44,21 +43,18 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='nav2_navfn_planner',
             node_executable='navfn_planner',
-            node_name='navfn_planner',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_simple_navigator',
             node_executable='simple_navigator',
-            node_name='simple_navigator',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_mission_executor',
             node_executable='mission_executor',
-            node_name='mission_executor',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
     ])

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -40,3 +40,15 @@ global_costmap:
         topic: /scan
         max_obstacle_height: 2.0
         clearing: True
+amcl:
+  ros__parameters:
+    use_sim_time: True
+navfn_planner:
+  ros__parameters:
+    use_sim_time: True
+simple_navigator:
+  ros__parameters:
+    use_sim_time: True
+mission_executor:
+  ros__parameters:
+    use_sim_time: True

--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -66,8 +66,7 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='nav2_amcl',
             node_executable='amcl',
-            output='screen',
-            parameters=[params_file]),
+            output='screen'),
 
         launch_ros.actions.Node(
             package='dwb_controller',
@@ -78,14 +77,12 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='nav2_navfn_planner',
             node_executable='navfn_planner',
-            output='screen',
-            parameters=[params_file]),
+            output='screen'),
 
         launch_ros.actions.Node(
             package='nav2_simple_navigator',
             node_executable='simple_navigator',
-            output='screen',
-            parameters=[params_file]),
+            output='screen'),
     ])
 
 

--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -66,9 +66,8 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='nav2_amcl',
             node_executable='amcl',
-            node_name='amcl',
             output='screen',
-            parameters=[{'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='dwb_controller',
@@ -79,16 +78,14 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='nav2_navfn_planner',
             node_executable='navfn_planner',
-            node_name='navfn_planner',
             output='screen',
-            parameters=[{'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
 
         launch_ros.actions.Node(
             package='nav2_simple_navigator',
             node_executable='simple_navigator',
-            node_name='simple_navigator',
             output='screen',
-            parameters=[{'use_sim_time': use_sim_time}]),
+            parameters=[params_file]),
     ])
 
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot 3 in Gazebo |

---

## Description of contribution in a few bullet points

* This works around ros2/rcl#375. This was causing our system test to fail consistently. Our system test should pass again with this workaround.
* This replaces #527 as a better alternative.
* The problem with this PR is that the `use_sim_time` parameter cannot be changed from the command line. Instead, if you want to use real time, you must manually change the nav2_params.yaml file. To fix this, we need to upgrade the ros2 launch tool, which is in the works.
* One last point. I did not apply the workaround to the map_server node. Due to fortunate circumstances, this node is not affected by the issue. By not applying the workaround, we are able leave the map file name as a parameter to the launch file.