### PR TITLE
Run dynamic params test independently. (flaky dynamic params test fix part 2)

### DIFF
--- a/tools/run_test_suite.bash
+++ b/tools/run_test_suite.bash
@@ -4,9 +4,26 @@ set -ex
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"  # gets the directory of this script
 
-colcon test --packages-skip nav2_system_tests
+# Skip nav2_system_tests because the system tests are flaky and need to be retried
+# a few times.
+#
+# Skip the nav2_dynamic_params tests because they fail when run concurrently with
+# other tests. We could run all the tests sequentially to fix this, however, by
+# just deferring this one package and running it later, we don't have to slow everything down.
+colcon test --packages-skip nav2_system_tests nav2_dynamic_params
+
+# run nav2_dynamic_params independently
+colcon test --packages-select nav2_dynamic_params
+
+# run the linters in nav2_system_tests. They only need to be run once.
 colcon test --packages-select nav2_system_tests --ctest-args --exclude-regex "test_.*"  # run the linters
+
+# Each of the `colcon test` lines above runs tests on independent sets of packages.
+# As a result the test logs of each line won't overwrite the others. The single
+# call to `colcon test-result` will look through all packages and report any errors
+# that happened in any of the `colcon test` lines above.
 colcon test-result --verbose
+
 $SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_localization
 $SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_simple_navigator
 $SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_bt_navigator


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #556 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* The dynamic params test fails when run concurrently with other packages' tests. This changes runs the dynamic_params tests independently in CI.
* This is part two of PR #568
