### PR TITLE
Check in lifecycle_manager for successful state transitions and some refactors

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -63,14 +63,20 @@ protected:
   void shutdownAllNodes();
   void destroyLifecycleServiceClients();
 
+  // For a node, transition to the new target state
+  bool changeStateForNode(const std::string & node_name, std::uint8_t transition);
+
   // For each node in the map, transition to the new target state
-  void changeStateForAllNodes(std::uint8_t transition);
+  bool changeStateForAllNodes(std::uint8_t transition);
 
   // Convenience function to highlight the output on the console
   void message(const std::string & msg);
 
   // A map of all nodes to be controlled
   std::map<std::string, std::shared_ptr<nav2_util::LifecycleServiceClient>> node_map_;
+
+  // A map of the expected transitions to primary states
+  std::unordered_map<std::uint8_t, std::uint8_t> transition_state_map_;
 
   // The names of the nodes to be managed, in the order of desired bring-up
   std::vector<std::string> node_names_;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #817 |

---

## Description of contribution in a few bullet points
- Added check for state of nodes after requesting transition
  - if an error causes node to fail transition to intended state, should now be inferred
- some refactor and cleanup of code

## Future work that may be required in bullet points
Since we don't have access to the actual callback return code (i.e. CallbackReturn::Error) when an error is thrown during a transition, we can only infer an error by the resultant state request after a transition request. A future proposal could be to add additional information to the srv/ChangeState so that service clients can more precisely learn what happened during a transition request. 

Also, for now if a call to `on_cleanup` or `on_shutdown` is made and the error is thrown  during those transitions, the resultant state could match the `on_error` primary state after the request is made (if returning SUCCESS (error goes to unconfigured) or FAILURE (error goes to finalized)), and the lifecycle manager wouldn't itself catch it. This may or may not be okay, depending on what actions are being taken during the `on_error` call. 
