### PR TITLE
Fix CI pipeline by controlling fail-on-build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,172 @@
+################################################################################
+# Repo
+
+# Prevent cache breaks when editing
+.dockerignore
+Dockerfile
+
+# Commented out CI
+#.git/*
+#.gitignore
+
+################################################################################
+# C++
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+################################################################################
+# Python
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+################################################################################
+# JetBrains IDEs
+
+# User-specific stuff
+**/.idea/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,12 +69,19 @@ RUN . $ROS_WS/install/setup.sh && \
 # build navigation2 package source
 RUN rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE
 ARG COVERAGE_ENABLED=False
+ARG FAIL_ON_BUILD_FAILURE
 RUN . $ROS_WS/install/setup.sh && \
-     colcon build \
-       --symlink-install \
-       --cmake-args \
-         -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
-         -DCOVERAGE_ENABLED=$COVERAGE_ENABLED
+    set +e && \
+    colcon build \
+      --symlink-install \
+      --cmake-args \
+        -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
+        -DCOVERAGE_ENABLED=$COVERAGE_ENABLED; \
+    if [ ! -z "$FAIL_ON_BUILD_FAILURE" ]; then \
+      $?; \
+    else \
+      true; \
+    fi
 
 # source navigation2 workspace from entrypoint
 RUN sed --in-place \


### PR DESCRIPTION
Presently the CI is deadlocked given the build for master branch is currently broken. This prevents our CI pipeline from completing and pushing updated docker images to our automated docker repo, thus blocking the use of CI for testing PR that could be merged to fix the build for master.

![image](https://user-images.githubusercontent.com/2293573/57044439-6a9d7200-6c1f-11e9-8b8f-d205547c24d2.png)

This PR simply adds a build ARG that controls the fail-on-build behavior that allows the docker build to succeed even if the colcon build for the repo fails (default), thus keeping sure the CI images remain fresh.

Alternatively, we could just skip the colcon build step entirely for the tag `rosplanning/navigation2:master`, given the build artifacts for workspace are wiped clean when used in CI anyhow. 