### PR TITLE
Motion primitives unit tests

### DIFF
--- a/nav2_motion_primitives/CMakeLists.txt
+++ b/nav2_motion_primitives/CMakeLists.txt
@@ -70,7 +70,11 @@ install(DIRECTORY include/
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+
   ament_lint_auto_find_test_dependencies()
+  ament_add_gtest(test_motion_primitives test/test_motion_primitives.cpp)
+  ament_target_dependencies(test_motion_primitives ${dependencies})
 endif()
 
 ament_export_include_directories(include)

--- a/nav2_motion_primitives/CMakeLists.txt
+++ b/nav2_motion_primitives/CMakeLists.txt
@@ -69,12 +69,11 @@ install(DIRECTORY include/
 )
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
-
+  find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-  ament_add_gtest(test_motion_primitives test/test_motion_primitives.cpp)
-  ament_target_dependencies(test_motion_primitives ${dependencies})
+  add_subdirectory(test)
 endif()
 
 ament_export_include_directories(include)

--- a/nav2_motion_primitives/include/nav2_motion_primitives/motion_primitive.hpp
+++ b/nav2_motion_primitives/include/nav2_motion_primitives/motion_primitive.hpp
@@ -57,7 +57,10 @@ public:
     RCLCPP_INFO(node_->get_logger(), "Initialized the %s server", taskName_.c_str());
   }
 
-  virtual ~MotionPrimitive() {}
+  virtual ~MotionPrimitive()
+  {
+    task_server_->exit();
+  }
 
   // Derived classes can override this method to catch the command and perform some checks
   // before getting into the main loop. The method will only be called
@@ -78,13 +81,14 @@ public:
   {
     RCLCPP_INFO(node_->get_logger(), "%s attempting behavior", taskName_.c_str());
 
-    ResultMsg result;
     auto status = onRun(command);
 
-    if (status == nav2_tasks::TaskStatus::SUCCEEDED) {
-      status = cycle(result);
+    if (status != nav2_tasks::TaskStatus::SUCCEEDED) {
+      return nav2_tasks::TaskStatus::FAILED;
     }
 
+    ResultMsg result;
+    status = cycle(result);
     task_server_->setResult(result);
 
     return status;

--- a/nav2_motion_primitives/include/nav2_motion_primitives/motion_primitive.hpp
+++ b/nav2_motion_primitives/include/nav2_motion_primitives/motion_primitive.hpp
@@ -52,14 +52,14 @@ public:
     task_server_->setExecuteCallback(std::bind(&MotionPrimitive::run, this, std::placeholders::_1));
 
     // Start listening for incoming Spin task requests
-    task_server_->startWorkerThread();
+    task_server_->start();
 
     RCLCPP_INFO(node_->get_logger(), "Initialized the %s server", taskName_.c_str());
   }
 
   virtual ~MotionPrimitive()
   {
-    task_server_->exit();
+    task_server_->stop();
   }
 
   // Derived classes can override this method to catch the command and perform some checks

--- a/nav2_motion_primitives/test/CMakeLists.txt
+++ b/nav2_motion_primitives/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+ament_add_gtest(test_motion_primitives
+  test_motion_primitives.cpp
+)
+
+ament_target_dependencies(test_motion_primitives
+  ${dependencies}
+)

--- a/nav2_motion_primitives/test/CMakeLists.txt
+++ b/nav2_motion_primitives/test/CMakeLists.txt
@@ -1,9 +1,0 @@
-
-#include_directories( ${PROJECT_SOURCE_DIR}/src )
-#include_directories( ${PROJECT_SOURCE_DIR}/test )
-
-ament_add_gtest(test_motion_primitives test_motion_primitives.cpp)
-
-ament_target_dependencies( test_motion_primitives
-  ${dependencies}
-)

--- a/nav2_motion_primitives/test/CMakeLists.txt
+++ b/nav2_motion_primitives/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+#include_directories( ${PROJECT_SOURCE_DIR}/src )
+#include_directories( ${PROJECT_SOURCE_DIR}/test )
+
+ament_add_gtest(test_motion_primitives test_motion_primitives.cpp)
+
+ament_target_dependencies( test_motion_primitives
+  ${dependencies}
+)

--- a/nav2_motion_primitives/test/test_motion_primitives.cpp
+++ b/nav2_motion_primitives/test/test_motion_primitives.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include <string>
+#include <memory>
+#include <chrono>
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "nav2_tasks/task_status.hpp"
+#include "nav2_motion_primitives/motion_primitive.hpp"
+
+using nav2_tasks::TaskStatus;
+using namespace std::chrono_literals;
+
+// A global object to initialize ROS
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+
+RclCppFixture g_rclcppfixture;
+
+// Let's create a motion primitive for testing the base class
+
+using DummyPrimitiveCommand = std_msgs::msg::String;
+using DummyPrimitiveResult = std_msgs::msg::String;
+
+class DummyPrimitive : public MotionPrimitives<DummyPrimitiveCommand, DummyPrimitiveResult>
+{
+public:
+  explicit DummyPrimitive(rclcpp::Node::SharedPtr & node)
+  : MotionPrimitive<DummyPrimitiveCommand, DummyPrimitiveResult>(node),
+    initialized_(false) {}
+
+  ~DummyPrimitive() {}
+
+  TaskStatus onRun(const DummyPrimitiveCommand::SharedPtr command) override
+  {
+    // A normal primitive would catch the command and initialize
+    initialized_ = false;
+    command_ = command;
+    start_time_ = std::chrono::system_clock::now();
+
+    // Method can have various possible outcomes (success, failure, cancelled)
+    // To generate the possible outcomes we use the command string.
+
+    if (command->data == "Testing failure") {
+      // Means initialization failed or command is invalid
+      return TaskStatus::FAILED;
+    } else if (command->data == "Testing success") {
+      // Means initialization succeeded
+      initialzed_ = true;
+      return TaskStatus::SUCCEEDED;
+    } else {
+      return TaskStatus::FAILED;
+    }
+  }
+
+  TaskStatus onCycleUpdate(DummyPrimitiveResult & result) override
+  {
+    // A normal primitive would set the robot in motion in the first call
+    // and check for robot states on subsequent calls to check if the movement
+    // was completed
+
+    if (command->data != "Testing success" || !initialized_) {
+      return TaskStatus::FAILED;
+    }
+
+    auto current_time = std::chrono::system_clock::now();
+    auto motion_duration = 5s;
+
+    if (current_time - start_time_ >= motion_duration) {
+      // Movement was completed
+      return TaskStatus::SUCCEEDED;
+    }
+
+    // Some computation
+    std::this_thread::sleep_for(5ms);
+
+    return TaskStatus::RUNNING;
+  }
+
+private:
+  bool initialized_;
+  std::shared_ptr<DummyPrimitiveCommand> command_;
+  std::chrono::system_clock::time_point start_time_;
+}
+
+// Define a test class to hold the context for the tests
+
+class MotionPrimitivesTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    dummy_node_ = std::make_shared<rclcpp::Node>("DummyNode");
+
+    // The motion primitives are not themselves a node
+    primitive_ = std::make_unique<DummyPrimitive>(dummy_node_);
+  }
+
+  void TearDown() override {}
+
+  void testSuccess();
+  void testFailure();
+  void testCancel();
+
+  std::shared_ptr<rclcpp::Node> dummy_node_;
+  std::unique_ptr<DummyPrimitive> primitive_;
+}
+
+// Finally, define the tests
+
+void MotionPrimitivesTest::testSuccess()
+{
+}
+
+void MotionPrimitivesTest::testFailure()
+{
+}
+
+void MotionPrimitivesTest::testCancel()
+{
+}
+
+TEST_F(MotionPrimitivesTest, allTests)
+{
+  testSuccess();
+  testFailure();
+  testCancel();
+}

--- a/nav2_motion_primitives/test/test_motion_primitives.cpp
+++ b/nav2_motion_primitives/test/test_motion_primitives.cpp
@@ -107,6 +107,20 @@ private:
   std::chrono::system_clock::time_point start_time_;
 };
 
+// The following getTaskName function is required and currently has to be
+// in the nav2_tasks namespace
+
+namespace nav2_tasks
+{
+
+template<>
+inline const char * getTaskName<DummyPrimitiveCommand, DummyPrimitiveResult>()
+{
+  return "TestMotionPrimitivesTask";
+}
+
+}
+
 // Define a test class to hold the context for the tests
 
 class MotionPrimitivesTest : public ::testing::Test

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -78,7 +78,7 @@ NavfnPlanner::NavfnPlanner()
     std::bind(&NavfnPlanner::computePathToPose, this, std::placeholders::_1));
 
   // Start listening for incoming ComputePathToPose task requests
-  task_server_->startWorkerThread();
+  task_server_->start();
 }
 
 NavfnPlanner::~NavfnPlanner()

--- a/nav2_system_tests/src/dummy_controller/dummy_controller.cpp
+++ b/nav2_system_tests/src/dummy_controller/dummy_controller.cpp
@@ -40,7 +40,7 @@ DummyController::DummyController()
     std::bind(&DummyController::followPath, this, std::placeholders::_1));
 
   // Start listening for incoming ComputePathToPose task requests
-  task_server_->startWorkerThread();
+  task_server_->start();
 
   RCLCPP_INFO(get_logger(), "Initialized DummyController");
 }

--- a/nav2_system_tests/src/dummy_planner/dummy_planner.cpp
+++ b/nav2_system_tests/src/dummy_planner/dummy_planner.cpp
@@ -36,7 +36,7 @@ DummyPlanner::DummyPlanner()
     std::bind(&DummyPlanner::computePathToPose, this, std::placeholders::_1));
 
   // Start listening for incoming ComputePathToPose task requests
-  task_server_->startWorkerThread();
+  task_server_->start();
 
   RCLCPP_INFO(get_logger(), "Initialized DummyPlanner");
 }

--- a/nav2_tasks/include/nav2_tasks/task_server.hpp
+++ b/nav2_tasks/include/nav2_tasks/task_server.hpp
@@ -63,15 +63,13 @@ public:
       };
 
     if (autoStart) {
-      startWorkerThread();
+      start();
     }
   }
 
   virtual ~TaskServer()
   {
-    if (workerThread_) {
-      stopWorkerThread();
-    }
+    stop();
   }
 
   typedef std::function<TaskStatus(const typename CommandMsg::SharedPtr command)> ExecuteCallback;
@@ -111,15 +109,14 @@ public:
     resultMsg_ = result;
   }
 
-  void startWorkerThread()
+  void start()
   {
     if (!workerThread_) {
-      stop_thread_ = false;
-      workerThread_ = new std::thread(&TaskServer::workerThread, this);
+      startWorkerThread();
     }
   }
 
-  void exit()
+  void stop()
   {
     if (workerThread_) {
       stopWorkerThread();
@@ -142,6 +139,12 @@ protected:
   // The pointer to our private worker thread
   std::thread * workerThread_;
   std::atomic<bool> stop_thread_;
+
+  void startWorkerThread()
+  {
+    stop_thread_ = false;
+    workerThread_ = new std::thread(&TaskServer::workerThread, this);
+  }
 
   // This class has the worker thread body which calls the user's execute() callback
   void workerThread()

--- a/nav2_tasks/include/nav2_tasks/task_server.hpp
+++ b/nav2_tasks/include/nav2_tasks/task_server.hpp
@@ -205,9 +205,6 @@ protected:
     } while (rclcpp::ok() && !stop_thread_);
   }
 
-  // TODO(mjeronimo): Make explicit start and stop calls to control
-  // the worker thread
-
   void stopWorkerThread()
   {
     stop_thread_ = true;


### PR DESCRIPTION
This PR adds some unit tests for the `MotionPrimitive` base class. Addressing #384.

In the process of making the tests, I found a need for adding a stop method to the task server base class.