### PR TITLE
Update NodeOptions API rename

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
@@ -76,7 +76,7 @@ std::vector<rclcpp::Parameter> getDefaultKinematicParameters()
 rclcpp::Node::SharedPtr makeTestNode(const std::string & name)
 {
   rclcpp::NodeOptions node_options = nav2_util::get_node_options_default();
-  node_options.initial_parameters(getDefaultKinematicParameters());
+  node_options.parameter_overrides(getDefaultKinematicParameters());
   return rclcpp::Node::make_shared(name, node_options);
 }
 

--- a/nav2_util/src/node_utils.cpp
+++ b/nav2_util/src/node_utils.cpp
@@ -77,7 +77,7 @@ get_node_options_default(bool allow_undeclared, bool declare_initial_params)
 {
   rclcpp::NodeOptions options;
   options.allow_undeclared_parameters(allow_undeclared);
-  options.automatically_declare_initial_parameters(declare_initial_params);
+  options.automatically_declare_parameters_from_overrides(declare_initial_params);
   return options;
 }
 


### PR DESCRIPTION
This PR un-breaks master to adapt for the recent API change in the NodeOptions functions for `parameter_overrides` and `automatically_declare_parameters_from_overrides`. 