### PR TITLE
Filter out IMU noise

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -12,9 +12,11 @@ DwbController:
     min_speed_xy: 0.0
     max_speed_xy: 0.26
     min_speed_theta: 0.0
+    min_x_velocity_threshold: 0.001
     # Add high threshold velocity for turtlebot 3 issue.
     # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
     min_y_velocity_threshold: 0.5
+    min_theta_velocity_threshold: 0.001
     acc_lim_x: 2.5
     acc_lim_y: 0.0
     acc_lim_theta: 3.2

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -10,13 +10,11 @@ DwbController:
     max_vel_y: 0.0
     max_vel_theta: 1.0
     min_speed_xy: 0.0
-    # Set max XY speed to a large value so noisy Y data from IMU doesn't
-    # prevent operation. Since this robot has no Y velocity capability, any Y
-    # velocity reported in /odom data is due to slippage or noise, and there is
-    # no need to reduce the robot's operating envelope when generating possible
-    # trajectories.
-    max_speed_xy: 100.0
+    max_speed_xy: 0.26
     min_speed_theta: 0.0
+    # Add high threshold velocity for turtlebot 3 issue.
+    # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
+    min_y_velocity_threshold: 0.5
     acc_lim_x: 2.5
     acc_lim_y: 0.0
     acc_lim_theta: 3.2

--- a/nav2_dwb_controller/dwb_critics/include/dwb_critics/oscillation.hpp
+++ b/nav2_dwb_controller/dwb_critics/include/dwb_critics/oscillation.hpp
@@ -120,16 +120,6 @@ public:
      */
     bool hasSignFlipped();
 
-    /**
-     * @brief Disable this command trend object if we don't care about this axis
-     */
-    void disable() {enabled_ = false;}
-
-    /**
-     * @brief Re-enable this command trend object
-     */
-    void enable() {enabled_ = true;}
-
 private:
     // Simple Enum for Tracking
     // cppcheck-suppress syntaxError
@@ -137,7 +127,6 @@ private:
 
     Sign sign_;
     bool positive_only_, negative_only_;
-    bool enabled_;
   };
 
   /**

--- a/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
@@ -49,7 +49,6 @@ namespace dwb_critics
 
 
 OscillationCritic::CommandTrend::CommandTrend()
-: enabled_(true)
 {
   reset();
 }
@@ -63,10 +62,6 @@ void OscillationCritic::CommandTrend::reset()
 
 bool OscillationCritic::CommandTrend::update(double velocity)
 {
-  if (!enabled_) {
-    return false;
-  }
-
   bool flag_set = false;
   if (velocity < 0.0) {
     if (sign_ == Sign::POSITIVE) {
@@ -86,19 +81,11 @@ bool OscillationCritic::CommandTrend::update(double velocity)
 
 bool OscillationCritic::CommandTrend::isOscillating(double velocity)
 {
-  if (!enabled_) {
-    return false;
-  }
-
   return (positive_only_ && velocity < 0.0) || (negative_only_ && velocity > 0.0);
 }
 
 bool OscillationCritic::CommandTrend::hasSignFlipped()
 {
-  if (!enabled_) {
-    return false;
-  }
-
   return positive_only_ || negative_only_;
 }
 
@@ -139,13 +126,6 @@ void OscillationCritic::onInit()
   // {
   //   x_only_threshold_ = 0.05;
   // }
-
-  // Disable y oscillation detection if the robot can't move in the Y axis
-  double max_vel_y;
-  nh_->get_parameter_or("max_vel_y", max_vel_y, 0.0);
-  if (max_vel_y == 0.0) {
-    y_trend_.disable();
-  }
 
   reset();
 }

--- a/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
@@ -40,8 +40,6 @@
 #include "pluginlib/class_list_macros.hpp"
 #include "angles/angles.h"
 
-const double EPSILON = 1E-5;
-
 PLUGINLIB_EXPORT_CLASS(dwb_critics::RotateToGoalCritic, dwb_core::TrajectoryCritic)
 
 namespace dwb_critics
@@ -78,7 +76,7 @@ double RotateToGoalCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & t
   }
 
   // If we're sufficiently close to the goal, any transforming velocity is invalid
-  if (fabs(traj.velocity.x) > EPSILON || fabs(traj.velocity.y) > EPSILON) {
+  if (fabs(traj.velocity.x) > 0 || fabs(traj.velocity.y) > 0) {
     throw nav_core2::IllegalTrajectoryException(name_, "Nonrotation command near goal.");
   }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #514  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot 3 |

---

## Description of contribution in a few bullet points

* Velocities from an IMU are likely to have a small noise component. This noise was getting filtered out in individual trajectory critics by removing any values below a threshold value.
* This PR removes the filtering from every critic that cares and replaces it with a single place to filter the noise out.
* This PR also makes the noise filter threshold configurable in X, Y and theta.