### PR TITLE
Safety Monitor

### DIFF
--- a/nav2_safety_monitor/CMakeLists.txt
+++ b/nav2_safety_monitor/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.5)
+project(nav2_safety_monitor)
+
+find_package(ament_cmake REQUIRED)
+find_package(nav2_common REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(laser_geometry REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+nav2_package()
+
+include_directories(
+  include
+)
+
+add_library(nav2_safety_monitor SHARED
+  src/nav2_safety_monitor.cpp
+  src/sensors/laser.cpp
+  src/sensors/sonar.cpp
+  src/sensors/contact.cpp
+)
+
+ament_target_dependencies(nav2_safety_monitor
+  rclcpp
+  sensor_msgs
+  tf2_ros
+  laser_geometry
+  std_msgs
+  geometry_msgs
+)
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY include/
+  DESTINATION include/
+)
+
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+
+ament_package()

--- a/nav2_safety_monitor/README.md
+++ b/nav2_safety_monitor/README.md
@@ -23,7 +23,7 @@ process:
         type: sonar
         topic: sonar_2
       bump:
-        type: collision
+        type: contact
         topic: bump
       collision_zone: [0.1, 0.1, 0.0, 0.0]
       safety_zone: [0.3, 0.3, 0.0, 0.0]

--- a/nav2_safety_monitor/README.md
+++ b/nav2_safety_monitor/README.md
@@ -1,0 +1,68 @@
+# Nav2 Safety Monitor
+
+`nav2_safety_monitor` is a package containing an implementation of a collision monitor for use of a 2D laser scanner, sonars, and contact/bump sensors, the main 3 "safety" sensors on a robot. More can be easily added by creating an instance of the SafetySensor abstract class. 
+
+It looks at the range values of obstacles in a configurable box. If the laser has returns in this box, the robot will be commanded to stop until the obstacle is gone or a timeout is achieved. For contact sensors, it looks for the boolean if in contact to stop. For sonars/range sensors, it is dependent on the non-zero ranges whether it falls into the safety (slow down) region or the collision region. Parameters for all can be seen in the example below.
+
+This may be an issue if you plan to get very close to obstacles and have a large collision box configuration. For applications where docking/interacting with items is required, a service is exposed so that the monitor can be toggled on or off as needed for specific maneuvers and get that state from an application level. 
+
+```
+Fully described parameter for the process this belongs to
+
+process:
+  process:
+    ros__parameters:
+      sensors: [laser, sonar1, sonar2, bump]
+      laser:
+        type: laser
+        topic: scan
+      sonar1:
+        type: sonar
+        topic: sonar_1
+      sonar2:
+        type: sonar
+        topic: sonar_2
+      bump:
+        type: collision
+        topic: bump
+      collision_zone: [0.1, 0.1, 0.0, 0.0]
+      safety_zone: [0.3, 0.3, 0.0, 0.0]
+      safety_timeout: 120.0
+      scan_timeout: 1.0
+      sonar_timeout: 1.0
+      global_frame: base_link
+      sonar_safety_range: 0.3
+      sonar_collision_range: 0.1
+```
+
+Example useage:
+
+```
+#include <nav2_safety_monitor/nav2_safety_monitor.hpp>
+
+auto node = ...
+
+nav2_safety_monitor::SafetyMonitor monitor(node);
+action_in_progress = true;
+
+while (rclcpp.ok() && action_in_progress) {
+
+  // do some stuff with a planner, controller, actuators, ... 
+
+  if (!monitor.isActive()) {
+    monitor.activate();
+  }
+
+  monitor.process();
+  if (monitor.isInCollisionZone()) {
+    // STOP!
+  } else if (monitor.isInSafetyZone()) {
+    // lower velocity scale to limit speed
+  }
+
+  if (success) {
+    action_in_progress = false;
+  }
+}
+
+```

--- a/nav2_safety_monitor/include/nav2_safety_monitor/laser_boxes.hpp
+++ b/nav2_safety_monitor/include/nav2_safety_monitor/laser_boxes.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Steve Macenski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_SAFETY_MONITOR__LASER_BOXES_HPP_
+#define NAV2_SAFETY_MONITOR__LASER_BOXES_HPP_
+
+namespace nav2_safety_monitor
+{
+
+struct LaserBoxes
+{
+  LaserBoxes() {
+    return;
+  }
+  
+  LaserBoxes(std::vector<double>& vals) {
+    width = vals.at(0);
+    length = vals.at(1);
+    offset_x = vals.at(2);
+    offset_y = vals.at(3);
+  }
+
+  double offset_x, offset_y;
+  double width, length;
+};
+
+} // end namespace nav2_safety_monitor
+
+#endif //NAV2_SAFETY_MONITOR__LASER_BOXES_HPP_

--- a/nav2_safety_monitor/include/nav2_safety_monitor/nav2_safety_monitor.hpp
+++ b/nav2_safety_monitor/include/nav2_safety_monitor/nav2_safety_monitor.hpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2019 Steve Macenski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_SAFETY_MONITOR__NAV2_SAFETY_MONITOR_HPP_
+#define NAV2_SAFETY_MONITOR__NAV2_SAFETY_MONITOR_HPP_
+
+#include <string>
+#include <memory>
+#include <std_srvs/srv/empty.hpp>
+#include "nav2_safety_monitor/sensors/abstract_sensor.hpp"
+#include "nav2_safety_monitor/sensors/laser.hpp"
+#include "nav2_safety_monitor/sensors/sonar.hpp"
+#include "nav2_safety_monitor/sensors/contact.hpp"
+
+namespace nav2_safety_monitor
+{
+
+class SafetyMonitor
+{
+public:
+  explicit SafetyMonitor(rclcpp::Node::SharedPtr & node);
+  SafetyMonitor() = delete;
+  ~SafetyMonitor();
+
+  // getters for states of collision based on readings
+  bool isInCollisionZone();
+  bool isInSafetyZone();
+
+  // process a laser scan, separated such that to run the check
+  void process();
+
+  // state info
+  bool isActive();
+  void activate();
+  void deactivate();
+
+protected:
+  // Subscription callbacks
+  void toggleCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
+    const std::shared_ptr<std_srvs::srv::Empty::Response> response);
+
+  // The ROS node to use to create publishers and subscribers
+  rclcpp::Node::SharedPtr node_;
+
+  // ROS interfaces
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr toggle_server_;
+
+  // state and sensors
+  bool active_;
+  std::vector<std::unique_ptr<SafetySensor> > safety_sensors_;
+};
+
+}  // namespace nav2_safety_monitor
+
+#endif  // NAV2_SAFETY_MONITOR__NAV2_SAFETY_MONITOR_HPP_

--- a/nav2_safety_monitor/include/nav2_safety_monitor/sensors/abstract_sensor.hpp
+++ b/nav2_safety_monitor/include/nav2_safety_monitor/sensors/abstract_sensor.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 Steve Macenski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_SAFETY_MONITOR__ABSTRACT_SENSOR_HPP_
+#define NAV2_SAFETY_MONITOR__ABSTRACT_SENSOR_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+enum class SafetyState {
+  UNKNOWN = 0,
+  FREE = 1,
+  SLOW = 2,
+  COLLISION = 3
+};
+
+class SafetySensor
+{
+
+public:
+  SafetySensor(rclcpp::Node::SharedPtr & node, std::string /*topic*/)
+  : node_(node), current_state_(SafetyState::UNKNOWN) {};
+
+  virtual ~SafetySensor() {return;};
+  
+  virtual void process() = 0;
+  virtual SafetyState getState() = 0;
+
+protected:
+  // The ROS node to use to create publishers and subscribers
+  rclcpp::Node::SharedPtr node_;
+  
+  // Current state of collision
+  SafetyState current_state_;
+};
+
+#endif

--- a/nav2_safety_monitor/include/nav2_safety_monitor/sensors/contact.hpp
+++ b/nav2_safety_monitor/include/nav2_safety_monitor/sensors/contact.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 Steve Macenski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_SAFETY_MONITOR__CONTACT_SENSOR_HPP_
+#define NAV2_SAFETY_MONITOR__CONTACT_SENSOR_HPP_
+
+#include <string>
+#include <memory>
+#include "std_msgs/msg/bool.hpp"
+#include "nav2_safety_monitor/sensors/abstract_sensor.hpp"
+
+namespace nav2_safety_monitor
+{
+
+class ContactSensor : public SafetySensor
+{
+public:
+  ContactSensor(rclcpp::Node::SharedPtr & node, std::string topic);
+
+  virtual void process();
+  virtual SafetyState getState();
+
+protected:
+  // Subscription callbacks
+  void bumpCallback(const std_msgs::msg::Bool::SharedPtr msg);
+
+  // subscribers
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr contact_sub_;
+  std_msgs::msg::Bool::SharedPtr current_measurement_;
+};
+
+} // end namespace nav2_safety_monitor
+
+#endif // NAV2_SAFETY_MONITOR__CONTACT_SENSOR_HPP_

--- a/nav2_safety_monitor/include/nav2_safety_monitor/sensors/laser.hpp
+++ b/nav2_safety_monitor/include/nav2_safety_monitor/sensors/laser.hpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 Steve Macenski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_SAFETY_MONITOR__LASER_SENSOR_HPP_
+#define NAV2_SAFETY_MONITOR__LASER_SENSOR_HPP_
+
+#include <string>
+#include <memory>
+#include "tf2_ros/buffer.h"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "geometry_msgs/msg/polygon_stamped.hpp"
+#include "laser_geometry/laser_geometry.hpp"
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include "nav2_safety_monitor/laser_boxes.hpp"
+#include "nav2_safety_monitor/sensors/abstract_sensor.hpp"
+
+namespace nav2_safety_monitor
+{
+
+class LaserSensor : public SafetySensor
+{
+public:
+  LaserSensor(rclcpp::Node::SharedPtr & node, std::string topic);
+
+  virtual void process();
+  virtual SafetyState getState();
+
+  // set the safety and collision zones
+  void setZones(const LaserBoxes & safety_zone, const LaserBoxes & collision_zone);
+
+protected:
+  // read and manipulate safety zones from params
+  void getSafetyZone();
+  void populateZoneMessages();
+
+  bool isPtInSafetyZone(const double & x, const double & y);
+  bool isPtInCollisionZone(const double & x, const double & y);
+  bool IsPtInZone(const double & x, const double & y, const LaserBoxes & region);
+
+  // Subscription callbacks
+  void laserCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg);
+
+  // subscriber and publisher
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr laser_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr safety_zone_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr collision_zone_pub_;
+  
+  // The current laser scan as received from the Laser subscription
+  sensor_msgs::msg::LaserScan::SharedPtr current_scan_;
+
+  // projector
+  laser_geometry::LaserProjection projector_;
+  std::unique_ptr<tf2_ros::Buffer> tf_;
+
+  // Boxes for safety and collision zones
+  LaserBoxes safety_zone_;
+  LaserBoxes collision_zone_;
+  geometry_msgs::msg::PolygonStamped poly_safety_, poly_collision_;
+
+  // Timeouts after which to ignore safety state
+  rclcpp::Duration safety_timeout_;
+  rclcpp::Duration scan_timeout_;
+  rclcpp::Time collision_start_time_;
+
+  std::string global_frame_;
+};
+
+} // end namespace nav2_safety_monitor
+
+#endif // NAV2_SAFETY_MONITOR__LASER_SENSOR_HPP_

--- a/nav2_safety_monitor/include/nav2_safety_monitor/sensors/sonar.hpp
+++ b/nav2_safety_monitor/include/nav2_safety_monitor/sensors/sonar.hpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2019 Steve Macenski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_SAFETY_MONITOR__SONAR_SENSOR_HPP_
+#define NAV2_SAFETY_MONITOR__SONAR_SENSOR_HPP_
+
+#include <string>
+#include <memory>
+#include <sensor_msgs/msg/range.hpp>
+#include "nav2_safety_monitor/sensors/abstract_sensor.hpp"
+
+namespace nav2_safety_monitor
+{
+
+class SonarSensor : public SafetySensor
+{
+public:
+  SonarSensor(rclcpp::Node::SharedPtr & node, std::string topic);
+
+  virtual void process();
+  virtual SafetyState getState();
+
+protected:
+  // Subscription callbacks
+  void sonarCallback(const sensor_msgs::msg::Range::SharedPtr msg);
+
+  // subscribers
+  rclcpp::Subscription<sensor_msgs::msg::Range>::SharedPtr sonar_sub_;
+  sensor_msgs::msg::Range::SharedPtr current_measurement_;
+
+  // params
+  double sonar_collision_range_, sonar_safety_range_;
+
+  // Timeouts after which to ignore safety state
+  rclcpp::Duration safety_timeout_;
+  rclcpp::Duration sonar_timeout_;
+  rclcpp::Time collision_start_time_;
+};
+
+} // end namespace nav2_safety_monitor
+
+#endif // NAV2_SAFETY_MONITOR__CONTACT_SENSOR_HPP_

--- a/nav2_safety_monitor/package.xml
+++ b/nav2_safety_monitor/package.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nav2_safety_monitor</name>
+  <version>0.1.5</version>
+  <description>an implementation of a loop-speed sensor-based safety collision monitor</description>
+  <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>nav2_common</build_depend>
+
+  <build_depend>rclcpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>laser_geometry</build_depend>
+  <build_depend>tf2_ros</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>laser_geometry</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_testing</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/nav2_safety_monitor/src/nav2_safety_monitor.cpp
+++ b/nav2_safety_monitor/src/nav2_safety_monitor.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) 2019 Steve Macenski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_safety_monitor/nav2_safety_monitor.hpp"
+
+namespace nav2_safety_monitor
+{
+
+SafetyMonitor::SafetyMonitor(rclcpp::Node::SharedPtr & node)
+: node_(node), active_(true)
+{
+  toggle_server_ = node_->create_service<std_srvs::srv::Empty>("toggle_safety_monitor",
+    std::bind(&SafetyMonitor::toggleCallback, this,
+    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+
+  std::string topic, config_type;
+  node_->get_parameter_or<std::string>("laser_topic", topic, std::string("scan"));
+  safety_sensors_.push_back(new LaserSensor(node_, topic));
+
+  rclcpp::Parameter sensors_param = node_->get_parameter("sensors");
+  std::vector<std::string> sensors_configs = sensors_param.as_string_array();
+
+  for (uint i=0; i != sensors_configs.size(); i++) {
+    config_type = std::string("");
+    topic = std::string("");
+    node_->get_parameter<std::string>(sensors_configs[i] + "." + "type", config_type);
+    node_->get_parameter<std::string>(sensors_configs[i] + "." + "topic", topic);
+
+    if (topic == std::string("") || config_type == std::string("")) {
+      RCLCPP_WARN(node_->get_logger(), "No topic given for config %s.", sensors_configs[i].c_str());
+    }
+
+    if (config_type == std::string("laser")) {
+      RCLCPP_INFO(node_->get_logger(), "Creating laser sensor of topic: %s.", topic.c_str());
+      safety_sensors_.push_back(std::make_unique<LaserSensor>(node_, topic));
+    } else if (config_type == std::string("collision")) {
+      RCLCPP_INFO(node_->get_logger(), "Creating collision sensor of topic: %s.", topic.c_str());
+      safety_sensors_.push_back(std::make_unique<CollisionSensor>(node_, topic));
+    } else if (config_type == std::string("sonar")) {
+      RCLCPP_INFO(node_->get_logger(), "Creating sonar sensor of topic: %s.", topic.c_str());
+      safety_sensors_.push_back(std::make_unique<SonarSensor>(node_, topic));
+    } else {
+      RCLCPP_WARN(node_->get_logger(), "Config: %s's type: %s is invalid. "
+        "Options are: laser, collision, or sonar.", sensors_configs[i].c_str(), config_type.c_str());
+    }
+  }
+}
+
+SafetyMonitor::~SafetyMonitor()
+{
+}
+
+void
+SafetyMonitor::toggleCallback(
+  const std::shared_ptr<rmw_request_id_t> /*request_header*/,
+  const std::shared_ptr<std_srvs::srv::Empty::Request> /*request*/,
+  const std::shared_ptr<std_srvs::srv::Empty::Response> /*response*/)
+{
+  active_ = !active_;
+  RCLCPP_INFO(node_->get_logger(), "Toggling to %s",
+    active_ ? "active" : "inactive");
+}
+
+void
+SafetyMonitor::process()
+{
+  std::vector<SafetySensor*>::const_iterator sensor = safety_sensors_.begin();
+  for ( ; sensor != safety_sensors_.end(); ++sensor) {
+    (*sensor)->process();
+  }
+}
+
+bool
+SafetyMonitor::isInCollisionZone()
+{
+  if (!active_) {
+    return false;
+  }
+
+  std::vector<SafetySensor*>::const_iterator sensor = safety_sensors_.begin();
+
+  for ( ; sensor != safety_sensors_.end(); ++sensor) {
+    if ((*sensor)->getState() == SafetyState::COLLISION) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool
+SafetyMonitor::isInSafetyZone()
+{
+  if (!active_) {
+    return false;
+  }
+
+  std::vector<SafetySensor*>::const_iterator sensor = safety_sensors_.begin();
+
+  for ( ; sensor != safety_sensors_.end(); ++sensor) {
+    if ((*sensor)->getState() == SafetyState::SLOW) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool
+SafetyMonitor::isActive()
+{
+  return active_;
+}
+
+void
+SafetyMonitor::activate()
+{
+  active_ = true;
+}
+
+void
+SafetyMonitor::deactivate()
+{
+  active_ = false;
+}
+
+}  // namespace nav2_safety_monitor

--- a/nav2_safety_monitor/src/sensors/contact.cpp
+++ b/nav2_safety_monitor/src/sensors/contact.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 Steve Macenski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_safety_monitor/sensors/contact.hpp"
+
+namespace nav2_safety_monitor
+{
+
+ContactSensor::ContactSensor(rclcpp::Node::SharedPtr & node, std::string topic)
+: SafetySensor(node, topic)
+{
+  contact_sub_ = node_->create_subscription<std_msgs::msg::Bool>(
+    topic, std::bind(&ContactSensor::bumpCallback,
+    this, std::placeholders::_1));
+}
+
+void
+ContactSensor::process()
+{
+  if (current_measurement_->data) {
+    RCLCPP_INFO(node_->get_logger(),"Stopping due to imminent collision!");
+    current_state_ = SafetyState::COLLISION;
+  } else {
+    current_state_ = SafetyState::FREE;
+  }
+}
+
+SafetyState
+ContactSensor::getState()
+{
+  if (current_state_ == SafetyState::UNKNOWN) {
+    return SafetyState::FREE;
+  }
+
+  return current_state_;
+}
+
+void
+ContactSensor::bumpCallback(const std_msgs::msg::Bool::SharedPtr msg)
+{
+  current_measurement_ = msg;
+}
+
+} // end namespace nav2_safety_monitor

--- a/nav2_safety_monitor/src/sensors/laser.cpp
+++ b/nav2_safety_monitor/src/sensors/laser.cpp
@@ -1,0 +1,240 @@
+// Copyright (c) 2019 Steve Macenski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_safety_monitor/sensors/laser.hpp"
+
+namespace nav2_safety_monitor
+{
+
+LaserSensor::LaserSensor(rclcpp::Node::SharedPtr & node, std::string topic)
+: SafetySensor(node, topic), tf_(nullptr),
+  safety_timeout_(0.0, 0.0), scan_timeout_(0.0, 0.0)
+{
+  tf_ = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
+
+  laser_sub_ = node_->create_subscription<sensor_msgs::msg::LaserScan>(
+    topic, std::bind(&LaserSensor::laserCallback,
+    this, std::placeholders::_1));
+  safety_zone_pub_ = node_->create_publisher<geometry_msgs::msg::PolygonStamped>(
+    "safety_zone", 1);
+  collision_zone_pub_ = node_->create_publisher<geometry_msgs::msg::PolygonStamped>(
+    "collision_zone", 1);
+
+  double safety_timeout_sec, scan_timeout_sec;
+  node_->get_parameter_or<double>("safety_timeout", safety_timeout_sec, 120.0);
+  node_->get_parameter_or<double>("scan_timeout", scan_timeout_sec, 10.0);
+  node_->get_parameter_or<std::string>("global_frame", global_frame_, "base_link");
+  safety_timeout_ = rclcpp::Duration(safety_timeout_sec, 0.0);
+  scan_timeout_ = rclcpp::Duration(scan_timeout_sec, 0.0);
+
+  getSafetyZone();
+}
+
+void
+LaserSensor::process()
+{
+  bool slow_pt = false;
+  double x = 0.0, y = 0.0;
+
+  // project the scan into a point cloud
+  sensor_msgs::msg::PointCloud2 cloud;
+  cloud.header = current_scan_->header;
+  try {
+    projector_.transformLaserScanToPointCloud(global_frame_, *current_scan_,
+      cloud, *tf_);
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_DEBUG(node_->get_logger(),
+      "High fidelity enabled, but TF returned a "
+      "failed transform, trying low fidelity.");
+    projector_.projectLaser(*current_scan_, cloud);
+  }
+
+  // find if any point is in a region
+  sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(cloud, "y");
+  for ( ; iter_x != iter_x.end(); ++iter_x, ++iter_y)
+  {
+    x = *iter_x;
+    y = *iter_y;
+    if (isPtInCollisionZone(x,y)) {
+      if (current_state_ != SafetyState::COLLISION) {
+        collision_start_time_ = node_->now();
+        RCLCPP_INFO(node_->get_logger(),"Stopping due to imminent collision!");
+      }
+      current_state_ = SafetyState::COLLISION;
+      return;
+    } else if (isPtInSafetyZone(x,y)) {
+      slow_pt = true;
+    }
+  }
+
+  if (slow_pt) {
+    current_state_ = SafetyState::SLOW;
+  } else {
+    current_state_ = SafetyState::FREE;
+  }
+
+  // publish debug visualizations
+  poly_safety_.header.stamp = node_->now();
+  poly_collision_.header.stamp = node_->now();
+  safety_zone_pub_->publish(poly_safety_);
+  collision_zone_pub_->publish(poly_collision_);
+}
+
+SafetyState
+LaserSensor::getState()
+{
+  if (current_state_ == SafetyState::UNKNOWN) {
+    return SafetyState::FREE;
+  }
+
+  if (node_->now() - current_scan_->header.stamp > scan_timeout_) {
+    return SafetyState::FREE;
+  }
+
+  if (current_state_ == SafetyState::COLLISION) {
+    if (node_->now() - collision_start_time_ < safety_timeout_) {
+      return SafetyState::COLLISION;
+    } else {
+      return SafetyState::FREE;
+    }
+  }
+
+  return current_state_;
+}
+
+void
+LaserSensor::laserCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg)
+{
+  current_scan_ = msg;
+}
+
+void
+LaserSensor::getSafetyZone()
+{
+  // TODO(stevemacenski) allow for multiple zones
+  rclcpp::Parameter safety_param = node_->get_parameter("safety_zone");
+  rclcpp::Parameter collision_param = node_->get_parameter("collision_zone");
+  try {
+    std::vector<double> safety_info = safety_param.as_double_array();
+    std::vector<double> collision_info = collision_param.as_double_array();
+    if (safety_info.size() != 4 || collision_info.size() != 4) {
+      RCLCPP_WARN(node_->get_logger(), "Collision or safety zone params "
+        "are malformed. Must be array size 4 of values: "
+        "[wid, len, offset_x, offset_y]"
+        " with respect to the laser coordinates."
+        "Defaulting to sizes 0.");
+      safety_info.clear();
+      collision_info.clear();
+      safety_info.resize(4, 0.0);
+      collision_info.resize(4, 0.0);
+    }
+
+    safety_zone_ = LaserBoxes(safety_info);
+    collision_zone_ = LaserBoxes(collision_info);
+  } catch (...) {
+    RCLCPP_ERROR(node_->get_logger(), "Unable to get safety zones from file."
+      "Exiting.");
+    exit(-1);
+  }
+
+  populateZoneMessages();
+  return;
+}
+
+void
+LaserSensor::setZones(const LaserBoxes & safety_zone,
+  const LaserBoxes & collision_zone)
+{
+  RCLCPP_INFO(node_->get_logger(), "Setting new safety regions.");
+  safety_zone_ = safety_zone;
+  collision_zone_ = collision_zone;
+  populateZoneMessages();
+}
+
+void
+LaserSensor::populateZoneMessages()
+{
+  poly_safety_.header.frame_id = global_frame_;
+  poly_safety_.header.stamp = node_->now();
+  poly_collision_.header = poly_safety_.header;
+
+  poly_safety_.polygon.points.resize(5);
+  poly_collision_.polygon.points.resize(5);
+
+  double half_width = safety_zone_.width / 2.0;
+  double half_length = safety_zone_.length / 2.0;
+  double off_x = safety_zone_.offset_x;
+  double off_y = safety_zone_.offset_y;
+
+  poly_safety_.polygon.points.at(0).x = off_x - half_length;
+  poly_safety_.polygon.points.at(0).y = off_y + half_width;
+  poly_safety_.polygon.points.at(0).z = 0.05;
+  poly_safety_.polygon.points.at(1).x = off_x + half_length;
+  poly_safety_.polygon.points.at(1).y = off_y + half_width;
+  poly_safety_.polygon.points.at(1).z = 0.05;
+  poly_safety_.polygon.points.at(2).x = off_x + half_length;
+  poly_safety_.polygon.points.at(2).y = off_y - half_width;
+  poly_safety_.polygon.points.at(2).z = 0.05;
+  poly_safety_.polygon.points.at(3).x = off_x - half_length;
+  poly_safety_.polygon.points.at(3).y = off_y - half_width;
+  poly_safety_.polygon.points.at(3).z = 0.05;
+  poly_safety_.polygon.points.at(4) = poly_safety_.polygon.points.at(0);
+
+  half_width = collision_zone_.width / 2.0;
+  half_length = collision_zone_.length / 2.0;
+  off_x = collision_zone_.offset_x;
+  off_y = collision_zone_.offset_y;
+
+  poly_collision_.polygon.points.at(0).x = off_x - half_length;
+  poly_collision_.polygon.points.at(0).y = off_y + half_width;
+  poly_collision_.polygon.points.at(0).z = 0.05;
+  poly_collision_.polygon.points.at(1).x = off_x + half_length;
+  poly_collision_.polygon.points.at(1).y = off_y + half_width;
+  poly_collision_.polygon.points.at(1).z = 0.05;
+  poly_collision_.polygon.points.at(2).x = off_x + half_length;
+  poly_collision_.polygon.points.at(2).y = off_y - half_width;
+  poly_collision_.polygon.points.at(2).z = 0.05;
+  poly_collision_.polygon.points.at(3).x = off_x - half_length;
+  poly_collision_.polygon.points.at(3).y = off_y - half_width;
+  poly_collision_.polygon.points.at(3).z = 0.05;
+  poly_collision_.polygon.points.at(4) = poly_collision_.polygon.points.at(0);
+}
+
+bool
+LaserSensor::isPtInCollisionZone(const double & x, const double & y)
+{
+  return IsPtInZone(x, y, collision_zone_);
+}
+
+bool
+LaserSensor::isPtInSafetyZone(const double & x, const double & y)
+{
+  return IsPtInZone(x, y, safety_zone_);
+}
+
+bool LaserSensor::IsPtInZone(const double & x, const double & y,
+  const LaserBoxes & region)
+{
+  if (x > region.offset_x - region.length/2.0 &&
+    x < region.offset_x + region.length/2.0) {
+    if (y > region.offset_y - region.width/2.0 &&
+      y < region.offset_y + region.width/2.0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // end namespace nav2_safety_monitor

--- a/nav2_safety_monitor/src/sensors/sonar.cpp
+++ b/nav2_safety_monitor/src/sensors/sonar.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2019 Steve Macenski
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_safety_monitor/sensors/sonar.hpp"
+
+namespace nav2_safety_monitor
+{
+
+SonarSensor::SonarSensor(rclcpp::Node::SharedPtr & node, std::string topic)
+: SafetySensor(node, topic), safety_timeout_(0.,0.), sonar_timeout_(0.,0.)
+{
+  sonar_sub_ = node_->create_subscription<sensor_msgs::msg::Range>(
+    topic, std::bind(&SonarSensor::sonarCallback,
+    this, std::placeholders::_1));
+
+  node_->get_parameter_or<double>("sonar_collision_range", sonar_collision_range_, 1.0);
+  node_->get_parameter_or<double>("sonar_safety_range", sonar_safety_range_, 5.0);
+
+  double safety_timeout_sec, sonar_timeout_sec;
+  node_->get_parameter_or<double>("safety_timeout", safety_timeout_sec, 120.0);
+  node_->get_parameter_or<double>("sonar_timeout", sonar_timeout_sec, 10.0);
+  safety_timeout_ = rclcpp::Duration(safety_timeout_sec, 0.0);
+  sonar_timeout_ = rclcpp::Duration(sonar_timeout_sec, 0.0);
+}
+
+void
+SonarSensor::process()
+{
+  double range = current_measurement_->range;
+
+  if (range < sonar_collision_range_ && range > 0.0) {
+    if (current_state_ != SafetyState::COLLISION) {
+      collision_start_time_ = node_->now();
+      RCLCPP_INFO(node_->get_logger(),"Stopping due to imminent collision!");
+    }
+    current_state_ = SafetyState::COLLISION;
+  } else if (range < sonar_safety_range_ && range > 0.0) {
+    current_state_ = SafetyState::SLOW;
+  } else {
+    current_state_ = SafetyState::FREE;
+  }
+}
+
+SafetyState
+SonarSensor::getState()
+{
+  if (current_state_ == SafetyState::UNKNOWN) {
+    return SafetyState::FREE;
+  }
+
+  if (node_->now() - current_measurement_->header.stamp > sonar_timeout_) {
+    return SafetyState::FREE;
+  }
+
+  if (current_state_ == SafetyState::COLLISION) {
+    if (node_->now() - collision_start_time_ < safety_timeout_) {
+      return SafetyState::COLLISION;
+    } else {
+      return SafetyState::FREE;
+    }
+  }
+
+  return current_state_;
+}
+
+void
+SonarSensor::sonarCallback(const sensor_msgs::msg::Range::SharedPtr msg)
+{
+  current_measurement_ = msg;
+}
+
+} // end namespace nav2_safety_monitor


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | A few, I'll look up later :-) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | none, yet |

---

## Description of contribution in a few bullet points

* Implementation of a sensor-level safety monitor for use in the stack
* Simple API to include in the main action server, or add in any `while` loop for an action
* Parameter example of how to fully use
* All typical safety sensors are included: laser, sonar, bump sensors
* Example in readme
* optional timeouts for sensors not publishing or in collision region for too long to make sure robot doesnt dead lock
* May work with any number of sensors (0-N lasers, sonars, and bump sensors)
---

## Future work that may be required in bullet points

* Support multiple safety or collision regions for laser
* Support more sensors (not sure what they'd be?)
* Configs for safety zones and ranges per sensor vs. per instance

---

This PR hasn't been largely tested, this is going up here to start a discussion about where it best belongs. It resolves different conversations we've had about using the laser for special things, now this should replace and self contain all the information needed to use a typical safety sensor for at-rate collision or slow down region detection. 

It implements on the laser level collision detection like [this](https://cdn.sick.com/media/content/hac/he7/9692847570974.jpg), sonar/range via looking at some minimum range, and collision sensor by, well, collisions.