### PR TITLE
Fixing missing dependencies

### DIFF
--- a/nav2_bt_navigator/package.xml
+++ b/nav2_bt_navigator/package.xml
@@ -17,6 +17,7 @@
   <build_depend>behaviortree_cpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>nav2_robot</build_depend>
+  <build_depend>std_srvs</build_depend>
 
   <exec_depend>behaviortree_cpp</exec_depend>
   <exec_depend>rclcpp</exec_depend>

--- a/nav2_tasks/package.xml
+++ b/nav2_tasks/package.xml
@@ -24,6 +24,7 @@
   <build_depend>tf2</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>nav2_robot</build_depend>
 
   <exec_depend>rclcpp</exec_depend>


### PR DESCRIPTION
These two packages were missing a dependency on `std_srvs` in their package.xml. This PR fixes that.