### PR TITLE
Rotate to goal fixes

### DIFF
--- a/nav2_dwb_controller/dwb_critics/include/dwb_critics/rotate_to_goal.hpp
+++ b/nav2_dwb_controller/dwb_critics/include/dwb_critics/rotate_to_goal.hpp
@@ -64,6 +64,7 @@ private:
   double goal_yaw_;
   double xy_goal_tolerance_;
   double xy_goal_tolerance_sq_;  ///< Cached squared tolerance
+  bool ignore_y_velocity_;
 };
 
 }  // namespace dwb_critics

--- a/nav2_dwb_controller/dwb_critics/include/dwb_critics/rotate_to_goal.hpp
+++ b/nav2_dwb_controller/dwb_critics/include/dwb_critics/rotate_to_goal.hpp
@@ -64,7 +64,6 @@ private:
   double goal_yaw_;
   double xy_goal_tolerance_;
   double xy_goal_tolerance_sq_;  ///< Cached squared tolerance
-  bool ignore_y_velocity_;
 };
 
 }  // namespace dwb_critics

--- a/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
@@ -100,7 +100,7 @@ double RotateToGoalCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & t
   }
 
   double end_yaw = traj.poses.back().theta;
-  return angles::shortest_angular_distance(end_yaw, goal_yaw_);
+  return fabs(angles::shortest_angular_distance(end_yaw, goal_yaw_));
 }
 
 }  // namespace dwb_critics

--- a/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
@@ -64,6 +64,9 @@ bool RotateToGoalCritic::prepare(
   if (dxy_sq > xy_goal_tolerance_sq_) {
     in_window_ = false;
   }
+  else {
+    in_window_ = true;
+  }
   goal_yaw_ = goal.theta;
   return true;
 }

--- a/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
@@ -70,8 +70,7 @@ bool RotateToGoalCritic::prepare(
   double dxy_sq = dx * dx + dy * dy;
   if (dxy_sq > xy_goal_tolerance_sq_) {
     in_window_ = false;
-  }
-  else {
+  } else {
     in_window_ = true;
   }
   goal_yaw_ = goal.theta;

--- a/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
@@ -51,13 +51,6 @@ void RotateToGoalCritic::onInit()
 {
   xy_goal_tolerance_ = nav_2d_utils::searchAndGetParam(nh_, "xy_goal_tolerance", 0.25);
   xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
-  double max_vel_y;
-  nh_->get_parameter_or("max_vel_y", max_vel_y, 0.0);
-  if (max_vel_y == 0.0) {
-    ignore_y_velocity_ = true;
-  } else {
-    ignore_y_velocity_ = false;
-  }
 }
 
 bool RotateToGoalCritic::prepare(
@@ -85,13 +78,8 @@ double RotateToGoalCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & t
   }
 
   // If we're sufficiently close to the goal, any transforming velocity is invalid
-  if (fabs(traj.velocity.x) > EPSILON) {
+  if (fabs(traj.velocity.x) > EPSILON || fabs(traj.velocity.y) > EPSILON) {
     throw nav_core2::IllegalTrajectoryException(name_, "Nonrotation command near goal.");
-  }
-  if (!ignore_y_velocity_) {
-    if (fabs(traj.velocity.y) > EPSILON) {
-      throw nav_core2::IllegalTrajectoryException(name_, "Nonrotation command near goal.");
-    }
   }
 
   if (traj.poses.empty()) {


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 |

---

## Description of contribution in a few bullet points

1. Scores need to be positive, so this takes the absolute value of the angle error.
2. Ignores Y velocity on differential drive robots. It's just IMU noise.
3. Reset flag that enables this critic once we are in range again.

1 and 3 are already fixed in @Dlu's repo, but in a different way. Soon I hope to rebase and I'll take the upstream changes instead.
2 is related to our noisy IMU in simulation (see #603) but should probably be upstreamed in some way.
