### PR TITLE
Rename the nav2_controller to nav2_lifecycle_manager

### DIFF
--- a/nav2_lifecycle_manager/CMakeLists.txt
+++ b/nav2_lifecycle_manager/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(nav2_controller)
+project(nav2_lifecycle_manager)
 
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -24,8 +24,8 @@ include_directories(
 set(library_name ${PROJECT_NAME}_core)
 
 add_library(${library_name} SHARED
-  src/nav2_controller.cpp
-  src/nav2_controller_client.cpp
+  src/lifecycle_manager.cpp
+  src/lifecycle_manager_client.cpp
 )
 
 set(dependencies
@@ -46,20 +46,20 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
-add_executable(nav2_controller
+add_executable(lifecycle_manager
   src/main.cpp
 )
 
-target_link_libraries(nav2_controller
+target_link_libraries(lifecycle_manager
   ${library_name}
 )
 
-ament_target_dependencies(nav2_controller
+ament_target_dependencies(lifecycle_manager
   ${dependencies}
 )
 
 install(TARGETS
-  nav2_controller
+  lifecycle_manager
   ${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NAV2_CONTROLLER__NAV2_CONTROLLER_HPP_
-#define NAV2_CONTROLLER__NAV2_CONTROLLER_HPP_
+#ifndef NAV2_LIFECYCLE_MANAGER__LIFECYCLE_MANAGER_HPP_
+#define NAV2_LIFECYCLE_MANAGER__LIFECYCLE_MANAGER_HPP_
 
 #include <map>
 #include <memory>
@@ -24,14 +24,14 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/empty.hpp"
 
-namespace nav2_controller
+namespace nav2_lifecycle_manager
 {
 
-class Nav2Controller : public rclcpp::Node
+class LifecycleManager : public rclcpp::Node
 {
 public:
-  Nav2Controller();
-  ~Nav2Controller();
+  LifecycleManager();
+  ~LifecycleManager();
 
 protected:
   // The ROS node to use when calling lifecycle services
@@ -90,6 +90,6 @@ protected:
   std::vector<std::string> node_names_;
 };
 
-}  // namespace nav2_controller
+}  // namespace nav2_lifecycle_manager
 
-#endif  // NAV2_CONTROLLER__NAV2_CONTROLLER_HPP_
+#endif  // NAV2_LIFECYCLE_MANAGER__LIFECYCLE_MANAGER_HPP_

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NAV2_CONTROLLER__NAV2_CONTROLLER_CLIENT_HPP_
-#define NAV2_CONTROLLER__NAV2_CONTROLLER_CLIENT_HPP_
+#ifndef NAV2_LIFECYCLE_MANAGER__LIFECYCLE_MANAGER_CLIENT_HPP_
+#define NAV2_LIFECYCLE_MANAGER__LIFECYCLE_MANAGER_CLIENT_HPP_
 
 #include <memory>
 
@@ -24,15 +24,15 @@
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "std_srvs/srv/empty.hpp"
 
-namespace nav2_controller
+namespace nav2_lifecycle_manager
 {
 
-class Nav2ControllerClient
+class LifecycleManagerClient
 {
 public:
-  Nav2ControllerClient();
+  LifecycleManagerClient();
 
-  // Client-side interface to the Nav2 controller
+  // Client-side interface to the Nav2 lifecycle manager
   void startup();
   void shutdown();
   void pause();
@@ -72,6 +72,6 @@ protected:
   geometry_msgs::msg::Quaternion orientationAroundZAxis(double angle);
 };
 
-}  // namespace nav2_controller
+}  // namespace nav2_lifecycle_manager
 
-#endif  // NAV2_CONTROLLER__NAV2_CONTROLLER_CLIENT_HPP_
+#endif  // NAV2_LIFECYCLE_MANAGER__LIFECYCLE_MANAGER_CLIENT_HPP_

--- a/nav2_lifecycle_manager/package.xml
+++ b/nav2_lifecycle_manager/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>nav2_controller</name>
+  <name>nav2_lifecycle_manager</name>
   <version>0.1.5</version>
   <description>A controller/manager for the lifecycle nodes of the Navigation 2 system</description>
   <maintainer email="michael.jeronimo@intel.com">Michael Jeronimo</maintainer>

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "nav2_controller/nav2_controller.hpp"
+#include "nav2_lifecycle_manager/lifecycle_manager.hpp"
 
 #include <chrono>
 #include <memory>
@@ -27,11 +27,11 @@ using namespace std::placeholders;
 using lifecycle_msgs::msg::Transition;
 using nav2_util::LifecycleServiceClient;
 
-namespace nav2_controller
+namespace nav2_lifecycle_manager
 {
 
-Nav2Controller::Nav2Controller()
-: Node("nav2_controller")
+LifecycleManager::LifecycleManager()
+: Node("lifecycle_manager")
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
@@ -43,28 +43,28 @@ Nav2Controller::Nav2Controller()
   declare_parameter("node_names", rclcpp::ParameterValue(default_node_names));
   get_parameter("node_names", node_names_);
 
-  startup_srv_ = create_service<std_srvs::srv::Empty>("nav2_controller/startup",
-      std::bind(&Nav2Controller::startupCallback, this, _1, _2, _3));
+  startup_srv_ = create_service<std_srvs::srv::Empty>("lifecycle_manager/startup",
+      std::bind(&LifecycleManager::startupCallback, this, _1, _2, _3));
 
-  shutdown_srv_ = create_service<std_srvs::srv::Empty>("nav2_controller/shutdown",
-      std::bind(&Nav2Controller::shutdownCallback, this, _1, _2, _3));
+  shutdown_srv_ = create_service<std_srvs::srv::Empty>("lifecycle_manager/shutdown",
+      std::bind(&LifecycleManager::shutdownCallback, this, _1, _2, _3));
 
-  pause_srv_ = create_service<std_srvs::srv::Empty>("nav2_controller/pause",
-      std::bind(&Nav2Controller::pauseCallback, this, _1, _2, _3));
+  pause_srv_ = create_service<std_srvs::srv::Empty>("lifecycle_manager/pause",
+      std::bind(&LifecycleManager::pauseCallback, this, _1, _2, _3));
 
-  resume_srv_ = create_service<std_srvs::srv::Empty>("nav2_controller/resume",
-      std::bind(&Nav2Controller::resumeCallback, this, _1, _2, _3));
+  resume_srv_ = create_service<std_srvs::srv::Empty>("lifecycle_manager/resume",
+      std::bind(&LifecycleManager::resumeCallback, this, _1, _2, _3));
 
-  service_client_node_ = std::make_shared<rclcpp::Node>("nav2_controller_service_client_node");
+  service_client_node_ = std::make_shared<rclcpp::Node>("lifecycle_manager");
 }
 
-Nav2Controller::~Nav2Controller()
+LifecycleManager::~LifecycleManager()
 {
   RCLCPP_INFO(get_logger(), "Destroying");
 }
 
 void
-Nav2Controller::startupCallback(
+LifecycleManager::startupCallback(
   const std::shared_ptr<rmw_request_id_t>/*request_header*/,
   const std::shared_ptr<std_srvs::srv::Empty::Request>/*request*/,
   std::shared_ptr<std_srvs::srv::Empty::Response>/*response*/)
@@ -73,7 +73,7 @@ Nav2Controller::startupCallback(
 }
 
 void
-Nav2Controller::shutdownCallback(
+LifecycleManager::shutdownCallback(
   const std::shared_ptr<rmw_request_id_t>/*request_header*/,
   const std::shared_ptr<std_srvs::srv::Empty::Request>/*request*/,
   std::shared_ptr<std_srvs::srv::Empty::Response>/*response*/)
@@ -82,7 +82,7 @@ Nav2Controller::shutdownCallback(
 }
 
 void
-Nav2Controller::pauseCallback(
+LifecycleManager::pauseCallback(
   const std::shared_ptr<rmw_request_id_t>/*request_header*/,
   const std::shared_ptr<std_srvs::srv::Empty::Request>/*request*/,
   std::shared_ptr<std_srvs::srv::Empty::Response>/*response*/)
@@ -91,7 +91,7 @@ Nav2Controller::pauseCallback(
 }
 
 void
-Nav2Controller::resumeCallback(
+LifecycleManager::resumeCallback(
   const std::shared_ptr<rmw_request_id_t>/*request_header*/,
   const std::shared_ptr<std_srvs::srv::Empty::Request>/*request*/,
   std::shared_ptr<std_srvs::srv::Empty::Response>/*response*/)
@@ -100,7 +100,7 @@ Nav2Controller::resumeCallback(
 }
 
 void
-Nav2Controller::createLifecycleServiceClients()
+LifecycleManager::createLifecycleServiceClients()
 {
   message("Creating and initializing lifecycle service clients");
   for (auto & node_name : node_names_) {
@@ -110,7 +110,7 @@ Nav2Controller::createLifecycleServiceClients()
 }
 
 void
-Nav2Controller::destroyLifecycleServiceClients()
+LifecycleManager::destroyLifecycleServiceClients()
 {
   message("Destroying lifecycle service clients");
   for (auto & kv : node_map_) {
@@ -119,7 +119,7 @@ Nav2Controller::destroyLifecycleServiceClients()
 }
 
 void
-Nav2Controller::changeStateForAllNodes(std::uint8_t transition)
+LifecycleManager::changeStateForAllNodes(std::uint8_t transition)
 {
   for (const auto & kv : node_map_) {
     if (!kv.second->change_state(transition)) {
@@ -130,7 +130,7 @@ Nav2Controller::changeStateForAllNodes(std::uint8_t transition)
 }
 
 bool
-Nav2Controller::bringupNode(const std::string & node_name)
+LifecycleManager::bringupNode(const std::string & node_name)
 {
   message(std::string("Configuring and activating ") + node_name);
   if (!node_map_[node_name]->change_state(Transition::TRANSITION_CONFIGURE)) {
@@ -148,7 +148,7 @@ Nav2Controller::bringupNode(const std::string & node_name)
 }
 
 void
-Nav2Controller::shutdownAllNodes()
+LifecycleManager::shutdownAllNodes()
 {
   message("Deactivate, cleanup, and shutdown nodes");
   changeStateForAllNodes(Transition::TRANSITION_DEACTIVATE);
@@ -157,7 +157,7 @@ Nav2Controller::shutdownAllNodes()
 }
 
 void
-Nav2Controller::startup()
+LifecycleManager::startup()
 {
   message("Starting the system bringup...");
   createLifecycleServiceClients();
@@ -171,7 +171,7 @@ Nav2Controller::startup()
 }
 
 void
-Nav2Controller::shutdown()
+LifecycleManager::shutdown()
 {
   message("Shutting down the system...");
   shutdownAllNodes();
@@ -180,7 +180,7 @@ Nav2Controller::shutdown()
 }
 
 void
-Nav2Controller::pause()
+LifecycleManager::pause()
 {
   message("Pausing the system...");
   for (const auto & kv : node_map_) {
@@ -195,7 +195,7 @@ Nav2Controller::pause()
 }
 
 void
-Nav2Controller::resume()
+LifecycleManager::resume()
 {
   message("Resuming the system...");
   for (auto & node_name : node_names_) {
@@ -215,9 +215,9 @@ Nav2Controller::resume()
 #define ANSI_COLOR_BLUE     "\x1b[34m"
 
 void
-Nav2Controller::message(const std::string & msg)
+LifecycleManager::message(const std::string & msg)
 {
   RCLCPP_INFO(get_logger(), ANSI_COLOR_BLUE "\33[1m%s\33[0m" ANSI_COLOR_RESET, msg.c_str());
 }
 
-}  // namespace nav2_controller
+}  // namespace nav2_lifecycle_manager

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -55,7 +55,7 @@ LifecycleManager::LifecycleManager()
   resume_srv_ = create_service<std_srvs::srv::Empty>("lifecycle_manager/resume",
       std::bind(&LifecycleManager::resumeCallback, this, _1, _2, _3));
 
-  service_client_node_ = std::make_shared<rclcpp::Node>("lifecycle_manager");
+  service_client_node_ = std::make_shared<rclcpp::Node>("lifecycle_manager_service_client");
 }
 
 LifecycleManager::~LifecycleManager()

--- a/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
@@ -25,7 +25,7 @@ namespace nav2_lifecycle_manager
 LifecycleManagerClient::LifecycleManagerClient()
 {
   // Create the node to use for all of the service clients
-  node_ = std::make_shared<rclcpp::Node>("lifecycle_manager_service_client");
+  node_ = std::make_shared<rclcpp::Node>("lifecycle_manager_client_service_client");
 
   // All of the services use the same (Empty) request
   request_ = std::make_shared<Empty::Request>();

--- a/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
@@ -12,29 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "nav2_controller/nav2_controller_client.hpp"
+#include "nav2_lifecycle_manager/lifecycle_manager_client.hpp"
 
 #include <cmath>
 #include <memory>
 
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
-namespace nav2_controller
+namespace nav2_lifecycle_manager
 {
 
-Nav2ControllerClient::Nav2ControllerClient()
+LifecycleManagerClient::LifecycleManagerClient()
 {
   // Create the node to use for all of the service clients
-  node_ = std::make_shared<rclcpp::Node>("nav2_controller_service_client");
+  node_ = std::make_shared<rclcpp::Node>("lifecycle_manager_service_client");
 
   // All of the services use the same (Empty) request
   request_ = std::make_shared<Empty::Request>();
 
   // Create the service clients
-  startup_client_ = node_->create_client<Empty>("nav2_controller/startup");
-  pause_client_ = node_->create_client<Empty>("nav2_controller/pause");
-  resume_client_ = node_->create_client<Empty>("nav2_controller/resume");
-  shutdown_client_ = node_->create_client<Empty>("nav2_controller/shutdown");
+  startup_client_ = node_->create_client<Empty>("lifecycle_manager/startup");
+  pause_client_ = node_->create_client<Empty>("lifecycle_manager/pause");
+  resume_client_ = node_->create_client<Empty>("lifecycle_manager/resume");
+  shutdown_client_ = node_->create_client<Empty>("lifecycle_manager/shutdown");
 
   navigate_action_client_ =
     rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(node_, "NavigateToPose");
@@ -44,31 +44,31 @@ Nav2ControllerClient::Nav2ControllerClient()
 }
 
 void
-Nav2ControllerClient::startup()
+LifecycleManagerClient::startup()
 {
-  callService(startup_client_, "nav2_controller/startup");
+  callService(startup_client_, "lifecycle_manager/startup");
 }
 
 void
-Nav2ControllerClient::shutdown()
+LifecycleManagerClient::shutdown()
 {
-  callService(shutdown_client_, "nav2_controller/shutdown");
+  callService(shutdown_client_, "lifecycle_manager/shutdown");
 }
 
 void
-Nav2ControllerClient::pause()
+LifecycleManagerClient::pause()
 {
-  callService(pause_client_, "nav2_controller/pause");
+  callService(pause_client_, "lifecycle_manager/pause");
 }
 
 void
-Nav2ControllerClient::resume()
+LifecycleManagerClient::resume()
 {
-  callService(resume_client_, "nav2_controller/resume");
+  callService(resume_client_, "lifecycle_manager/resume");
 }
 
 geometry_msgs::msg::Quaternion
-Nav2ControllerClient::orientationAroundZAxis(double angle)
+LifecycleManagerClient::orientationAroundZAxis(double angle)
 {
   tf2::Quaternion q;
   q.setRPY(0, 0, angle);  // void returning function
@@ -76,7 +76,7 @@ Nav2ControllerClient::orientationAroundZAxis(double angle)
 }
 
 void
-Nav2ControllerClient::set_initial_pose(double x, double y, double theta)
+LifecycleManagerClient::set_initial_pose(double x, double y, double theta)
 {
   const double PI = 3.141592653589793238463;
   geometry_msgs::msg::PoseWithCovarianceStamped pose;
@@ -95,7 +95,7 @@ Nav2ControllerClient::set_initial_pose(double x, double y, double theta)
 }
 
 bool
-Nav2ControllerClient::navigate_to_pose(double x, double y, double theta)
+LifecycleManagerClient::navigate_to_pose(double x, double y, double theta)
 {
   navigate_action_client_->wait_for_action_server();
 
@@ -140,11 +140,11 @@ Nav2ControllerClient::navigate_to_pose(double x, double y, double theta)
 }
 
 void
-Nav2ControllerClient::callService(
+LifecycleManagerClient::callService(
   rclcpp::Client<Empty>::SharedPtr service_client,
   const char * service_name)
 {
-  RCLCPP_INFO(node_->get_logger(), "Waiting for the nav2_controller's %s service...", service_name);
+  RCLCPP_INFO(node_->get_logger(), "Waiting for the lifecycle_manager's %s service...", service_name);
   while (!service_client->wait_for_service(std::chrono::seconds(1))) {
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(node_->get_logger(), "Client interrupted while waiting for service to appear");
@@ -153,9 +153,9 @@ Nav2ControllerClient::callService(
     RCLCPP_INFO(node_->get_logger(), "Waiting for service to appear...");
   }
 
-  RCLCPP_INFO(node_->get_logger(), "send_async_request (%s) to the nav2_controller", service_name);
+  RCLCPP_INFO(node_->get_logger(), "send_async_request (%s) to the lifecycle_manager", service_name);
   auto future_result = service_client->async_send_request(request_);
   rclcpp::spin_until_future_complete(node_, future_result);
 }
 
-}  // namespace nav2_controller
+}  // namespace nav2_lifecycle_manager

--- a/nav2_lifecycle_manager/src/main.cpp
+++ b/nav2_lifecycle_manager/src/main.cpp
@@ -14,13 +14,13 @@
 
 #include <memory>
 
-#include "nav2_controller/nav2_controller.hpp"
+#include "nav2_lifecycle_manager/lifecycle_manager.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<nav2_controller::Nav2Controller>();
+  auto node = std::make_shared<nav2_lifecycle_manager::LifecycleManager>();
   rclcpp::spin(node->get_node_base_interface());
   rclcpp::shutdown();
 

--- a/nav2_rviz_plugins/CMakeLists.txt
+++ b/nav2_rviz_plugins/CMakeLists.txt
@@ -16,8 +16,8 @@ set(CMAKE_AUTOMOC ON)
 
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(nav2_controller REQUIRED)
 find_package(nav2_lifecycle REQUIRED)
+find_package(nav2_lifecycle_manager REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
@@ -53,8 +53,8 @@ add_library(${library_name} SHARED
 
 set(dependencies
   geometry_msgs
-  nav2_controller
   nav2_lifecycle
+  nav2_lifecycle_manager
   nav2_msgs
   nav2_msgs
   nav_msgs

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -15,10 +15,10 @@
 #ifndef NAV2_RVIZ_PLUGINS__NAV2_PANEL_HPP_
 #define NAV2_RVIZ_PLUGINS__NAV2_PANEL_HPP_
 
-#include "nav2_controller/nav2_controller_client.hpp"
-#include "rviz_common/panel.hpp"
-
 #include <QtWidgets>
+
+#include "nav2_lifecycle_manager/lifecycle_manager_client.hpp"
+#include "rviz_common/panel.hpp"
 
 class QPushButton;
 
@@ -50,7 +50,7 @@ private:
   void loadLogFiles();
 
   // The client used to control the nav2 stack
-  nav2_controller::Nav2ControllerClient client_;
+  nav2_lifecycle_manager::LifecycleManagerClient client_;
 
   QPushButton * start_stop_button_{nullptr};
   QPushButton * pause_resume_button_{nullptr};

--- a/nav2_rviz_plugins/package.xml
+++ b/nav2_rviz_plugins/package.xml
@@ -11,8 +11,8 @@
   <build_depend>qtbase5-dev</build_depend>
 
   <depend>geometry_msgs</depend>
-  <depend>nav2_controller</depend>
   <depend>nav2_lifecycle</depend>
+  <depend>nav2_lifecycle_manager</depend>
   <depend>nav2_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -112,28 +112,28 @@ void
 Nav2Panel::onStartup()
 {
   QFuture<void> future =
-    QtConcurrent::run(std::bind(&nav2_controller::Nav2ControllerClient::startup, &client_));
+    QtConcurrent::run(std::bind(&nav2_lifecycle_manager::LifecycleManagerClient::startup, &client_));
 }
 
 void
 Nav2Panel::onShutdown()
 {
   QFuture<void> future =
-    QtConcurrent::run(std::bind(&nav2_controller::Nav2ControllerClient::shutdown, &client_));
+    QtConcurrent::run(std::bind(&nav2_lifecycle_manager::LifecycleManagerClient::shutdown, &client_));
 }
 
 void
 Nav2Panel::onPause()
 {
   QFuture<void> future =
-    QtConcurrent::run(std::bind(&nav2_controller::Nav2ControllerClient::pause, &client_));
+    QtConcurrent::run(std::bind(&nav2_lifecycle_manager::LifecycleManagerClient::pause, &client_));
 }
 
 void
 Nav2Panel::onResume()
 {
   QFuture<void> future =
-    QtConcurrent::run(std::bind(&nav2_controller::Nav2ControllerClient::resume, &client_));
+    QtConcurrent::run(std::bind(&nav2_lifecycle_manager::LifecycleManagerClient::resume, &client_));
 }
 
 void

--- a/nav2_rviz_plugins/src/navigation_dialog.cpp
+++ b/nav2_rviz_plugins/src/navigation_dialog.cpp
@@ -42,7 +42,7 @@ NavigationDialog::onCancelButtonPressed()
 NavigationDialog::NavigationDialog(QWidget * parent)
 : QDialog(parent)
 {
-  client_node_ = std::make_shared<rclcpp::Node>("nav_to_pose_action_client");
+  client_node_ = std::make_shared<rclcpp::Node>("navigation_dialog_action_client");
   action_client_ = rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(client_node_,
       "NavigateToPose");
   goal_ = nav2_msgs::action::NavigateToPose::Goal();


### PR DESCRIPTION
## Description

* Per review feedback, to avoid potential confusion, rename the nav2_controller to be nav2_lifecycle_manger. 

## Future Work
* Will integrate the headers that are currently in nav2_lifecycle into nav2_util. There are only a couple there and they will eventually become obsolete. This will help keep down the number of directories. 