### PR TITLE
Enabled parallel global planner

### DIFF
--- a/nav2_bt_navigator/behavior_trees/parallel.xml
+++ b/nav2_bt_navigator/behavior_trees/parallel.xml
@@ -17,17 +17,17 @@
 
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
-    <SequenceStar name="root">
-      <ComputePathToPose goal="${goal}" path="${path}"/>
-      <ParallelNode threshold="1">
-        <FollowPath path="${path}"/>
-        <Sequence>
+    <FallbackStar name="root">
+      <GoalReached/>
+      <Sequence>
+       <Fallback>
+          <GoalReached/>
           <RateController hz="1.0">
             <ComputePathToPose goal="${goal}" path="${path}"/>
           </RateController>
-          <UpdatePath/>
-        </Sequence>
-      </ParallelNode>
-    </SequenceStar>
+       </Fallback>
+       <FollowPath path="${path}"/>
+      </Sequence>
+    </FallbackStar>
   </BehaviorTree>
 </root>

--- a/nav2_bt_navigator/behavior_trees/parallel.xml
+++ b/nav2_bt_navigator/behavior_trees/parallel.xml
@@ -4,17 +4,20 @@
 
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
-    <FallbackStar name="root">
-      <GoalReached/>
+    <SequenceStar name="root">
+      <ComputePathToPose goal="${goal}" path="${path}"/>
       <Sequence>
-       <Fallback>
+        <Fallback>
           <GoalReached/>
           <RateController hz="1.0">
-            <ComputePathToPose goal="${goal}" path="${path}"/>
+            <Sequence>
+              <ComputePathToPose goal="${goal}" path="${path}"/>
+              <UpdatePath/>
+            </Sequence> 
           </RateController>
-       </Fallback>
-       <FollowPath path="${path}"/>
+        </Fallback>
+        <FollowPath path="${path}"/>
       </Sequence>
-    </FallbackStar>
+    </SequenceStar>
   </BehaviorTree>
 </root>

--- a/nav2_bt_navigator/behavior_trees/parallel.xml
+++ b/nav2_bt_navigator/behavior_trees/parallel.xml
@@ -1,18 +1,5 @@
 <!--
-  This Behavior Tree first computes a path using the global planner (ComputePathToPose).
-  Then, it runs two sub-branches in parallel. The first sub-branch is a FollowPath
-  operation (the local planner). In parallel, there is a rate controlled execution of
-  FollowPath (the global planner). Each time a new path is computed, the path update
-  is sent to the local planner. The right branch, which is the rate controlled
-  ComputePathToPose, always returns RUNNING. Because the Parallel node uses a
-  threshold of 1, whenever the FollowPath returns SUCCESS or FAILURE, the parallel
-  node will return this result.
-
-  The goal (input to the global planner) and the resulting path (output of the global
-  planner and input to the local planner) are passed on the blackboard.
-
-  The rate at which the ComputePathToPose operation is invoked can be controlled with
-  the hz parameter to the RateController node.
+  This Behavior Tree replans the global path periodically at 1 Hz.
 -->
 
 <root main_tree_to_execute="MainTree">

--- a/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
+++ b/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
@@ -75,7 +75,7 @@ BT::NodeStatus NavigateToPoseBehaviorTree::updatePath(BT::TreeNode & tree_node)
     "path");
 
   follow_path_task_client_->sendUpdate(path);
-  return BT::NodeStatus::RUNNING;
+  return BT::NodeStatus::SUCCESS;
 }
 
 BT::NodeStatus NavigateToPoseBehaviorTree::globalLocalizationServiceRequest()

--- a/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
+++ b/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
@@ -24,6 +24,7 @@
 #include "nav2_tasks/back_up_action.hpp"
 #include "nav2_tasks/spin_action.hpp"
 #include "nav2_tasks/is_localized_condition.hpp"
+#include "nav2_tasks/goal_reached_condition.hpp"
 
 
 using namespace std::chrono_literals;
@@ -44,6 +45,7 @@ NavigateToPoseBehaviorTree::NavigateToPoseBehaviorTree(rclcpp::Node::SharedPtr n
   // Register our custom condition nodes
   factory_.registerNodeType<nav2_tasks::IsStuckCondition>("IsStuck");
   factory_.registerNodeType<nav2_tasks::IsLocalizedCondition>("IsLocalized");
+  factory_.registerNodeType<nav2_tasks::GoalReachedCondition>("GoalReached");
 
   // Register our Simple Condition nodes
   factory_.registerSimpleCondition("initialPoseReceived",

--- a/nav2_tasks/include/nav2_tasks/goal_reached_condition.hpp
+++ b/nav2_tasks/include/nav2_tasks/goal_reached_condition.hpp
@@ -43,19 +43,21 @@ public:
   BT::NodeStatus tick() override
   {
     if (!initialized_) {
-      node_ = blackboard()->template get<rclcpp::Node::SharedPtr>("node");
-
-      node_->get_parameter_or<double>("goal_reached_tol", goal_reached_tol_, 0.25);
-
-      robot_ = std::make_unique<nav2_robot::Robot>(node_);
-
-      initialized_ = true;
+      initialize();
     }
 
     if (goalReached()) {
       return BT::NodeStatus::SUCCESS;
     }
     return BT::NodeStatus::FAILURE;
+  }
+
+  void initialize()
+  {
+    node_ = blackboard()->template get<rclcpp::Node::SharedPtr>("node");
+    node_->get_parameter_or<double>("goal_reached_tol", goal_reached_tol_, 0.25);
+    robot_ = std::make_unique<nav2_robot::Robot>(node_);
+    initialized_ = true;
   }
 
   bool
@@ -67,17 +69,16 @@ public:
       RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
       return false;
     }
-
-    blackboard()->get<nav2_tasks::ComputePathToPoseCommand::SharedPtr>("goal", command_); 
+    // TODO(mhpanah): replace this with a function
+    blackboard()->get<nav2_tasks::ComputePathToPoseCommand::SharedPtr>("goal", command_);
     double dx = command_->pose.position.x - current_pose->pose.pose.position.x;
     double dy = command_->pose.position.y - current_pose->pose.pose.position.y;
 
     if ( (dx * dx + dy * dy) <= (goal_reached_tol_ * goal_reached_tol_) ) {
       return true;
-    } else
-    {
+    } else {
       return false;
-    }   
+    }
   }
 
 private:
@@ -88,7 +89,6 @@ private:
 
   bool initialized_;
   double goal_reached_tol_;
-
 };
 
 }  // namespace nav2_tasks

--- a/nav2_tasks/include/nav2_tasks/goal_reached_condition.hpp
+++ b/nav2_tasks/include/nav2_tasks/goal_reached_condition.hpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_TASKS__GOAL_REACHED_CONDITION_HPP_
+#define NAV2_TASKS__GOAL_REACHED_CONDITION_HPP_
+
+#include <string>
+#include <memory>
+#include "rclcpp/rclcpp.hpp"
+#include "behaviortree_cpp/condition_node.h"
+#include "nav2_robot/robot.hpp"
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "nav2_tasks/compute_path_to_pose_task.hpp"
+
+namespace nav2_tasks
+{
+
+class GoalReachedCondition : public BT::ConditionNode
+{
+public:
+  explicit GoalReachedCondition(const std::string & condition_name)
+  : BT::ConditionNode(condition_name), initialized_(false)
+  {
+  }
+
+  GoalReachedCondition() = delete;
+
+  ~GoalReachedCondition()
+  {
+  }
+
+  BT::NodeStatus tick() override
+  {
+    if (!initialized_) {
+      node_ = blackboard()->template get<rclcpp::Node::SharedPtr>("node");
+
+      node_->get_parameter_or<double>("goal_reached_tol", goal_reached_tol_, 0.25);
+
+      robot_ = std::make_unique<nav2_robot::Robot>(node_);
+
+      initialized_ = true;
+    }
+
+    if (goalReached()) {
+      return BT::NodeStatus::SUCCESS;
+    }
+    return BT::NodeStatus::FAILURE;
+  }
+
+  bool
+  goalReached()
+  {
+    auto current_pose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
+
+    if (!robot_->getCurrentPose(current_pose)) {
+      RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
+      return false;
+    }
+
+    blackboard()->get<nav2_tasks::ComputePathToPoseCommand::SharedPtr>("goal", command_); 
+    double dx = command_->pose.position.x - current_pose->pose.pose.position.x;
+    double dy = command_->pose.position.y - current_pose->pose.pose.position.y;
+
+    if ( (dx * dx + dy * dy) <= (goal_reached_tol_ * goal_reached_tol_) ) {
+      return true;
+    } else
+    {
+      return false;
+    }   
+  }
+
+private:
+  rclcpp::Node::SharedPtr node_;
+  std::unique_ptr<nav2_robot::Robot> robot_;
+  geometry_msgs::msg::PoseStamped::SharedPtr goal_;
+  geometry_msgs::msg::PoseStamped::SharedPtr command_;
+
+  bool initialized_;
+  double goal_reached_tol_;
+
+};
+
+}  // namespace nav2_tasks
+
+#endif  // NAV2_TASKS__GOAL_REACHED_CONDITION_HPP_


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (fixes #641) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (Turtlebot3 simulation) |

---

## Description of contribution in a few bullet points

- Created BT tree to enable parallel planning

- The global planner will not replan if the robot is within a close proximity to goal. The user can decide what the tolerance should be.

---

## Future work that may be required in bullet points

- Currently the goal checker is being used in DWB, BT, and system tests. We need to factor out goal checker to utils so that it can be used in other modules

- Probably a better approach would be to create  a "goal checker" node and have other modules to listen to it via topics. This way, the goal checker would be modular and can easily be replaced with something else.

---
