### PR TITLE
Fix oscillation problem and tune DWB critics

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -23,9 +23,18 @@ DwbController:
     decel_lim_x: -2.5
     decel_lim_y: 0.0
     decel_lim_theta: -3.2
+    ObstacleFootprint.scale: 1.0
+    ObstacleFootprint.max_scaling_factor: 0.2
+    ObstacleFootprint.scaling_speed: 0.25
+    PathAlign.scale: 32.0
+    GoalAlign.scale: 24.0
+    PathDist.scale: 32.0
+    GoalDist.scale: 24.0
+    RotateToGoal.scale: 32.0
 local_costmap:
   local_costmap:
     ros__parameters:
+      robot_radius: 0.092
       obstacle_layer:
         enabled: False
       always_send_full_costmap: True

--- a/nav2_dwb_controller/dwb_critics/include/dwb_critics/oscillation.hpp
+++ b/nav2_dwb_controller/dwb_critics/include/dwb_critics/oscillation.hpp
@@ -120,6 +120,16 @@ public:
      */
     bool hasSignFlipped();
 
+    /**
+     * @brief Disable this command trend object if we don't care about this axis
+     */
+    void disable() {enabled_ = false;}
+
+    /**
+     * @brief Re-enable this command trend object
+     */
+    void enable() {enabled_ = true;}
+
 private:
     // Simple Enum for Tracking
     // cppcheck-suppress syntaxError
@@ -127,6 +137,7 @@ private:
 
     Sign sign_;
     bool positive_only_, negative_only_;
+    bool enabled_;
   };
 
   /**

--- a/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
@@ -49,6 +49,7 @@ namespace dwb_critics
 
 
 OscillationCritic::CommandTrend::CommandTrend()
+: enabled_(true)
 {
   reset();
 }
@@ -62,6 +63,10 @@ void OscillationCritic::CommandTrend::reset()
 
 bool OscillationCritic::CommandTrend::update(double velocity)
 {
+  if (!enabled_) {
+    return false;
+  }
+
   bool flag_set = false;
   if (velocity < 0.0) {
     if (sign_ == Sign::POSITIVE) {
@@ -81,11 +86,19 @@ bool OscillationCritic::CommandTrend::update(double velocity)
 
 bool OscillationCritic::CommandTrend::isOscillating(double velocity)
 {
+  if (!enabled_) {
+    return false;
+  }
+
   return (positive_only_ && velocity < 0.0) || (negative_only_ && velocity > 0.0);
 }
 
 bool OscillationCritic::CommandTrend::hasSignFlipped()
 {
+  if (!enabled_) {
+    return false;
+  }
+
   return positive_only_ || negative_only_;
 }
 
@@ -126,6 +139,13 @@ void OscillationCritic::onInit()
   // {
   //   x_only_threshold_ = 0.05;
   // }
+
+  // Disable y oscillation detection if the robot can't move in the Y axis
+  double max_vel_y;
+  nh_->get_parameter_or("max_vel_y", max_vel_y, 0.0);
+  if (max_vel_y == 0.0) {
+    y_trend_.disable();
+  }
 
   reset();
 }

--- a/nav2_system_tests/params/nav2_params.yaml
+++ b/nav2_system_tests/params/nav2_params.yaml
@@ -18,9 +18,18 @@ DwbController:
     decel_lim_x: -2.5
     decel_lim_y: 0.0
     decel_lim_theta: -3.2
+    ObstacleFootprint.scale: 1.0
+    ObstacleFootprint.max_scaling_factor: 0.2
+    ObstacleFootprint.scaling_speed: 0.25
+    PathAlign.scale: 32.0
+    GoalAlign.scale: 24.0
+    PathDist.scale: 32.0
+    GoalDist.scale: 24.0
+    RotateToGoal.scale: 32.0
 local_costmap:
   local_costmap:
     ros__parameters:
+      robot_radius: 0.092
       always_send_full_costmap: True
 global_costmap:
   global_costmap:


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #520, fixes #570  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |Turtlebot 3 in gazebo |

---

## Description of contribution in a few bullet points

* Disables oscillation detection on the Y-axis if the robot is not capable of Y-axis motion (eg. a differential drive robot) . See #520 for reasoning.
* Rough tuning of the DWB critics to get reliable motion. I upped the obstacle avoidance critic and the rotate to goal critic based on observed motion.
* Decreased the radius of the robot based on measurements of the model in gazebo.

---

## Future work that may be required in bullet points

* Need to sync the oscillation critic changes with @DLu 