### PR TITLE
lifecycle branch - remove apt key from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,9 @@
 # This dockerfile expects proxies to be set via --build-arg if needed
 # It also expects to be contained in the /navigation2 root folder for file copy
 # Example build command:
-# export http_proxy=http://my.proxy.com:80
 # export CMAKE_BUILD_TYPE=Debug
-# docker build -t nav2:latest --build-arg http_proxy --build-arg CMAKE_BUILD_TYPE ./
+# docker build -t nav2:latest --build-arg CMAKE_BUILD_TYPE ./
 FROM osrf/ros2:nightly
-
-# setup keys
-ARG http_proxy
-RUN if [ "$http_proxy" != "" ]; \
-    then \
-      apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-      --keyserver-options http-proxy=$http_proxy \
-      --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654; \
-    fi
 
 # install ROS2 dependencies
 RUN apt-get update && apt-get install -q -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN if [ "$http_proxy" != "" ]; \
     then \
       apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
       --keyserver-options http-proxy=$http_proxy \
-      --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116; \
+      --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654; \
     fi
 
 # install ROS2 dependencies


### PR DESCRIPTION
## Description of contribution in a few bullet points
See #797 - this is the same change for the lifecycle branch

~~THIS SHOULD BE MERGED ASAP before any other PRs so that we can unblock the build (again)~~

Correction - the build works without this change because the key already exists in the upstream OSRF docker image.