### PR TITLE
Clear entire costmap from BT

### DIFF
--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp
@@ -20,6 +20,8 @@
 #include "nav2_tasks/behavior_tree_engine.hpp"
 #include "nav2_tasks/follow_path_task.hpp"
 #include "nav2_tasks/global_localization_service_client.hpp"
+#include "nav2_tasks/clear_entirely_costmap_service_client.hpp"
+#include "nav2_msgs/srv/clear_entire_costmap.hpp"
 
 namespace nav2_bt_navigator
 {
@@ -35,6 +37,7 @@ private:
   BT::NodeStatus updatePath(BT::TreeNode & tree_node);
   BT::NodeStatus globalLocalizationServiceRequest();
   BT::NodeStatus initialPoseReceived(BT::TreeNode & tree_node);
+  BT::NodeStatus clearEntirelyCostmapServiceRequest(BT::TreeNode & tree_node);
   std::unique_ptr<nav2_tasks::FollowPathTaskClient> follow_path_task_client_;
   nav2_tasks::GlobalLocalizationServiceClient global_localization_;
 };

--- a/nav2_tasks/include/nav2_tasks/clear_entirely_costmap_service_client.hpp
+++ b/nav2_tasks/include/nav2_tasks/clear_entirely_costmap_service_client.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_TASKS__CLEAR_ENTIRELY_COSTMAP_SERVICE_CLIENT_HPP_
+#define NAV2_TASKS__CLEAR_ENTIRELY_COSTMAP_SERVICE_CLIENT_HPP_
+
+#include <string>
+#include "nav2_util/service_client.hpp"
+#include "std_srvs/srv/empty.hpp"
+#include "nav2_msgs/srv/clear_entire_costmap.hpp"
+
+namespace nav2_tasks
+{
+
+class ClearEntirelyCostmapServiceClient
+  : public nav2_util::ServiceClient<nav2_msgs::srv::ClearEntireCostmap>
+{
+public:
+  explicit ClearEntirelyCostmapServiceClient(const std::string & service_name)
+  : nav2_util::ServiceClient<nav2_msgs::srv::ClearEntireCostmap>(service_name)
+  {
+  }
+
+  using clearEntirelyCostmapServiceRequest =
+    nav2_util::ServiceClient<nav2_msgs::srv::ClearEntireCostmap>::RequestType;
+  using clearEntirelyCostmapServiceResponse =
+    nav2_util::ServiceClient<nav2_msgs::srv::ClearEntireCostmap>::ResponseType;
+};
+
+}  // namespace nav2_tasks
+
+#endif  // NAV2_TASKS__CLEAR_ENTIRELY_COSTMAP_SERVICE_CLIENT_HPP_


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | () |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (Gazebo simulation) |

---

## Description of contribution in a few bullet points
- Created a service client in nav2_tasks to invoke a service call to clear entire costmap.

- Created a simple action node in BT to be able to clear entire costmap

- To clear global costmap from BT:
`<clearEntirelyCostmapServiceRequest service_name="/global_costmap/clear_entirely_global_costmap"/>`

- To clear local costmap BT:
`<clearEntirelyCostmapServiceRequest service_name="/local_costmap/clear_entirely_local_costmap"/>`
