### PR TITLE
package.xml files are missing nav2_common dependency

### DIFF
--- a/nav2_lifecycle_manager/package.xml
+++ b/nav2_lifecycle_manager/package.xml
@@ -18,6 +18,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>nav2_common</build_depend>
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>

--- a/nav2_map_server/package.xml
+++ b/nav2_map_server/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>nav2_common</build_depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>nav_msgs</depend>
   <depend>std_msgs</depend>

--- a/nav2_mission_executor/package.xml
+++ b/nav2_mission_executor/package.xml
@@ -18,6 +18,7 @@
   <build_depend>nav2_util</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>behaviortree_cpp</build_depend>
+  <build_depend>nav2_common</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_action</exec_depend>

--- a/nav2_navfn_planner/package.xml
+++ b/nav2_navfn_planner/package.xml
@@ -20,6 +20,7 @@
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>builtin_interfaces</build_depend>
+  <build_depend>nav2_common</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_action</exec_depend>

--- a/nav2_robot/package.xml
+++ b/nav2_robot/package.xml
@@ -16,6 +16,7 @@
   <build_depend>urdf</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>nav2_util</build_depend>
+  <build_depend>nav2_common</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>

--- a/nav2_tasks/package.xml
+++ b/nav2_tasks/package.xml
@@ -29,6 +29,7 @@
   <build_depend>nav2_robot</build_depend>
   <build_depend>nav2_util</build_depend>
   <build_depend>lifecycle_msgs</build_depend>
+  <build_depend>nav2_common</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_action</exec_depend>

--- a/nav2_world_model/package.xml
+++ b/nav2_world_model/package.xml
@@ -14,6 +14,7 @@
   <build_depend>nav2_msgs</build_depend>
   <build_depend>nav2_costmap_2d</build_depend>
   <build_depend>tf2_ros</build_depend>
+  <build_depend>nav2_common</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>nav2_util</exec_depend>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* Adds missing nav2_common dependencies to package.xml files.