### PR TITLE
Ignore goal alignment if we are far away.

### DIFF
--- a/nav2_dwb_controller/dwb_critics/include/dwb_critics/goal_align.hpp
+++ b/nav2_dwb_controller/dwb_critics/include/dwb_critics/goal_align.hpp
@@ -62,6 +62,8 @@ public:
 
 protected:
   double forward_point_distance_;
+  double xy_goal_align_tolerance_sq_;
+  bool in_window_;
 };
 
 }  // namespace dwb_critics

--- a/nav2_dwb_controller/dwb_critics/src/goal_align.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/goal_align.cpp
@@ -46,8 +46,10 @@ void GoalAlignCritic::onInit()
 {
   GoalDistCritic::onInit();
   stop_on_failure_ = false;
-  forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_, "forward_point_distance", 0.325);
-  double xy_goal_align_tolerance = nav_2d_utils::searchAndGetParam(nh_, "xy_goal_align_tolerance", 1.0);
+  forward_point_distance_ =
+    nav_2d_utils::searchAndGetParam(nh_, "forward_point_distance", 0.325);
+  double xy_goal_align_tolerance =
+    nav_2d_utils::searchAndGetParam(nh_, "xy_goal_align_tolerance", 1.0);
   xy_goal_align_tolerance_sq_ = xy_goal_align_tolerance * xy_goal_align_tolerance;
 }
 
@@ -72,8 +74,7 @@ bool GoalAlignCritic::prepare(
   double dxy_sq = dx * dx + dy * dy;
   if (dxy_sq > xy_goal_align_tolerance_sq_) {
     in_window_ = false;
-  }
-  else {
+  } else {
     in_window_ = true;
   }
 
@@ -87,7 +88,7 @@ double GoalAlignCritic::scorePose(const geometry_msgs::msg::Pose2D & pose)
     return 0.0;
   }
 
-return GoalDistCritic::scorePose(getForwardPose(pose, forward_point_distance_));
+  return GoalDistCritic::scorePose(getForwardPose(pose, forward_point_distance_));
 }
 
 }  // namespace dwb_critics


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 |

---

## Description of contribution in a few bullet points

* This change disables the goal alignment critic if it is too far away from the goal. If we are far away, we don't much care how well we are aligned with the goal; we are more interested in being aligned with the path.

I'm not entirely sure this change is needed. Other changes made a much bigger difference. I'll do some more testing before actually merging this PR

