### PR TITLE
Change DWB trajectories displayed in RViz to be on the red-green spectrum instead.

### DIFF
--- a/nav2_dwb_controller/dwb_core/src/publisher.cpp
+++ b/nav2_dwb_controller/dwb_core/src/publisher.cpp
@@ -121,10 +121,10 @@ void DWBPublisher::publishTrajectories(const dwb_msgs::msg::LocalPlanEvaluation 
     const dwb_msgs::msg::TrajectoryScore & twist = results.twists[i];
     double displayLevel = (twist.total - best_cost) / (worst_cost - best_cost);
     if (twist.total >= 0) {
-      m.color.r = 0;
-      m.color.g = 0;
-      m.color.b = 1.0;
-      m.color.a = 1.0 - displayLevel;
+      m.color.r = displayLevel;
+      m.color.g = 1.0 - displayLevel;
+      m.color.b = 0;
+      m.color.a = 1.0;
       m.ns = validNamespace;
       m.id = currentValidId;
       ++currentValidId;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 |

---

## Description of contribution in a few bullet points

* Changed the color of DWB trajectories to be change from red for worst trajectory to green for best, with intermediate trajectories being some mix of the colors in-between.

The old color scheme was intense blue for the best with the blue fading away for the worst. This made it hard to see the worst against the background, or to tell if they were just missing.

Invalid trajectories are still black.
