### PR TITLE
Fixing memory leak within Costmap2D Inflation Layer

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -182,8 +182,7 @@ private:
 
   double resolution_;
 
-  bool * seen_;
-  int seen_size_;
+  std::vector<bool> seen_;
 
   unsigned char ** cached_costs_;
   double ** cached_distances_;

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -201,11 +201,7 @@ void InflationLayer::updateCosts(
   unsigned char * master_array = master_grid.getCharMap();
   unsigned int size_x = master_grid.getSizeInCellsX(), size_y = master_grid.getSizeInCellsY();
 
-  if (seen_.empty()) {
-    RCLCPP_WARN(rclcpp::get_logger(
-        "nav2_costmap_2d"), "InflationLayer::updateCosts(): seen_ vector is empty");
-    seen_ = std::vector<bool>(size_x * size_y, false);
-  } else if (seen_.size() != size_x * size_y) {
+  if (seen_.size() != size_x * size_y) {
     RCLCPP_WARN(rclcpp::get_logger(
         "nav2_costmap_2d"), "InflationLayer::updateCosts(): seen_ vector size is wrong");
     seen_ = std::vector<bool>(size_x * size_y, false);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #581  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | gazebo sim of turtlebot |

---

## Description of contribution in a few bullet points

The `seen_` was being used as a container for bool values and implemented as a dynamically allocated array (raw pointer), however, it was never deleted on the inflation layer destructor.

This PR implements using std::vector<bool>.

There's been [discussion](https://isocpp.org/blog/2012/11/on-vectorbool) on whether `vector<bool>` should be used at all. In this case looks fine, let me know what you think.
