### PR TITLE
Add last pose to DWB trajectory

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -88,11 +88,11 @@ dwb_msgs::msg::Trajectory2D LimitedAccelGenerator::generateTrajectory(
   geometry_msgs::msg::Pose2D pose = start_pose;
 
   std::vector<double> steps = getTimeSteps(cmd_vel);
+  traj.poses.push_back(start_pose);
   for (double dt : steps) {
-    traj.poses.push_back(pose);
-
     //  update the position using the constant cmd_vel
     pose = computeNewPosition(pose, cmd_vel, dt);
+    traj.poses.push_back(pose);
   }
 
   return traj;

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -148,6 +148,7 @@ dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
   geometry_msgs::msg::Pose2D pose = start_pose;
   nav_2d_msgs::msg::Twist2D vel = start_vel;
   std::vector<double> steps = getTimeSteps(cmd_vel);
+  traj.poses.push_back(start_pose);
   for (double dt : steps) {
     //  calculate velocities
     vel = computeNewVelocity(cmd_vel, vel, dt);

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -149,12 +149,13 @@ dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
   nav_2d_msgs::msg::Twist2D vel = start_vel;
   std::vector<double> steps = getTimeSteps(cmd_vel);
   for (double dt : steps) {
-    traj.poses.push_back(pose);
     //  calculate velocities
     vel = computeNewVelocity(cmd_vel, vel, dt);
 
     //  update the position of the robot using the velocities passed in
     pose = computeNewPosition(pose, vel, dt);
+
+    traj.poses.push_back(pose);
   }  //  end for simulation steps
 
   return traj;

--- a/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
@@ -299,11 +299,11 @@ TEST(TrajectoryGenerator, basic)
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.duration), 1.7);
   int n = res.poses.size();
-  EXPECT_EQ(n, 2);
+  EXPECT_EQ(n, 3);
   ASSERT_GT(n, 0);
 
   matchPose(res.poses[0], origin);
-  matchPose(res.poses[n - 1], 0.255, 0, 0);
+  matchPose(res.poses[n - 2], 0.255, 0, 0);
 }
 
 TEST(TrajectoryGenerator, too_slow)
@@ -317,7 +317,7 @@ TEST(TrajectoryGenerator, too_slow)
   matchTwist(res.velocity, cmd);
   EXPECT_DOUBLE_EQ(durationToSec(res.duration), 1.7);
   int n = res.poses.size();
-  EXPECT_EQ(n, 1);
+  EXPECT_EQ(n, 2);
   ASSERT_GT(n, 0);
 
   matchPose(res.poses[0], origin);
@@ -335,11 +335,11 @@ TEST(TrajectoryGenerator, holonomic)
   matchTwist(res.velocity, cmd);
   EXPECT_DOUBLE_EQ(durationToSec(res.duration), 1.7);
   int n = res.poses.size();
-  EXPECT_EQ(n, 2);
+  EXPECT_EQ(n, 3);
   ASSERT_GT(n, 0);
 
   matchPose(res.poses[0], origin);
-  matchPose(res.poses[n - 1], 0.255, 0.17, 0);
+  matchPose(res.poses[n - 2], 0.255, 0.17, 0);
 }
 
 TEST(TrajectoryGenerator, twisty)
@@ -355,11 +355,11 @@ TEST(TrajectoryGenerator, twisty)
   matchTwist(res.velocity, cmd);
   EXPECT_DOUBLE_EQ(durationToSec(res.duration), 1.7);
   int n = res.poses.size();
-  EXPECT_EQ(n, 8);
+  EXPECT_EQ(n, 9);
   ASSERT_GT(n, 0);
 
   matchPose(res.poses[0], origin);
-  matchPose(res.poses[n - 1], 0.4656489295054273, -0.2649090438962528, 0.16511250000000002);
+  matchPose(res.poses[n - 2], 0.4656489295054273, -0.2649090438962528, 0.16511250000000002);
 }
 
 TEST(TrajectoryGenerator, sim_time)
@@ -372,11 +372,11 @@ TEST(TrajectoryGenerator, sim_time)
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.duration), 2.5);
   int n = res.poses.size();
-  EXPECT_EQ(n, 2);
+  EXPECT_EQ(n, 3);
   ASSERT_GT(n, 0);
 
   matchPose(res.poses[0], origin);
-  matchPose(res.poses[n - 1], 0.375, 0, 0);
+  matchPose(res.poses[n - 2], 0.375, 0, 0);
 }
 
 TEST(TrajectoryGenerator, accel)
@@ -393,7 +393,7 @@ TEST(TrajectoryGenerator, accel)
   dwb_msgs::msg::Trajectory2D res = gen.generateTrajectory(origin, zero, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.duration), 5.0);
-  ASSERT_EQ(res.poses.size(), 5u);
+  ASSERT_EQ(res.poses.size(), 6u);
   matchPose(res.poses[0], origin);
   matchPose(res.poses[1], 0.1, 0, 0);
   matchPose(res.poses[2], 0.3, 0, 0);
@@ -417,7 +417,7 @@ TEST(TrajectoryGenerator, dwa)
   dwb_msgs::msg::Trajectory2D res = gen.generateTrajectory(origin, zero, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.duration), 5.0);
-  ASSERT_EQ(res.poses.size(), 5u);
+  ASSERT_EQ(res.poses.size(), 6u);
   matchPose(res.poses[0], origin);
   matchPose(res.poses[1], 0.3, 0, 0);
   matchPose(res.poses[2], 0.6, 0, 0);


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 |

---

## Description of contribution in a few bullet points

* The trajectories generated in DWB should include the start pose and the end pose. Instead, the end pose was being left off. This was particularly problematic because sometimes there are no intermediate poses. This PR fixes that problem