### PR TITLE
Enable Obstacle Layer on Global and Local costmaps

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -242,6 +242,7 @@ private:
 
   bool tf_broadcast_;
   int scan_error_count_ = 0;
+  bool initial_pose_received;
 };
 
 #endif  // NAV2_AMCL__AMCL_NODE_HPP_

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -92,7 +92,8 @@ AmclNode::AmclNode()
 
   createMotionModel();
 
-  updatePoseFromServer();
+  // updatePoseFromServer();
+  initial_pose_received = false;
 
   tfb_.reset(new tf2_ros::TransformBroadcaster(node_));
   tf_.reset(new tf2_ros::Buffer(get_clock()));
@@ -279,6 +280,7 @@ void AmclNode::updatePoseFromServer()
   } else {
     RCLCPP_WARN(get_logger(), "ignoring NAN in initial covariance AA");
   }
+  initial_pose_received = true;
 */
 }
 
@@ -574,7 +576,9 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
   if (map_ == NULL) {
     return;
   }
-
+  if (!initial_pose_received) {
+    return;
+  }
   std::lock_guard<std::recursive_mutex> lr(configuration_mutex_);
   int laser_index = -1;
 
@@ -932,6 +936,7 @@ void
 AmclNode::initialPoseReceived(geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
 {
   handleInitialPoseMessage(*msg);
+  initial_pose_received = true;
 }
 
 void

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -536,12 +536,6 @@ AmclNode::globalLocalizationCallback(
   if (map_ == NULL) {
     return;
   }
-  init_pose_[0] = 0.0;
-  init_pose_[1] = 0.0;
-  init_pose_[2] = 0.0;
-  init_cov_[0] = 0.5 * 0.5;
-  init_cov_[1] = 0.5 * 0.5;
-  init_cov_[2] = (M_PI / 12.0) * (M_PI / 12.0);
 
   std::lock_guard<std::recursive_mutex> gl(configuration_mutex_);
 

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -536,6 +536,12 @@ AmclNode::globalLocalizationCallback(
   if (map_ == NULL) {
     return;
   }
+  init_pose_[0] = 0.0;
+  init_pose_[1] = 0.0;
+  init_pose_[2] = 0.0;
+  init_cov_[0] = 0.5 * 0.5;
+  init_cov_[1] = 0.5 * 0.5;
+  init_cov_[2] = (M_PI / 12.0) * (M_PI / 12.0);
 
   std::lock_guard<std::recursive_mutex> gl(configuration_mutex_);
 

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -543,7 +543,7 @@ AmclNode::globalLocalizationCallback(
   pf_init_model(pf_, (pf_init_model_fn_t)AmclNode::uniformPoseGenerator,
     reinterpret_cast<void *>(map_));
   RCLCPP_INFO(get_logger(), "Global initialisation done!");
-
+  initial_pose_received = true;
   pf_init_ = false;
 }
 

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -543,7 +543,7 @@ AmclNode::globalLocalizationCallback(
   pf_init_model(pf_, (pf_init_model_fn_t)AmclNode::uniformPoseGenerator,
     reinterpret_cast<void *>(map_));
   RCLCPP_INFO(get_logger(), "Global initialisation done!");
-  initial_pose_received = true;
+
   pf_init_ = false;
 }
 

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -41,7 +41,7 @@ local_costmap:
     ros__parameters:
       robot_radius: 0.092
       obstacle_layer:
-        enabled: False
+        enabled: True
       always_send_full_costmap: True
       observation_sources: scan
       scan:
@@ -53,7 +53,7 @@ global_costmap:
   global_costmap:
     ros__parameters:
       obstacle_layer:
-        enabled: False
+        enabled: True
       always_send_full_costmap: True
       observation_sources: scan
       scan:

--- a/nav2_system_tests/src/system/test_system_node.py
+++ b/nav2_system_tests/src/system/test_system_node.py
@@ -135,10 +135,10 @@ def test_RobotMovesToGoal(test_robot):
 
 def test_all(test_robot):
     # set transforms to use_sim_time
-    test_robot.setSimTime()
     result = True
     if (result):
         result = test_InitialPose(test_robot, 10)
+        test_robot.setSimTime()
     if (result):
         result = test_RobotMovesToGoal(test_robot)
     if (not result):


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (fixes #613) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | () |

---

## Description of contribution in a few bullet points

- Changed AMCL to not broadcast transforms before initial pose is received either via initialpose topic or later when pose from server is available.
    - This way robot knows it location with respect to map before putting obstacles on map.
- Enabled obstacle layers for both global and local costmaps

---