### PR TITLE
Add parallel planning and obstacle layer.

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_2nd_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_2nd_launch.py
@@ -2,11 +2,15 @@ import os
 from launch import LaunchDescription
 import launch.actions
 import launch_ros.actions
+from ament_index_python.packages import get_package_prefix
 
 def generate_launch_description():
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default=
         [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
+    bt_navigator_install_path = get_package_prefix('nav2_bt_navigator')
+    bt_navigator_xml = os.path.join(bt_navigator_install_path,
+                                    'behavior_trees/parallel.xml')
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -32,11 +36,11 @@ def generate_launch_description():
             parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
-            package='nav2_simple_navigator',
-            node_executable='simple_navigator',
-            node_name='simple_navigator',
+            package='nav2_bt_navigator',
+            node_executable='bt_navigator',
+            node_name='bt_navigator',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[{'use_sim_time': use_sim_time}, {'bt_xml_filename': bt_navigator_xml}]),
 
         launch_ros.actions.Node(
             package='nav2_mission_executor',

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -2,12 +2,17 @@ import os
 from launch import LaunchDescription
 import launch.actions
 import launch_ros.actions
+from ament_index_python.packages import get_package_prefix
+
 
 def generate_launch_description():
     map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default=
         [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
+    bt_navigator_install_path = get_package_prefix('nav2_bt_navigator')
+    bt_navigator_xml = os.path.join(bt_navigator_install_path,
+                                    'behavior_trees/parallel.xml')
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -49,11 +54,11 @@ def generate_launch_description():
             parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
-            package='nav2_simple_navigator',
-            node_executable='simple_navigator',
-            node_name='simple_navigator',
+            package='nav2_bt_navigator',
+            node_executable='bt_navigator',
+            node_name='bt_navigator',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[{'use_sim_time': use_sim_time}, {'bt_xml_filename': bt_navigator_xml}]),
 
         launch_ros.actions.Node(
             package='nav2_mission_executor',

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -41,7 +41,7 @@ local_costmap:
     ros__parameters:
       robot_radius: 0.092
       obstacle_layer:
-        enabled: False
+        enabled: True
       always_send_full_costmap: True
       observation_sources: scan
       scan:
@@ -53,7 +53,7 @@ global_costmap:
   global_costmap:
     ros__parameters:
       obstacle_layer:
-        enabled: False
+        enabled: True
       always_send_full_costmap: True
       observation_sources: scan
       scan:


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot 3 |

---

## Description of contribution in a few bullet points

* Switches the default navigator to bt_navigator with the parallel replan configuration
* Enables obstacle layer in both global and local costmaps. This part duplicates what's in #630.

