### PR TITLE
[WIP] Remove unneccessary additional ROS 2 dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,10 @@ references:
             awk '$1 ~ /^resolution\:/' | \
             awk -F'[][]' '{print $2}' | \
             tr -d \, | xargs -n1 | sort -u | xargs)
-          dpkg -s $dependencies | \
+          if [ -n "$dependencies" ]; then dpkg -s $dependencies | \
             sha256sum | \
-            awk '{print "upstream dependencies "$1}' >> $ROS_WS/checksum.txt
+            awk '{print "upstream dependencies "$1}' >> $ROS_WS/checksum.txt ; \
+          fi
   restore_upstream_cache: &restore_upstream_cache
     restore_cache:
       name: Restore Upstream Cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
 
 # install navigation2 package dependencies
 WORKDIR $NAV2_WS
+RUN rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE
 RUN . $ROS_WS/install/setup.sh && \
     apt-get update && \
     rosdep install -q -y \
@@ -66,7 +67,6 @@ RUN . $ROS_WS/install/setup.sh && \
     && rm -rf /var/lib/apt/lists/*
 
 # build navigation2 package source
-RUN rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE
 RUN . $ROS_WS/install/setup.sh && \
     colcon build \
       --symlink-install \

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -1,13 +1,2 @@
 repositories:
-  BehaviorTree.CPP:
-    type: git
-    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: ros2
-  angles:
-    type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
-  gazebo_ros_pkgs:
-    type: git
-    url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-    version: 3.0.0
+  


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #345  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* Removes `angles`, `behavior tree` and `gazebo ros pkgs` from our extra dependencies. They all get pulled in by `rosdep`