### PR TITLE
Default to a release build if unspecified.

### DIFF
--- a/nav2_common/cmake/nav2_package.cmake
+++ b/nav2_common/cmake/nav2_package.cmake
@@ -18,6 +18,15 @@
 # @public
 #
 macro(nav2_package)
+  if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to Release as none was specified.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE
+        STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+      "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+  endif()
+
   # Default to C++14
   if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 14)
@@ -33,4 +42,5 @@ macro(nav2_package)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
   endif()
+
 endmacro()

--- a/nav2_common/cmake/nav2_package.cmake
+++ b/nav2_common/cmake/nav2_package.cmake
@@ -42,5 +42,4 @@ macro(nav2_package)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
   endif()
-
 endmacro()


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* Sets the CMAKE_BUILD_TYPE flag to Release if it was unspecifed. Without this, if the user doesn't specify, they get an unoptimized build with no debug info - the worst of both worlds. I'm defaulting to Release because if someone just downloads the source, builds and runs it, we want their code to run as fast as possible to avoid them reporting performance related issues; robot motion can become unstable if the controller doesn't run fast enough.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

---

<!-- OPTIONAL -->

I'd like to request maintainer: <blank> to review this PR.
