### PR TITLE
Fix DWB memory leak

### DIFF
--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -43,6 +43,9 @@ DwbController::DwbController(rclcpp::executor::Executor & executor)
   vel_pub_ =
     this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", 1);
 
+  auto nh = shared_from_this();
+  planner_.initialize(nh, shared_ptr<tf2_ros::Buffer>(&tfBuffer_, NO_OP_DELETER), cm_);
+
   task_server_ = std::make_unique<nav2_tasks::FollowPathTaskServer>(temp_node);
   task_server_->setExecuteCallback(
     std::bind(&DwbController::followPath, this, std::placeholders::_1));
@@ -58,9 +61,7 @@ DwbController::followPath(const nav2_tasks::FollowPathCommand::SharedPtr command
   RCLCPP_INFO(get_logger(), "Starting controller");
   try {
     auto path = nav_2d_utils::pathToPath2D(*command);
-    auto nh = shared_from_this();
 
-    planner_.initialize(nh, shared_ptr<tf2_ros::Buffer>(&tfBuffer_, NO_OP_DELETER), cm_);
     planner_.setPlan(path);
     RCLCPP_INFO(get_logger(), "Initialized");
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #564  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 on Gazebo |

---

## Description of contribution in a few bullet points

* Moved the DWB initialize call from the Execute method to the constructor.
* I ran Valgrind and saw a bunch of leaks related to loading the plugins in DWB and Costmap. By moving this code to the constructor, it only runs once. This makes more sense logically and makes DWB a bit faster to start moving.