### PR TITLE
Increase RVIZ logging severity level

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -87,7 +87,8 @@ def generate_launch_description():
         cwd=[launch_dir], output='screen')
 
     start_rviz_cmd = launch.actions.ExecuteProcess(
-        cmd=[os.path.join(get_package_prefix('rviz2'), 'lib/rviz2/rviz2'), ],
+        cmd=[os.path.join(get_package_prefix('rviz2'), 'lib/rviz2/rviz2'),
+            [ "__log_level:=fatal"]],
         cwd=[launch_dir], output='screen')
 
     exit_event_handler = launch.actions.RegisterEventHandler(


### PR DESCRIPTION
We get too much output from the RVIZ logger, most of it related to some errors around message filters.
By increasing the severity level to `fatal` we don't log these messages.
We can set it back to `info` once the message filters on RVIZ have been resolved.