### PR TITLE
Printout should be error instead of info (trivial change)

### DIFF
--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -103,7 +103,7 @@ DwbController::followPath(const nav2_tasks::FollowPathCommand::SharedPtr command
       loop_rate.sleep();
     }
   } catch (nav_core2::PlannerException & e) {
-    RCLCPP_INFO(this->get_logger(), e.what());
+    RCLCPP_ERROR(this->get_logger(), e.what());
     publishZeroVelocity();
     return TaskStatus::FAILED;
   }


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 |

---

## Description of contribution in a few bullet points

* If we fail to find a valid trajectory, the message should be an error, not just an info.

