### PR TITLE
Fix latest failing tests in CI

### DIFF
--- a/nav2_costmap_2d/test/integration/costmap_tests_launch.py
+++ b/nav2_costmap_2d/test/integration/costmap_tests_launch.py
@@ -39,7 +39,6 @@ def main(argv=sys.argv[1:]):
         output='screen'
     )
 
-    ld.add_action(test1_action)
     lts = LaunchTestService()
     lts.add_test_action(ld, test1_action)
     ls = LaunchService(argv=argv)

--- a/nav2_dynamic_params/test/dynamic_params_test.launch.py
+++ b/nav2_dynamic_params/test/dynamic_params_test.launch.py
@@ -42,7 +42,6 @@ def main(argv=sys.argv[1:]):
         name='test_dynamic_params_client',
     )
 
-    ld.add_action(test1_action)
     lts = LaunchTestService()
     lts.add_test_action(ld, test1_action)
     ls = LaunchService(argv=argv)

--- a/nav2_map_server/test/component/test_occ_grid_launch.py
+++ b/nav2_map_server/test/component/test_occ_grid_launch.py
@@ -35,7 +35,6 @@ def main(argv=sys.argv[1:]):
         cmd=[testExecutable],
         name='test_occ_grid_node',
     )
-    ld.add_action(test1_action)
     lts = LaunchTestService()
     lts.add_test_action(ld, test1_action)
     ls = LaunchService(argv=argv)

--- a/nav2_system_tests/src/localization/test_localization_launch.py
+++ b/nav2_system_tests/src/localization/test_localization_launch.py
@@ -61,7 +61,7 @@ def main(argv=sys.argv[1:]):
         name='test_localization_node',
         output='screen'
     )
-    ld.add_action(test1_action)
+
     lts = LaunchTestService()
     lts.add_test_action(ld, test1_action)
     ls = LaunchService(argv=argv)

--- a/nav2_system_tests/src/planning/test_planner_launch.py
+++ b/nav2_system_tests/src/planning/test_planner_launch.py
@@ -41,7 +41,6 @@ def main(argv=sys.argv[1:]):
         output='screen'
     )
 
-    ld.add_action(test1_action)
     lts = LaunchTestService()
     lts.add_test_action(ld, test1_action)
     ls = LaunchService(argv=argv)

--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -118,7 +118,6 @@ def main(argv=sys.argv[1:]):
         name='test_system_node',
         output='screen')
 
-    ld.add_action(test1_action)
     lts = LaunchTestService()
     lts.add_test_action(ld, test1_action)
     ls = LaunchService(argv=argv)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* A bunch of tests were failing CI as can be seen in this build [log](https://travis-ci.org/ros-planning/navigation2/builds/502734132?utm_source=github_status&utm_medium=notification)
* This started happening due to a change in the `launch_testing` package.
* Seems we were using the package wrong and the change exposed that problem as described in ros2/launch#194
* This change removes a duplicate addition of the test action from the launch description.
