### PR TITLE
[WIP] Use tf2_transform data to get current robot pose in NavFn

### DIFF
--- a/nav2_msgs/CMakeLists.txt
+++ b/nav2_msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TaskStatus.msg"
   "msg/VoxelGrid.msg"
   "srv/GetCostmap.srv"
+  "srv/GetRobotPose.srv"
   "srv/ClearCostmapExceptRegion.srv"
   "srv/ClearCostmapAroundRobot.srv"
   "srv/ClearEntireCostmap.srv"

--- a/nav2_msgs/srv/GetCostmap.srv
+++ b/nav2_msgs/srv/GetCostmap.srv
@@ -4,3 +4,5 @@
 nav2_msgs/CostmapMetaData specs
 ---
 nav2_msgs/Costmap map
+geometry_msgs/PoseStamped pose
+bool is_pose_valid

--- a/nav2_msgs/srv/GetRobotPose.srv
+++ b/nav2_msgs/srv/GetRobotPose.srv
@@ -1,0 +1,6 @@
+# Get the latest robot pose in the frame of the costmap
+
+std_msgs/Empty request
+---
+geometry_msgs/PoseStamped pose
+bool is_pose_valid

--- a/nav2_navfn_planner/CMakeLists.txt
+++ b/nav2_navfn_planner/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(visualization_msgs REQUIRED)
 find_package(nav2_tasks REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(nav2_msgs REQUIRED)
-find_package(nav2_robot REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(builtin_interfaces REQUIRED)
@@ -30,7 +29,6 @@ set(dependencies
   nav2_util
   nav2_tasks
   nav2_msgs
-  nav2_robot
   nav_msgs
   geometry_msgs
   builtin_interfaces

--- a/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
+++ b/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
@@ -24,12 +24,12 @@
 #include "nav2_tasks/compute_path_to_pose_task.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
 #include "nav2_tasks/costmap_service_client.hpp"
+#include "nav2_tasks/get_robot_pose_client.hpp"
 #include "nav2_navfn_planner/navfn.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/point.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "visualization_msgs/msg/marker.hpp"
-#include "nav2_robot/robot.hpp"
 
 namespace nav2_navfn_planner
 {
@@ -96,8 +96,11 @@ private:
 
   // Request costmap from world model
   void getCostmap(
-    nav2_msgs::msg::Costmap & costmap, const std::string layer = "master",
-    const std::chrono::nanoseconds waitTime = std::chrono::milliseconds(100));
+    nav2_msgs::msg::Costmap & costmap,
+    const std::string layer = "master");
+
+  // get latest robot pose from the world model
+  geometry_msgs::msg::Pose getRobotPose();
 
   // Print costmap to terminal
   void printCostmap(const nav2_msgs::msg::Costmap & costmap);
@@ -116,6 +119,7 @@ private:
 
   // Service client for getting the costmap
   nav2_tasks::CostmapServiceClient costmap_client_;
+  nav2_tasks::GetRobotPoseClient get_robot_pose_client_;
 
   // Publishers for the path and endpoints
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr plan_publisher_;
@@ -136,8 +140,6 @@ private:
 
   // Whether to use the astar planner or default dijkstras
   bool use_astar_;
-
-  std::unique_ptr<nav2_robot::Robot> robot_;
 };
 
 }  // namespace nav2_navfn_planner

--- a/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
+++ b/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
@@ -97,7 +97,7 @@ private:
   // Request costmap from world model
   void getCostmap(
     nav2_msgs::msg::Costmap & costmap, const std::string layer = "master",
-    const std::chrono::milliseconds waitTime = std::chrono::milliseconds(100));
+    const std::chrono::nanoseconds waitTime = std::chrono::milliseconds(100));
 
   // Print costmap to terminal
   void printCostmap(const nav2_msgs::msg::Costmap & costmap);

--- a/nav2_navfn_planner/package.xml
+++ b/nav2_navfn_planner/package.xml
@@ -16,7 +16,6 @@
   <build_depend>nav2_tasks</build_depend>
   <build_depend>nav2_util</build_depend>
   <build_depend>nav2_msgs</build_depend>
-  <build_depend>nav2_robot</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>builtin_interfaces</build_depend>
@@ -25,7 +24,6 @@
   <exec_depend>visualization_msgs</exec_depend>
   <exec_depend>nav2_tasks</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
-  <exec_depend>nav2_robot</exec_depend>
   <exec_depend>nav2_util</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -474,7 +474,7 @@ NavfnPlanner::clearRobotCell(unsigned int mx, unsigned int my)
 void
 NavfnPlanner::getCostmap(
   nav2_msgs::msg::Costmap & costmap, const std::string /*layer*/,
-  const std::chrono::milliseconds /*waitTime*/)
+  const std::chrono::nanoseconds /*waitTime*/)
 {
   // TODO(orduno): explicitly provide specifications for costmap using the costmap on the request,
   //               including master (aggregate) layer

--- a/nav2_tasks/include/nav2_tasks/get_robot_pose_client.hpp
+++ b/nav2_tasks/include/nav2_tasks/get_robot_pose_client.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_TASKS__GET_ROBOT_POSE_CLIENT_HPP_
+#define NAV2_TASKS__GET_ROBOT_POSE_CLIENT_HPP_
+
+#include "nav2_util/service_client.hpp"
+#include "nav2_msgs/srv/get_robot_pose.hpp"
+
+namespace nav2_tasks
+{
+
+class GetRobotPoseClient : public nav2_util::ServiceClient<nav2_msgs::srv::GetRobotPose>
+{
+public:
+  GetRobotPoseClient()
+  : nav2_util::ServiceClient<nav2_msgs::srv::GetRobotPose>("GetRobotPose")
+  {
+  }
+
+  using GetRobotPoseRequest =
+    nav2_util::ServiceClient<nav2_msgs::srv::GetRobotPose>::RequestType;
+  using GetRobotPoseResponse =
+    nav2_util::ServiceClient<nav2_msgs::srv::GetRobotPose>::ResponseType;
+};
+
+}  // namespace nav2_tasks
+
+#endif  // NAV2_TASKS__GET_ROBOT_POSE_CLIENT_HPP_

--- a/nav2_util/include/nav2_util/service_client.hpp
+++ b/nav2_util/include/nav2_util/service_client.hpp
@@ -43,7 +43,7 @@ public:
 
   typename ResponseType::SharedPtr invoke(
     typename RequestType::SharedPtr & request,
-    const std::chrono::seconds timeout = std::chrono::seconds::max())
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::max())
   {
     auto result_future = client_->async_send_request(request);
 
@@ -56,7 +56,7 @@ public:
     return result_future.get();
   }
 
-  void wait_for_service(const std::chrono::seconds timeout = std::chrono::seconds::max())
+  void wait_for_service(const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::max())
   {
     while (!client_->wait_for_service(timeout)) {
       if (!rclcpp::ok()) {

--- a/nav2_world_model/include/nav2_world_model/world_model.hpp
+++ b/nav2_world_model/include/nav2_world_model/world_model.hpp
@@ -23,6 +23,7 @@
 #include "nav2_util/costmap.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
 #include "nav2_msgs/srv/get_costmap.hpp"
+#include "nav2_msgs/srv/get_robot_pose.hpp"
 #include "tf2_ros/transform_listener.h"
 
 namespace nav2_world_model
@@ -39,9 +40,13 @@ private:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<nav2_msgs::srv::GetCostmap::Request> request,
     const std::shared_ptr<nav2_msgs::srv::GetCostmap::Response> response);
+  void get_robot_pose_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<nav2_msgs::srv::GetRobotPose::Request> request,
+    const std::shared_ptr<nav2_msgs::srv::GetRobotPose::Response> response);
 
-  // Server for providing a costmap
   rclcpp::Service<nav2_msgs::srv::GetCostmap>::SharedPtr costmapServer_;
+  rclcpp::Service<nav2_msgs::srv::GetRobotPose>::SharedPtr get_robot_pose_service_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   nav2_costmap_2d::Costmap2D * costmap_;
   tf2_ros::Buffer tfBuffer_;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #595  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot 3 |

---

## Description of contribution in a few bullet points

* I piggy-backed the current pose from costmap onto the GetCostmap service request in World Model
* I changed timeout values to be in nanoseconds. std::chrono will let you auto-convert from larger time intervals to smaller, but not the other way
* I added a timeout on the GetCostmap service call that NavFn makes

## Rationale

I tried to make a standalone version of the getCurrentPose function, but it had so many dependencies, that it seemed the wrong approach to solving the problem. All those dependencies were already available in costmap, and it seems reasonable to ask the world model/costmap where the robot is; it's sort of the equivalent of a "You are here" indicator on a real map.

I was going to add a separate service call to World Model to get the robot pose, but we currently have latency issues with service calls. Instead, I added the pose to the GetCostmap service call. It seems unlikely you will get the costmap without also needing to know where you are on the map at the same time, so it seemed reasonable to combine them until our service call latency issues can be fixed.

**NOTE**
Updated to use a separate service to get the pose. Need to target this to the lifecycle branch still.