### PR TITLE
Enable Behavior Tree navigator with recovery and retry

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_2nd_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_2nd_launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
             node_name='motion_primitives',
             output='screen',
             parameters=[{ 'use_sim_time': use_sim_time}]),
-        
+
         launch_ros.actions.Node(
             package='nav2_bt_navigator',
             node_executable='bt_navigator',

--- a/nav2_bringup/launch/nav2_bringup_2nd_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_2nd_launch.py
@@ -2,11 +2,17 @@ import os
 from launch import LaunchDescription
 import launch.actions
 import launch_ros.actions
+from ament_index_python.packages import get_package_prefix
 
 def generate_launch_description():
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default=
         [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
+   
+    bt_navigator_install_path = get_package_prefix('nav2_bt_navigator')
+    bt_navigator_xml = os.path.join(bt_navigator_install_path,
+                                    'behavior_trees',
+                                    'navigate_w_recovery_retry.xml') # TODO(mkhansen): change to an input parameter
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -32,17 +38,17 @@ def generate_launch_description():
             parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
-            package='nav2_simple_navigator',
-            node_executable='simple_navigator',
-            node_name='simple_navigator',
+            package='nav2_motion_primitives',
+            node_executable='motion_primitives_node',
+            node_name='motion_primitives',
             output='screen',
             parameters=[{ 'use_sim_time': use_sim_time}]),
-
+        
         launch_ros.actions.Node(
-            package='nav2_mission_executor',
-            node_executable='mission_executor',
-            node_name='mission_executor',
+            package='nav2_bt_navigator',
+            node_executable='bt_navigator',
+            node_name='bt_navigator',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[{'use_sim_time': use_sim_time}, {'bt_xml_filename': bt_navigator_xml}])
 
     ])

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -2,12 +2,18 @@ import os
 from launch import LaunchDescription
 import launch.actions
 import launch_ros.actions
+from ament_index_python.packages import get_package_prefix
 
 def generate_launch_description():
     map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default=
         [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
+
+    bt_navigator_install_path = get_package_prefix('nav2_bt_navigator')
+    bt_navigator_xml = os.path.join(bt_navigator_install_path,
+                                        'behavior_trees',
+                                        'navigate_w_recovery_retry.xml') # TODO(mkhansen): change to an input parameter
 
     return LaunchDescription([
         launch.actions.DeclareLaunchArgument(
@@ -49,16 +55,16 @@ def generate_launch_description():
             parameters=[{ 'use_sim_time': use_sim_time}]),
 
         launch_ros.actions.Node(
-            package='nav2_simple_navigator',
-            node_executable='simple_navigator',
-            node_name='simple_navigator',
+            package='nav2_motion_primitives',
+            node_executable='motion_primitives_node',
+            node_name='motion_primitives',
             output='screen',
             parameters=[{ 'use_sim_time': use_sim_time}]),
-
+        
         launch_ros.actions.Node(
-            package='nav2_mission_executor',
-            node_executable='mission_executor',
-            node_name='mission_executor',
+            package='nav2_bt_navigator',
+            node_executable='bt_navigator',
+            node_name='bt_navigator',
             output='screen',
-            parameters=[{ 'use_sim_time': use_sim_time}]),
+            parameters=[{'use_sim_time': use_sim_time}, {'bt_xml_filename': bt_navigator_xml}])
     ])

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -4,7 +4,7 @@ map_server:
 DwbController:
   ros__parameters:
     debug_trajectory_details: True
-    min_vel_x: -0.26
+    min_vel_x: 0.0
     min_vel_y: 0.0
     max_vel_x: 0.26
     max_vel_y: 0.0

--- a/nav2_bt_navigator/behavior_trees/navigate_w_recovery_retry.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_recovery_retry.xml
@@ -1,0 +1,21 @@
+<root main_tree_to_execute="BehaviorTree">
+    <!-- ////////// -->
+    <BehaviorTree ID="BehaviorTree">
+ 		<RetryUntilSuccesful name="retry_navigate" num_attempts="7"> 
+            <FallbackStar>
+                <SequenceStar name="navigate">
+          	        <ComputePathToPose endpoints="${endpoints}" path="${path}"/>
+	        		<FollowPath path="${path}"/>                    
+                </SequenceStar>
+                <ForceFailure>
+                  <SequenceStar name="recovery">
+                    <BackUp/>
+	        		<Spin/>                
+	        	  </SequenceStar>
+	        	</ForceFailure>
+            </FallbackStar> 
+         </RetryUntilSuccesful>
+    </BehaviorTree>
+    <TreeNodesModel/>
+</root>
+

--- a/nav2_bt_navigator/behavior_trees/navigate_w_recovery_retry.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_recovery_retry.xml
@@ -1,21 +1,20 @@
 <root main_tree_to_execute="BehaviorTree">
-    <!-- ////////// -->
-    <BehaviorTree ID="BehaviorTree">
- 		<RetryUntilSuccesful name="retry_navigate" num_attempts="7"> 
-            <FallbackStar>
-                <SequenceStar name="navigate">
-          	        <ComputePathToPose endpoints="${endpoints}" path="${path}"/>
-	        		<FollowPath path="${path}"/>                    
-                </SequenceStar>
-                <ForceFailure>
-                  <SequenceStar name="recovery">
-                    <BackUp/>
-	        		<Spin/>                
-	        	  </SequenceStar>
-	        	</ForceFailure>
-            </FallbackStar> 
-         </RetryUntilSuccesful>
-    </BehaviorTree>
-    <TreeNodesModel/>
+  <BehaviorTree ID="BehaviorTree">
+    <RetryUntilSuccesful name="retry_navigate" num_attempts="7">
+      <FallbackStar>
+        <SequenceStar name="navigate">
+          <ComputePathToPose endpoints="${endpoints}" path="${path}"/>
+	  <FollowPath path="${path}"/>
+        </SequenceStar>
+        <ForceFailure>
+          <SequenceStar name="recovery">
+            <clearEntirelyCostmapServiceRequest service_name="/local_costmap/clear_entirely_local_costmap"/>
+            <clearEntirelyCostmapServiceRequest service_name="/global_costmap/clear_entirely_global_costmap"/>
+            <Spin/>
+          </SequenceStar>
+        </ForceFailure>
+      </FallbackStar>
+    </RetryUntilSuccesful>
+  </BehaviorTree>
 </root>
 

--- a/nav2_motion_primitives/src/spin.cpp
+++ b/nav2_motion_primitives/src/spin.cpp
@@ -91,7 +91,7 @@ nav2_tasks::TaskStatus Spin::timedSpin()
 
   // TODO(orduno) #423 fixed time
   auto current_time = std::chrono::system_clock::now();
-  if (current_time - start_time_ >= 4s) {
+  if (current_time - start_time_ >= 6s) {  // almost 180 degrees
     // Stop the robot
     cmd_vel.angular.z = 0.0;
     robot_->sendVelocity(cmd_vel);

--- a/nav2_system_tests/src/system/CMakeLists.txt
+++ b/nav2_system_tests/src/system/CMakeLists.txt
@@ -29,6 +29,6 @@ ament_add_test(test_bt_navigator
     TEST_PARAMS=${PROJECT_SOURCE_DIR}/params/nav2_params.yaml
     GAZEBO_MODEL_PATH=${PROJECT_SOURCE_DIR}/models
     NAVIGATOR=bt
-    BT_NAVIGATOR_XML=simple_sequential.xml
+    BT_NAVIGATOR_XML=navigate_w_recovery_retry.xml
     ASTAR=True
 )


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #642 Enable Recovery Actions |
| Primary OS tested on | Ubuntu 18.04) |
| Robotic platform tested on | Turtlebot3 in simulation |

---

## Description of contribution in a few bullet points
This changes the default navigator to the bt_navigator and adds a behavior tree for running with the backup and spin recovery behaviors, and a retry set to 7. I know that's high but in simulation, it seemed to work most reliably that way.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

---

## Future work that may be required in bullet points

- Add parameter to the launch files for changing the behavior tree XML file. I tried to do this but was getting errors from launch

- Change backup and spin motion primitives to check for clear space and ensure no collisions occur

- Add a clear costmap motion primitive and enable it as part of this 

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

---

