### PR TITLE
Enable BaseObstacle critic and declare critic scale parameters

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -80,8 +80,7 @@ dwb_controller:
     sim_time: 1.7
     linear_granularity: 0.05
     xy_goal_tolerance: 0.25
-    # critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
-    critics: ["RotateToGoal", "Oscillation", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+    critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
     BaseObstacle.scale: 0.02
     PathAlign.scale: 32.0
     GoalAlign.scale: 24.0

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
@@ -99,7 +99,8 @@ public:
     name_ = name;
     costmap_ros_ = costmap_ros;
     nh_ = nh;
-    nh_->get_parameter_or(name_ + ".scale", scale_, 1.0);
+    nh_->declare_parameter(name_ + ".scale", rclcpp::ParameterValue(1.0));
+    nh_->get_parameter(name_ + ".scale", scale_);
     onInit();
   }
   virtual void onInit() {}


### PR DESCRIPTION
The `BaseObstacle` critic was commented out during the rebase, so it is now enabled. The scale parameters were not seen on the node but given a default in the code, so this PR declares them so they can be tuned in the system yaml file. Now, the robot should actually avoid obstacles and make progress towards the goal with the right critic scale values.

## Contribution in a few bullet points
- Re-enables BaseObstacle critic in `nav2_params.yaml`
- Declares trajectory critic scale parameters

