### PR TITLE
Localization test should publish only once.

### DIFF
--- a/nav2_system_tests/src/localization/test_localization_node.cpp
+++ b/nav2_system_tests/src/localization/test_localization_node.cpp
@@ -77,8 +77,8 @@ private:
 
 bool TestAmclPose::defaultAmclTest()
 {
+  initial_pose_pub_->publish(testPose_);
   while (!pose_callback_) {
-    initial_pose_pub_->publish(testPose_);
     rclcpp::spin_some(node);
   }
   if (std::abs(amcl_pose_x - testPose_.pose.pose.position.x) < tol_ &&


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | System tests |

---

## Description of contribution in a few bullet points
 * test_localization was publish intial pose in a tight loop. It should only publish once and then wait for a result. This was resulting in huge amounts of messages like below in the log output
```
[amcl-5] [INFO] [amcl]: Setting pose (1553299060.487872): -2.000 -0.500 0.000
```