### PR TITLE
Initialize variables to avoid errors in the release build

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -66,7 +66,7 @@ void LimitedAccelGenerator::initialize(const nav2_lifecycle::LifecycleNode::Shar
 
 void LimitedAccelGenerator::checkUseDwaParam(const nav2_lifecycle::LifecycleNode::SharedPtr & nh)
 {
-  bool use_dwa;
+  bool use_dwa = false;
   nh->get_parameter("use_dwa", use_dwa);
   if (!use_dwa) {
     throw nav_core2::PlannerException("Deprecated parameter use_dwa set to false. "

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -90,7 +90,7 @@ void StandardTrajectoryGenerator::initializeIterator(
 void StandardTrajectoryGenerator::checkUseDwaParam(
   const nav2_lifecycle::LifecycleNode::SharedPtr & nh)
 {
-  bool use_dwa;
+  bool use_dwa = true;
   nh->get_parameter("use_dwa", use_dwa);
   if (use_dwa) {
     throw nav_core2::PlannerException("Deprecated parameter use_dwa set to true. "

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
@@ -89,7 +89,7 @@ param_t loadParameterWithDeprecation(
   const nav2_lifecycle::LifecycleNode::SharedPtr & nh, const std::string current_name,
   const std::string old_name, const param_t & default_value)
 {
-  param_t value;
+  param_t value = 0;
   if (nh->get_parameter(current_name, value)) {
     return value;
   }


### PR DESCRIPTION
## Description 

* In the release build, there were a few occurances of uninitialized variables. These values are set by the get_parameter call, but the compiler doesn't know that, and issues a warning. With warnings treated as errors, this resulted in a release build failure. 