### PR TITLE
Avoid delay on last tick of RateController

### DIFF
--- a/nav2_bringup/launch/bt_navigator.xml
+++ b/nav2_bringup/launch/bt_navigator.xml
@@ -1,29 +1,16 @@
 <!--
-  This Behavior Tree first computes a path using the global planner (ComputePathToPose).
-  Then, it runs two sub-branches in parallel. The first sub-branch is a FollowPath
-  operation (the local planner). In parallel, there is a rate controlled execution of
-  FollowPath (the global planner). Each time a new path is computed, the path update
-  is sent to the local planner. The right branch, which is the rate controlled
-  ComputePathToPose, always returns RUNNING. Because the Parallel node uses a
-  threshold of 1, whenever the FollowPath returns SUCCESS or FAILURE, the parallel
-  node will return this result.
-
-  The goal (input to the global planner) and the resulting path (output of the global
-  planner and input to the local planner) are passed on the blackboard.
-
-  The rate at which the ComputePathToPose operation is invoked can be controlled with
-  the hz parameter to the RateController node.
+  This Behavior Tree replans the global path periodically at 1 Hz.
 -->
 
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <Sequence name="root">
-      <RateController hz="1.0">
-        <Fallback>
-          <GoalReached/>
+      <Fallback>
+        <GoalReached/>
+        <RateController hz="1.0">
           <ComputePathToPose goal="${goal}"/>
-        </Fallback>
-      </RateController>
+        </RateController>
+      </Fallback>
       <FollowPath path="${path}"/>
     </Sequence>
   </BehaviorTree>

--- a/nav2_bt_navigator/behavior_trees/auto_localization_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/auto_localization_w_replanning_and_recovery.xml
@@ -30,12 +30,12 @@
       <RetryUntilSuccesful name="navigate_w_replanning_and_retry" num_attempts="6">
         <Fallback>
           <Sequence>
-            <RateController hz="1.0">
-              <Fallback>
-                <GoalReached/>
-                <ComputePathToPose goal="${goal}" path="${path}"/>
-              </Fallback>
-            </RateController>
+            <Fallback>
+              <GoalReached/>
+              <RateController hz="1.0">
+                <ComputePathToPose goal="${goal}"/>
+              </RateController>
+            </Fallback>
             <FollowPath path="${path}"/>
           </Sequence>
           <ForceFailure>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning.xml
@@ -5,12 +5,12 @@
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <Sequence name="root">
-      <RateController hz="1.0">
-        <Fallback>
-          <GoalReached/>
+      <Fallback>
+        <GoalReached/>
+        <RateController hz="1.0">
           <ComputePathToPose goal="${goal}"/>
-        </Fallback>
-      </RateController>
+        </RateController>
+      </Fallback>
       <FollowPath path="${path}"/>
     </Sequence>
   </BehaviorTree>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
@@ -7,12 +7,12 @@
     <RetryUntilSuccesful name="retry_navigate" num_attempts="6">
       <Fallback>
         <Sequence>
-          <RateController hz="1.0">
-            <Fallback>
-              <GoalReached/>
-              <ComputePathToPose goal="${goal}" path="${path}"/>
-            </Fallback>
-          </RateController>
+          <Fallback>
+            <GoalReached/>
+            <RateController hz="1.0">
+              <ComputePathToPose goal="${goal}"/>
+            </RateController>
+          </Fallback>
           <FollowPath path="${path}"/>
         </Sequence>
         <ForceFailure>

--- a/nav2_tasks/include/nav2_tasks/goal_reached_condition.hpp
+++ b/nav2_tasks/include/nav2_tasks/goal_reached_condition.hpp
@@ -56,7 +56,7 @@ public:
   void initialize()
   {
     node_ = blackboard()->template get<rclcpp::Node::SharedPtr>("node");
-    node_->get_parameter_or<double>("goal_reached_tol", goal_reached_tol_, 0.25);
+    node_->get_parameter_or<double>("goal_reached_tol", goal_reached_tol_, 0.50);
     robot_ = std::make_unique<nav2_robot::Robot>(
       node_->get_node_base_interface(),
       node_->get_node_topics_interface(),
@@ -70,6 +70,7 @@ public:
   {
     auto current_pose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
 
+    rclcpp::spin_some(node_);
     if (!robot_->getCurrentPose(current_pose)) {
       RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
       return false;

--- a/nav2_tasks/include/nav2_tasks/goal_reached_condition.hpp
+++ b/nav2_tasks/include/nav2_tasks/goal_reached_condition.hpp
@@ -70,7 +70,6 @@ public:
   {
     auto current_pose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
 
-    rclcpp::spin_some(node_);
     if (!robot_->getCurrentPose(current_pose)) {
       RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
       return false;

--- a/nav2_tasks/include/nav2_tasks/is_localized_condition.hpp
+++ b/nav2_tasks/include/nav2_tasks/is_localized_condition.hpp
@@ -69,7 +69,6 @@ public:
   {
     auto current_pose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
 
-    rclcpp::spin_some(node_);
     if (!robot_->getCurrentPose(current_pose)) {
       RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
       return false;

--- a/nav2_tasks/include/nav2_tasks/is_localized_condition.hpp
+++ b/nav2_tasks/include/nav2_tasks/is_localized_condition.hpp
@@ -69,6 +69,7 @@ public:
   {
     auto current_pose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
 
+    rclcpp::spin_some(node_);
     if (!robot_->getCurrentPose(current_pose)) {
       RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
       return false;


### PR DESCRIPTION
## Description
* The current Behavior Trees resulted in a delay where the RateController object would be ticked and wouldn't succeed until the RateController allowed the tick to propagate to its children. This PR reorganizes the BTs a bit to pull the GoalReached checkout out of the RateController so that it can succeed immediately when ticked. 
* Also,  because the tolerance for the GoalReached check was the same as the toleranced used by DWB, the GoalReached would never fire, resulting in an extra ComputePathToPose, after DWB has succeeded. I've set the tolerance to 0.5 for now for testing, but am open to other values to use that are greater than DWB's tolerance so that the GoalReached actually kicks in and stops the ComputePathToPose recomputations. 
* Finally, the GoalReached and IsLocalized conditions need to spin the node they get from the blackboard in order to have the call to robot->getCurrentPose succeed. 