### PR TITLE
Add docker file that builds against crystal release for use in testing the crystal-devel branch

### DIFF
--- a/Dockerfile.crystal
+++ b/Dockerfile.crystal
@@ -1,10 +1,13 @@
 # This dockerfile expects proxies to be set via --build-arg if needed
 # It also expects to be contained in the /navigation2 root folder for file copy
+#
 # Example build command:
 # export CMAKE_BUILD_TYPE=Debug
 # export BUILD_SYSTEM_TESTS=False
-# docker build -t nav2:latest --build-arg BUILD_SYSTEM_TESTS --build-arg CMAKE_BUILD_TYPE ./
-FROM osrf/ros:crystal-desktop
+# docker build -t nav2:crystal --build-arg BUILD_SYSTEM_TESTS
+#   --build-arg CMAKE_BUILD_TYPE -f Dockerfile.crystal ./
+
+FROM ros:crystal
 
 # install ROS2 dependencies
 RUN apt-get update && apt-get install -q -y \
@@ -22,6 +25,14 @@ RUN mkdir -p $NAV2_WS/src
 WORKDIR $NAV2_WS/src
 COPY ./ navigation2/
 
+# delete nav2_system_tests/COLCON_IGNORE before running rosdep, otherwise it
+# doesn't install nav2_system_tests dependencies.
+ARG BUILD_SYSTEM_TESTS=True
+RUN if [ "$BUILD_SYSTEM_TESTS" = "True" ] ; then \
+        rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE ; \
+        echo "Building of system tests enabled" ; \
+    fi
+
 # install navigation2 package dependencies
 WORKDIR $NAV2_WS
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
@@ -31,13 +42,6 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
         src \
       --ignore-src \
     && rm -rf /var/lib/apt/lists/*
-
-
-ARG BUILD_SYSTEM_TESTS=True
-RUN if [ "$BUILD_SYSTEM_TESTS" = "True" ] then
-        rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE
-        echo "Building of system tests enabled"
-    fi
 
 # build navigation2 package source
 ARG CMAKE_BUILD_TYPE=Release

--- a/Dockerfile.crystal
+++ b/Dockerfile.crystal
@@ -22,6 +22,8 @@ RUN mkdir -p $NAV2_WS/src
 WORKDIR $NAV2_WS/src
 COPY ./ navigation2/
 
+RUN rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE
+
 # install navigation2 package dependencies
 WORKDIR $NAV2_WS
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
@@ -35,7 +37,6 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
 ARG CMAKE_BUILD_TYPE=Release
 
 # build navigation2 package source
-RUN rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
     colcon build \
       --symlink-install \

--- a/Dockerfile.crystal
+++ b/Dockerfile.crystal
@@ -48,6 +48,6 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
         -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
 
 # source navigation2 workspace from entrypoint
-RUN sed --in-place \
-      's|^source .*|source "$NAV2_WS/install/setup.bash"|' \
+RUN sed --in-place --expression \
+      '$isource "$NAV2_WS/install/setup.bash"' \
       /ros_entrypoint.sh

--- a/Dockerfile.crystal
+++ b/Dockerfile.crystal
@@ -8,13 +8,13 @@ FROM osrf/ros:crystal-desktop
 
 # install ROS2 dependencies
 RUN apt-get update && apt-get install -q -y \
-build-essential \
-cmake \
-git \
-python3-colcon-common-extensions \
-python3-vcstool \
-wget \
-&& rm -rf /var/lib/apt/lists/*
+      build-essential \
+      cmake \
+      git \
+      python3-colcon-common-extensions \
+      python3-vcstool \
+      wget \
+    && rm -rf /var/lib/apt/lists/*
 
 # copy ros package repo
 ENV NAV2_WS /opt/nav2_ws

--- a/Dockerfile.crystal
+++ b/Dockerfile.crystal
@@ -1,9 +1,9 @@
 # This dockerfile expects proxies to be set via --build-arg if needed
 # It also expects to be contained in the /navigation2 root folder for file copy
 # Example build command:
-# export http_proxy=http://my.proxy.com:80
 # export CMAKE_BUILD_TYPE=Debug
-# docker build -t nav2:latest --build-arg http_proxy --build-arg CMAKE_BUILD_TYPE ./
+# export BUILD_SYSTEM_TESTS=False
+# docker build -t nav2:latest --build-arg BUILD_SYSTEM_TESTS --build-arg CMAKE_BUILD_TYPE ./
 FROM osrf/ros:crystal-desktop
 
 # install ROS2 dependencies
@@ -22,8 +22,6 @@ RUN mkdir -p $NAV2_WS/src
 WORKDIR $NAV2_WS/src
 COPY ./ navigation2/
 
-RUN rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE
-
 # install navigation2 package dependencies
 WORKDIR $NAV2_WS
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
@@ -34,9 +32,15 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
       --ignore-src \
     && rm -rf /var/lib/apt/lists/*
 
-ARG CMAKE_BUILD_TYPE=Release
+
+ARG BUILD_SYSTEM_TESTS=True
+RUN if [ "$BUILD_SYSTEM_TESTS" = "True" ] then
+        rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE
+        echo "Building of system tests enabled"
+    fi
 
 # build navigation2 package source
+ARG CMAKE_BUILD_TYPE=Release
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
     colcon build \
       --symlink-install \

--- a/Dockerfile.crystal
+++ b/Dockerfile.crystal
@@ -1,0 +1,48 @@
+# This dockerfile expects proxies to be set via --build-arg if needed
+# It also expects to be contained in the /navigation2 root folder for file copy
+# Example build command:
+# export http_proxy=http://my.proxy.com:80
+# export CMAKE_BUILD_TYPE=Debug
+# docker build -t nav2:latest --build-arg http_proxy --build-arg CMAKE_BUILD_TYPE ./
+FROM osrf/ros:crystal-desktop
+
+# install ROS2 dependencies
+RUN apt-get update && apt-get install -q -y \
+build-essential \
+cmake \
+git \
+python3-colcon-common-extensions \
+python3-vcstool \
+wget \
+&& rm -rf /var/lib/apt/lists/*
+
+# copy ros package repo
+ENV NAV2_WS /opt/nav2_ws
+RUN mkdir -p $NAV2_WS/src
+WORKDIR $NAV2_WS/src
+COPY ./ navigation2/
+
+# install navigation2 package dependencies
+WORKDIR $NAV2_WS
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
+    apt-get update && \
+    rosdep install -q -y \
+      --from-paths \
+        src \
+      --ignore-src \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG CMAKE_BUILD_TYPE=Release
+
+# build navigation2 package source
+RUN rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
+    colcon build \
+      --symlink-install \
+      --cmake-args \
+        -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+
+# source navigation2 workspace from entrypoint
+RUN sed --in-place \
+      's|^source .*|source "$NAV2_WS/install/setup.bash"|' \
+      /ros_entrypoint.sh


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | related to #421 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* This new docker file builds against the Cyrstal release instead of ROS2 master, and relies entirely on `rosdep` to bring in dependencies. It is intended to be used to test the crystal-devel branch, and maybe make a crystal dockerhub image.

