### PR TITLE
Delete pause/resume buttons and services

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -40,8 +40,6 @@ protected:
   // The services provided by this node
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr startup_srv_;
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr shutdown_srv_;
-  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr pause_srv_;
-  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr resume_srv_;
 
   void startupCallback(
     const std::shared_ptr<rmw_request_id_t> request_header,
@@ -53,21 +51,9 @@ protected:
     const std::shared_ptr<std_srvs::srv::Empty::Request> request,
     std::shared_ptr<std_srvs::srv::Empty::Response> response);
 
-  void pauseCallback(
-    const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
-    std::shared_ptr<std_srvs::srv::Empty::Response> response);
-
-  void resumeCallback(
-    const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
-    std::shared_ptr<std_srvs::srv::Empty::Response> response);
-
   // Support functions for the service calls
   void startup();
   void shutdown();
-  void pause();
-  void resume();
 
   // Support functions for bring-up
   void createLifecycleServiceClients();

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
@@ -35,8 +35,6 @@ public:
   // Client-side interface to the Nav2 lifecycle manager
   void startup();
   void shutdown();
-  void pause();
-  void resume();
 
   // A couple convenience methods to facilitate scripting tests
   void set_initial_pose(double x, double y, double theta);
@@ -56,8 +54,6 @@ protected:
 
   // The service clients
   rclcpp::Client<Empty>::SharedPtr startup_client_;
-  rclcpp::Client<Empty>::SharedPtr pause_client_;
-  rclcpp::Client<Empty>::SharedPtr resume_client_;
   rclcpp::Client<Empty>::SharedPtr shutdown_client_;
 
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -52,12 +52,6 @@ LifecycleManager::LifecycleManager()
   shutdown_srv_ = create_service<std_srvs::srv::Empty>("lifecycle_manager/shutdown",
       std::bind(&LifecycleManager::shutdownCallback, this, _1, _2, _3));
 
-  pause_srv_ = create_service<std_srvs::srv::Empty>("lifecycle_manager/pause",
-      std::bind(&LifecycleManager::pauseCallback, this, _1, _2, _3));
-
-  resume_srv_ = create_service<std_srvs::srv::Empty>("lifecycle_manager/resume",
-      std::bind(&LifecycleManager::resumeCallback, this, _1, _2, _3));
-
   service_client_node_ = std::make_shared<rclcpp::Node>("lifecycle_manager_service_client");
 
   if (autostart_) {
@@ -86,24 +80,6 @@ LifecycleManager::shutdownCallback(
   std::shared_ptr<std_srvs::srv::Empty::Response>/*response*/)
 {
   shutdown();
-}
-
-void
-LifecycleManager::pauseCallback(
-  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
-  const std::shared_ptr<std_srvs::srv::Empty::Request>/*request*/,
-  std::shared_ptr<std_srvs::srv::Empty::Response>/*response*/)
-{
-  pause();
-}
-
-void
-LifecycleManager::resumeCallback(
-  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
-  const std::shared_ptr<std_srvs::srv::Empty::Request>/*request*/,
-  std::shared_ptr<std_srvs::srv::Empty::Response>/*response*/)
-{
-  resume();
 }
 
 void
@@ -184,34 +160,6 @@ LifecycleManager::shutdown()
   shutdownAllNodes();
   destroyLifecycleServiceClients();
   message("The system has been sucessfully shut down");
-}
-
-void
-LifecycleManager::pause()
-{
-  message("Pausing the system...");
-  for (const auto & kv : node_map_) {
-    if (!kv.second->change_state(Transition::TRANSITION_DEACTIVATE) ||
-      !kv.second->change_state(Transition::TRANSITION_CLEANUP))
-    {
-      RCLCPP_ERROR(get_logger(), "Failed to change state for node: %s", kv.first.c_str());
-      return;
-    }
-  }
-  message("The system has been paused");
-}
-
-void
-LifecycleManager::resume()
-{
-  message("Resuming the system...");
-  for (auto & node_name : node_names_) {
-    if (!bringupNode(node_name)) {
-      RCLCPP_ERROR(get_logger(), "Failed to resume node: %s, aborting", node_name.c_str());
-      return;
-    }
-  }
-  message("The system has been resumed");
 }
 
 // TODO(mjeronimo): This is used to emphasize the major events during system bring-up and

--- a/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
@@ -32,8 +32,6 @@ LifecycleManagerClient::LifecycleManagerClient()
 
   // Create the service clients
   startup_client_ = node_->create_client<Empty>("lifecycle_manager/startup");
-  pause_client_ = node_->create_client<Empty>("lifecycle_manager/pause");
-  resume_client_ = node_->create_client<Empty>("lifecycle_manager/resume");
   shutdown_client_ = node_->create_client<Empty>("lifecycle_manager/shutdown");
 
   navigate_action_client_ =
@@ -54,18 +52,6 @@ void
 LifecycleManagerClient::shutdown()
 {
   callService(shutdown_client_, "lifecycle_manager/shutdown");
-}
-
-void
-LifecycleManagerClient::pause()
-{
-  callService(pause_client_, "lifecycle_manager/pause");
-}
-
-void
-LifecycleManagerClient::resume()
-{
-  callService(resume_client_, "lifecycle_manager/resume");
 }
 
 geometry_msgs::msg::Quaternion

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -43,8 +43,6 @@ public:
 private Q_SLOTS:
   void onStartup();
   void onShutdown();
-  void onPause();
-  void onResume();
 
 private:
   void loadLogFiles();
@@ -53,15 +51,12 @@ private:
   nav2_lifecycle_manager::LifecycleManagerClient client_;
 
   QPushButton * start_stop_button_{nullptr};
-  QPushButton * pause_resume_button_{nullptr};
 
   QStateMachine machine_;
 
   QState * initial_{nullptr};
   QState * starting_{nullptr};
   QState * stopping_{nullptr};
-  QState * pausing_{nullptr};
-  QState * resuming_{nullptr};
 };
 
 }  // namespace nav2_rviz_plugins


### PR DESCRIPTION
We don't yet have a full solution for bringing nodes into a state where
their parameters can be reconfigured and then the nodes reactivated. So,
we don't want to expose a partial solution for the Dashing release that
could potentially be confusing for users, so we will only expose startup
and shutdown for now. 

Currently, all lifecycle node parameters are read during on_configure.
Going forward, we will re-assess all parameters to allow for other
options, such as on_activate. Once parameters are associated with different
state transitions, we'll then have to clearly document the parameters and
their state associations and/or come up with an automated way to allow for
node reconfiguration.