### PR TITLE
Nav2 lifecycle controller

### DIFF
--- a/nav2_controller/CMakeLists.txt
+++ b/nav2_controller/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 3.5)
+project(nav2_controller)
+
+find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+find_package(nav2_common REQUIRED)
+find_package(nav2_lifecycle REQUIRED)
+find_package(nav2_msgs REQUIRED)
+find_package(nav2_util REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
+
+nav2_package()
+
+include_directories(
+  include
+)
+
+set(library_name ${PROJECT_NAME}_core)
+
+add_library(${library_name} SHARED
+  src/nav2_controller.cpp
+  src/nav2_controller_client.cpp
+)
+
+set(dependencies
+  geometry_msgs
+  lifecycle_msgs
+  nav2_lifecycle
+  nav2_msgs
+  nav2_util
+  rclcpp
+  rclcpp_action
+  rclcpp_lifecycle
+  std_msgs
+  std_srvs
+)
+
+ament_target_dependencies(${library_name}
+  ${dependencies}
+)
+
+add_executable(nav2_controller
+  src/main.cpp
+)
+
+target_link_libraries(nav2_controller
+  ${library_name}
+)
+
+ament_target_dependencies(nav2_controller
+  ${dependencies}
+)
+
+install(TARGETS
+  nav2_controller
+  ${library_name}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY include/ DESTINATION include/)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_include_directories(include)
+ament_export_libraries(${library_name})
+ament_export_dependencies(${dependencies})
+
+ament_package()

--- a/nav2_controller/CMakeLists.txt
+++ b/nav2_controller/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 nav2_package()
 
@@ -38,6 +39,7 @@ set(dependencies
   rclcpp_lifecycle
   std_msgs
   std_srvs
+  tf2_geometry_msgs
 )
 
 ament_target_dependencies(${library_name}

--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -1,0 +1,94 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_CONTROLLER__NAV2_CONTROLLER_HPP_
+#define NAV2_CONTROLLER__NAV2_CONTROLLER_HPP_
+
+#include <condition_variable>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "nav2_util/lifecycle_service_client.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "std_srvs/srv/empty.hpp"
+
+namespace nav2_controller
+{
+
+class Nav2Controller : public rclcpp::Node
+{
+public:
+  Nav2Controller();
+  ~Nav2Controller();
+
+  void startup();
+  void shutdown();
+  void pause();
+  void resume();
+
+  void setAutostart(std::chrono::seconds waitfor = std::chrono::seconds(10));
+
+protected:
+  rclcpp::Node::SharedPtr client_;
+
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr startup_srv_;
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr shutdown_srv_;
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr pause_srv_;
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr resume_srv_;
+
+  void startupCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
+    std::shared_ptr<std_srvs::srv::Empty::Response> response);
+
+  void shutdownCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
+    std::shared_ptr<std_srvs::srv::Empty::Response> response);
+
+  void pauseCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
+    std::shared_ptr<std_srvs::srv::Empty::Response> response);
+
+  void resumeCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
+    std::shared_ptr<std_srvs::srv::Empty::Response> response);
+
+  // Support functions for bring-up
+  void createLifecycleServiceClients();
+  void activateMapServer();
+  void activateLocalizer();
+  void activateWorldModel();
+  void activateLocalPlanner();
+  void activateRemainingNodes();
+
+  // Support functions for shutdown
+  void shutdownAllNodes();
+  void destroyLifecycleServiceClients();
+
+  // For each node in the map, transition to the new target state
+  void changeStateForAllNodes(std::uint8_t transition);
+
+  // A map of all nodes to be controlled
+  std::map<std::string, std::shared_ptr<nav2_util::LifecycleServiceClient>> node_map;
+};
+
+}  // namespace nav2_controller
+
+#endif  // NAV2_CONTROLLER__NAV2_CONTROLLER_HPP_

--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Open Source Robotics Foundation, Inc.
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ protected:
 
   // Support functions for bring-up
   void createLifecycleServiceClients();
-  void bringupNode(const std::string & node_name);
+  bool bringupNode(const std::string & node_name);
 
   // Support functions for shutdown
   void shutdownAllNodes();
@@ -80,8 +80,9 @@ protected:
   // For each node in the map, transition to the new target state
   void changeStateForAllNodes(std::uint8_t transition);
 
-  // A convenience function to highlight the output on the console
+  // Convenience functions to highlight the output on the console
   void message(const std::string & msg);
+  void error(const std::string & msg);
 
   // A map of all nodes to be controlled
   std::map<std::string, std::shared_ptr<nav2_util::LifecycleServiceClient>> node_map_;

--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -80,9 +80,8 @@ protected:
   // For each node in the map, transition to the new target state
   void changeStateForAllNodes(std::uint8_t transition);
 
-  // Convenience functions to highlight the output on the console
+  // Convenience function to highlight the output on the console
   void message(const std::string & msg);
-  void error(const std::string & msg);
 
   // A map of all nodes to be controlled
   std::map<std::string, std::shared_ptr<nav2_util::LifecycleServiceClient>> node_map_;

--- a/nav2_controller/include/nav2_controller/nav2_controller_client.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller_client.hpp
@@ -43,22 +43,22 @@ public:
   bool navigate_to_pose(double x, double y, double theta);
 
 protected:
-  using Srv = std_srvs::srv::Empty;
+  using Empty = std_srvs::srv::Empty;
 
   // A generic method used to call startup, shutdown, etc.
-  void callService(rclcpp::Client<Srv>::SharedPtr service_client, const char * service_name);
+  void callService(rclcpp::Client<Empty>::SharedPtr service_client, const char * service_name);
 
   // The node to use for the service call
   rclcpp::Node::SharedPtr node_;
 
   // The same (empty) request for all of the services
-  std::shared_ptr<Srv::Request> request_;
+  std::shared_ptr<Empty::Request> request_;
 
   // The service clients
-  rclcpp::Client<Srv>::SharedPtr startup_client_;
-  rclcpp::Client<Srv>::SharedPtr pause_client_;
-  rclcpp::Client<Srv>::SharedPtr resume_client_;
-  rclcpp::Client<Srv>::SharedPtr shutdown_client_;
+  rclcpp::Client<Empty>::SharedPtr startup_client_;
+  rclcpp::Client<Empty>::SharedPtr pause_client_;
+  rclcpp::Client<Empty>::SharedPtr resume_client_;
+  rclcpp::Client<Empty>::SharedPtr shutdown_client_;
 
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 

--- a/nav2_controller/include/nav2_controller/nav2_controller_client.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller_client.hpp
@@ -1,0 +1,64 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_CONTROLLER__NAV2_CONTROLLER_CLIENT_HPP_
+#define NAV2_CONTROLLER__NAV2_CONTROLLER_CLIENT_HPP_
+
+#include <memory>
+
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "nav2_msgs/action/navigate_to_pose.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+#include "std_srvs/srv/empty.hpp"
+
+namespace nav2_controller
+{
+
+class Nav2ControllerClient
+{
+public:
+  Nav2ControllerClient();
+
+  void startup();
+  void shutdown();
+  void pause();
+  void resume();
+
+  void set_initial_pose(double x, double y, double theta);
+  bool navigate_to_pose(double x, double y, double theta);
+
+protected:
+  using Srv = std_srvs::srv::Empty;
+
+  void callService(rclcpp::Client<Srv>::SharedPtr service_client, const char * service_name);
+
+  rclcpp::Node::SharedPtr node_;
+
+  std::shared_ptr<Srv::Request> request_;
+
+  rclcpp::Client<Srv>::SharedPtr startup_client_;
+  rclcpp::Client<Srv>::SharedPtr pause_client_;
+  rclcpp::Client<Srv>::SharedPtr resume_client_;
+  rclcpp::Client<Srv>::SharedPtr shutdown_client_;
+
+  using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
+
+  rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr initial_pose_publisher_;
+  rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SharedPtr navigate_action_client_;
+};
+
+}  // namespace nav2_controller
+
+#endif  // NAV2_CONTROLLER__NAV2_CONTROLLER_CLIENT_HPP_

--- a/nav2_controller/include/nav2_controller/nav2_controller_client.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller_client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Open Source Robotics Foundation, Inc.
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "geometry_msgs/msg/quaternion.hpp"
 #include "nav2_msgs/action/navigate_to_pose.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -31,23 +32,29 @@ class Nav2ControllerClient
 public:
   Nav2ControllerClient();
 
+  // Client-side interface to the Nav2 controller
   void startup();
   void shutdown();
   void pause();
   void resume();
 
+  // A couple convenience methods to facilitate scripting tests
   void set_initial_pose(double x, double y, double theta);
   bool navigate_to_pose(double x, double y, double theta);
 
 protected:
   using Srv = std_srvs::srv::Empty;
 
+  // A generic method used to call startup, shutdown, etc.
   void callService(rclcpp::Client<Srv>::SharedPtr service_client, const char * service_name);
 
+  // The node to use for the service call
   rclcpp::Node::SharedPtr node_;
 
+  // The same (empty) request for all of the services
   std::shared_ptr<Srv::Request> request_;
 
+  // The service clients
   rclcpp::Client<Srv>::SharedPtr startup_client_;
   rclcpp::Client<Srv>::SharedPtr pause_client_;
   rclcpp::Client<Srv>::SharedPtr resume_client_;
@@ -55,8 +62,14 @@ protected:
 
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
+  // For convenience, this client also supports sending the initial pose
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr initial_pose_publisher_;
+
+  // Also, for convenience, this client supports invoking the NavigateToPose action
   rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SharedPtr navigate_action_client_;
+
+  // A convenience function to convert from an algle to a Quaternion
+  geometry_msgs::msg::Quaternion orientationAroundZAxis(double angle);
 };
 
 }  // namespace nav2_controller

--- a/nav2_controller/package.xml
+++ b/nav2_controller/package.xml
@@ -18,6 +18,7 @@
   <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>
@@ -28,6 +29,7 @@
   <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/nav2_controller/package.xml
+++ b/nav2_controller/package.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nav2_controller</name>
+  <version>0.1.5</version>
+  <description>TODO</description>
+  <maintainer email="michael.jeronimo@intel.com">Michael Jeronimo</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>lifecycle_msgs</build_depend>
+  <build_depend>nav2_lifecycle</build_depend>
+  <build_depend>nav2_msgs</build_depend>
+  <build_depend>nav2_util</build_depend>
+  <build_depend>rclcpp_action</build_depend>
+  <build_depend>rclcpp_lifecycle</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>lifecycle_msgs</exec_depend>
+  <exec_depend>nav2_lifecycle</exec_depend>
+  <exec_depend>nav2_msgs</exec_depend>
+  <exec_depend>nav2_util</exec_depend>
+  <exec_depend>rclcpp_action</exec_depend>
+  <exec_depend>rclcpp_lifecycle</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/nav2_controller/package.xml
+++ b/nav2_controller/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>nav2_controller</name>
   <version>0.1.5</version>
-  <description>TODO</description>
+  <description>A controller/manager for the lifecycle nodes of the Navigation 2 system</description>
   <maintainer email="michael.jeronimo@intel.com">Michael Jeronimo</maintainer>
   <license>Apache License 2.0</license>
 

--- a/nav2_controller/src/main.cpp
+++ b/nav2_controller/src/main.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "nav2_controller/nav2_controller.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<nav2_controller::Nav2Controller>();
+  rclcpp::spin(node->get_node_base_interface());
+  rclcpp::shutdown();
+
+  RCLCPP_INFO(node->get_logger(), "Exiting, returning 0");
+  return 0;
+}

--- a/nav2_controller/src/main.cpp
+++ b/nav2_controller/src/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,5 @@ int main(int argc, char ** argv)
   rclcpp::spin(node->get_node_base_interface());
   rclcpp::shutdown();
 
-  RCLCPP_INFO(node->get_logger(), "Exiting, returning 0");
   return 0;
 }

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -1,0 +1,258 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "nav2_controller/nav2_controller.hpp"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "rclcpp/rclcpp.hpp"
+
+#define ANSI_COLOR_RED     "\x1b[31m"
+#define ANSI_COLOR_GREEN   "\x1b[32m"
+#define ANSI_COLOR_YELLOW  "\x1b[33m"
+#define ANSI_COLOR_BLUE    "\x1b[34m"
+#define ANSI_COLOR_MAGENTA "\x1b[35m"
+#define ANSI_COLOR_CYAN    "\x1b[36m"
+#define ANSI_COLOR_RESET   "\x1b[0m"
+
+using namespace std::chrono_literals;
+using namespace std::placeholders;
+
+using lifecycle_msgs::msg::Transition;
+using nav2_util::LifecycleServiceClient;
+
+namespace nav2_controller
+{
+
+static void
+message(const char * msg)
+{
+  fprintf(stderr, ANSI_COLOR_BLUE "\33[1m%s\33[0m" ANSI_COLOR_RESET "\n", msg);
+}
+
+Nav2Controller::Nav2Controller()
+: Node("nav2_controller")
+{
+  RCLCPP_INFO(get_logger(), "Creating");
+
+  startup_srv_ = create_service<std_srvs::srv::Empty>("nav2_controller/startup",
+      std::bind(&Nav2Controller::startupCallback, this, _1, _2, _3));
+
+  shutdown_srv_ = create_service<std_srvs::srv::Empty>("nav2_controller/shutdown",
+      std::bind(&Nav2Controller::shutdownCallback, this, _1, _2, _3));
+
+  pause_srv_ = create_service<std_srvs::srv::Empty>("nav2_controller/pause",
+      std::bind(&Nav2Controller::pauseCallback, this, _1, _2, _3));
+
+  resume_srv_ = create_service<std_srvs::srv::Empty>("nav2_controller/resume",
+      std::bind(&Nav2Controller::resumeCallback, this, _1, _2, _3));
+
+  client_ = std::make_shared<rclcpp::Node>("nav2_controller_lifecycle_client_node");
+}
+
+Nav2Controller::~Nav2Controller()
+{
+  RCLCPP_INFO(get_logger(), "Destroying");
+}
+
+void
+Nav2Controller::startupCallback(
+  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+  const std::shared_ptr<std_srvs::srv::Empty::Request>/*req*/,
+  std::shared_ptr<std_srvs::srv::Empty::Response>/*res*/)
+{
+  RCLCPP_INFO(get_logger(), "startupCallback");
+  startup();
+}
+
+void
+Nav2Controller::shutdownCallback(
+  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+  const std::shared_ptr<std_srvs::srv::Empty::Request>/*req*/,
+  std::shared_ptr<std_srvs::srv::Empty::Response>/*res*/)
+{
+  RCLCPP_INFO(get_logger(), "shutdownCallback");
+  shutdown();
+}
+
+void
+Nav2Controller::pauseCallback(
+  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+  const std::shared_ptr<std_srvs::srv::Empty::Request>/*req*/,
+  std::shared_ptr<std_srvs::srv::Empty::Response>/*res*/)
+{
+  RCLCPP_INFO(get_logger(), "pauseCallback");
+  pause();
+}
+
+void
+Nav2Controller::resumeCallback(
+  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+  const std::shared_ptr<std_srvs::srv::Empty::Request>/*req*/,
+  std::shared_ptr<std_srvs::srv::Empty::Response>/*res*/)
+{
+  RCLCPP_INFO(get_logger(), "resumeCallback");
+  resume();
+}
+
+void
+Nav2Controller::createLifecycleServiceClients()
+{
+  message("Creating and initializing lifecycle service clients");
+
+  node_map["amcl"] = std::make_shared<LifecycleServiceClient>("amcl", client_);
+  node_map["map_server"] = std::make_shared<LifecycleServiceClient>("map_server", client_);
+  node_map["dwb_controller"] = std::make_shared<LifecycleServiceClient>("dwb_controller", client_);
+  node_map["navfn_planner"] = std::make_shared<LifecycleServiceClient>("navfn_planner", client_);
+  node_map["bt_navigator"] = std::make_shared<LifecycleServiceClient>("bt_navigator", client_);
+  node_map["world_model"] = std::make_shared<LifecycleServiceClient>("world_model", client_);
+}
+
+void
+Nav2Controller::destroyLifecycleServiceClients()
+{
+  message("Destroying lifecycle service clients");
+  for (auto & kv : node_map) {
+    kv.second.reset();
+  }
+}
+
+void
+Nav2Controller::changeStateForAllNodes(std::uint8_t transition)
+{
+  for (const auto & kv : node_map) {
+    if (!kv.second->change_state(transition)) {
+      fprintf(stderr,
+        ANSI_COLOR_RED "Failed to change state for %s\n" ANSI_COLOR_RESET, kv.first.c_str());
+      return;
+    }
+  }
+}
+
+void
+Nav2Controller::activateMapServer()
+{
+  message("Configuring and activating the MapServer");
+  node_map["map_server"]->change_state(Transition::TRANSITION_CONFIGURE);
+  node_map["map_server"]->change_state(Transition::TRANSITION_ACTIVATE);
+}
+
+void
+Nav2Controller::activateLocalizer()
+{
+  message("Configuring and activating AMCL");
+  node_map["amcl"]->change_state(Transition::TRANSITION_CONFIGURE);
+  node_map["amcl"]->change_state(Transition::TRANSITION_ACTIVATE);
+}
+
+void
+Nav2Controller::activateWorldModel()
+{
+  message("Configuring and activating the world model");
+
+  node_map["world_model"]->change_state(Transition::TRANSITION_CONFIGURE);
+  node_map["world_model"]->change_state(Transition::TRANSITION_ACTIVATE);
+}
+
+void
+Nav2Controller::activateLocalPlanner()
+{
+  message("Configuring and activating DWB");
+
+  node_map["dwb_controller"]->change_state(Transition::TRANSITION_CONFIGURE);
+  node_map["dwb_controller"]->change_state(Transition::TRANSITION_ACTIVATE);
+}
+
+void
+Nav2Controller::activateRemainingNodes()
+{
+  message("Configuring and activating the global planner");
+
+  node_map["navfn_planner"]->change_state(Transition::TRANSITION_CONFIGURE);
+  node_map["navfn_planner"]->change_state(Transition::TRANSITION_ACTIVATE);
+
+  message("Configuring and activating the navigator");
+
+  node_map["bt_navigator"]->change_state(Transition::TRANSITION_CONFIGURE);
+  node_map["bt_navigator"]->change_state(Transition::TRANSITION_ACTIVATE);
+}
+
+void
+Nav2Controller::shutdownAllNodes()
+{
+  message("Deactivate, cleanup, and shutdown nodes");
+  changeStateForAllNodes(Transition::TRANSITION_DEACTIVATE);
+  changeStateForAllNodes(Transition::TRANSITION_CLEANUP);
+  changeStateForAllNodes(Transition::TRANSITION_UNCONFIGURED_SHUTDOWN);
+}
+
+void
+Nav2Controller::startup()
+{
+  message("Starting the system bringup...");
+  createLifecycleServiceClients();
+  activateMapServer();
+  activateLocalizer();
+  activateWorldModel();
+  activateLocalPlanner();
+  activateRemainingNodes();
+  message("The system is active");
+}
+
+void
+Nav2Controller::shutdown()
+{
+  message("Shutting down the system...");
+  shutdownAllNodes();
+  destroyLifecycleServiceClients();
+  message("The system has been sucessfully shut down");
+  std::this_thread::sleep_for(2s);
+}
+
+void
+Nav2Controller::pause()
+{
+  message("Pausing the system...");
+  for (const auto & kv : node_map) {
+    if (!kv.second->change_state(Transition::TRANSITION_DEACTIVATE)) {
+      fprintf(stderr,
+        ANSI_COLOR_RED "Failed to change state for %s\n" ANSI_COLOR_RESET, kv.first.c_str());
+      return;
+    }
+    if (!kv.second->change_state(Transition::TRANSITION_CLEANUP)) {
+      fprintf(stderr,
+        ANSI_COLOR_RED "Failed to change state for %s\n" ANSI_COLOR_RESET, kv.first.c_str());
+      return;
+    }
+  }
+  message("The system has been paused");
+}
+
+void
+Nav2Controller::resume()
+{
+  message("Resuming the system...");
+  activateMapServer();
+  activateLocalizer();
+  activateWorldModel();
+  activateLocalPlanner();
+  activateRemainingNodes();
+  message("The system has been resumed");
+}
+
+}  // namespace nav2_controller

--- a/nav2_controller/src/nav2_controller_client.cpp
+++ b/nav2_controller/src/nav2_controller_client.cpp
@@ -26,13 +26,13 @@ Nav2ControllerClient::Nav2ControllerClient()
   node_ = std::make_shared<rclcpp::Node>("nav2_controller_service_client");
 
   // All of the services use the same (Empty) request
-  request_ = std::make_shared<Srv::Request>();
+  request_ = std::make_shared<Empty::Request>();
 
   // Create the service clients
-  startup_client_ = node_->create_client<Srv>("nav2_controller/startup");
-  pause_client_ = node_->create_client<Srv>("nav2_controller/pause");
-  resume_client_ = node_->create_client<Srv>("nav2_controller/resume");
-  shutdown_client_ = node_->create_client<Srv>("nav2_controller/shutdown");
+  startup_client_ = node_->create_client<Empty>("nav2_controller/startup");
+  pause_client_ = node_->create_client<Empty>("nav2_controller/pause");
+  resume_client_ = node_->create_client<Empty>("nav2_controller/resume");
+  shutdown_client_ = node_->create_client<Empty>("nav2_controller/shutdown");
 
   navigate_action_client_ =
     rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(node_, "NavigateToPose");
@@ -144,7 +144,7 @@ Nav2ControllerClient::navigate_to_pose(double x, double y, double theta)
 
 void
 Nav2ControllerClient::callService(
-  rclcpp::Client<Srv>::SharedPtr service_client,
+  rclcpp::Client<Empty>::SharedPtr service_client,
   const char * service_name)
 {
   RCLCPP_INFO(node_->get_logger(), "Waiting for the nav2_controller's %s service...", service_name);

--- a/nav2_controller/src/nav2_controller_client.cpp
+++ b/nav2_controller/src/nav2_controller_client.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Open Source Robotics Foundation, Inc.
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,7 +65,8 @@ Nav2ControllerClient::resume()
   callService(resume_client_, "nav2_controller/resume");
 }
 
-geometry_msgs::msg::Quaternion orientationAroundZAxis(double angle)
+geometry_msgs::msg::Quaternion
+Nav2ControllerClient::orientationAroundZAxis(double angle)
 {
   auto orientation = geometry_msgs::msg::Quaternion();
 

--- a/nav2_controller/src/nav2_controller_client.cpp
+++ b/nav2_controller/src/nav2_controller_client.cpp
@@ -1,0 +1,163 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_controller/nav2_controller_client.hpp"
+
+#include <cmath>
+#include <memory>
+
+namespace nav2_controller
+{
+
+Nav2ControllerClient::Nav2ControllerClient()
+{
+  // Create the node to use for all of the service clients
+  node_ = std::make_shared<rclcpp::Node>("nav2_controller_service_client");
+
+  // All of the services use the same (Empty) request
+  request_ = std::make_shared<Srv::Request>();
+
+  // Create the service clients
+  startup_client_ = node_->create_client<Srv>("nav2_controller/startup");
+  pause_client_ = node_->create_client<Srv>("nav2_controller/pause");
+  resume_client_ = node_->create_client<Srv>("nav2_controller/resume");
+  shutdown_client_ = node_->create_client<Srv>("nav2_controller/shutdown");
+
+  navigate_action_client_ =
+    rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(node_, "NavigateToPose");
+
+  initial_pose_publisher_ =
+    node_->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("initialpose");
+}
+
+void
+Nav2ControllerClient::startup()
+{
+  callService(startup_client_, "nav2_controller/startup");
+}
+
+void
+Nav2ControllerClient::shutdown()
+{
+  callService(shutdown_client_, "nav2_controller/shutdown");
+}
+
+void
+Nav2ControllerClient::pause()
+{
+  callService(pause_client_, "nav2_controller/pause");
+}
+
+void
+Nav2ControllerClient::resume()
+{
+  callService(resume_client_, "nav2_controller/resume");
+}
+
+geometry_msgs::msg::Quaternion orientationAroundZAxis(double angle)
+{
+  auto orientation = geometry_msgs::msg::Quaternion();
+
+  orientation.x = 0.0;
+  orientation.y = 0.0;
+  orientation.z = sin(angle) / (2 * cos(angle / 2));
+  orientation.w = cos(angle / 2);
+
+  return orientation;
+}
+
+void
+Nav2ControllerClient::set_initial_pose(double x, double y, double theta)
+{
+  const double PI = 3.141592653589793238463;
+  geometry_msgs::msg::PoseWithCovarianceStamped pose;
+
+  pose.header.frame_id = "map";
+  pose.header.stamp = node_->now();
+  pose.pose.pose.position.x = x;
+  pose.pose.pose.position.y = y;
+  pose.pose.pose.position.z = 0.0;
+  pose.pose.pose.orientation = orientationAroundZAxis(theta);
+  pose.pose.covariance[6 * 0 + 0] = 0.5 * 0.5;
+  pose.pose.covariance[6 * 1 + 1] = 0.5 * 0.5;
+  pose.pose.covariance[6 * 5 + 5] = PI / 12.0 * PI / 12.0;
+
+  initial_pose_publisher_->publish(pose);
+}
+
+bool
+Nav2ControllerClient::navigate_to_pose(double x, double y, double theta)
+{
+  navigate_action_client_->wait_for_action_server();
+
+  // Initialize the goal
+  geometry_msgs::msg::PoseStamped target_pose;
+  target_pose.pose.position.x = x;
+  target_pose.pose.position.y = y;
+  target_pose.pose.position.z = 0;
+  target_pose.pose.orientation = orientationAroundZAxis(theta);
+
+  auto goal = nav2_msgs::action::NavigateToPose::Goal();
+  goal.pose = target_pose;
+
+  // Send it
+  auto future_goal_handle = navigate_action_client_->async_send_goal(goal);
+  if (rclcpp::spin_until_future_complete(node_, future_goal_handle) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_ERROR(node_->get_logger(), "send goal call failed");
+    return false;
+  }
+
+  // Get the goal handle
+  auto goal_handle = future_goal_handle.get();
+  if (!goal_handle) {
+    RCLCPP_ERROR(node_->get_logger(), "Goal was rejected by server");
+    return false;
+  }
+
+  // Wait for the action to complete
+  auto future_result = goal_handle->async_result();
+  if (rclcpp::spin_until_future_complete(node_, future_result) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_ERROR(node_->get_logger(), "get result call failed");
+    return false;
+  }
+
+  // Get the final result
+  auto wrapped_result = future_result.get();
+  return wrapped_result.code == rclcpp_action::ResultCode::SUCCEEDED;
+}
+
+void
+Nav2ControllerClient::callService(
+  rclcpp::Client<Srv>::SharedPtr service_client,
+  const char * service_name)
+{
+  RCLCPP_INFO(node_->get_logger(), "Waiting for the nav2_controller's %s service...", service_name);
+  while (!service_client->wait_for_service(std::chrono::seconds(1))) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(node_->get_logger(), "Client interrupted while waiting for service to appear");
+      return;
+    }
+    RCLCPP_INFO(node_->get_logger(), "Waiting for service to appear...");
+  }
+
+  RCLCPP_INFO(node_->get_logger(), "send_async_request (%s) to the nav2_controller", service_name);
+  auto future_result = service_client->async_send_request(request_);
+  rclcpp::spin_until_future_complete(node_, future_result);
+}
+
+}  // namespace nav2_controller

--- a/nav2_controller/src/nav2_controller_client.cpp
+++ b/nav2_controller/src/nav2_controller_client.cpp
@@ -17,6 +17,8 @@
 #include <cmath>
 #include <memory>
 
+#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+
 namespace nav2_controller
 {
 
@@ -68,14 +70,9 @@ Nav2ControllerClient::resume()
 geometry_msgs::msg::Quaternion
 Nav2ControllerClient::orientationAroundZAxis(double angle)
 {
-  auto orientation = geometry_msgs::msg::Quaternion();
-
-  orientation.x = 0.0;
-  orientation.y = 0.0;
-  orientation.z = sin(angle) / (2 * cos(angle / 2));
-  orientation.w = cos(angle / 2);
-
-  return orientation;
+  tf2::Quaternion q;
+  q.setRPY(0, 0, angle);  // void returning function
+  return tf2::toMsg(q);
 }
 
 void


### PR DESCRIPTION
## Description

* Adds a controller node for the various lifecycle nodes. This node walks the lifecycle node through their various states for startup and shutdown. It also does pause (getting the nodes back into a configurable state) and resume. 

## Future work

* This node will be renamed to nav2_lifecycle_manager once all of the lifecycle changes are integrated into the lifecycle branch
* Not all nodes correctly support being paused and resumed (that is, de-activate + cleanup and then configure + activate). In particular, those nodes that rely on plug-ins, which don't have a lifecycle-style interface (yet), still need more work. 
