### PR TITLE
Don't set the path_updated flag the first time through

### DIFF
--- a/nav2_tasks/include/nav2_tasks/compute_path_to_pose_action.hpp
+++ b/nav2_tasks/include/nav2_tasks/compute_path_to_pose_action.hpp
@@ -40,8 +40,16 @@ public:
   void on_success() override
   {
     *(blackboard()->get<nav2_msgs::msg::Path::SharedPtr>("path")) = result_.result->path;
-    blackboard()->set<bool>("path_updated", true);  // NOLINT
+
+    if (first_time_) {
+      first_time_ = false;
+    } else {
+      blackboard()->set<bool>("path_updated", true);  // NOLINT
+    }
   }
+
+private:
+  bool first_time_{true};
 };
 
 }  // namespace nav2_tasks


### PR DESCRIPTION
## Description
* In the ComputePathToPose BT action, the code was setting path_updated on the blackboard the first time it was called. This results in the path being sent to the Action server and, immediately, the same path being sent as a pre-emption/update. This change avoids setting the path_updated flag on the blackboard the first time through. 