### PR TITLE
Tuning parameters for turtlebot 3.

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -27,10 +27,10 @@ DwbController:
     vy_samples: 5
     vtheta_samples: 20
     sim_time: 1.7
+    linear_granularity: 0.05
     xy_goal_tolerance: 0.25
-    ObstacleFootprint.scale: 0.1
-    ObstacleFootprint.max_scaling_factor: 0.2
-    ObstacleFootprint.scaling_speed: 0.25
+    critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+    BaseObstacle.scale: 0.02
     PathAlign.scale: 32.0
     GoalAlign.scale: 24.0
     PathDist.scale: 32.0
@@ -39,7 +39,8 @@ DwbController:
 local_costmap:
   local_costmap:
     ros__parameters:
-      robot_radius: 0.092
+      robot_radius: 0.17
+      inflation_layer.cost_scaling_factor: 3.0
       obstacle_layer:
         enabled: True
       always_send_full_costmap: True
@@ -52,6 +53,7 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
+      robot_radius: 0.17
       obstacle_layer:
         enabled: True
       always_send_full_costmap: True


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu 18 |
| Robotic platform tested on | Turtlebot 3 in Gazebo |

---

## Description of contribution in a few bullet points
* Default linear_granularity was 0.5m. This seemed too long a distance to look for obstacles. The turtlebot seemed to clip corners with the setting at the default.
* Replace the obstacle footprint critic with base obstacle. When using the inflation layer in costmap to make obstacles bigger, base obstacle should be sufficient to prevent obstacles. We also saw strange behavior with obstacle footprint that needs to be investigated further. It reported the robot had collided when it clearly hadn't, even according to the costmap data.
* The turtlebot3 waffle is our main model we test with. Make the robot radius match that platform rather than the burger model. Since the wafflehas a larger footprint than the burger, it is a safer setting anyhow.
* Changing the inflation cost scaling factor to match what's used by the turtlebot in ROS 1. This setting causes the robot to give obstacles a wider berth if possible.

---

## Future work that may be required in bullet points

* Investigate why the obstacle footprint critic reports a collision when there isn't one.
* Investigate why the inflation layer inflates such a small amount when using a footprint polygon instead of a robot radius.