### PR TITLE
Fix empty path re-sent to the local planner

### DIFF
--- a/nav2_tasks/include/nav2_tasks/rate_controller_node.hpp
+++ b/nav2_tasks/include/nav2_tasks/rate_controller_node.hpp
@@ -83,7 +83,9 @@ inline BT::NodeStatus RateController::tick()
 
       case BT::NodeStatus::FAILURE:
       default:
-        // We'll try again next time
+        // Reset the timer, we'll try again next time
+        start_ = std::chrono::high_resolution_clock::now();
+
         child_node_->setStatus(BT::NodeStatus::IDLE);
         return BT::NodeStatus::RUNNING;
     }


### PR DESCRIPTION
## Description of contribution in a few bullet points

* When changing the BtActionNode class to use the BehaviorTree library's CoroActionNode the BtActionNode::halt method was not updated correctly. 
* When a child node of the RateController fails, wait until the next time interval to try again (instead of re-trying immedately)
* When a BtActionNode finishes (with SUCCEEDED, FAILED, or CANCELED) set the node state to IDLE
