### PR TITLE
Revert "Get the build working again"

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -38,10 +38,7 @@
 #include "nav_msgs/srv/get_map.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "std_srvs/srv/empty.hpp"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
 #include "tf2_ros/transform_broadcaster.h"
-#pragma GCC diagnostic pop
 #include "tf2_ros/transform_listener.h"
 #include "nav2_util/sensors/laser/laser.hpp"
 #include "nav2_util/motion_model/motion_model.hpp"

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -43,6 +43,7 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/message_filter.h"
+#include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
 #include "message_filters/subscriber.h"
 


### PR DESCRIPTION
Reverts ros-planning/navigation2#701

ros2/geometry2#112 has been integrated upstream. This change should no longer be needed.