### PR TITLE
Workaround for sliding sideways bug

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -10,7 +10,7 @@ DwbController:
     max_vel_y: 0.0
     max_vel_theta: 1.0
     min_speed_xy: 0.0
-    max_speed_xy: 0.26
+    max_speed_xy: 100.0
     min_speed_theta: 0.0
     acc_lim_x: 2.5
     acc_lim_y: 0.0

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -10,6 +10,11 @@ DwbController:
     max_vel_y: 0.0
     max_vel_theta: 1.0
     min_speed_xy: 0.0
+    # Set max XY speed to a large value so noisy Y data from IMU doesn't
+    # prevent operation. Since this robot has no Y velocity capability, any Y
+    # velocity reported in /odom data is due to slippage or noise, and there is
+    # no need to reduce the robot's operating envelope when generating possible
+    # trajectories.
     max_speed_xy: 100.0
     min_speed_theta: 0.0
     acc_lim_x: 2.5


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #514  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot 3 on Gazebo |

---

## Description of contribution in a few bullet points

* I set the XY speed limit to a large value. This way even if the Y speed is high in the odom data, the robot continues to have X speed to maneuver with. The robot will still think it is slipping sideways resulting in a maneuver that tries to compensate, but it at least won't fail saying there are no valid trajectories.
* There is maybe an increased chance of collision due to the robot continuing to maneuver with faulty data, however, I see no increase in system test failures.

This can be reverted if ROBOTIS-GIT/turtlebot3_simulations#75 is fixed