### PR TITLE
Adding a check to DWB controller to return failure if it can't make progress.

### DIFF
--- a/nav2_dwb_controller/dwb_controller/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_controller/CMakeLists.txt
@@ -29,6 +29,7 @@ set(library_name ${executable_name}_core)
 
 add_library(${library_name}
   src/dwb_controller.cpp
+  src/progress_checker.cpp
 )
 
 set(dependencies

--- a/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
+++ b/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
@@ -23,7 +23,7 @@
 #include "nav_2d_msgs/msg/pose2_d_stamped.hpp"
 #include "nav_2d_utils/odom_subscriber.hpp"
 
-namespace nav2_dwb_controller
+namespace dwb_controller
 {
 
 class DwbController : public rclcpp::Node
@@ -49,6 +49,6 @@ protected:
   tf2_ros::TransformListener tfListener_;
 };
 
-}  // namespace nav2_dwb_controller
+}  // namespace dwb_controller
 
 #endif  // DWB_CONTROLLER__DWB_CONTROLLER_HPP_

--- a/nav2_dwb_controller/dwb_controller/include/dwb_controller/progress_checker.hpp
+++ b/nav2_dwb_controller/dwb_controller/include/dwb_controller/progress_checker.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DWB_CONTROLLER_PROGRESS_CHECKER_HPP_
-#define DWB_CONTROLLER_PROGRESS_CHECKER_HPP_
+#ifndef DWB_CONTROLLER__PROGRESS_CHECKER_HPP_
+#define DWB_CONTROLLER__PROGRESS_CHECKER_HPP_
 
 #include "rclcpp/rclcpp.hpp"
 #include "nav_2d_msgs/msg/pose2_d_stamped.hpp"
@@ -24,7 +24,7 @@ namespace dwb_controller
 class ProgressChecker
 {
 public:
-  ProgressChecker(const rclcpp::Node::SharedPtr & node);
+  explicit ProgressChecker(const rclcpp::Node::SharedPtr & node);
   void check(nav_2d_msgs::msg::Pose2DStamped & current_pose);
 
 protected:
@@ -39,8 +39,8 @@ protected:
   geometry_msgs::msg::Pose2D baseline_pose_;
   rclcpp::Time baseline_time_;
 
-  bool baseline_pose_set_;
+  bool baseline_pose_set_{false};
 };
 }  // namespace dwb_controller
 
-#endif  // DWB_CONTROLLER_PROGRESS_CHECKER_HPP_
+#endif  // DWB_CONTROLLER__PROGRESS_CHECKER_HPP_

--- a/nav2_dwb_controller/dwb_controller/include/dwb_controller/progress_checker.hpp
+++ b/nav2_dwb_controller/dwb_controller/include/dwb_controller/progress_checker.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DWB_CONTROLLER_PROGRESS_CHECKER_HPP_
+#define DWB_CONTROLLER_PROGRESS_CHECKER_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+#include "nav_2d_msgs/msg/pose2_d_stamped.hpp"
+
+namespace dwb_controller
+{
+
+class ProgressChecker
+{
+public:
+  ProgressChecker(const rclcpp::Node::SharedPtr & node);
+  void check(nav_2d_msgs::msg::Pose2DStamped & current_pose);
+
+protected:
+  bool isRobotMovedEnough(const geometry_msgs::msg::Pose2D & pose);
+  void reset_baseline_pose(const geometry_msgs::msg::Pose2D & pose);
+
+  rclcpp::Node::SharedPtr nh_;
+
+  double radius_;
+  rclcpp::Duration time_allowance_{0, 0};
+
+  geometry_msgs::msg::Pose2D baseline_pose_;
+  rclcpp::Time baseline_time_;
+
+  bool baseline_pose_set_;
+};
+}  // namespace dwb_controller
+
+#endif  // DWB_CONTROLLER_PROGRESS_CHECKER_HPP_

--- a/nav2_dwb_controller/dwb_controller/include/dwb_controller/progress_checker.hpp
+++ b/nav2_dwb_controller/dwb_controller/include/dwb_controller/progress_checker.hpp
@@ -28,7 +28,7 @@ public:
   void check(nav_2d_msgs::msg::Pose2DStamped & current_pose);
 
 protected:
-  bool isRobotMovedEnough(const geometry_msgs::msg::Pose2D & pose);
+  bool is_robot_moved_enough(const geometry_msgs::msg::Pose2D & pose);
   void reset_baseline_pose(const geometry_msgs::msg::Pose2D & pose);
 
   rclcpp::Node::SharedPtr nh_;

--- a/nav2_dwb_controller/dwb_controller/src/main.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   rclcpp::executors::SingleThreadedExecutor exec;
-  auto controller_node = std::make_shared<nav2_dwb_controller::DwbController>(exec);
+  auto controller_node = std::make_shared<dwb_controller::DwbController>(exec);
   exec.add_node(controller_node);
   exec.spin();
   rclcpp::shutdown();

--- a/nav2_dwb_controller/dwb_controller/src/progress_checker.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/progress_checker.cpp
@@ -22,7 +22,7 @@ namespace dwb_controller
 static double pose_distance(const geometry_msgs::msg::Pose2D &, const geometry_msgs::msg::Pose2D &);
 
 ProgressChecker::ProgressChecker(const rclcpp::Node::SharedPtr & node)
- : nh_(node), baseline_pose_set_(false)
+: nh_(node)
 {
   // Scale is set to 0 by default, so if it was not set otherwise, set to 0
   nh_->get_parameter_or("required_movement_radius", radius_, 0.5);
@@ -41,7 +41,6 @@ void ProgressChecker::check(nav_2d_msgs::msg::Pose2DStamped & current_pose)
   if ((nh_->now() - baseline_time_) > time_allowance_) {
     throw nav_core2::PlannerException("Failed to make progress");
   }
-  return;
 }
 
 void ProgressChecker::reset_baseline_pose(const geometry_msgs::msg::Pose2D & pose)

--- a/nav2_dwb_controller/dwb_controller/src/progress_checker.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/progress_checker.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dwb_controller/progress_checker.hpp"
+#include <cmath>
+#include "dwb_core/exceptions.hpp"
+#include "nav2_util/duration_conversions.hpp"
+
+namespace dwb_controller
+{
+static double pose_distance(const geometry_msgs::msg::Pose2D &, const geometry_msgs::msg::Pose2D &);
+
+ProgressChecker::ProgressChecker(const rclcpp::Node::SharedPtr & node)
+ : nh_(node), baseline_pose_set_(false)
+{
+  // Scale is set to 0 by default, so if it was not set otherwise, set to 0
+  nh_->get_parameter_or("required_movement_radius", radius_, 0.5);
+  double time_allowance_param;
+  nh_->get_parameter_or("movement_time_allowance_", time_allowance_param, 10.0);
+  time_allowance_ = nav2_util::duration_from_seconds(time_allowance_param);
+}
+
+void ProgressChecker::check(nav_2d_msgs::msg::Pose2DStamped & current_pose)
+{
+  // relies on short circuit evaluation to not call isRobotMovedEnough if baseline_pose is not set.
+  if ((!baseline_pose_set_) || (isRobotMovedEnough(current_pose.pose))) {
+    reset_baseline_pose(current_pose.pose);
+    return;
+  }
+  if ((nh_->now() - baseline_time_) > time_allowance_) {
+    throw nav_core2::PlannerException("Failed to make progress");
+  }
+  return;
+}
+
+void ProgressChecker::reset_baseline_pose(const geometry_msgs::msg::Pose2D & pose)
+{
+  baseline_pose_ = pose;
+  baseline_time_ = nh_->now();
+  baseline_pose_set_ = true;
+}
+
+bool ProgressChecker::isRobotMovedEnough(const geometry_msgs::msg::Pose2D & pose)
+{
+  if (pose_distance(pose, baseline_pose_) > radius_) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+static double pose_distance(
+  const geometry_msgs::msg::Pose2D & pose1,
+  const geometry_msgs::msg::Pose2D & pose2)
+{
+  double dx = pose1.x - pose2.x;
+  double dy = pose1.y - pose2.y;
+
+  return std::hypot(dx, dy);
+}
+
+}  // namespace dwb_controller

--- a/nav2_dwb_controller/dwb_controller/src/progress_checker.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/progress_checker.cpp
@@ -33,8 +33,9 @@ ProgressChecker::ProgressChecker(const rclcpp::Node::SharedPtr & node)
 
 void ProgressChecker::check(nav_2d_msgs::msg::Pose2DStamped & current_pose)
 {
-  // relies on short circuit evaluation to not call isRobotMovedEnough if baseline_pose is not set.
-  if ((!baseline_pose_set_) || (isRobotMovedEnough(current_pose.pose))) {
+  // relies on short circuit evaluation to not call is_robot_moved_enough if
+  // baseline_pose is not set.
+  if ((!baseline_pose_set_) || (is_robot_moved_enough(current_pose.pose))) {
     reset_baseline_pose(current_pose.pose);
     return;
   }
@@ -50,7 +51,7 @@ void ProgressChecker::reset_baseline_pose(const geometry_msgs::msg::Pose2D & pos
   baseline_pose_set_ = true;
 }
 
-bool ProgressChecker::isRobotMovedEnough(const geometry_msgs::msg::Pose2D & pose)
+bool ProgressChecker::is_robot_moved_enough(const geometry_msgs::msg::Pose2D & pose)
 {
   if (pose_distance(pose, baseline_pose_) > radius_) {
     return true;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 in Gazebo |

---

## Description of contribution in a few bullet points

* The main controller loop checks that the robot has moved at least 0.5m every 10s or else it returns failure so that recovery actions can be attempted.
* The distance and time are configurable parameters.

---

## Future work that may be required in bullet points

* There is nothing DWB specific about this check. I think it should be a BT node once we figure out how to cancel an action from another node.
