### PR TITLE
removed bullet dependency from map_server

### DIFF
--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(ament_cmake REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(nav_msgs REQUIRED)
-find_package(Bullet REQUIRED)
 find_package(SDL REQUIRED)
 find_package(SDL_image REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
@@ -16,7 +15,6 @@ nav2_package()
 
 include_directories(
   include
-  ${BULLET_INCLUDE_DIRS}
   ${SDL_INCLUDE_DIR}
   ${SDL_IMAGE_INCLUDE_DIRS}
 )
@@ -76,7 +74,6 @@ target_link_libraries(${map_saver_executable}
 )
 
 target_link_libraries(${library_name}
-  ${BULLET_LIBRARIES}
   ${SDL_LIBRARY}
   ${SDL_IMAGE_LIBRARIES}
 )

--- a/nav2_map_server/package.xml
+++ b/nav2_map_server/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>nav2_common</build_depend>
 
-  <depend>bullet</depend>
   <depend>nav_msgs</depend>
   <depend>std_msgs</depend>
   <depend>rclcpp</depend>

--- a/nav2_map_server/src/occ_grid_loader.cpp
+++ b/nav2_map_server/src/occ_grid_loader.cpp
@@ -39,7 +39,7 @@
 #include <memory>
 #include <stdexcept>
 
-#include "LinearMath/btQuaternion.h"
+#include "tf2/LinearMath/Quaternion.h"
 #include "SDL/SDL_image.h"
 
 using namespace std::chrono_literals;
@@ -136,9 +136,8 @@ void OccGridLoader::loadMapFromFile(const std::string & map_name)
   msg_.info.origin.position.x = origin_[0];
   msg_.info.origin.position.y = origin_[1];
   msg_.info.origin.position.z = 0.0;
-  btQuaternion q;
-  // setEulerZYX(yaw, pitch, roll)
-  q.setEulerZYX(origin_[2], 0, 0);
+  tf2::Quaternion q;
+  q.setRPY(0, 0, origin_[2]);
   msg_.info.origin.orientation.x = q.x();
   msg_.info.origin.orientation.y = q.y();
   msg_.info.origin.orientation.z = q.z();


### PR DESCRIPTION

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo  |

---

## Description of contribution in a few bullet points

* Removed `Bullet` dependency from `map_server` as it was only used to convert RPY to quaternions.

---


