### PR TITLE
Spin the node from the blackboard before calling getCurrentPose

### DIFF
--- a/nav2_tasks/include/nav2_tasks/goal_reached_condition.hpp
+++ b/nav2_tasks/include/nav2_tasks/goal_reached_condition.hpp
@@ -70,6 +70,7 @@ public:
   {
     auto current_pose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
 
+    rclcpp::spin_some(node_);
     if (!robot_->getCurrentPose(current_pose)) {
       RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
       return false;

--- a/nav2_tasks/include/nav2_tasks/is_localized_condition.hpp
+++ b/nav2_tasks/include/nav2_tasks/is_localized_condition.hpp
@@ -69,6 +69,7 @@ public:
   {
     auto current_pose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
 
+    rclcpp::spin_some(node_);
     if (!robot_->getCurrentPose(current_pose)) {
       RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
       return false;


### PR DESCRIPTION
## Description
* The node on the blackboard is not on an executor. Before calling getRobotPose, we must spin_some so that it processes incoming messages. 