### PR TITLE
Update the MissionExecutor for lifecycle nodes

### DIFF
--- a/nav2_mission_executor/CMakeLists.txt
+++ b/nav2_mission_executor/CMakeLists.txt
@@ -4,9 +4,12 @@ project(nav2_mission_executor)
 find_package(ament_cmake REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(nav2_tasks REQUIRED)
 find_package(nav2_msgs REQUIRED)
+find_package(nav2_lifecycle REQUIRED)
 find_package(behaviortree_cpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
@@ -31,9 +34,12 @@ add_library(${library_name} SHARED
 
 set(dependencies
   rclcpp
+  rclcpp_action
+  rclcpp_lifecycle
   std_msgs
   nav2_tasks
   nav2_msgs
+  nav2_lifecycle
   behaviortree_cpp
   geometry_msgs
 )
@@ -57,6 +63,7 @@ install(TARGETS ${executable_name} ${library_name}
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  add_subdirectory(test)
 endif()
 
 ament_export_include_directories(include)

--- a/nav2_mission_executor/include/nav2_mission_executor/execute_mission_behavior_tree.hpp
+++ b/nav2_mission_executor/include/nav2_mission_executor/execute_mission_behavior_tree.hpp
@@ -24,8 +24,7 @@ namespace nav2_mission_executor
 class ExecuteMissionBehaviorTree : public nav2_tasks::BehaviorTreeEngine
 {
 public:
-  explicit ExecuteMissionBehaviorTree(rclcpp::Node::SharedPtr node);
-  ExecuteMissionBehaviorTree() = delete;
+  ExecuteMissionBehaviorTree();
 };
 
 }  // namespace nav2_mission_executor

--- a/nav2_mission_executor/include/nav2_mission_executor/mission_executor.hpp
+++ b/nav2_mission_executor/include/nav2_mission_executor/mission_executor.hpp
@@ -16,22 +16,40 @@
 #define NAV2_MISSION_EXECUTOR__MISSION_EXECUTOR_HPP_
 
 #include <memory>
-#include "nav2_tasks/execute_mission_task.hpp"
-#include "geometry_msgs/msg/pose_stamped.hpp"
+
+#include "nav2_lifecycle/lifecycle_node.hpp"
+#include "nav2_msgs/action/execute_mission.hpp"
+#include "nav2_util/simple_action_server.hpp"
 
 namespace nav2_mission_executor
 {
 
-class MissionExecutor : public rclcpp::Node
+class MissionExecutor : public nav2_lifecycle::LifecycleNode
 {
 public:
   MissionExecutor();
+  ~MissionExecutor();
 
-  nav2_tasks::TaskStatus executeMission(
-    const nav2_tasks::ExecuteMissionCommand::SharedPtr command);
+protected:
+  // Implement the lifecycle interface
+  nav2_lifecycle::CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
+  nav2_lifecycle::CallbackReturn on_error(const rclcpp_lifecycle::State & state) override;
 
-private:
-  std::unique_ptr<nav2_tasks::ExecuteMissionTaskServer> task_server_;
+  using GoalHandle = rclcpp_action::ServerGoalHandle<nav2_msgs::action::ExecuteMission>;
+  using ActionServer = nav2_util::SimpleActionServer<nav2_msgs::action::ExecuteMission>;
+
+  // Out action server implements the ExecuteMission action
+  std::unique_ptr<ActionServer> action_server_;
+
+  // The action server callback
+  void executeMission(const std::shared_ptr<GoalHandle> goal_handle);
+
+  // A regular, non-spinning ROS node that we can use for the Behavior Tree
+  rclcpp::Node::SharedPtr client_node_;
 };
 
 }  // namespace nav2_mission_executor

--- a/nav2_mission_executor/package.xml
+++ b/nav2_mission_executor/package.xml
@@ -8,19 +8,24 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
   <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_action</build_depend>
+  <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>nav2_tasks</build_depend>
   <build_depend>nav2_msgs</build_depend>
+  <build_depend>nav2_lifecycle</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>behaviortree_cpp</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_action</exec_depend>
+  <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>nav2_tasks</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
+  <exec_depend>nav2_lifecycle</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>behaviortree_cpp</exec_depend>
 

--- a/nav2_mission_executor/src/execute_mission_behavior_tree.cpp
+++ b/nav2_mission_executor/src/execute_mission_behavior_tree.cpp
@@ -20,8 +20,7 @@ using namespace std::chrono_literals;
 namespace nav2_mission_executor
 {
 
-ExecuteMissionBehaviorTree::ExecuteMissionBehaviorTree(rclcpp::Node::SharedPtr node)
-: BehaviorTreeEngine(node)
+ExecuteMissionBehaviorTree::ExecuteMissionBehaviorTree()
 {
   // Register our custom action nodes so that they can be included in XML description
   factory_.registerNodeType<nav2_tasks::NavigateToPoseAction>("NavigateToPose");

--- a/nav2_mission_executor/src/main.cpp
+++ b/nav2_mission_executor/src/main.cpp
@@ -24,6 +24,5 @@ int main(int argc, char ** argv)
   rclcpp::spin(node->get_node_base_interface());
   rclcpp::shutdown();
 
-  RCLCPP_INFO(node->get_logger(), "Exiting, returning 0");
   return 0;
 }

--- a/nav2_mission_executor/src/main.cpp
+++ b/nav2_mission_executor/src/main.cpp
@@ -13,14 +13,17 @@
 // limitations under the License.
 
 #include <memory>
-#include "rclcpp/rclcpp.hpp"
+
 #include "nav2_mission_executor/mission_executor.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<nav2_mission_executor::MissionExecutor>());
+  auto node = std::make_shared<nav2_mission_executor::MissionExecutor>();
+  rclcpp::spin(node->get_node_base_interface());
   rclcpp::shutdown();
 
+  RCLCPP_INFO(node->get_logger(), "Exiting, returning 0");
   return 0;
 }

--- a/nav2_mission_executor/src/mission_executor.cpp
+++ b/nav2_mission_executor/src/mission_executor.cpp
@@ -102,7 +102,8 @@ MissionExecutor::executeMission(const std::shared_ptr<GoalHandle> goal_handle)
 
   // Set a couple values on the blackboard that all of the nodes require
   blackboard->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
-  blackboard->set<std::chrono::milliseconds>("node_loop_timeout", std::chrono::milliseconds(100));  // NOLINT
+  blackboard->set<std::chrono::milliseconds>("node_loop_timeout",  // NOLINT
+    std::chrono::milliseconds(100));
 
   // Create the Behavior Tree for this mission
   ExecuteMissionBehaviorTree bt;
@@ -115,17 +116,17 @@ MissionExecutor::executeMission(const std::shared_ptr<GoalHandle> goal_handle)
   switch (rc) {
     case nav2_tasks::BtStatus::SUCCEEDED:
       RCLCPP_INFO(get_logger(), "Mission succeeded");
-      goal_handle->set_succeeded(result);
+      goal_handle->succeed(result);
       return;
 
     case nav2_tasks::BtStatus::FAILED:
       RCLCPP_ERROR(get_logger(), "Mission failed");
-      goal_handle->set_aborted(result);
+      goal_handle->abort(result);
       return;
 
     case nav2_tasks::BtStatus::CANCELED:
       RCLCPP_INFO(get_logger(), "Mission canceled");
-      goal_handle->set_canceled(result);
+      goal_handle->canceled(result);
       return;
 
     default:

--- a/nav2_mission_executor/src/mission_executor.cpp
+++ b/nav2_mission_executor/src/mission_executor.cpp
@@ -34,7 +34,7 @@ MissionExecutor::~MissionExecutor()
 }
 
 nav2_lifecycle::CallbackReturn
-MissionExecutor::on_configure(const rclcpp_lifecycle::State &)
+MissionExecutor::on_configure(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Configuring");
 
@@ -48,21 +48,21 @@ MissionExecutor::on_configure(const rclcpp_lifecycle::State &)
 }
 
 nav2_lifecycle::CallbackReturn
-MissionExecutor::on_activate(const rclcpp_lifecycle::State &)
+MissionExecutor::on_activate(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Activating");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 
 nav2_lifecycle::CallbackReturn
-MissionExecutor::on_deactivate(const rclcpp_lifecycle::State &)
+MissionExecutor::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Deactivating");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 
 nav2_lifecycle::CallbackReturn
-MissionExecutor::on_cleanup(const rclcpp_lifecycle::State &)
+MissionExecutor::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Cleaning up");
 
@@ -73,14 +73,14 @@ MissionExecutor::on_cleanup(const rclcpp_lifecycle::State &)
 }
 
 nav2_lifecycle::CallbackReturn
-MissionExecutor::on_error(const rclcpp_lifecycle::State &)
+MissionExecutor::on_error(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_ERROR(get_logger(), "Handling error state");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 
 nav2_lifecycle::CallbackReturn
-MissionExecutor::on_shutdown(const rclcpp_lifecycle::State &)
+MissionExecutor::on_shutdown(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Shutting down");
   return nav2_lifecycle::CallbackReturn::SUCCESS;

--- a/nav2_mission_executor/test/CMakeLists.txt
+++ b/nav2_mission_executor/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+ament_add_gtest(test_mission_executor test_mission_executor.cpp)
+ament_target_dependencies(test_mission_executor ${dependencies})
+target_link_libraries(test_mission_executor ${library_name})

--- a/nav2_mission_executor/test/test_mission_executor.cpp
+++ b/nav2_mission_executor/test/test_mission_executor.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+// #include "gtest/gtest.h"
+#include "nav2_msgs/action/execute_mission.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+
+static const char xml_text[] =
+  R"(
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <Sequence name="root">
+      <NavigateToPose position="1;2;0" orientation="0;0;0;1"/>
+    </Sequence>
+  </BehaviorTree>
+</root>
+)";
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<rclcpp::Node>("mission_executor_test_node");
+  auto action_client =
+    rclcpp_action::create_client<nav2_msgs::action::ExecuteMission>(node, "ExecuteMission");
+
+  action_client->wait_for_action_server();
+
+  // The goal contains the XML representation of the BT
+  auto goal = nav2_msgs::action::ExecuteMission::Goal();
+  goal.mission_plan.mission_plan = xml_text;
+
+  // Send the goal
+  auto future_goal_handle = action_client->async_send_goal(goal);
+  if (rclcpp::spin_until_future_complete(node, future_goal_handle) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_ERROR(node->get_logger(), "send goal call failed");
+    return 1;
+  }
+
+  auto goal_handle = future_goal_handle.get();
+  if (!goal_handle) {
+    RCLCPP_ERROR(node->get_logger(), "Goal was rejected by server");
+    return 1;
+  }
+
+  // Wait for the result
+  auto future_result = goal_handle->async_result();
+  if (rclcpp::spin_until_future_complete(node, future_result) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_ERROR(node->get_logger(), "get result call failed");
+    return 1;
+  }
+
+  auto wrapped_result = future_result.get();
+  int rc = 0;
+
+  switch (wrapped_result.code) {
+    case rclcpp_action::ResultCode::SUCCEEDED:
+      break;
+
+    case rclcpp_action::ResultCode::ABORTED:
+    case rclcpp_action::ResultCode::CANCELED:
+    default:
+      RCLCPP_ERROR(node->get_logger(), "Mission failed");
+      rc = 1;
+      break;
+  }
+
+  rclcpp::shutdown();
+  return rc;
+}


### PR DESCRIPTION
## Description
* Update the MissionExecutor for lifecycle nodes
* Add a test action client that can be used to send a mission plan to the mission executor.

## Future work
* Convert the test to a gtest-based unit test