### PR TITLE
Change footprint_sub topic to dynamic_footprint

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -141,7 +141,7 @@ Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
   // subscribe to the footprint topic
   std::string topic_param, topic;
   get_parameter_or<std::string>("footprint_topic", topic_param, std::string("footprint_topic"));
-  get_parameter_or<std::string>(topic_param, topic, std::string("footprint"));
+  get_parameter_or<std::string>(topic_param, topic, std::string("dynamic_footprint"));
   footprint_sub_ = create_subscription<geometry_msgs::msg::Polygon>(topic,
       std::bind(&Costmap2DROS::setUnpaddedRobotFootprintPolygon, this, std::placeholders::_1));
   get_parameter_or<std::string>(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation/issues/885 |
| Primary OS tested on | Ubuntu 18.04|
| Robotic platform tested on | turtlebot3 simulation in Gazebo |

---

## Description of contribution in a few bullet points
The footprint subscriber in the costmap is subscribing to the footprint topic with a different message type (geometry_msgs::Polygon) than is being published (geometry_msgs::PolygonStamped). Due to this, running with the Opensplice DDS implementation causes the costmaps to crash. This change makes the default subscriber topic "dynamic_footprint" instead of just "footprint". 

According to this issue:
https://github.com/ros-planning/navigation/issues/885

These publishers and subscribers are performing 2 different things. The publisher is for visualization using RVIZ. The subscriber is for making dynamic changes to the robot footprint, such as when it is pulling a cart. They are **NOT** meant to be connected together. So to me this implies the default topics should be different. 



<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

---

<!-- OPTIONAL -->

I'd like to request maintainer: <blank> to review this PR.
