### PR TITLE
Use AsyncActionNode instead of CoroActionNode

### DIFF
--- a/nav2_bringup/launch/bt_navigator.xml
+++ b/nav2_bringup/launch/bt_navigator.xml
@@ -21,7 +21,9 @@
       <RateController hz="1.0">
         <ComputePathToPose goal="${goal}"/>
       </RateController>
-      <FollowPath path="${path}"/>
+      <SequenceStar name="RememberFollowPathResult">
+        <FollowPath path="${path}"/>
+      </SequenceStar>
     </Sequence>
   </BehaviorTree>
 </root>

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -72,7 +72,6 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   // Put items on the blackboard
   blackboard_->set<geometry_msgs::msg::PoseStamped::SharedPtr>("goal", goal_);  // NOLINT
   blackboard_->set<nav2_msgs::msg::Path::SharedPtr>("path", path_);  // NOLINT
-  blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
   blackboard_->set<std::chrono::milliseconds>("node_loop_timeout", std::chrono::milliseconds(10));  // NOLINT
   blackboard_->set<bool>("path_updated", false);  // NOLINT
   blackboard_->set<bool>("initial_pose_received", false);  // NOLINT


### PR DESCRIPTION
## Description
* The Behavior Tree library's CoroActionNode uses coroutines, while AsyncActionNode uses separate threads. When using coroutines, there was a race condition where the result of an action was occasionally missed. This happens when one coroutine is executing, such as ComputePathToPose, while the FollowPath coroutine is not executing. When it gets a chance to run again, FollowPath does not properly receive the result, even though the Action server has sent it. 
* Using separate threads for the actions means that they can no longer share the same node when invoking the actions. Therefore, removed the node from the blackboard and each bt_action has its own node, generated with nav2_util::generate_internal_node(). 
* Also update the bt_navigator.xml Behavior Tree so that FollowPath is wrapped by a SequenceStar, ensuring that FollowPath is invoked only once. 