### PR TITLE
Fix launch test service import.

### DIFF
--- a/nav2_costmap_2d/test/integration/costmap_tests_launch.py
+++ b/nav2_costmap_2d/test/integration/costmap_tests_launch.py
@@ -22,7 +22,7 @@ from launch import LaunchService
 from launch.actions import ExecuteProcess
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch_testing import LaunchTestService
+from launch_testing.legacy import LaunchTestService
 
 
 def main(argv=sys.argv[1:]):

--- a/nav2_dynamic_params/test/dynamic_params_test.launch.py
+++ b/nav2_dynamic_params/test/dynamic_params_test.launch.py
@@ -21,7 +21,7 @@ from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess
 import launch_ros.actions
-from launch_testing import LaunchTestService
+from launch_testing.legacy import LaunchTestService
 
 
 def generate_launch_description():

--- a/nav2_map_server/test/component/test_occ_grid_launch.py
+++ b/nav2_map_server/test/component/test_occ_grid_launch.py
@@ -22,7 +22,7 @@ from launch import LaunchService
 from launch.actions import ExecuteProcess
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch_testing import LaunchTestService
+from launch_testing.legacy import LaunchTestService
 
 
 def main(argv=sys.argv[1:]):

--- a/nav2_system_tests/src/localization/test_localization_launch.py
+++ b/nav2_system_tests/src/localization/test_localization_launch.py
@@ -22,7 +22,7 @@ from launch import LaunchService
 import launch.actions
 from launch.actions import ExecuteProcess
 import launch_ros.actions
-from launch_testing import LaunchTestService
+from launch_testing.legacy import LaunchTestService
 
 
 def main(argv=sys.argv[1:]):

--- a/nav2_system_tests/src/planning/test_planner_launch.py
+++ b/nav2_system_tests/src/planning/test_planner_launch.py
@@ -23,7 +23,7 @@ from launch.actions import ExecuteProcess
 
 import launch_ros.actions
 
-from launch_testing import LaunchTestService
+from launch_testing.legacy import LaunchTestService
 
 
 def main(argv=sys.argv[1:]):

--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -23,7 +23,7 @@ from launch import LaunchDescription
 from launch import LaunchService
 import launch.actions
 import launch_ros.actions
-from launch_testing import LaunchTestService
+from launch_testing.legacy import LaunchTestService
 
 
 def generate_launch_description():


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* ros2/launch#215 changed the launch test facilities. The old LaunchTestService is now a legacy interface and needs to be imported in a new way. These tests are broken without this change.

