### PR TITLE
Port nav2_robot to lifecycle nodes

### DIFF
--- a/nav2_robot/CMakeLists.txt
+++ b/nav2_robot/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(rclcpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(urdf REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(nav2_lifecycle REQUIRED)
 
 nav2_package()
 
@@ -23,6 +24,7 @@ ament_target_dependencies(nav2_robot
   urdf
   geometry_msgs
   nav_msgs
+  nav2_lifecycle
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/nav2_robot/include/nav2_robot/robot.hpp
+++ b/nav2_robot/include/nav2_robot/robot.hpp
@@ -16,20 +16,22 @@
 #define NAV2_ROBOT__ROBOT_HPP_
 
 #include <string>
-#include "nav2_robot/robot.hpp"
+
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "nav2_lifecycle/lifecycle_node.hpp"
+#include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "urdf/model.h"
-#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
-#include "nav_msgs/msg/odometry.hpp"
 
 namespace nav2_robot
 {
 
-class Robot
+class Robot : public nav2_lifecycle::LifecycleHelperInterface
 {
 public:
-  explicit Robot(rclcpp::Node::SharedPtr & node);
+  explicit Robot(nav2_lifecycle::LifecycleNode::SharedPtr node);
   Robot() = delete;
+  ~Robot();
 
   bool getGlobalLocalizerPose(
     geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr & robot_pose);
@@ -39,14 +41,19 @@ public:
   std::string getName();
   void sendVelocity(geometry_msgs::msg::Twist twist);
 
-protected:
   // The ROS node to use to create publishers and subscribers
-  rclcpp::Node::SharedPtr node_;
+  nav2_lifecycle::LifecycleNode::SharedPtr node_;
 
+  nav2_lifecycle::CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override;
+
+protected:
   // Publishers and subscribers
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_sub_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
-  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr vel_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr vel_pub_;
 
   // Subscription callbacks
   void onPoseReceived(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
@@ -59,8 +66,8 @@ protected:
   nav_msgs::msg::Odometry::SharedPtr current_odom_;
 
   // Whether the subscriptions have been received
-  bool initial_pose_received_;
-  bool initial_odom_received_;
+  bool initial_pose_received_{false};
+  bool initial_odom_received_{false};
 
   // Information about the robot is contained in the URDF file
   std::string urdf_file_;

--- a/nav2_robot/package.xml
+++ b/nav2_robot/package.xml
@@ -9,17 +9,18 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>urdf</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>nav2_lifecycle</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>nav2_lifecycle</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
@@ -27,6 +28,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_testing</test_depend>
+  <test_depend>nav2_util</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nav2_robot/test/CMakeLists.txt
+++ b/nav2_robot/test/CMakeLists.txt
@@ -1,10 +1,12 @@
 include_directories( ${PROJECT_SOURCE_DIR}/src )
 
+find_package(nav2_util REQUIRED)
+
 ament_add_gtest(test_robot_class
   test_robot_class.cpp
 )
 ament_target_dependencies(test_robot_class
-  ${dependencies}
+  ${dependencies} nav2_util
 )
 target_link_libraries(test_robot_class nav2_robot)
 

--- a/nav2_robot/test/test_robot_class.cpp
+++ b/nav2_robot/test/test_robot_class.cpp
@@ -15,12 +15,15 @@
 #include <gtest/gtest.h>
 #include <string>
 #include <memory>
-#include "rclcpp/rclcpp.hpp"
-#include "nav2_robot/robot.hpp"
+
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "nav2_robot/robot.hpp"
+#include "nav2_util/lifecycle_service_client.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 using std::placeholders::_1;
+using lifecycle_msgs::msg::Transition;
 
 class RclCppFixture
 {
@@ -28,35 +31,134 @@ public:
   RclCppFixture() {rclcpp::init(0, nullptr);}
   ~RclCppFixture() {rclcpp::shutdown();}
 };
+
 RclCppFixture g_rclcppfixture;
+
+class TestLifecycleNode : public nav2_lifecycle::LifecycleNode
+{
+public:
+  TestLifecycleNode()
+  : nav2_lifecycle::LifecycleNode("TestLifecycleNode")
+  {
+  }
+
+  nav2_lifecycle::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State & state) override
+  {
+    robot_ = std::make_unique<nav2_robot::Robot>(shared_from_this());
+    robot_->on_configure(state);
+    return nav2_lifecycle::CallbackReturn::SUCCESS;
+  }
+
+  nav2_lifecycle::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State & state) override
+  {
+    robot_->on_activate(state);
+    return nav2_lifecycle::CallbackReturn::SUCCESS;
+  }
+
+  nav2_lifecycle::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State & state) override
+  {
+    robot_->on_deactivate(state);
+    return nav2_lifecycle::CallbackReturn::SUCCESS;
+  }
+
+  nav2_lifecycle::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State & state) override
+  {
+    robot_->on_cleanup(state);
+    robot_.reset();
+    return nav2_lifecycle::CallbackReturn::SUCCESS;
+  }
+
+  bool getOdometry(nav_msgs::msg::Odometry::SharedPtr & robot_odom)
+  {
+    return robot_->getOdometry(robot_odom);
+  }
+
+  std::string getName()
+  {
+    return robot_->getName();
+  }
+
+  bool getCurrentPose(
+    geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr & robot_pose)
+  {
+    return robot_->getCurrentPose(robot_pose);
+  }
+
+  void sendVelocity(geometry_msgs::msg::Twist twist)
+  {
+    robot_->sendVelocity(twist);
+  }
+
+protected:
+  std::unique_ptr<nav2_robot::Robot> robot_;
+};
 
 class TestRobotClass : public ::testing::Test
 {
 public:
   TestRobotClass()
   {
-    node_ = rclcpp::Node::make_shared("robot_class_test");
-    robot_ = std::make_unique<nav2_robot::Robot>(node_);
+    // Create a lifecycle node that uses a robot and start a thread to handle its messages
+    lifecycle_node_ = std::make_shared<TestLifecycleNode>();
+
+    lifecycle_thread_ = std::make_unique<std::thread>(
+      [this](nav2_lifecycle::LifecycleNode::SharedPtr node) {
+        for (;; ) {
+          rclcpp::spin_some(node->get_node_base_interface());
+          if (shut_down_threads_) {return;}
+        }
+      }, lifecycle_node_
+    );
+
+    client_ = std::make_shared<rclcpp::Node>("test_robot_client_node");
+
+    lifecycle_client_ =
+      std::make_shared<nav2_util::LifecycleServiceClient>("TestLifecycleNode", client_);
+
+    lifecycle_client_->change_state(Transition::TRANSITION_CONFIGURE);
+    lifecycle_client_->change_state(Transition::TRANSITION_ACTIVATE);
 
     // Initializing Pose and Twist messages
     initTestPose();
     initTestTwist();
 
     // Creating fake publishers
-    pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("amcl_pose");
-    odom_pub_ = node_->create_publisher<nav_msgs::msg::Odometry>("odom");
+    rmw_qos_profile_t pose_qos_profile = rmw_qos_profile_default;
+    pose_qos_profile.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+
+    pose_pub_ = client_->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
+      "amcl_pose", pose_qos_profile);
+    odom_pub_ = client_->create_publisher<nav_msgs::msg::Odometry>("odom");
 
     // Subscribing to cmdVelocity topic to make sure Robot class is publishing velocity
-    vel_sub_ = node_->create_subscription<geometry_msgs::msg::Twist>("/cmd_vel",
+    vel_sub_ = client_->create_subscription<geometry_msgs::msg::Twist>("cmd_vel",
         std::bind(&TestRobotClass::velocityReceived, this, std::placeholders::_1));
 
     velocityCmdReceived_ = false;
   }
+
+  ~TestRobotClass()
+  {
+    lifecycle_client_->change_state(Transition::TRANSITION_DEACTIVATE);
+    lifecycle_client_->change_state(Transition::TRANSITION_CLEANUP);
+
+    shut_down_threads_ = true;
+    lifecycle_thread_->join();
+  }
+
   void velocityReceived(const geometry_msgs::msg::Twist::SharedPtr msg);
 
 protected:
-  std::shared_ptr<rclcpp::Node> node_;
-  std::unique_ptr<nav2_robot::Robot> robot_;
+  std::shared_ptr<rclcpp::Node> client_;
+
+  std::shared_ptr<TestLifecycleNode> lifecycle_node_;
+  std::unique_ptr<std::thread> lifecycle_thread_;
+
+  std::shared_ptr<nav2_util::LifecycleServiceClient> lifecycle_client_;
 
   geometry_msgs::msg::PoseWithCovarianceStamped testPose_;
   geometry_msgs::msg::Twist testTwist_;
@@ -64,6 +166,7 @@ protected:
   geometry_msgs::msg::Twist velocityReceived_;
 
   bool velocityCmdReceived_;
+  bool shut_down_threads_{false};
 
   void initTestPose();
   void initTestTwist();
@@ -127,16 +230,16 @@ void TestRobotClass::initTestTwist()
 
 TEST_F(TestRobotClass, getNameTest)
 {
-  std::string robotName = robot_->getName();
+  std::string robotName = lifecycle_node_->getName();
   EXPECT_EQ(robotName, "turtlebot");
 }
 
 TEST_F(TestRobotClass, getPoseTest)
 {
   auto currentPose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
-  while (!(robot_->getCurrentPose(currentPose))) {
+  while (!(lifecycle_node_->getCurrentPose(currentPose))) {
     publishPose();
-    rclcpp::spin_some(node_);
+    rclcpp::spin_some(client_);
   }
   EXPECT_EQ(*currentPose, testPose_);
 }
@@ -145,9 +248,8 @@ TEST_F(TestRobotClass, getOdometryTest)
 {
   auto currentOdom = std::make_shared<nav_msgs::msg::Odometry>();
   rclcpp::Rate r(10);
-  while (!(robot_->getOdometry(currentOdom))) {
+  while (!(lifecycle_node_->getOdometry(currentOdom))) {
     publishOdom();
-    rclcpp::spin_some(node_);
     r.sleep();
   }
   EXPECT_EQ(*currentOdom, testOdom_);
@@ -157,8 +259,8 @@ TEST_F(TestRobotClass, sendVelocityTest)
 {
   rclcpp::Rate r(10);
   while (!velocityCmdReceived_) {
-    robot_->sendVelocity(testTwist_);
-    rclcpp::spin_some(node_);
+    lifecycle_node_->sendVelocity(testTwist_);
+    rclcpp::spin_some(client_);
     r.sleep();
   }
   EXPECT_EQ(testTwist_, velocityReceived_);


### PR DESCRIPTION
## Description

* Enabling nav2_robot for lifecycle nodes
* Remove COLCON_IGNORE in SimpleNavigator. Now that nav2_robot is enabled, Simple Navigator from the previous PR will compile.