### PR TITLE
Fix typos in dependencies

### DIFF
--- a/nav2_dwb_controller/dwb_core/package.xml
+++ b/nav2_dwb_controller/dwb_core/package.xml
@@ -35,7 +35,7 @@
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>nav2_lifecyle</exec_depend>
+  <exec_depend>nav2_lifecycle</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_motion_primitives/package.xml
+++ b/nav2_motion_primitives/package.xml
@@ -12,7 +12,7 @@
 
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_action</build_depend>
-  <build_depend>nav_lifecycle</build_depend>
+  <build_depend>nav2_lifecycle</build_depend>
   <build_depend>nav2_tasks</build_depend>
   <build_depend>nav2_util</build_depend>
   <build_depend>nav2_msgs</build_depend>

--- a/nav2_navfn_planner/package.xml
+++ b/nav2_navfn_planner/package.xml
@@ -16,7 +16,7 @@
   <build_depend>nav2_util</build_depend>
   <build_depend>nav2_msgs</build_depend>
   <build_depend>nav2_robot</build_depend>
-  <build_depend>nav_lifecycle</build_depend>
+  <build_depend>nav2_lifecycle</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>builtin_interfaces</build_depend>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #755  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* Dependencies on nav2_lifecycle package had typos in various places. This fixes them.
