### PR TITLE
[WIP] Enable Obstacle Layer on Global and Local costmaps

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -223,8 +223,8 @@ void AmclNode::updatePoseFromServer()
   init_pose_[0] = 0.0;
   init_pose_[1] = 0.0;
   init_pose_[2] = 0.0;
-  init_cov_[0] = 0.5 * 0.5;
-  init_cov_[1] = 0.5 * 0.5;
+  init_cov_[0] = 0.75 * 0.75;
+  init_cov_[1] = 0.75 * 0.75;
   init_cov_[2] = (M_PI / 12.0) * (M_PI / 12.0);
 
   // TODO(mhpanah): Enable reading pose from parameter server.

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -36,7 +36,8 @@ local_costmap:
     ros__parameters:
       robot_radius: 0.092
       obstacle_layer:
-        enabled: False
+        enabled: True
+        local_costmap_flag: True
       always_send_full_costmap: True
       observation_sources: scan
       scan:
@@ -48,7 +49,8 @@ global_costmap:
   global_costmap:
     ros__parameters:
       obstacle_layer:
-        enabled: False
+        enabled: True
+        local_costmap_flag: False
       always_send_full_costmap: True
       observation_sources: scan
       scan:

--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(nav2_dynamic_params)
 find_package(nav2_util)
 find_package(nav2_voxel_grid REQUIRED)
 find_package(nav2_msgs REQUIRED)
+find_package(nav2_robot REQUIRED)
 
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 find_package(Eigen3 REQUIRED)
@@ -71,6 +72,7 @@ set(dependencies
   nav2_voxel_grid
   nav2_msgs
   visualization_msgs
+  nav2_robot
 )
 
 ament_target_dependencies(nav2_costmap_2d_core

--- a/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
@@ -155,6 +155,7 @@ protected:
 
   std::vector<geometry_msgs::msg::Point> transformed_footprint_;
   bool footprint_clearing_enabled_;
+  bool obstacle_enabled_flag;
   bool local_costmap_flag_;
   void updateFootprint(
     double robot_x, double robot_y, double robot_yaw, double * min_x,
@@ -187,6 +188,7 @@ protected:
   int combination_method_;
 
   std::unique_ptr<nav2_dynamic_params::DynamicParamsClient> dynamic_param_client_;
+  std::unique_ptr<nav2_util::IsLocalized> localized;
 
 private:
   void reconfigureCB();

--- a/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
@@ -55,6 +55,7 @@
 #include "nav2_costmap_2d/layered_costmap.hpp"
 #include "nav2_costmap_2d/observation_buffer.hpp"
 #include "nav2_costmap_2d/footprint.hpp"
+#include "nav2_util/is_localized.hpp"
 
 namespace nav2_costmap_2d
 {
@@ -154,6 +155,7 @@ protected:
 
   std::vector<geometry_msgs::msg::Point> transformed_footprint_;
   bool footprint_clearing_enabled_;
+  bool local_costmap_flag_;
   void updateFootprint(
     double robot_x, double robot_y, double robot_yaw, double * min_x,
     double * min_y,
@@ -188,6 +190,7 @@ protected:
 
 private:
   void reconfigureCB();
+  void enableObstacleLayer();
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -64,6 +64,7 @@ namespace nav2_costmap_2d
 void ObstacleLayer::onInitialize()
 {
   node_->get_parameter_or_set(name_ + "." + "enabled", enabled_, true);
+  node_->get_parameter_or_set(name_ + "." + "enable_always", local_costmap_flag_, true);
   node_->get_parameter_or_set(
     name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_, true);
   node_->get_parameter_or_set(name_ + "." + "max_obstacle_height", max_obstacle_height_, 2.0);
@@ -238,6 +239,8 @@ void ObstacleLayer::reconfigureCB()
 
   dynamic_param_client_->get_event_param(
     name_ + "." + "enabled", enabled_);
+  dynamic_param_client_->get_event_param(
+    name_ + "." + "enable_always", local_costmap_flag_);
   dynamic_param_client_->get_event_param(
     name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_);
   dynamic_param_client_->get_event_param(
@@ -414,6 +417,7 @@ void ObstacleLayer::updateCosts(
   int max_i,
   int max_j)
 {
+  enableObstacleLayer();
   if (!enabled_) {
     return;
   }
@@ -610,6 +614,20 @@ void ObstacleLayer::reset()
   resetMaps();
   current_ = true;
   activate();
+}
+
+void ObstacleLayer::enableObstacleLayer()
+{
+  nav2_util::IsLocalized localized;
+
+  if (local_costmap_flag_) {
+    enabled_ = true;
+    return;
+  } else if (!local_costmap_flag_ && localized.isLocalized()) {
+    enabled_ = true;
+  } else {
+    enabled_ = false;
+  }
 }
 
 }  // namespace nav2_costmap_2d

--- a/nav2_robot/src/robot.cpp
+++ b/nav2_robot/src/robot.cpp
@@ -26,10 +26,10 @@ Robot::Robot(rclcpp::Node::SharedPtr & node)
 {
   // TODO(mhpanah): Topic names for pose and odom should should be configured with parameters
   pose_sub_ = node_->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "amcl_pose", std::bind(&Robot::onPoseReceived, this, std::placeholders::_1));
+    "/amcl_pose", std::bind(&Robot::onPoseReceived, this, std::placeholders::_1));
 
   odom_sub_ = node_->create_subscription<nav_msgs::msg::Odometry>(
-    "odom", std::bind(&Robot::onOdomReceived, this, std::placeholders::_1));
+    "/odom", std::bind(&Robot::onOdomReceived, this, std::placeholders::_1));
 
   vel_pub_ = node_->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", 1);
 }

--- a/nav2_util/CMakeLists.txt
+++ b/nav2_util/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(SDL_image REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
+find_package(nav2_robot REQUIRED)
 
 nav2_package()
 
@@ -24,6 +25,7 @@ add_library(${library_name} SHARED
   src/lifecycle_service_client.cpp
   src/string_utils.cpp
   src/lifecycle_utils.cpp
+  src/is_localized.cpp
 )
 
 ament_target_dependencies(${library_name}
@@ -34,6 +36,7 @@ ament_target_dependencies(${library_name}
   nav_msgs
   geometry_msgs
   lifecycle_msgs
+  nav2_robot
 )
 
 add_library(map_lib SHARED
@@ -76,6 +79,7 @@ ament_target_dependencies(map_loader
   nav_msgs
   SDL
   SDL_image
+  nav2_robot
 )
 
 target_link_libraries(map_loader

--- a/nav2_util/include/nav2_util/is_localized.hpp
+++ b/nav2_util/include/nav2_util/is_localized.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_UTIL__IS_LOCALIZED_HPP_
+#define NAV2_UTIL__IS_LOCALIZED_HPP_
+
+#include <string>
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_robot/robot.hpp"
+
+namespace nav2_util
+{
+
+class IsLocalized
+{
+
+public:
+  IsLocalized();
+  bool isLocalized();
+
+private:
+  static const int cov_x_ = 0;
+  static const int cov_y_ = 7;
+  static const int cov_a_ = 35;
+
+  rclcpp::Node::SharedPtr node_;
+  std::unique_ptr<nav2_robot::Robot> robot_;
+
+  double x_tol_;
+  double y_tol_;
+  double rot_tol_;
+};
+
+}  // namespace nav2_util
+
+#endif  // NAV2_UTIL__IS_LOCALIZED_HPP_

--- a/nav2_util/include/nav2_util/is_localized.hpp
+++ b/nav2_util/include/nav2_util/is_localized.hpp
@@ -26,7 +26,7 @@ class IsLocalized
 {
 
 public:
-  IsLocalized();
+  IsLocalized(const rclcpp::Node::SharedPtr & node);
   bool isLocalized();
 
 private:

--- a/nav2_util/package.xml
+++ b/nav2_util/package.xml
@@ -20,6 +20,7 @@
   <build_depend>sdl</build_depend>
   <build_depend>sdl-image</build_depend>
   <build_depend>lifecycle_msgs</build_depend>
+  <build_depend>nav2_robot</build_depend>
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclcpp</exec_depend>
@@ -30,6 +31,7 @@
   <exec_depend>sdl</exec_depend>
   <exec_depend>sdl-image</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>
+  <exec_depend>nav2_robot</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_util/src/is_localized.cpp
+++ b/nav2_util/src/is_localized.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_util/is_localized.hpp"
+#include "nav2_robot/robot.hpp"
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+
+namespace nav2_util
+{
+
+IsLocalized::IsLocalized()
+{
+  node_ = rclcpp::Node::make_shared("is_localized_class");
+  robot_ = std::make_unique<nav2_robot::Robot>(node_);
+
+  node_->get_parameter_or<double>("is_localized.x_tol", x_tol_, 0.25);
+  node_->get_parameter_or<double>("is_localized.y_tol", y_tol_, 0.25);
+  node_->get_parameter_or<double>("is_localized.rot_tol", rot_tol_, M_PI / 4);
+
+}
+
+bool
+IsLocalized::isLocalized()
+{
+  auto current_pose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
+
+  if (!robot_->getCurrentPose(current_pose)) {
+    RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
+    return false;
+  }
+
+  // Naive way to check if the robot has been localized
+  // TODO(mhpanah): come up with a method to properly check particles convergence
+  if (current_pose->pose.covariance[cov_x_] < x_tol_ &&
+    current_pose->pose.covariance[cov_y_] < y_tol_ &&
+    current_pose->pose.covariance[cov_a_] < rot_tol_)
+  {
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace nav2_util

--- a/nav2_util/src/is_localized.cpp
+++ b/nav2_util/src/is_localized.cpp
@@ -20,9 +20,9 @@
 namespace nav2_util
 {
 
-IsLocalized::IsLocalized()
+IsLocalized::IsLocalized(const rclcpp::Node::SharedPtr & node)
+: node_(node)
 {
-  node_ = rclcpp::Node::make_shared("is_localized_class");
   robot_ = std::make_unique<nav2_robot::Robot>(node_);
 
   node_->get_parameter_or<double>("is_localized.x_tol", x_tol_, 0.25);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (fixes #613 ) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | () |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
WIP -- Please do not review.

- Created a method in obstacle layer to enabled both Global and Local obstacle layers. 
    - Local costmap gets enabled at start. The global costmap gets enabled when robot is localized to prevent putting garbage on global costmap.
- Factored out isLocalized method to util directory to check AMCL pose to determine if robot is localized or not.
   -TODO: isLocalized method still exists in is_localized_condition node within BT, will factor this out on a different PR.





---