### PR TITLE
Adding a service to clear a costmap around the robot

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
@@ -66,7 +66,7 @@ private:
     const std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion::Response> response);
 
   rclcpp::Service<nav2_msgs::srv::ClearCostmapAroundRobot>::SharedPtr clear_around_service_;
-  void clearAroundCallback(
+  void clearAroundRobotCallback(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<nav2_msgs::srv::ClearCostmapAroundRobot::Request> request,
     const std::shared_ptr<nav2_msgs::srv::ClearCostmapAroundRobot::Response> response);

--- a/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/clear_costmap_service.hpp
@@ -21,6 +21,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_msgs/srv/clear_costmap_except_region.hpp"
+#include "nav2_msgs/srv/clear_costmap_around_robot.hpp"
 #include "nav2_msgs/srv/clear_entire_costmap.hpp"
 #include "nav2_costmap_2d/costmap_layer.hpp"
 
@@ -38,6 +39,9 @@ public:
 
   // Clears the region outside of a user-specified area reverting to the static map
   void clearExceptRegion(double reset_distance = 3.0);
+
+  // Clears within a window around the robot
+  void clearAroundRobot(double window_size_x, double window_size_y);
 
   // Clears all layers
   void clearEntirely();
@@ -60,6 +64,12 @@ private:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion::Request> request,
     const std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion::Response> response);
+
+  rclcpp::Service<nav2_msgs::srv::ClearCostmapAroundRobot>::SharedPtr clear_around_service_;
+  void clearAroundCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<nav2_msgs::srv::ClearCostmapAroundRobot::Request> request,
+    const std::shared_ptr<nav2_msgs::srv::ClearCostmapAroundRobot::Response> response);
 
   rclcpp::Service<nav2_msgs::srv::ClearEntireCostmap>::SharedPtr clear_entire_service_;
   void clearEntireCallback(

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -28,6 +28,7 @@ using std::string;
 using std::shared_ptr;
 using std::any_of;
 using ClearExceptRegion = nav2_msgs::srv::ClearCostmapExceptRegion;
+using ClearAroundRobot = nav2_msgs::srv::ClearCostmapAroundRobot;
 using ClearEntirely = nav2_msgs::srv::ClearEntireCostmap;
 
 ClearCostmapService::ClearCostmapService(rclcpp::Node::SharedPtr & node, Costmap2DROS & costmap)
@@ -40,6 +41,11 @@ ClearCostmapService::ClearCostmapService(rclcpp::Node::SharedPtr & node, Costmap
   clear_except_service_ = node_->create_service<ClearExceptRegion>(
     "clear_except_" + costmap_.getName(),
     std::bind(&ClearCostmapService::clearExceptRegionCallback, this,
+    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+
+  clear_around_service_ = node_->create_service<ClearAroundRobot>(
+    "clear_around_" + costmap.getName(),
+    std::bind(&ClearCostmapService::clearAroundCallback, this,
     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
   clear_entire_service_ = node_->create_service<ClearEntirely>(
@@ -57,6 +63,17 @@ void ClearCostmapService::clearExceptRegionCallback(
     "Received request to clear except a region the " + costmap_.getName());
 
   clearExceptRegion(request->reset_distance);
+}
+
+void ClearCostmapService::clearAroundCallback(
+  const shared_ptr<rmw_request_id_t>/*request_header*/,
+  const shared_ptr<ClearAroundRobot::Request> request,
+  const shared_ptr<ClearAroundRobot::Response>/*response*/)
+{
+  RCLCPP_INFO(node_->get_logger(),
+    "Received request to clear around robot the " + costmap_.getName());
+
+  clearAroundRobot(request->window_size_x, request->window_size_y);
 }
 
 void ClearCostmapService::clearEntireCallback(
@@ -86,6 +103,37 @@ void ClearCostmapService::clearExceptRegion(const double reset_distance)
       clearLayerExceptRegion(costmap_layer, x, y, reset_distance);
     }
   }
+}
+
+void ClearCostmapService::clearAroundRobot(double window_size_x, double window_size_y)
+{
+  double pose_x, pose_y;
+
+  if (!getPosition(pose_x, pose_y)) {
+    RCLCPP_ERROR(node_->get_logger(), "Cannot clear map because robot pose cannot be retrieved.");
+    return;
+  }
+
+  std::vector<geometry_msgs::msg::Point> clear_poly;
+  geometry_msgs::msg::Point pt;
+
+  pt.x = pose_x - window_size_x / 2;
+  pt.y = pose_y - window_size_y / 2;
+  clear_poly.push_back(pt);
+
+  pt.x = pose_x + window_size_x / 2;
+  pt.y = pose_y - window_size_y / 2;
+  clear_poly.push_back(pt);
+
+  pt.x = pose_x + window_size_x / 2;
+  pt.y = pose_y + window_size_y / 2;
+  clear_poly.push_back(pt);
+
+  pt.x = pose_x - window_size_x / 2;
+  pt.y = pose_y + window_size_y / 2;
+  clear_poly.push_back(pt);
+
+  costmap_.getCostmap()->setConvexPolygonCost(clear_poly, reset_value_);
 }
 
 void ClearCostmapService::clearEntirely()

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -45,7 +45,7 @@ ClearCostmapService::ClearCostmapService(rclcpp::Node::SharedPtr & node, Costmap
 
   clear_around_service_ = node_->create_service<ClearAroundRobot>(
     "clear_around_" + costmap.getName(),
-    std::bind(&ClearCostmapService::clearAroundCallback, this,
+    std::bind(&ClearCostmapService::clearAroundRobotCallback, this,
     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
   clear_entire_service_ = node_->create_service<ClearEntirely>(
@@ -65,13 +65,18 @@ void ClearCostmapService::clearExceptRegionCallback(
   clearExceptRegion(request->reset_distance);
 }
 
-void ClearCostmapService::clearAroundCallback(
+void ClearCostmapService::clearAroundRobotCallback(
   const shared_ptr<rmw_request_id_t>/*request_header*/,
   const shared_ptr<ClearAroundRobot::Request> request,
   const shared_ptr<ClearAroundRobot::Response>/*response*/)
 {
   RCLCPP_INFO(node_->get_logger(),
     "Received request to clear around robot the " + costmap_.getName());
+
+  if ((request->window_size_x == 0) || (request->window_size_y == 0)) {
+    clearEntirely();
+    return;
+  }
 
   clearAroundRobot(request->window_size_x, request->window_size_y);
 }

--- a/nav2_msgs/CMakeLists.txt
+++ b/nav2_msgs/CMakeLists.txt
@@ -19,6 +19,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/VoxelGrid.msg"
   "srv/GetCostmap.srv"
   "srv/ClearCostmapExceptRegion.srv"
+  "srv/ClearCostmapAroundRobot.srv"
   "srv/ClearEntireCostmap.srv"
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs
 )

--- a/nav2_msgs/srv/ClearCostmapAroundRobot.srv
+++ b/nav2_msgs/srv/ClearCostmapAroundRobot.srv
@@ -1,0 +1,6 @@
+# Clears the costmap within a window around the robot
+
+float32 window_size_x
+float32 window_size_y
+---
+std_msgs/Empty response


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #551  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on |Gazebo simulation of Turtlebot |

---

## Description of contribution in a few bullet points

This PR adds a service for clearing a window around the robot, similar to the [clear costmap window service](https://github.com/ros-planning/navigation/blob/a6f3d4b49335b6de5c33044dd2123df0f491453f/move_base/src/move_base.cpp#L330-L338) available in ROS1 move base.

This is the last item pending from #551. 