### PR TITLE
Fixed for auto localization 

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -537,6 +537,7 @@ AmclNode::globalLocalizationCallback(
     return;
   }
 
+  initial_pose_received = true;
   std::lock_guard<std::recursive_mutex> gl(configuration_mutex_);
 
   RCLCPP_INFO(get_logger(), "Initializing with uniform distribution");


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (fixes #635 ) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (TB3 Gazebo simulation) |

---

## Description of contribution in a few bullet points

In PR #630 if 'initial_pose_received' flag is not set, amcl will not publish a pose.   Therefore, for Auto Localization we have to set this flag manually in global localization callback since the initial pose is never expected to be received. 

---


