### PR TITLE
Use RCLCPP_FATAL upon a lifecycle node entering error state

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -228,7 +228,7 @@ AmclNode::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
 nav2_lifecycle::CallbackReturn
 AmclNode::on_error(const rclcpp_lifecycle::State & /*state*/)
 {
-  RCLCPP_ERROR(get_logger(), "Handling error state");
+  RCLCPP_FATAL(get_logger(), "Lifecycle node entered error state");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -145,7 +145,7 @@ BtNavigator::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
 nav2_lifecycle::CallbackReturn
 BtNavigator::on_error(const rclcpp_lifecycle::State & /*state*/)
 {
-  RCLCPP_ERROR(get_logger(), "Handling error state");
+  RCLCPP_FATAL(get_logger(), "Lifecycle node entered error state");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -237,7 +237,7 @@ Costmap2DROS::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
 nav2_lifecycle::CallbackReturn
 Costmap2DROS::on_error(const rclcpp_lifecycle::State &)
 {
-  RCLCPP_ERROR(get_logger(), "Handling error state");
+  RCLCPP_FATAL(get_logger(), "Lifecycle node entered error state");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -113,7 +113,7 @@ DwbController::on_cleanup(const rclcpp_lifecycle::State & state)
 nav2_lifecycle::CallbackReturn
 DwbController::on_error(const rclcpp_lifecycle::State &)
 {
-  RCLCPP_ERROR(get_logger(), "Handling error state");
+  RCLCPP_FATAL(get_logger(), "Lifecycle node entered error state");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_map_server/src/map_server.cpp
+++ b/nav2_map_server/src/map_server.cpp
@@ -112,7 +112,7 @@ MapServer::on_cleanup(const rclcpp_lifecycle::State & state)
 nav2_lifecycle::CallbackReturn
 MapServer::on_error(const rclcpp_lifecycle::State &)
 {
-  RCLCPP_ERROR(get_logger(), "Handling error state");
+  RCLCPP_FATAL(get_logger(), "Lifecycle node entered error state");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_mission_executor/src/mission_executor.cpp
+++ b/nav2_mission_executor/src/mission_executor.cpp
@@ -75,7 +75,7 @@ MissionExecutor::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
 nav2_lifecycle::CallbackReturn
 MissionExecutor::on_error(const rclcpp_lifecycle::State & /*state*/)
 {
-  RCLCPP_ERROR(get_logger(), "Handling error state");
+  RCLCPP_FATAL(get_logger(), "Lifecycle node entered error state");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -141,7 +141,7 @@ NavfnPlanner::on_cleanup(const rclcpp_lifecycle::State & state)
 nav2_lifecycle::CallbackReturn
 NavfnPlanner::on_error(const rclcpp_lifecycle::State &)
 {
-  RCLCPP_ERROR(get_logger(), "Handling error state");
+  RCLCPP_FATAL(get_logger(), "Lifecycle node entered error state");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_world_model/src/world_model.cpp
+++ b/nav2_world_model/src/world_model.cpp
@@ -88,7 +88,7 @@ WorldModel::on_cleanup(const rclcpp_lifecycle::State & state)
 nav2_lifecycle::CallbackReturn
 WorldModel::on_error(const rclcpp_lifecycle::State & /*state*/)
 {
-  RCLCPP_ERROR(get_logger(), "Handling error state");
+  RCLCPP_FATAL(get_logger(), "Lifecycle node entered error state");
   return nav2_lifecycle::CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
Previous review feedback recommended having the lifecycle nodes exit upon entering an error state since we're not doing any error handling yet. So, this PR converts the messages to RCLCPP_FATAL. 