### PR TITLE
Add default NodeOptions to fix new parameter changes

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -28,6 +28,7 @@
 #include "nav2_amcl/amcl_node.hpp"
 #include "nav2_util/pf/pf.hpp"  // pf_vector_t
 #include "nav2_util/string_utils.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "nav2_tasks/map_service_client.hpp"
 
 // For transform support
@@ -69,7 +70,7 @@ std::vector<std::pair<int, int>> AmclNode::free_space_indices;
 #endif
 
 AmclNode::AmclNode()
-: Node("amcl"),
+: Node("amcl", nav2_util::get_node_options_default()),
   sent_first_transform_(false),
   latest_tf_valid_(false),
   map_(NULL),

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(nav2_msgs REQUIRED)
 find_package(behaviortree_cpp REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(nav2_robot REQUIRED)
+find_package(nav2_util REQUIRED)
 
 nav2_package()
 
@@ -40,6 +41,7 @@ set(dependencies
   behaviortree_cpp
   std_srvs
   nav2_robot
+  nav2_util
 )
 
 ament_target_dependencies(${executable_name}

--- a/nav2_bt_navigator/package.xml
+++ b/nav2_bt_navigator/package.xml
@@ -18,6 +18,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>nav2_robot</build_depend>
   <build_depend>std_srvs</build_depend>
+  <build_depend>nav2_util</build_depend>
 
   <exec_depend>behaviortree_cpp</exec_depend>
   <exec_depend>rclcpp</exec_depend>
@@ -25,6 +26,7 @@
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>nav2_util</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -20,6 +20,7 @@
 #include "nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp"
 #include "nav2_tasks/compute_path_to_pose_task.hpp"
 #include "nav2_tasks/bt_conversions.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "behaviortree_cpp/blackboard/blackboard_local.h"
 
 using nav2_tasks::TaskStatus;
@@ -28,7 +29,7 @@ namespace nav2_bt_navigator
 {
 
 BtNavigator::BtNavigator()
-: Node("BtNavigator")
+: Node("BtNavigator", nav2_util::get_node_options_default())
 {
   auto temp_node = std::shared_ptr<rclcpp::Node>(this, [](rclcpp::Node *) {});
 

--- a/nav2_common/cmake/nav2_package.cmake
+++ b/nav2_common/cmake/nav2_package.cmake
@@ -24,7 +24,7 @@ macro(nav2_package)
   endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror -fPIC)
+    add_compile_options(-Wall -Wextra -Wpedantic -fPIC)
   endif()
 
   option(COVERAGE_ENABLED "Enable code coverage" FALSE)

--- a/nav2_common/cmake/nav2_package.cmake
+++ b/nav2_common/cmake/nav2_package.cmake
@@ -24,7 +24,7 @@ macro(nav2_package)
   endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic -fPIC)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations -fPIC)
   endif()
 
   option(COVERAGE_ENABLED "Enable code coverage" FALSE)

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -47,13 +47,14 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 #include "nav2_util/duration_conversions.hpp"
 #include "nav2_util/execution_timer.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "nav2_costmap_2d/layered_costmap.hpp"
 
 namespace nav2_costmap_2d
 {
 
 Costmap2DROS::Costmap2DROS(const std::string & name, tf2_ros::Buffer & tf)
-: Node(name, name),
+: Node(name, name, nav2_util::get_node_options_default()),
   layered_costmap_(NULL),
   name_(name),
   tf_(tf),

--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -43,6 +43,7 @@
 #include "nav2_costmap_2d/inflation_layer.hpp"
 #include "nav2_costmap_2d/observation_buffer.hpp"
 #include "nav2_costmap_2d/testing_helper.hpp"
+#include "nav2_util/node_utils.hpp"
 
 using geometry_msgs::msg::Point;
 using nav2_costmap_2d::CellData;
@@ -60,7 +61,8 @@ class TestNode : public ::testing::Test
 public:
   TestNode()
   {
-    node_ = rclcpp::Node::make_shared("inflation_test_node");
+    node_ = rclcpp::Node::make_shared(
+      "inflation_test_node", nav2_util::get_node_options_default());
     // Set cost_scaling_factor parameter to 1.0 for inflation layer
     node_->set_parameters({rclcpp::Parameter("inflation.cost_scaling_factor", 1.0)});
   }

--- a/nav2_costmap_2d/test/integration/obstacle_tests.cpp
+++ b/nav2_costmap_2d/test/integration/obstacle_tests.cpp
@@ -39,7 +39,7 @@
 #include "nav2_costmap_2d/layered_costmap.hpp"
 #include "nav2_costmap_2d/observation_buffer.hpp"
 #include "nav2_costmap_2d/testing_helper.hpp"
-
+#include "nav2_util/node_utils.hpp"
 
 class RclCppFixture
 {
@@ -54,7 +54,8 @@ class TestNode : public ::testing::Test
 public:
   TestNode()
   {
-    node_ = rclcpp::Node::make_shared("obstacle_test_node");
+    node_ = rclcpp::Node::make_shared(
+      "obstacle_test_node", nav2_util::get_node_options_default());
   }
 
   ~TestNode() {}

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include "dwb_core/exceptions.hpp"
 #include "nav_2d_utils/conversions.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "dwb_controller/progress_checker.hpp"
 
 using namespace std::chrono_literals;
@@ -32,7 +33,7 @@ namespace dwb_controller
 {
 
 DwbController::DwbController(rclcpp::executor::Executor & executor)
-: Node("DwbController"),
+: Node("DwbController", nav2_util::get_node_options_default()),
   tfBuffer_(get_clock()),
   tfListener_(tfBuffer_)
 {

--- a/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
@@ -40,6 +40,7 @@
 #include "dwb_plugins/standard_traj_generator.hpp"
 #include "dwb_plugins/limited_accel_generator.hpp"
 #include "dwb_core/exceptions.hpp"
+#include "nav2_util/node_utils.hpp"
 
 using std::hypot;
 using std::fabs;
@@ -74,7 +75,7 @@ std::vector<rclcpp::Parameter> getDefaultKinematicParameters()
 
 rclcpp::Node::SharedPtr makeTestNode(const std::string & name)
 {
-  rclcpp::NodeOptions node_options;
+  rclcpp::NodeOptions node_options = nav2_util::get_node_options_default();
   node_options.initial_parameters(getDefaultKinematicParameters());
   return rclcpp::Node::make_shared(name, node_options);
 }

--- a/nav2_dynamic_params/test/test_dynamic_params_client.cpp
+++ b/nav2_dynamic_params/test/test_dynamic_params_client.cpp
@@ -22,6 +22,7 @@
 #include "nav2_dynamic_params/dynamic_params_client.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_util/lifecycle_utils.hpp"
+#include "nav2_util/node_utils.hpp"
 
 using namespace std::chrono_literals;
 
@@ -63,7 +64,8 @@ class ClientTest : public ::testing::Test
 public:
   ClientTest()
   {
-    node_ = rclcpp::Node::make_shared("dynamic_param_client_test");
+    node_ = rclcpp::Node::make_shared(
+      "dynamic_param_client_test", nav2_util::get_node_options_default());
     dynamic_params_client_ = std::make_unique<DynamicParamsClientTest>(node_);
   }
 

--- a/nav2_dynamic_params/test/test_dynamic_params_helper.cpp
+++ b/nav2_dynamic_params/test/test_dynamic_params_helper.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "nav2_dynamic_params/dynamic_params_client.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
@@ -25,9 +26,10 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  auto node_A = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
+  auto node_A = rclcpp_lifecycle::LifecycleNode::make_shared(
+    "test_node", nav2_util::get_node_options_default());
   auto node_B = rclcpp_lifecycle::LifecycleNode::make_shared(
-    "test_node", "test_namespace", rclcpp::NodeOptions());
+    "test_node", "test_namespace", nav2_util::get_node_options_default());
 
   node_A->set_parameters({rclcpp::Parameter("foo", 1.0)});
   node_B->set_parameters({rclcpp::Parameter("bar", 1)});

--- a/nav2_dynamic_params/test/test_dynamic_params_validator.cpp
+++ b/nav2_dynamic_params/test/test_dynamic_params_validator.cpp
@@ -18,6 +18,7 @@
 
 #include "gtest/gtest.h"
 #include "nav2_dynamic_params/dynamic_params_validator.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 using rcl_interfaces::msg::SetParametersResult;
@@ -59,7 +60,8 @@ class ValidatorTest : public ::testing::Test
 public:
   ValidatorTest()
   {
-    node_ = rclcpp::Node::make_shared("dynamic_param_validator_test");
+    node_ = rclcpp::Node::make_shared(
+      "dynamic_param_validator_test", nav2_util::get_node_options_default());
     param_validator_ = std::make_unique<nav2_dynamic_params::DynamicParamsValidator>(node_);
   }
 

--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(SDL_image REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(nav2_util REQUIRED)
 
 nav2_package()
 
@@ -45,6 +46,7 @@ set(map_server_dependencies
   yaml_cpp_vendor
   std_msgs
   tf2
+  nav2_util
 )
 
 set(map_saver_dependencies

--- a/nav2_map_server/package.xml
+++ b/nav2_map_server/package.xml
@@ -21,6 +21,7 @@
   <depend>launch_ros</depend>
   <depend>launch_testing</depend>
   <depend>tf2</depend>
+  <depend>nav2_util</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_map_server/src/map_server.cpp
+++ b/nav2_map_server/src/map_server.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <stdexcept>
 #include "nav2_map_server/occ_grid_loader.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "yaml-cpp/yaml.h"
 
 using namespace std::chrono_literals;
@@ -28,7 +29,7 @@ namespace nav2_map_server
 {
 
 MapServer::MapServer(const std::string & node_name)
-: Node(node_name)
+: Node(node_name, nav2_util::get_node_options_default())
 {
   // Get the MAP YAML file, which includes the image filename and the map type
   getParameters();

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -32,6 +32,7 @@
 #include "nav2_navfn_planner/navfn_planner.hpp"
 #include "nav2_navfn_planner/navfn.hpp"
 #include "nav2_util/costmap.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
 #include "nav2_msgs/srv/get_costmap.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -47,7 +48,7 @@ namespace nav2_navfn_planner
 {
 
 NavfnPlanner::NavfnPlanner()
-: Node("NavfnPlanner"),
+: Node("NavfnPlanner", nav2_util::get_node_options_default()),
   global_frame_("map"),
   allow_unknown_(true)
 {

--- a/nav2_util/include/nav2_util/node_utils.hpp
+++ b/nav2_util/include/nav2_util/node_utils.hpp
@@ -70,6 +70,9 @@ rclcpp::Node::SharedPtr generate_internal_node(const std::string & prefix = "");
  */
 std::string time_to_string(size_t len);
 
+rclcpp::NodeOptions
+get_node_options_default(bool allow_undeclared = true, bool declare_initial_params = true);
+
 }  // namespace nav2_util
 
 #endif  // NAV2_UTIL__NODE_UTILS_HPP_

--- a/nav2_util/src/node_utils.cpp
+++ b/nav2_util/src/node_utils.cpp
@@ -72,4 +72,13 @@ rclcpp::Node::SharedPtr generate_internal_node(const std::string & prefix)
   return rclcpp::Node::make_shared(generate_internal_node_name(prefix));
 }
 
+rclcpp::NodeOptions
+get_node_options_default(bool allow_undeclared, bool declare_initial_params)
+{
+  auto options = rclcpp::NodeOptions();
+  options.allow_undeclared_parameters(allow_undeclared);
+  options.automatically_declare_initial_parameters(declare_initial_params);
+  return options;
+}
+
 }  // namespace nav2_util

--- a/nav2_util/src/node_utils.cpp
+++ b/nav2_util/src/node_utils.cpp
@@ -75,7 +75,7 @@ rclcpp::Node::SharedPtr generate_internal_node(const std::string & prefix)
 rclcpp::NodeOptions
 get_node_options_default(bool allow_undeclared, bool declare_initial_params)
 {
-  rclcpp::NodeOptions options();
+  rclcpp::NodeOptions options;
   options.allow_undeclared_parameters(allow_undeclared);
   options.automatically_declare_initial_parameters(declare_initial_params);
   return options;

--- a/nav2_util/src/node_utils.cpp
+++ b/nav2_util/src/node_utils.cpp
@@ -75,7 +75,7 @@ rclcpp::Node::SharedPtr generate_internal_node(const std::string & prefix)
 rclcpp::NodeOptions
 get_node_options_default(bool allow_undeclared, bool declare_initial_params)
 {
-  auto options = rclcpp::NodeOptions();
+  rclcpp::NodeOptions options();
   options.allow_undeclared_parameters(allow_undeclared);
   options.automatically_declare_initial_parameters(declare_initial_params);
   return options;


### PR DESCRIPTION
## Description of contribution in a few bullet points

- Temporarily fixes master branch after rclcpp parameter changes
- Adds default NodeOptions to nav2 Nodes with parameters
- Defaults to automatically declare initial parameters (from yaml) and to allow undeclared parameters
- added function in nav2_util to return default NodeOptions object
- Temporarily removed error for warnings to allow for deprecated parameter functions while we are in transition


## Future work that may be required in bullet points
- These changes can be removed (or modified) after we integrate lifecycle nodes with parameter changes
