### PR TITLE
Port BT Navigator to lifecycle nodes

### DIFF
--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -4,13 +4,16 @@ project(nav2_bt_navigator)
 find_package(ament_cmake REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(nav2_tasks REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(behaviortree_cpp REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(nav2_robot REQUIRED)
+find_package(nav2_lifecycle REQUIRED)
 
 nav2_package()
 
@@ -33,13 +36,16 @@ add_library(${library_name} SHARED
 
 set(dependencies
   rclcpp
+  rclcpp_action
   std_msgs
+  geometry_msgs
   nav2_tasks
   nav_msgs
   nav2_msgs
   behaviortree_cpp
   std_srvs
   nav2_robot
+  nav2_lifecycle
 )
 
 ament_target_dependencies(${executable_name}

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -24,8 +24,8 @@
 #include "nav2_lifecycle/lifecycle_node.hpp"
 #include "nav2_msgs/action/navigate_to_pose.hpp"
 #include "nav2_msgs/msg/path.hpp"
-#include "nav2_util/simple_action_client.hpp"
 #include "nav2_util/simple_action_server.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
 
 namespace nav2_bt_navigator
 {
@@ -45,13 +45,13 @@ protected:
   nav2_lifecycle::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
   nav2_lifecycle::CallbackReturn on_error(const rclcpp_lifecycle::State & state) override;
 
-  // An action server that implements the NavigateToPose action
-  std::unique_ptr<nav2_util::SimpleActionServer<nav2_msgs::action::NavigateToPose>> action_server_;
-
   using GoalHandle = rclcpp_action::ServerGoalHandle<nav2_msgs::action::NavigateToPose>;
   using ActionServer = nav2_util::SimpleActionServer<nav2_msgs::action::NavigateToPose>;
 
-  // The method invoked by the action server
+  // Our action server implements the NavigateToPose action
+  std::unique_ptr<ActionServer> action_server_;
+
+  // The action server callback
   void navigateToPose(const std::shared_ptr<GoalHandle> goal_handle);
 
   // A subscription and callback to handle the topic-based goal published from rviz

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -15,24 +15,72 @@
 #ifndef NAV2_BT_NAVIGATOR__BT_NAVIGATOR_HPP_
 #define NAV2_BT_NAVIGATOR__BT_NAVIGATOR_HPP_
 
-#include <string>
 #include <memory>
-#include "nav2_tasks/navigate_to_pose_task.hpp"
+#include <string>
+
+#include "behaviortree_cpp/blackboard/blackboard_local.h"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp"
+#include "nav2_lifecycle/lifecycle_node.hpp"
+#include "nav2_msgs/action/navigate_to_pose.hpp"
+#include "nav2_msgs/msg/path.hpp"
+#include "nav2_util/simple_action_client.hpp"
+#include "nav2_util/simple_action_server.hpp"
 
 namespace nav2_bt_navigator
 {
 
-class BtNavigator : public rclcpp::Node
+class BtNavigator : public nav2_lifecycle::LifecycleNode
 {
 public:
   BtNavigator();
+  ~BtNavigator();
 
-  nav2_tasks::TaskStatus navigateToPose(
-    const nav2_tasks::NavigateToPoseCommand::SharedPtr command);
+protected:
+  // The lifecycle node interface
+  nav2_lifecycle::CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_error(const rclcpp_lifecycle::State & state) override;
 
-private:
-  std::unique_ptr<nav2_tasks::NavigateToPoseTaskServer> task_server_;
-  std::string bt_xml_filename_;
+  // An action server that implements the NavigateToPose action
+  std::unique_ptr<nav2_util::SimpleActionServer<nav2_msgs::action::NavigateToPose>> action_server_;
+
+  using GoalHandle = rclcpp_action::ServerGoalHandle<nav2_msgs::action::NavigateToPose>;
+  using ActionServer = nav2_util::SimpleActionServer<nav2_msgs::action::NavigateToPose>;
+
+  // The method invoked by the action server
+  void navigateToPose(const std::shared_ptr<GoalHandle> goal_handle);
+
+  // A subscription and callback to handle the topic-based goal published from rviz
+  void onGoalPoseReceived(const geometry_msgs::msg::PoseStamped::SharedPtr pose);
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr goal_sub_;
+
+  // The blackboard shared by all of the nodes in the tree
+  BT::Blackboard::Ptr blackboard_;
+
+  // The goal (on the blackboard) to be passed to ComputePath
+  std::shared_ptr<geometry_msgs::msg::PoseStamped> goal_;
+
+  // The path (on the blackboard) to be returned from ComputePath and sent to the FollowPath task
+  std::shared_ptr<nav2_msgs::msg::Path> path_;
+
+  // The XML string that defines the Behavior Tree to create
+  std::string xml_string_;
+
+  // The wrapper class for the BT functionality
+  std::unique_ptr<NavigateToPoseBehaviorTree> bt_;
+
+  // The complete behavior tree that results from parsing the incoming XML
+  std::unique_ptr<BT::Tree> tree_;
+
+  // A client that we'll use to send a command message to our own task server
+  rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SharedPtr self_client_;
+
+  // A regular, non-spinning ROS node that we can use for calls to the action client
+  rclcpp::Node::SharedPtr client_node_;
 };
 
 }  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp
@@ -19,7 +19,6 @@
 
 #include "nav2_lifecycle/lifecycle_node.hpp"
 #include "nav2_tasks/behavior_tree_engine.hpp"
-#include "nav2_tasks/follow_path_task.hpp"
 #include "nav2_util/global_localization_service_client.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -29,17 +28,14 @@ namespace nav2_bt_navigator
 class NavigateToPoseBehaviorTree : public nav2_tasks::BehaviorTreeEngine
 {
 public:
-  explicit NavigateToPoseBehaviorTree(nav2_lifecycle::LifecycleNode::SharedPtr node);
-  NavigateToPoseBehaviorTree() = delete;
+  NavigateToPoseBehaviorTree();
 
 private:
   // Methods used to register as (simple action) BT nodes
-  BT::NodeStatus updatePath(BT::TreeNode & tree_node);
   BT::NodeStatus globalLocalizationServiceRequest();
   BT::NodeStatus initialPoseReceived(BT::TreeNode & tree_node);
 
   // Service clients
-  std::unique_ptr<nav2_tasks::FollowPathTaskClient> follow_path_task_client_;
   std::unique_ptr<nav2_util::GlobalLocalizationServiceClient> global_localization_client_;
 };
 

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp
@@ -16,10 +16,12 @@
 #define NAV2_BT_NAVIGATOR__NAVIGATE_TO_POSE_BEHAVIOR_TREE_HPP_
 
 #include <memory>
-#include "rclcpp/rclcpp.hpp"
+
+#include "nav2_lifecycle/lifecycle_node.hpp"
 #include "nav2_tasks/behavior_tree_engine.hpp"
 #include "nav2_tasks/follow_path_task.hpp"
-#include "nav2_tasks/global_localization_service_client.hpp"
+#include "nav2_util/global_localization_service_client.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 namespace nav2_bt_navigator
 {
@@ -27,16 +29,18 @@ namespace nav2_bt_navigator
 class NavigateToPoseBehaviorTree : public nav2_tasks::BehaviorTreeEngine
 {
 public:
-  explicit NavigateToPoseBehaviorTree(rclcpp::Node::SharedPtr node);
+  explicit NavigateToPoseBehaviorTree(nav2_lifecycle::LifecycleNode::SharedPtr node);
   NavigateToPoseBehaviorTree() = delete;
 
 private:
-  // Support for a BT SimpleActionNode that updates the FollowPath task
+  // Methods used to register as (simple action) BT nodes
   BT::NodeStatus updatePath(BT::TreeNode & tree_node);
   BT::NodeStatus globalLocalizationServiceRequest();
   BT::NodeStatus initialPoseReceived(BT::TreeNode & tree_node);
+
+  // Service clients
   std::unique_ptr<nav2_tasks::FollowPathTaskClient> follow_path_task_client_;
-  nav2_tasks::GlobalLocalizationServiceClient global_localization_;
+  std::unique_ptr<nav2_util::GlobalLocalizationServiceClient> global_localization_client_;
 };
 
 }  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/package.xml
+++ b/nav2_bt_navigator/package.xml
@@ -9,22 +9,27 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>nav2_common</build_depend>
-
   <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_action</build_depend>
   <build_depend>nav2_tasks</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>nav2_msgs</build_depend>
   <build_depend>behaviortree_cpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>nav2_robot</build_depend>
   <build_depend>std_srvs</build_depend>
+  <build_depend>nav2_lifecycle</build_depend>
 
   <exec_depend>behaviortree_cpp</exec_depend>
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_action</exec_depend>
   <exec_depend>nav2_tasks</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>nav2_lifecycle</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
-#include <memory>
-#include <fstream>
-#include <streambuf>
 #include "nav2_bt_navigator/bt_navigator.hpp"
-#include "nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp"
-#include "nav2_tasks/compute_path_to_pose_task.hpp"
+
+#include <fstream>
+#include <memory>
+#include <streambuf>
+#include <string>
+#include <utility>
+
 #include "nav2_tasks/bt_conversions.hpp"
-#include "behaviortree_cpp/blackboard/blackboard_local.h"
+#include "nav2_tasks/task_status.hpp"
 
 using nav2_tasks::TaskStatus;
 
@@ -28,60 +29,190 @@ namespace nav2_bt_navigator
 {
 
 BtNavigator::BtNavigator()
-: Node("BtNavigator")
+: nav2_lifecycle::LifecycleNode("bt_navigator", "", true)
 {
-  auto temp_node = std::shared_ptr<rclcpp::Node>(this, [](rclcpp::Node *) {});
-
-  task_server_ = std::make_unique<nav2_tasks::NavigateToPoseTaskServer>(temp_node);
-  task_server_->setExecuteCallback(
-    std::bind(&BtNavigator::navigateToPose, this, std::placeholders::_1));
+  RCLCPP_INFO(get_logger(), "Creating");
 }
 
-TaskStatus
-BtNavigator::navigateToPose(const nav2_tasks::NavigateToPoseCommand::SharedPtr command)
+BtNavigator::~BtNavigator()
 {
-  RCLCPP_INFO(get_logger(), "Begin navigating from current location to (%.2f, %.2f)",
-    command->pose.position.x, command->pose.position.y);
+  RCLCPP_INFO(get_logger(), "Destroying");
+}
+
+nav2_lifecycle::CallbackReturn
+BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
+{
+  RCLCPP_INFO(get_logger(), "Configuring");
+  auto node = shared_from_this();
+
+  // Support for handling the topic-based goal pose from rviz
+  client_node_ = std::make_shared<rclcpp::Node>("bt_navigator_client_node");
+
+  self_client_ = rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(
+    client_node_, "navigate_to_pose");
+
+  goal_sub_ = rclcpp_node_->create_subscription<geometry_msgs::msg::PoseStamped>("goal",
+      std::bind(&BtNavigator::onGoalPoseReceived, this, std::placeholders::_1));
+
+  // Create an action server that we implement with our navigateToPose method
+  action_server_ = std::make_unique<ActionServer>(rclcpp_node_, "navigate_to_pose",
+      std::bind(&BtNavigator::navigateToPose, this, std::placeholders::_1));
+
+  // Create the class that registers our custom nodes and executes the BT
+  bt_ = std::make_unique<NavigateToPoseBehaviorTree>(node);
+
+  // Create the path that will be returned from ComputePath and sent to FollowPath
+  goal_ = std::make_shared<geometry_msgs::msg::PoseStamped>();
+  path_ = std::make_shared<nav2_msgs::msg::Path>();
 
   // Create the blackboard that will be shared by all of the nodes in the tree
-  BT::Blackboard::Ptr blackboard = BT::Blackboard::create<BT::BlackboardLocal>();
+  blackboard_ = BT::Blackboard::create<BT::BlackboardLocal>();
 
-  // Create the path to be returned from ComputePath and sent to the FollowPath task
-  auto path = std::make_shared<nav2_tasks::ComputePathToPoseResult>();
+  // Put items on the blackboard
+  blackboard_->set<geometry_msgs::msg::PoseStamped::SharedPtr>("goal", goal_);  // NOLINT
+  blackboard_->set<nav2_msgs::msg::Path::SharedPtr>("path", path_);  // NOLINT
+  blackboard_->set<nav2_lifecycle::LifecycleNode::SharedPtr>("node", node);  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>("node_loop_timeout", std::chrono::milliseconds(10));  // NOLINT
+  blackboard_->set<bool>("initial_pose_received", false);  // NOLINT
 
-  // Set the shared data (commands/results)
-  blackboard->set<nav2_tasks::ComputePathToPoseCommand::SharedPtr>("goal", command);
-  blackboard->set<nav2_tasks::ComputePathToPoseResult::SharedPtr>("path", path);  // NOLINT
-  blackboard->set<bool>("initial_pose_received", task_server_->isInitialPoseReceieved());  // NOLINT
-
-  // Get the filename to use from the parameter
-  get_parameter_or<std::string>("bt_xml_filename", bt_xml_filename_,
+  // Get the BT filename to use from the node parameter
+  std::string bt_xml_filename;
+  get_parameter_or<std::string>(std::string("bt_xml_filename"), bt_xml_filename,
     std::string("bt_navigator.xml"));
 
-  // Read the input BT XML file into a string
-  std::ifstream xml_file(bt_xml_filename_);
+  // Read the input BT XML from the specified file into a string
+  std::ifstream xml_file(bt_xml_filename);
 
   if (!xml_file.good()) {
-    RCLCPP_ERROR(get_logger(), "Couldn't open input XML file: %s", bt_xml_filename_.c_str());
-    return TaskStatus::FAILED;
+    RCLCPP_ERROR(get_logger(), "Couldn't open input XML file: %s", bt_xml_filename.c_str());
+    return nav2_lifecycle::CallbackReturn::FAILURE;
   }
 
-  std::string xml_string((std::istreambuf_iterator<char>(xml_file)),
-    std::istreambuf_iterator<char>());
+  xml_string_ = std::string(std::istreambuf_iterator<char>(xml_file),
+      std::istreambuf_iterator<char>());
 
-  RCLCPP_INFO(get_logger(), "Behavior Tree file: '%s'", bt_xml_filename_.c_str());
-  RCLCPP_INFO(get_logger(), "Behavior Tree XML: %s", xml_string.c_str());
+  RCLCPP_DEBUG(get_logger(), "Behavior Tree file: '%s'", bt_xml_filename.c_str());
+  RCLCPP_DEBUG(get_logger(), "Behavior Tree XML: %s", xml_string_.c_str());
 
-  // Create and run the behavior tree
-  NavigateToPoseBehaviorTree bt(shared_from_this());
+  // Create the Behavior Tree from the XML input (after registering our own node types)
+  BT::Tree temp_tree = bt_->buildTreeFromText(xml_string_, blackboard_);
 
-  TaskStatus result = bt.run(blackboard, xml_string,
-      std::bind(&nav2_tasks::NavigateToPoseTaskServer::cancelRequested, task_server_.get()));
+  // Unfortunately, the BT library provides the tree as a struct instead of a pointer. So, we will
+  // createa new BT::Tree ourselves and move the data over
+  tree_ = std::make_unique<BT::Tree>();
+  tree_->root_node = temp_tree.root_node;
+  tree_->nodes = std::move(temp_tree.nodes);
+  temp_tree.root_node = nullptr;
 
-  task_server_->setInitialPose(blackboard->get<bool>("initial_pose_received"));
+  return nav2_lifecycle::CallbackReturn::SUCCESS;
+}
 
-  RCLCPP_INFO(get_logger(), "Completed navigation: result: %d", result);
-  return result;
+nav2_lifecycle::CallbackReturn
+BtNavigator::on_activate(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "Activating");
+
+  return nav2_lifecycle::CallbackReturn::SUCCESS;
+}
+
+nav2_lifecycle::CallbackReturn
+BtNavigator::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "Deactivating");
+
+  return nav2_lifecycle::CallbackReturn::SUCCESS;
+}
+
+nav2_lifecycle::CallbackReturn
+BtNavigator::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "Cleaning up");
+
+  goal_sub_.reset();
+  client_node_.reset();
+  self_client_.reset();
+  action_server_.reset();
+  path_.reset();
+  xml_string_.clear();
+  tree_.reset();
+  blackboard_.reset();
+  bt_.reset();
+
+  return nav2_lifecycle::CallbackReturn::SUCCESS;
+}
+
+nav2_lifecycle::CallbackReturn
+BtNavigator::on_error(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_ERROR(get_logger(), "Handling error state");
+  return nav2_lifecycle::CallbackReturn::SUCCESS;
+}
+
+nav2_lifecycle::CallbackReturn
+BtNavigator::on_shutdown(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "Shutting down");
+  return nav2_lifecycle::CallbackReturn::SUCCESS;
+}
+
+void
+BtNavigator::navigateToPose(const std::shared_ptr<GoalHandle> goal_handle)
+{
+  // Initialize the goal and result
+  auto goal = goal_handle->get_goal();
+  auto result = std::make_shared<nav2_msgs::action::NavigateToPose::Result>();
+
+  // TODO(mjeronimo): handle or reject an attempted pre-emption
+
+  RCLCPP_INFO(get_logger(), "Begin navigating from current location to (%.2f, %.2f)",
+    goal->pose.pose.position.x, goal->pose.pose.position.y);
+
+  // Get the goal pointer off of the blackboard...
+  auto bb_goal = blackboard_->get<geometry_msgs::msg::PoseStamped::SharedPtr>("goal");
+
+  // and update it with the incoming command
+  *bb_goal = goal->pose;
+
+  // Execute the BT that was previously created in the configure step
+  auto is_canceling = [goal_handle]() -> bool {return goal_handle->is_canceling();};
+  TaskStatus rc = bt_->run(tree_, is_canceling);
+
+  switch (rc) {
+    case TaskStatus::CANCELED:
+      // Even though the BT is no longer running, remote actions may still be executing. So,
+      // an explicit canceling of all actions allows the task clients to send cancel messages
+      // to their corresponding task servers
+      bt_->cancelAllActions(tree_->root_node);
+
+      // Reset the BT so that it can be run again in the future
+      bt_->resetTree(tree_->root_node);
+      goal_handle->set_canceled(result);
+      break;
+
+    case TaskStatus::SUCCEEDED:
+      goal_handle->set_succeeded(result);
+      break;
+
+    case TaskStatus::FAILED:
+      goal_handle->set_aborted(result);
+      break;
+
+    default:
+      throw std::logic_error("Invalid status return from BT");
+  }
+
+  RCLCPP_INFO(get_logger(), "Completed navigation: result: %d", rc);
+}
+
+void
+BtNavigator::onGoalPoseReceived(const geometry_msgs::msg::PoseStamped::SharedPtr pose)
+{
+  RCLCPP_INFO(get_logger(), "onGoalPoseReceived");
+
+  nav2_msgs::action::NavigateToPose::Goal goal;
+  goal.pose = *pose;
+
+  self_client_->async_send_goal(goal);
 }
 
 }  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/src/main.cpp
+++ b/nav2_bt_navigator/src/main.cpp
@@ -24,6 +24,5 @@ int main(int argc, char ** argv)
   rclcpp::spin(node->get_node_base_interface());
   rclcpp::shutdown();
 
-  RCLCPP_INFO(node->get_logger(), "Exiting, returning 0");
   return 0;
 }

--- a/nav2_bt_navigator/src/main.cpp
+++ b/nav2_bt_navigator/src/main.cpp
@@ -13,14 +13,17 @@
 // limitations under the License.
 
 #include <memory>
-#include "rclcpp/rclcpp.hpp"
+
 #include "nav2_bt_navigator/bt_navigator.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<nav2_bt_navigator::BtNavigator>());
+  auto node = std::make_shared<nav2_bt_navigator::BtNavigator>();
+  rclcpp::spin(node->get_node_base_interface());
   rclcpp::shutdown();
 
+  RCLCPP_INFO(node->get_logger(), "Exiting, returning 0");
   return 0;
 }

--- a/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
+++ b/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
@@ -15,14 +15,14 @@
 #include <memory>
 
 #include "nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp"
-#include "nav2_tasks/back_up_action.hpp"
+// #include "nav2_tasks/back_up_action.hpp"
 #include "nav2_tasks/compute_path_to_pose_action.hpp"
 #include "nav2_tasks/follow_path_action.hpp"
 #include "nav2_tasks/is_localized_condition.hpp"
 #include "nav2_tasks/is_stuck_condition.hpp"
 #include "nav2_tasks/rate_controller_node.hpp"
-#include "nav2_tasks/spin_action.hpp"
-#include "nav2_tasks/stop_action.hpp"
+// #include "nav2_tasks/spin_action.hpp"
+// #include "nav2_tasks/stop_action.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 using namespace std::chrono_literals;
@@ -30,16 +30,14 @@ using namespace std::chrono_literals;
 namespace nav2_bt_navigator
 {
 
-NavigateToPoseBehaviorTree::NavigateToPoseBehaviorTree(
-  nav2_lifecycle::LifecycleNode::SharedPtr node)
-: BehaviorTreeEngine(node)
+NavigateToPoseBehaviorTree::NavigateToPoseBehaviorTree()
 {
   // Register our custom action nodes so that they can be included in XML description
   factory_.registerNodeType<nav2_tasks::ComputePathToPoseAction>("ComputePathToPose");
   factory_.registerNodeType<nav2_tasks::FollowPathAction>("FollowPath");
-  factory_.registerNodeType<nav2_tasks::StopAction>("Stop");
-  factory_.registerNodeType<nav2_tasks::BackUpAction>("BackUp");
-  factory_.registerNodeType<nav2_tasks::SpinAction>("Spin");
+  // factory_.registerNodeType<nav2_tasks::StopAction>("Stop");
+  // factory_.registerNodeType<nav2_tasks::BackUpAction>("BackUp");
+  // factory_.registerNodeType<nav2_tasks::SpinAction>("Spin");
 
   // Register our custom condition nodes
   factory_.registerNodeType<nav2_tasks::IsStuckCondition>("IsStuck");
@@ -53,40 +51,21 @@ NavigateToPoseBehaviorTree::NavigateToPoseBehaviorTree(
   factory_.registerNodeType<nav2_tasks::RateController>("RateController");
 
   // Register our simple action nodes
-  factory_.registerSimpleAction("UpdatePath",
-    std::bind(&NavigateToPoseBehaviorTree::updatePath, this, std::placeholders::_1));
-
   factory_.registerSimpleAction("globalLocalizationServiceRequest",
     std::bind(&NavigateToPoseBehaviorTree::globalLocalizationServiceRequest, this));
-
-  follow_path_task_client_ = std::make_unique<nav2_tasks::FollowPathTaskClient>(node, true);
 
   global_localization_client_ =
     std::make_unique<nav2_util::GlobalLocalizationServiceClient>("bt_navigator");
 }
 
 BT::NodeStatus
-NavigateToPoseBehaviorTree::updatePath(BT::TreeNode & tree_node)
-{
-  // Get the updated path from the blackboard and send to the FollowPath task server
-  auto path = tree_node.blackboard()->template get<nav2_tasks::ComputePathToPoseResult::SharedPtr>(
-    "path");
-
-  follow_path_task_client_->sendUpdate(path);
-  return BT::NodeStatus::RUNNING;
-}
-
-BT::NodeStatus
 NavigateToPoseBehaviorTree::globalLocalizationServiceRequest()
 {
   auto request = std::make_shared<std_srvs::srv::Empty::Request>();
-  try {
-    auto result = global_localization_client_->invoke(request, std::chrono::seconds(1));
-    return BT::NodeStatus::SUCCESS;
-  } catch (std::runtime_error & e) {
-    RCLCPP_WARN(node_->get_logger(), e.what());
-    return BT::NodeStatus::FAILURE;
-  }
+  auto response = std::make_shared<std_srvs::srv::Empty::Response>();
+
+  auto succeeded = global_localization_client_->invoke(request, response);
+  return succeeded ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
 }
 
 BT::NodeStatus


### PR DESCRIPTION
## Description

* Port the BT Navigator to lifecycle nodes
* Implement a ROS2 Action server instead of task server

## Future work

* The task clients still need to be converted to action clients once the other task servers are converted to action servers