### PR TITLE
Re-enable obstacle layer 

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -95,7 +95,7 @@ local_costmap:
       robot_radius: 0.17
       inflation_layer.cost_scaling_factor: 3.0
       obstacle_layer:
-        enabled: False
+        enabled: True
       always_send_full_costmap: True
       observation_sources: scan
       scan:
@@ -119,7 +119,7 @@ global_costmap:
     ros__parameters:
       robot_radius: 0.17
       obstacle_layer:
-        enabled: False
+        enabled: True
       always_send_full_costmap: True
       observation_sources: scan
       scan:

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -183,7 +183,7 @@ void ObstacleLayer::onInitialize()
       source.c_str(), topic.c_str(),
       global_frame_.c_str(), expected_update_rate, observation_keep_time);
 
-    rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
+    rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_sensor_data;
     custom_qos_profile.depth = 50;
 
     // create a callback for the topic


### PR DESCRIPTION
This PR re-enables the obstacle layer in the lifecycle branch. The obstacle behavior seems to behave normally in adding observations to the costmap. The qos setting in the obstacle layer laser scan subscriber is also changed to `rmw_qos_profile_sensor_data` which appears to resolve issues with not receiving laser scan topic. 
