### PR TITLE
Use namespaces on costmap nodes so that pub/subs can co-exist

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -83,25 +83,26 @@ dwb_controller:
     GoalDist.scale: 24.0
     RotateToGoal.scale: 32.0
 
-dwb_controller_local_costmap:
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      use_sim_time: True
+      robot_radius: 0.092
+      obstacle_layer:
+        enabled: False
+      always_send_full_costmap: True
+      observation_sources: scan
+      scan:
+        topic: /scan
+        max_obstacle_height: 2.0
+        clearing: True
+        marking: True
+
+local_costmap_client:
   ros__parameters:
     use_sim_time: True
-    robot_radius: 0.092
-    obstacle_layer:
-      enabled: False
-    always_send_full_costmap: True
-    observation_sources: scan
-    scan:
-      topic: /scan
-      max_obstacle_height: 2.0
-      clearing: True
-      marking: True
 
-dwb_controller_local_costmap_client:
-  ros__parameters:
-    use_sim_time: True
-
-dwb_controller_local_costmap_rclcpp_node:
+local_costmap_rclcpp_node:
   ros__parameters:
     use_sim_time: True
 
@@ -110,11 +111,15 @@ map_server:
     use_sim_time: True
     yaml_filename: "turtlebot3_world.yaml"
 
-nav2_controller:
+lifecycle_manager:
   ros__parameters:
     use_sim_time: True
 
-nav2_controller_lifecycle_client_node:
+lifecycle_manager_service_client:
+  ros__parameters:
+    use_sim_time: True
+
+lifecycle_manager_client_service_client:
   ros__parameters:
     use_sim_time: True
 
@@ -140,23 +145,25 @@ world_model:
   ros__parameters:
     use_sim_time: True
 
-world_model_global_costmap:
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      use_sim_time: True
+      robot_radius: 0.092
+      obstacle_layer:
+        enabled: False
+      always_send_full_costmap: True
+      observation_sources: scan
+      scan:
+        topic: /scan
+        max_obstacle_height: 2.0
+        clearing: True
+        marking: True
+
+global_costmap_client:
   ros__parameters:
     use_sim_time: True
-    obstacle_layer:
-      enabled: False
-    always_send_full_costmap: True
-    observation_sources: scan
-    scan:
-      topic: /scan
-      max_obstacle_height: 2.0
-      clearing: True
-      marking: True
 
-world_model_global_costmap_client:
-  ros__parameters:
-    use_sim_time: True
-
-world_model_global_costmap_rclcpp_node:
+global_costmap_rclcpp_node:
   ros__parameters:
     use_sim_time: True

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -53,7 +53,7 @@ namespace nav2_costmap_2d
 {
 
 Costmap2DROS::Costmap2DROS(const std::string & name)
-: nav2_lifecycle::LifecycleNode(name, "", true), name_(name)
+: nav2_lifecycle::LifecycleNode(name, name, true), name_(name)
 {
   RCLCPP_INFO(get_logger(), "Creating");
   client_node_ = std::make_shared<rclcpp::Node>(name + "_client");

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -31,7 +31,7 @@ DwbController::DwbController()
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
-  costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>("dwb_controller_local_costmap");
+  costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>("local_costmap");
   costmap_thread_ = std::make_unique<std::thread>(
     [](rclcpp_lifecycle::LifecycleNode::SharedPtr node)
     {rclcpp::spin(node->get_node_base_interface());}, costmap_ros_);

--- a/nav2_lifecycle/src/lifecycle_node.cpp
+++ b/nav2_lifecycle/src/lifecycle_node.cpp
@@ -45,7 +45,7 @@ LifecycleNode::LifecycleNode(
   use_rclcpp_node_(use_rclcpp_node)
 {
   if (use_rclcpp_node_) {
-    rclcpp_node_ = std::make_shared<rclcpp::Node>(node_name + "_rclcpp_node", namespace_);
+    rclcpp_node_ = std::make_shared<rclcpp::Node>(node_name + "_rclcpp_node");
     rclcpp_thread_ = std::make_unique<std::thread>(
       [](rclcpp::Node::SharedPtr node) {rclcpp::spin(node);}, rclcpp_node_
     );

--- a/nav2_system_tests/params/nav2_params.yaml
+++ b/nav2_system_tests/params/nav2_params.yaml
@@ -1,7 +1,8 @@
 map_server:
   ros__parameters:
     yaml_filename: "test_map.yaml"
-DwbController:
+
+dwb_controller:
   ros__parameters:
     debug_trajectory_details: True
     min_vel_x: -0.26
@@ -26,11 +27,13 @@ DwbController:
     PathDist.scale: 32.0
     GoalDist.scale: 24.0
     RotateToGoal.scale: 32.0
+
 local_costmap:
   local_costmap:
     ros__parameters:
       robot_radius: 0.092
       always_send_full_costmap: True
+
 global_costmap:
   global_costmap:
     ros__parameters:

--- a/nav2_world_model/src/world_model.cpp
+++ b/nav2_world_model/src/world_model.cpp
@@ -25,7 +25,7 @@ WorldModel::WorldModel()
   RCLCPP_INFO(get_logger(), "Creating");
 
   // The costmap node is used in the implementation of the world model
-  costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>("world_model_global_costmap");
+  costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
 
   // Launch a thread to run the costmap node
   costmap_thread_ = std::make_unique<std::thread>(


### PR DESCRIPTION
## Description

* When implementing lifecycle nodes I removed the namespace from the costmap(s) not realizing that the namespaces are required so that the publishers and subscribers from each costmap instance remain separate. This PR restores the namespaces and costmap node names as before. 
* Not using namespaces for the utility nodes (those that are created simply for the purpose of calling a service, for example)
* Updated the lifecycle manager node name

## Future work

* There will be subsequent changes to the nav2_params.yaml file as we rebase with the master branch and get things in sync