### PR TITLE
Fix "no valid trajectories" when obstacle on path

### DIFF
--- a/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
@@ -47,17 +47,8 @@ namespace dwb_critics
 {
 
 // Customization of the CostmapQueue validCellToQueue method
-bool MapGridCritic::MapGridQueue::validCellToQueue(const costmap_queue::CellData & cell)
+bool MapGridCritic::MapGridQueue::validCellToQueue(const costmap_queue::CellData & /*cell*/)
 {
-  unsigned char cost = costmap_.getCost(cell.x_, cell.y_);
-  if (cost == nav2_costmap_2d::LETHAL_OBSTACLE ||
-    cost == nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE ||
-    cost == nav2_costmap_2d::NO_INFORMATION)
-  {
-    parent_.setAsObstacle(cell.index_);
-    return false;
-  }
-
   return true;
 }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 in Gazebo |

---

## Description of contribution in a few bullet points

* There is a flaw in the Goal* critics that cause them to reject valid trajectories. This is most easily reproduced by "navigating to pose" and then dropping an obstacle onto the path some distance ahead of the robot. DWB will fail well before it reaches the obstacle saying no valid trajectories were found.
* The root cause is in the way the Goal* critics expand their cost function. They add a 0 cost goal cell and then expand out from their add 1 to the cost at each step. However there is an optimization in the expansion that skips cells that are invalid. When the goal itself is invalid, absolutely no cells get enqueued and the Goal* critics think every trajectory hits an unknown area.
* This PR removes that optimization. It's still a WIP because I'd like to fix this in a way that doesn't hurt performance, but if there is no time, I'd like to still add this PR as is to the dashing release because it fixes a fairly major bug.