### PR TITLE
AMCL to use sensor data qos for scan topic

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -133,7 +133,7 @@ AmclNode::AmclNode()
     };
   set_map_srv_ = create_service<nav_msgs::srv::SetMap>("set_map", handle_set_map_callback);
 
-
+  custom_qos_profile = rmw_qos_profile_sensor_data;
   custom_qos_profile.depth = 1;
   laser_scan_sub_ = new message_filters::Subscriber<sensor_msgs::msg::LaserScan>(this,
       scan_topic_, custom_qos_profile);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* Changes AMCL to use the QOS profile for sensor data when subscribing to the 'scan' topic.

This was suggested by @miguelcompany in this issue: https://github.com/ros2/rmw_fastrtps/issues/280

I tested this change and see our tests pass now with the latest FastRTPS.
