### PR TITLE
Use_sim_time missing from a couple nodes in the params file

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -91,6 +91,7 @@ dwb_controller:
 local_costmap:
   local_costmap:
     ros__parameters:
+      use_sim_time: True
       robot_radius: 0.17
       inflation_layer.cost_scaling_factor: 3.0
       obstacle_layer:
@@ -116,6 +117,7 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
+      use_sim_time: True
       robot_radius: 0.17
       obstacle_layer:
         enabled: True


### PR DESCRIPTION
Probably lost these in the recent rebasing of lifecycle against master. In any case, all nodes in the nav2 system should have use_sim_time set. The use_sim_time value can be modified with a command-line parameter to the launch script(s). 