### PR TITLE
Add service to fully clear costmap

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
@@ -55,13 +55,13 @@ private:
   std::vector<std::string> clearable_layers_;
 
   // Server for clearing the costmap
-  rclcpp::Service<nav2_msgs::srv::ClearCostmapExceptRegion>::SharedPtr except_region_server_;
+  rclcpp::Service<nav2_msgs::srv::ClearCostmapExceptRegion>::SharedPtr clear_except_service_;
   void clearExceptRegionCallback(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion::Request> request,
     const std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion::Response> response);
 
-  rclcpp::Service<nav2_msgs::srv::ClearEntireCostmap>::SharedPtr entire_clearing_server_;
+  rclcpp::Service<nav2_msgs::srv::ClearEntireCostmap>::SharedPtr clear_entire_service_;
   void clearEntireCallback(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<nav2_msgs::srv::ClearEntireCostmap::Request> request,

--- a/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
@@ -21,6 +21,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_msgs/srv/clear_costmap_except_region.hpp"
+#include "nav2_msgs/srv/clear_entire_costmap.hpp"
 #include "nav2_costmap_2d/costmap_layer.hpp"
 
 namespace nav2_costmap_2d
@@ -38,6 +39,9 @@ public:
   // Clears the region outside of a user-specified area reverting to the static map
   void clearExceptRegion(double reset_distance = 3.0);
 
+  // Clears all layers
+  void clearEntirely();
+
 private:
   // The ROS node to use for getting parameters, creating the service and logging
   rclcpp::Node::SharedPtr node_;
@@ -51,11 +55,17 @@ private:
   std::vector<std::string> clearable_layers_;
 
   // Server for clearing the costmap
-  rclcpp::Service<nav2_msgs::srv::ClearCostmapExceptRegion>::SharedPtr server_;
+  rclcpp::Service<nav2_msgs::srv::ClearCostmapExceptRegion>::SharedPtr except_region_server_;
   void clearExceptRegionCallback(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion::Request> request,
     const std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion::Response> response);
+
+  rclcpp::Service<nav2_msgs::srv::ClearEntireCostmap>::SharedPtr entire_clearing_server_;
+  void clearEntireCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<nav2_msgs::srv::ClearEntireCostmap::Request> request,
+    const std::shared_ptr<nav2_msgs::srv::ClearEntireCostmap::Response> response);
 
   void clearLayerExceptRegion(
     std::shared_ptr<CostmapLayer> & costmap, double pose_x, double pose_y, double reset_distance);

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -269,7 +269,8 @@ void StaticLayer::reset()
   if (first_map_only_) {
     has_updated_data_ = true;
   } else {
-    onInitialize();
+    // TODO(orduno) Issue #580, calling onInitialize() when the node is already spinning results on an error.
+    // onInitialize();
   }
 }
 

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -224,7 +224,7 @@ void StaticLayer::incomingMap(const nav_msgs::msg::OccupancyGrid::SharedPtr new_
   map_received_ = true;
   has_updated_data_ = true;
 
-  // shutdown the map subscrber if firt_map_only_ flag is on
+  // shutdown the map subscrber if first_map_only_ flag is on
   if (first_map_only_) {
     RCLCPP_INFO(node_->get_logger(),
       "Shutting down the map subscriber. first_map_only flag is on");

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -51,7 +51,7 @@ void ClearCostmapService::clearExceptRegionCallback(
   const shared_ptr<ClearExceptRegion::Request> request,
   const shared_ptr<ClearExceptRegion::Response>/*response*/)
 {
-  RCLCPP_INFO(node_->get_logger(), "Received request to clear " + costmap_.getName());
+  RCLCPP_INFO(node_->get_logger(), "Received request to clear expect region the " + costmap_.getName());
 
   clearExceptRegion(request->reset_distance);
 }
@@ -61,7 +61,7 @@ void ClearCostmapService::clearEntireCallback(
   const std::shared_ptr<ClearEntirely::Request>/*request*/,
   const std::shared_ptr<ClearEntirely::Response>/*response*/)
 {
-  RCLCPP_INFO(node_->get_logger(), "Received request to clear entirely " + costmap_.getName());
+  RCLCPP_INFO(node_->get_logger(), "Received request to clear entirely the " + costmap_.getName());
 
   clearEntirely();
 }
@@ -87,8 +87,7 @@ void ClearCostmapService::clearExceptRegion(const double reset_distance)
 
 void ClearCostmapService::clearEntirely()
 {
-  // std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getCostmap()->getMutex()));
-  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getLayeredCostmap()->getCostmap()->getMutex()));
+  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getCostmap()->getMutex()));
   costmap_.resetLayers();
 }
 

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -28,6 +28,7 @@ using std::string;
 using std::shared_ptr;
 using std::any_of;
 using ClearExceptRegion = nav2_msgs::srv::ClearCostmapExceptRegion;
+using ClearEntirely =nav2_msgs::srv::ClearEntireCostmap;
 
 ClearCostmapService::ClearCostmapService(rclcpp::Node::SharedPtr & node, Costmap2DROS & costmap)
 : node_(node), costmap_(costmap)
@@ -36,8 +37,12 @@ ClearCostmapService::ClearCostmapService(rclcpp::Node::SharedPtr & node, Costmap
 
   node_->get_parameter_or_set("clearable_layers", clearable_layers_, {"obstacle_layer"});
 
-  server_ = node_->create_service<ClearExceptRegion>("clear_except_" + costmap_.getName(),
+  except_region_server_ = node_->create_service<ClearExceptRegion>("clear_except_" + costmap_.getName(),
       std::bind(&ClearCostmapService::clearExceptRegionCallback, this,
+      std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+
+  entire_clearing_server_ = node_->create_service<ClearEntirely>("clear_entirely_" + costmap_.getName(),
+      std::bind(&ClearCostmapService::clearEntireCallback, this,
       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 }
 
@@ -49,6 +54,16 @@ void ClearCostmapService::clearExceptRegionCallback(
   RCLCPP_INFO(node_->get_logger(), "Received request to clear " + costmap_.getName());
 
   clearExceptRegion(request->reset_distance);
+}
+
+void ClearCostmapService::clearEntireCallback(
+  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+  const std::shared_ptr<ClearEntirely::Request>/*request*/,
+  const std::shared_ptr<ClearEntirely::Response>/*response*/)
+{
+  RCLCPP_INFO(node_->get_logger(), "Received request to clear entirely " + costmap_.getName());
+
+  clearEntirely();
 }
 
 void ClearCostmapService::clearExceptRegion(const double reset_distance)
@@ -68,6 +83,13 @@ void ClearCostmapService::clearExceptRegion(const double reset_distance)
       clearLayerExceptRegion(costmap_layer, x, y, reset_distance);
     }
   }
+}
+
+void ClearCostmapService::clearEntirely()
+{
+  // std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getCostmap()->getMutex()));
+  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getLayeredCostmap()->getCostmap()->getMutex()));
+  costmap_.resetLayers();
 }
 
 bool ClearCostmapService::isClearable(const string & layer_name) const

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -37,12 +37,12 @@ ClearCostmapService::ClearCostmapService(rclcpp::Node::SharedPtr & node, Costmap
 
   node_->get_parameter_or_set("clearable_layers", clearable_layers_, {"obstacle_layer"});
 
-  except_region_server_ = node_->create_service<ClearExceptRegion>(
+  clear_except_service_ = node_->create_service<ClearExceptRegion>(
     "clear_except_" + costmap_.getName(),
     std::bind(&ClearCostmapService::clearExceptRegionCallback, this,
     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
-  entire_clearing_server_ = node_->create_service<ClearEntirely>(
+  clear_entire_service_ = node_->create_service<ClearEntirely>(
     "clear_entirely_" + costmap_.getName(),
     std::bind(&ClearCostmapService::clearEntireCallback, this,
     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
@@ -54,7 +54,7 @@ void ClearCostmapService::clearExceptRegionCallback(
   const shared_ptr<ClearExceptRegion::Response>/*response*/)
 {
   RCLCPP_INFO(node_->get_logger(),
-    "Received request to clear expect region the " + costmap_.getName());
+    "Received request to clear except a region the " + costmap_.getName());
 
   clearExceptRegion(request->reset_distance);
 }

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -28,7 +28,7 @@ using std::string;
 using std::shared_ptr;
 using std::any_of;
 using ClearExceptRegion = nav2_msgs::srv::ClearCostmapExceptRegion;
-using ClearEntirely =nav2_msgs::srv::ClearEntireCostmap;
+using ClearEntirely = nav2_msgs::srv::ClearEntireCostmap;
 
 ClearCostmapService::ClearCostmapService(rclcpp::Node::SharedPtr & node, Costmap2DROS & costmap)
 : node_(node), costmap_(costmap)
@@ -37,13 +37,15 @@ ClearCostmapService::ClearCostmapService(rclcpp::Node::SharedPtr & node, Costmap
 
   node_->get_parameter_or_set("clearable_layers", clearable_layers_, {"obstacle_layer"});
 
-  except_region_server_ = node_->create_service<ClearExceptRegion>("clear_except_" + costmap_.getName(),
-      std::bind(&ClearCostmapService::clearExceptRegionCallback, this,
-      std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+  except_region_server_ = node_->create_service<ClearExceptRegion>(
+    "clear_except_" + costmap_.getName(),
+    std::bind(&ClearCostmapService::clearExceptRegionCallback, this,
+    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
-  entire_clearing_server_ = node_->create_service<ClearEntirely>("clear_entirely_" + costmap_.getName(),
-      std::bind(&ClearCostmapService::clearEntireCallback, this,
-      std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+  entire_clearing_server_ = node_->create_service<ClearEntirely>(
+    "clear_entirely_" + costmap_.getName(),
+    std::bind(&ClearCostmapService::clearEntireCallback, this,
+    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 }
 
 void ClearCostmapService::clearExceptRegionCallback(
@@ -51,7 +53,8 @@ void ClearCostmapService::clearExceptRegionCallback(
   const shared_ptr<ClearExceptRegion::Request> request,
   const shared_ptr<ClearExceptRegion::Response>/*response*/)
 {
-  RCLCPP_INFO(node_->get_logger(), "Received request to clear expect region the " + costmap_.getName());
+  RCLCPP_INFO(node_->get_logger(),
+    "Received request to clear expect region the " + costmap_.getName());
 
   clearExceptRegion(request->reset_distance);
 }

--- a/nav2_msgs/CMakeLists.txt
+++ b/nav2_msgs/CMakeLists.txt
@@ -19,6 +19,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/VoxelGrid.msg"
   "srv/GetCostmap.srv"
   "srv/ClearCostmapExceptRegion.srv"
+  "srv/ClearEntireCostmap.srv"
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs
 )
 

--- a/nav2_msgs/package.xml
+++ b/nav2_msgs/package.xml
@@ -6,6 +6,7 @@
   <description>Messages and service files for the navigation2 stack</description>
   <maintainer email="michael.jeronimo@intel.com">Michael Jeronimo</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
+  <maintainer email="carlos.a.orduno@intel.com">Carlos Orduno</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/nav2_msgs/srv/ClearEntireCostmap.srv
+++ b/nav2_msgs/srv/ClearEntireCostmap.srv
@@ -1,0 +1,5 @@
+# Clears all layers on the costmap
+
+std_msgs/Empty request
+---
+std_msgs/Empty response


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #551  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on |Gazebo simulation of Turtlebot |

---

## Description of contribution in a few bullet points

This is a continuation of #551. A service for clearing all locations outside of a region was already incorporated in #559. This new PR adds service for clearing the costmap entirely, similar to the [big reset service](https://github.com/ros-planning/navigation/blob/a6f3d4b49335b6de5c33044dd2123df0f491453f/move_base/src/move_base.cpp#L330-L338) available in ROS1 move base.
