### PR TITLE
Add BT Navigator System Test

### DIFF
--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -62,6 +62,10 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
+install(DIRECTORY behavior_trees/
+  DESTINATION behavior_trees/
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/nav2_system_tests/src/system/CMakeLists.txt
+++ b/nav2_system_tests/src/system/CMakeLists.txt
@@ -1,4 +1,4 @@
-ament_add_test(test_system_node
+ament_add_test(test_simple_navigator
   GENERATE_RESULT_FOR_RETURN_CODE_ZERO
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_system_launch.py"
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
@@ -9,4 +9,20 @@ ament_add_test(test_system_node
     TEST_WORLD=${PROJECT_SOURCE_DIR}/worlds/turtlebot3_ros2_demo.world
     TEST_PARAMS=${PROJECT_SOURCE_DIR}/params/nav2_params.yaml
     GAZEBO_MODEL_PATH=${PROJECT_SOURCE_DIR}/models
+    NAVIGATOR=simple
+)
+
+ament_add_test(test_bt_navigator
+  GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_system_launch.py"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  TIMEOUT 120
+  ENV
+    TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+    TEST_MAP=${PROJECT_SOURCE_DIR}/maps/map_circular.yaml
+    TEST_WORLD=${PROJECT_SOURCE_DIR}/worlds/turtlebot3_ros2_demo.world
+    TEST_PARAMS=${PROJECT_SOURCE_DIR}/params/nav2_params.yaml
+    GAZEBO_MODEL_PATH=${PROJECT_SOURCE_DIR}/models
+    NAVIGATOR=bt
+    BT_NAVIGATOR_XML=simple_sequential.xml
 )

--- a/tools/ctest_retry.bash
+++ b/tools/ctest_retry.bash
@@ -48,7 +48,7 @@ for ((i=1;i<=total;i++))
   do
     ctest -V $SPECIFIC_TEST
     result=$?
-    if [ "$result" == "0" ]
+    if [ "$result" == "0" ]  # if ctest succeeded, then exit the retry loop
     then
       echo "Test succeeded on try " $i
       exit 0

--- a/tools/ctest_retry.bash
+++ b/tools/ctest_retry.bash
@@ -1,12 +1,52 @@
 #!/bin/bash
 
-fail=0
-total=$1
-# Change the file path manually to where you want to log fails
+usage() {
+  echo "ctest_retry.bash [options]"
+  echo "Reruns ctest until the test passes or it has run 3 times (by default)."
+  echo "  -r <number> Retry the test up to <number> times [Default: 3]"
+  echo "  -d <path> Execute ctest from the given path [Default: Current working directory]"
+  echo "  -t <testname> Execute only <testname> [Default: execute all tests available in <path> ]"
+  echo "  -h displays this usage summary"
+  exit 0
+}
+
+RETRIES=3
+TESTDIR=.
+SPECIFIC_TEST=""
+
+# Check Options
+while getopts ":hr:d:t:" opt; do
+  case "$opt" in
+    h)
+      usage
+      ;;
+    r)
+      RETRIES=$OPTARG
+      ;;
+    d)
+      TESTDIR=$OPTARG
+      ;;
+    t)
+      SPECIFIC_TEST="-R $OPTARG"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      usage
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+total=$RETRIES
+cd $TESTDIR
 echo "Retrying Ctest up to " $total " times."
 for ((i=1;i<=total;i++))
   do
-    ctest
+    ctest -V $SPECIFIC_TEST
     result=$?
     if [ "$result" == "0" ]
     then

--- a/tools/run_test_suite.bash
+++ b/tools/run_test_suite.bash
@@ -8,4 +8,5 @@ colcon test --packages-skip nav2_system_tests
 colcon test --packages-select nav2_system_tests --ctest-args --exclude-regex "test_.*"  # run the linters
 colcon test-result --verbose
 $SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_localization
-$SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_system_node
+$SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_simple_navigator
+$SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_bt_navigator

--- a/tools/run_test_suite.bash
+++ b/tools/run_test_suite.bash
@@ -2,8 +2,12 @@
 
 set -ex
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"  # gets the directory of this script
+
 colcon test --packages-skip nav2_system_tests
+colcon test --packages-select nav2_system_tests --ctest-args --exclude-regex "test_.*"  # run the linters
 colcon test-result --verbose
-cp src/navigation2/tools/ctest_retry.bash build/nav2_system_tests
-cd build/nav2_system_tests
-./ctest_retry.bash 3
+$SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_localization
+$SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_system_node
+#colcon test --retest-until-pass 2 --packages-select nav2_system_tests --ctest-args -R test_localization --output-on-failure
+#colcon test --retest-until-pass 2 --packages-select nav2_system_tests --ctest-args -R test_system_node --output-on-failure

--- a/tools/run_test_suite.bash
+++ b/tools/run_test_suite.bash
@@ -9,5 +9,3 @@ colcon test --packages-select nav2_system_tests --ctest-args --exclude-regex "te
 colcon test-result --verbose
 $SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_localization
 $SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_system_node
-#colcon test --retest-until-pass 2 --packages-select nav2_system_tests --ctest-args -R test_localization --output-on-failure
-#colcon test --retest-until-pass 2 --packages-select nav2_system_tests --ctest-args -R test_system_node --output-on-failure


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #542 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

* Creates a new system test that runs the BT Navigator node.
* Installs the XML bt navigator config files.
* Enhances the `ctest_retry.bash` script to:
  * avoid the need to copy it in to the nav2_system_test build folder.
  * display test output
  * allow running only one system test at a time so they can be retried individually instead of all together.