### PR TITLE
Stop spinning rclcpp_node thread in LifecycleNode destructor

### DIFF
--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -51,6 +51,7 @@ protected:
 
   // When creating a local node, this class will launch a separate thread created to spin the node
   std::unique_ptr<std::thread> rclcpp_thread_;
+  std::atomic<bool> stop_rclcpp_thread_{false};
 };
 
 }  // namespace nav2_util

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -47,9 +47,11 @@ LifecycleNode::LifecycleNode(
   use_rclcpp_node_(use_rclcpp_node)
 {
   if (use_rclcpp_node_) {
+    stop_rclcpp_thread_ = false;
     rclcpp_node_ = std::make_shared<rclcpp::Node>(node_name + "_rclcpp_node", namespace_);
     rclcpp_thread_ = std::make_unique<std::thread>(
-      [](rclcpp::Node::SharedPtr node) {rclcpp::spin(node);}, rclcpp_node_
+      [&](rclcpp::Node::SharedPtr node) {
+        while (!stop_rclcpp_thread_ && rclcpp::ok()) {rclcpp::spin_some(node);}}, rclcpp_node_
     );
   }
 }
@@ -63,6 +65,7 @@ LifecycleNode::~LifecycleNode()
   }
 
   if (use_rclcpp_node_) {
+    stop_rclcpp_thread_ = true;
     rclcpp_thread_->join();
   }
 }


### PR DESCRIPTION
This PR addresses an issue I've had with threads in gtests. In particular, the `nav2_lifecycle::LifecycleNode` optionally creates a `rclcpp_node_` with its own thread spinning the node. In normal operation, the thread would be killed and destroyed along with the node when `rclcpp_shudown` is called. However, in gtests, I've observed these threads to hang at the end of a test case, preventing termination and causing a timeout, likely because no `rclcpp::shutdown` is called until after all the tests are through completion. 

I've added an atomic bool check in the thread that is set to stop the thread from spinning the node when the destructor of the class is called. 