### PR TITLE
Adding missing dependencies in the nav2_util CMakeLists.txt

### DIFF
--- a/nav2_util/CMakeLists.txt
+++ b/nav2_util/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(motions_lib SHARED
   src/motion_model/omni_motion_model.cpp
   src/motion_model/differential_motion_model.cpp
 )
+target_link_libraries(motions_lib pf_lib)
 
 add_library(map_loader SHARED
   src/map_loader/map_loader.cpp

--- a/nav2_util/CMakeLists.txt
+++ b/nav2_util/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(sensors_lib SHARED
   src/sensors/laser/likelihood_field_model.cpp
   src/sensors/laser/likelihood_field_model_prob.cpp
 )
+target_link_libraries(sensors_lib pf_lib)
 
 add_library(motions_lib SHARED
   src/motion_model/omni_motion_model.cpp


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #656 |
| Primary OS tested on | OS X |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* The nav2_util CMake file is missing some `add_target_dependencies` statements. Shared libraries need to link with their dependencies. Sensors_lib has a dependency on pf_lib that was not specified. For some reason this did not cause a problem on Ubuntu 18.04 building with GCC but does cause a problem for Clang on OS X.
