### PR TITLE
Work around rviz_common import error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,10 @@ RUN . $ROS_WS/install/setup.sh && \
       --ignore-src \
     && rm -rf /var/lib/apt/lists/*
 
+#Workaround hard coded paths in nightly tarball setup scripts
+ARG UPSTREAM_CI_WS=/home/jenkins-agent/workspace/packaging_linux/ws
+RUN mkdir -p $UPSTREAM_CI_WS && ln -s /opt/ros/$ROS_DISTRO $UPSTREAM_CI_WS/install
+
 # build navigation2 package source
 RUN rm $NAV2_WS/src/navigation2/nav2_system_tests/COLCON_IGNORE
 ARG COVERAGE_ENABLED=False


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #799  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* Nightly build tarball used in the osrf/ros2 docker image has hardcoded paths to the ROS 2 build farm's install location. This specifically is a problem for packages that use the ament_export_interfaces mechanism such as rviz_common. When trying to import that package using `find_package(rviz_common REQUIRED)`, we get the error 
```
Imported target "rviz_common::rviz_common" includes non-existent path

    "/home/jenkins-agent/workspace/packaging_linux/ws/install/include"
```
* To work around that problem, this PR creates the invalid path in the docker image and symlinks it to the real ros2 location.