### PR TITLE
Adding check for successful action cancellation after halting a bt action node

### DIFF
--- a/nav2_tasks/include/nav2_tasks/bt_action_node.hpp
+++ b/nav2_tasks/include/nav2_tasks/bt_action_node.hpp
@@ -173,7 +173,11 @@ new_goal_received:
       auto future_cancel = action_client_->async_cancel_goal(goal_handle_);
       {
         std::lock_guard<std::mutex> guard(spin_mutex_);
-        rclcpp::spin_until_future_complete(node_, future_cancel);
+        if (rclcpp::spin_until_future_complete(node_, future_cancel) !=
+          rclcpp::executor::FutureReturnCode::SUCCESS) {
+          RCLCPP_ERROR(node_->get_logger(),
+            "Failed to cancel action server for %s", action_name_.c_str());
+        }
       }
     }
 


### PR DESCRIPTION
When a BT action node is halted, the (ROS) action client should cancel the goal and check for successful cancellation.