### PR TITLE
Set atomic_bool on StaticLayer::has_updated_data_

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
@@ -38,6 +38,7 @@
 #ifndef NAV2_COSTMAP_2D__STATIC_LAYER_HPP_
 #define NAV2_COSTMAP_2D__STATIC_LAYER_HPP_
 
+#include <atomic>
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
@@ -89,7 +90,7 @@ private:
   std::string map_frame_;  /// @brief frame that map is located in
   bool subscribe_to_updates_;
   bool map_received_;
-  bool has_updated_data_;
+  std::atomic<bool> has_updated_data_;
   unsigned int x_, y_, width_, height_;
   bool track_unknown_space_;
   bool use_maximum_;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
@@ -38,7 +38,7 @@
 #ifndef NAV2_COSTMAP_2D__STATIC_LAYER_HPP_
 #define NAV2_COSTMAP_2D__STATIC_LAYER_HPP_
 
-#include <atomic>
+#include <mutex>
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
@@ -90,7 +90,7 @@ private:
   std::string map_frame_;  /// @brief frame that map is located in
   bool subscribe_to_updates_;
   bool map_received_;
-  std::atomic<bool> has_updated_data_;
+  bool has_updated_data_;
   unsigned int x_, y_, width_, height_;
   bool track_unknown_space_;
   bool use_maximum_;

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -127,6 +127,7 @@ void StaticLayer::reconfigureCB()
   dynamic_param_client_->get_event_param_or(name_ + "." + "enabled", enabled, true);
 
   if (enabled != enabled_) {
+    std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
     enabled_ = enabled;
     has_updated_data_ = true;
     x_ = y_ = 0;
@@ -215,6 +216,7 @@ void StaticLayer::incomingMap(const nav_msgs::msg::OccupancyGrid::SharedPtr new_
   map_frame_ = new_map->header.frame_id;
 
   // we have a new map, update full size of map
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   x_ = y_ = 0;
   width_ = size_x_;
   height_ = size_y_;
@@ -240,6 +242,7 @@ void StaticLayer::incomingUpdate(map_msgs::msg::OccupancyGridUpdate::ConstShared
       costmap_[index] = interpretValue(update->data[di++]);
     }
   }
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   x_ = update->x;
   y_ = update->y;
   width_ = update->width;
@@ -264,6 +267,7 @@ void StaticLayer::deactivate()
 void StaticLayer::reset()
 {
   if (first_map_only_) {
+    std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
     has_updated_data_ = true;
   } else {
     // TODO(orduno) Issue #580, calling onInitialize() when the node is already spinning results on an error.
@@ -286,7 +290,8 @@ void StaticLayer::updateBounds(
   useExtraBounds(min_x, min_y, max_x, max_y);
 
   double wx, wy;
-
+  
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   mapToWorld(x_, y_, wx, wy);
   *min_x = std::min(wx, *min_x);
   *min_y = std::min(wy, *min_y);

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -126,8 +126,8 @@ void StaticLayer::reconfigureCB()
   bool enabled = true;
   dynamic_param_client_->get_event_param_or(name_ + "." + "enabled", enabled, true);
 
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (enabled != enabled_) {
-    std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
     enabled_ = enabled;
     has_updated_data_ = true;
     x_ = y_ = 0;
@@ -281,6 +281,7 @@ void StaticLayer::updateBounds(
   double * max_x,
   double * max_y)
 {
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (!layered_costmap_->isRolling() ) {
     if (!map_received_ || !(has_updated_data_ || has_extra_bounds_)) {
       return;
@@ -290,8 +291,7 @@ void StaticLayer::updateBounds(
   useExtraBounds(min_x, min_y, max_x, max_y);
 
   double wx, wy;
-  
-  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
+
   mapToWorld(x_, y_, wx, wy);
   *min_x = std::min(wx, *min_x);
   *min_y = std::min(wy, *min_y);
@@ -307,6 +307,7 @@ void StaticLayer::updateCosts(
   nav2_costmap_2d::Costmap2D & master_grid,
   int min_i, int min_j, int max_i, int max_j)
 {
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (!map_received_) {
     return;
   }


### PR DESCRIPTION
Signed-off-by: vinnamkim <vinnam.kim@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #636 ) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (gazebo simulation) |

---

## Description of contribution in a few bullet points

Fix data race condition between map update thread and ROS callback thread.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

---
