### PR TITLE
Do not process Y velocity in differential drive robots

### DIFF
--- a/nav2_dwb_controller/dwb_critics/include/dwb_critics/oscillation.hpp
+++ b/nav2_dwb_controller/dwb_critics/include/dwb_critics/oscillation.hpp
@@ -120,16 +120,6 @@ public:
      */
     bool hasSignFlipped();
 
-    /**
-     * @brief Disable this command trend object if we don't care about this axis
-     */
-    void disable() {enabled_ = false;}
-
-    /**
-     * @brief Re-enable this command trend object
-     */
-    void enable() {enabled_ = true;}
-
 private:
     // Simple Enum for Tracking
     // cppcheck-suppress syntaxError
@@ -137,7 +127,6 @@ private:
 
     Sign sign_;
     bool positive_only_, negative_only_;
-    bool enabled_;
   };
 
   /**

--- a/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
@@ -49,7 +49,6 @@ namespace dwb_critics
 
 
 OscillationCritic::CommandTrend::CommandTrend()
-: enabled_(true)
 {
   reset();
 }
@@ -63,10 +62,6 @@ void OscillationCritic::CommandTrend::reset()
 
 bool OscillationCritic::CommandTrend::update(double velocity)
 {
-  if (!enabled_) {
-    return false;
-  }
-
   bool flag_set = false;
   if (velocity < 0.0) {
     if (sign_ == Sign::POSITIVE) {
@@ -86,19 +81,11 @@ bool OscillationCritic::CommandTrend::update(double velocity)
 
 bool OscillationCritic::CommandTrend::isOscillating(double velocity)
 {
-  if (!enabled_) {
-    return false;
-  }
-
   return (positive_only_ && velocity < 0.0) || (negative_only_ && velocity > 0.0);
 }
 
 bool OscillationCritic::CommandTrend::hasSignFlipped()
 {
-  if (!enabled_) {
-    return false;
-  }
-
   return positive_only_ || negative_only_;
 }
 
@@ -139,13 +126,6 @@ void OscillationCritic::onInit()
   // {
   //   x_only_threshold_ = 0.05;
   // }
-
-  // Disable y oscillation detection if the robot can't move in the Y axis
-  double max_vel_y;
-  nh_->get_parameter_or("max_vel_y", max_vel_y, 0.0);
-  if (max_vel_y == 0.0) {
-    y_trend_.disable();
-  }
 
   reset();
 }

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
@@ -39,6 +39,7 @@
 #include <mutex>
 #include <string>
 #include <cctype>
+#include <algorithm>
 #include "rclcpp/rclcpp.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "nav_2d_msgs/msg/twist2_d_stamped.hpp"
@@ -46,7 +47,8 @@
 namespace nav_2d_utils
 {
 
-enum RobotType {
+enum RobotType
+{
   DIFFERENTIAL,
   HOLONOMIC
 };
@@ -98,12 +100,13 @@ protected:
   RobotType convertStringToRobotType(std::string robot_type)
   {
     std::transform(begin(robot_type), end(robot_type), begin(robot_type), ::tolower);
-    if (robot_type ==  "differential") {
+    if (robot_type == "differential") {
       return DIFFERENTIAL;
     } else if (robot_type == "holonomic") {
       return HOLONOMIC;
     } else {
-      throw std::runtime_error("robot_type parameter is invalid. Must be 'holonomic' or 'differential'");
+      throw std::runtime_error(
+              "robot_type parameter is invalid. Must be 'holonomic' or 'differential'");
     }
   }
 

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
@@ -69,10 +69,10 @@ public:
   explicit OdomSubscriber(rclcpp::Node & nh, std::string default_topic = "odom")
   {
     std::string odom_topic;
-    std::string robot_type;
+    bool robot_type;
     nh.get_parameter_or("odom_topic", odom_topic, default_topic);
-    nh.get_parameter_or<std::string>("robot_type", robot_type, "differential");
-    robot_type_ = convertStringToRobotType(robot_type);
+    nh.get_parameter_or("holonomic_robot", robot_type, true);
+    robot_type_ = robot_type ? HOLONOMIC : DIFFERENTIAL;
     odom_sub_ =
       nh.create_subscription<nav_msgs::msg::Odometry>(odom_topic,
         [&](const nav_msgs::msg::Odometry::SharedPtr msg) {odomCallback(msg);},


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #514 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB 3 in Gazebo |

---

## Description of contribution in a few bullet points

* ROS 1 move base does not pass on the current Y velocity data to diff drive robots. This change matches that behavior.
* This also backs out a less general workaround that was introduced previously.


