### PR TITLE
Extended the SimpleActionServer interface

### DIFF
--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -45,17 +45,16 @@ protected:
   nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
   nav2_util::CallbackReturn on_error(const rclcpp_lifecycle::State & state) override;
 
-  using GoalHandle = rclcpp_action::ServerGoalHandle<nav2_msgs::action::NavigateToPose>;
   using ActionServer = nav2_util::SimpleActionServer<nav2_msgs::action::NavigateToPose>;
 
   // Our action server implements the NavigateToPose action
   std::unique_ptr<ActionServer> action_server_;
 
   // The action server callback
-  void navigateToPose(const std::shared_ptr<GoalHandle> goal_handle);
+  void navigateToPose();
 
   // Goal pose initialization on the blackboard
-  void initializeGoalPose(std::shared_ptr<GoalHandle> goal_handle);
+  void initializeGoalPose();
 
   // A subscription and callback to handle the topic-based goal published from rviz
   void onGoalPoseReceived(const geometry_msgs::msg::PoseStamped::SharedPtr pose);

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -60,7 +60,7 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
 
   // Create an action server that we implement with our navigateToPose method
   action_server_ = std::make_unique<ActionServer>(rclcpp_node_, "NavigateToPose",
-      std::bind(&BtNavigator::navigateToPose, this, std::placeholders::_1), false);
+      std::bind(&BtNavigator::navigateToPose, this), false);
 
   // Create the class that registers our custom nodes and executes the BT
   bt_ = std::make_unique<NavigateToPoseBehaviorTree>();
@@ -164,22 +164,18 @@ BtNavigator::on_shutdown(const rclcpp_lifecycle::State & /*state*/)
 }
 
 void
-BtNavigator::navigateToPose(const std::shared_ptr<GoalHandle> goal_handle)
+BtNavigator::navigateToPose()
 {
-  // The action may be pre-empted, so keep a pointer to the current goal handle
-  std::shared_ptr<GoalHandle> current_goal_handle = goal_handle;
-  auto result = std::make_shared<nav2_msgs::action::NavigateToPose::Result>();
-
-  initializeGoalPose(current_goal_handle);
+  initializeGoalPose();
 
   // Execute the BT that was previously created in the configure step
-  auto is_canceling = [&current_goal_handle]() -> bool
-    {return current_goal_handle->is_canceling();};
+  auto is_canceling =
+    [this]() -> bool {return action_server_->is_cancelling_current_goal();};
 
-  auto on_loop = [this, &current_goal_handle] {
+  auto on_loop = [this]() {
       if (action_server_->preempt_requested()) {
-        current_goal_handle = action_server_->get_updated_goal_handle();
-        initializeGoalPose(current_goal_handle);
+        action_server_->accept_pending_goal();
+        initializeGoalPose();
       }
     };
 
@@ -188,17 +184,17 @@ BtNavigator::navigateToPose(const std::shared_ptr<GoalHandle> goal_handle)
   switch (rc) {
     case nav2_tasks::BtStatus::SUCCEEDED:
       RCLCPP_INFO(get_logger(), "Navigation succeeded");
-      current_goal_handle->succeed(result);
+      action_server_->succeeded_current();
       break;
 
     case nav2_tasks::BtStatus::FAILED:
       RCLCPP_ERROR(get_logger(), "Navigation failed");
-      current_goal_handle->abort(result);
+      action_server_->abort_all();
       break;
 
     case nav2_tasks::BtStatus::CANCELED:
       RCLCPP_INFO(get_logger(), "Navigation canceled");
-      current_goal_handle->canceled(result);
+      action_server_->cancel_all();
       // Reset the BT so that it can be run again in the future
       bt_->resetTree(tree_->root_node);
       break;
@@ -209,9 +205,9 @@ BtNavigator::navigateToPose(const std::shared_ptr<GoalHandle> goal_handle)
 }
 
 void
-BtNavigator::initializeGoalPose(std::shared_ptr<GoalHandle> goal_handle)
+BtNavigator::initializeGoalPose()
 {
-  auto goal = goal_handle->get_goal();
+  auto goal = action_server_->get_current_goal();
 
   RCLCPP_INFO(get_logger(), "Begin navigating from current location to (%.2f, %.2f)",
     goal->pose.pose.position.x, goal->pose.pose.position.y);

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -168,17 +168,17 @@ BtNavigator::navigateToPose()
 {
   initializeGoalPose();
 
-  // Execute the BT that was previously created in the configure step
-  auto is_canceling =
-    [this]() -> bool {return action_server_->is_cancelling_current_goal();};
+  auto is_canceling = [this]() {return action_server_->is_cancelling();};
 
   auto on_loop = [this]() {
       if (action_server_->preempt_requested()) {
+        RCLCPP_INFO(get_logger(), "Received goal preemption request");
         action_server_->accept_pending_goal();
         initializeGoalPose();
       }
     };
 
+  // Execute the BT that was previously created in the configure step
   nav2_tasks::BtStatus rc = bt_->run(tree_, on_loop, is_canceling);
 
   switch (rc) {

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -168,7 +168,7 @@ BtNavigator::navigateToPose()
 {
   initializeGoalPose();
 
-  auto is_canceling = [this]() {return action_server_->is_cancelling();};
+  auto is_canceling = [this]() {return action_server_->is_cancel_requested();};
 
   auto on_loop = [this]() {
       if (action_server_->preempt_requested()) {

--- a/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
+++ b/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
@@ -26,10 +26,11 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_msgs/action/follow_path.hpp"
 #include "nav2_util/simple_action_server.hpp"
-#include "dwb_controller/progress_checker.hpp"
 
 namespace dwb_controller
 {
+
+class ProgressChecker;
 
 class DwbController : public nav2_util::LifecycleNode
 {
@@ -55,9 +56,8 @@ protected:
   void followPath();
 
   void setPlannerPath(const nav2_msgs::msg::Path & path);
-  bool computeAndUpdate(ProgressChecker & progress_checker);
-  bool shouldCancel();
-  bool checkPreemption();
+  void computeAndPublishVelocity();
+  void updateGlobalPath();
   void publishVelocity(const nav_2d_msgs::msg::Twist2DStamped & velocity);
   void publishZeroVelocity();
   bool isGoalReached();
@@ -76,6 +76,8 @@ protected:
 
   // An executor used to spin the costmap node
   std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> costmap_executor_;
+
+  std::unique_ptr<ProgressChecker> progress_checker_;
 };
 
 }  // namespace dwb_controller

--- a/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
+++ b/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
@@ -56,8 +56,8 @@ protected:
 
   void setPlannerPath(const nav2_msgs::msg::Path & path);
   bool computeAndUpdate(ProgressChecker & progress_checker);
-  void cancelAndStop();
-  void processPendingPreemption();
+  bool shouldCancel();
+  bool checkPreemption();
   void publishVelocity(const nav_2d_msgs::msg::Twist2DStamped & velocity);
   void publishZeroVelocity();
   bool isGoalReached();

--- a/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
+++ b/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
@@ -26,6 +26,7 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_msgs/action/follow_path.hpp"
 #include "nav2_util/simple_action_server.hpp"
+#include "dwb_controller/progress_checker.hpp"
 
 namespace dwb_controller
 {
@@ -45,18 +46,21 @@ protected:
   nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
   nav2_util::CallbackReturn on_error(const rclcpp_lifecycle::State & state) override;
 
-  using GoalHandle = rclcpp_action::ServerGoalHandle<nav2_msgs::action::FollowPath>;
   using ActionServer = nav2_util::SimpleActionServer<nav2_msgs::action::FollowPath>;
 
   // Our action server implements the FollowPath action
   std::unique_ptr<ActionServer> action_server_;
 
   // The action server callback
-  void followPath(const std::shared_ptr<GoalHandle> goal_handle);
+  void followPath();
 
-  bool isGoalReached(const nav_2d_msgs::msg::Pose2DStamped & pose2d);
+  void setPlannerPath(const nav2_msgs::msg::Path & path);
+  bool computeAndUpdate(ProgressChecker & progress_checker);
+  void cancelAndStop();
+  void processPendingPreemption();
   void publishVelocity(const nav_2d_msgs::msg::Twist2DStamped & velocity);
   void publishZeroVelocity();
+  bool isGoalReached();
   bool getRobotPose(nav_2d_msgs::msg::Pose2DStamped & pose2d);
 
   // The DWBController contains a costmap node

--- a/nav2_dwb_controller/dwb_controller/include/dwb_controller/progress_checker.hpp
+++ b/nav2_dwb_controller/dwb_controller/include/dwb_controller/progress_checker.hpp
@@ -26,6 +26,7 @@ class ProgressChecker
 public:
   explicit ProgressChecker(const rclcpp::Node::SharedPtr & node);
   void check(nav_2d_msgs::msg::Pose2DStamped & current_pose);
+  void reset() {baseline_pose_set_ = false;}
 
 protected:
   bool is_robot_moved_enough(const geometry_msgs::msg::Pose2D & pose);

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -149,7 +149,7 @@ void DwbController::followPath()
 
     rclcpp::Rate loop_rate(100ms);
     while (rclcpp::ok()) {
-      if (action_server_->is_cancelling()) {
+      if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(get_logger(), "Goal was canceled. Cancelling and stopping.");
         action_server_->cancel_all();
         publishZeroVelocity();

--- a/nav2_map_server/include/nav2_map_server/map_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_server.hpp
@@ -37,8 +37,20 @@ protected:
   nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
   nav2_util::CallbackReturn on_error(const rclcpp_lifecycle::State & state) override;
 
+  using GoalHandle = rclcpp_action::ServerGoalHandle<nav2_msgs::action::ExecuteMission>;
+  using ActionServer = nav2_util::SimpleActionServer<nav2_msgs::action::ExecuteMission>;
+
   // The map loader that will actually do the work
   std::unique_ptr<nav2_util::LifecycleHelperInterface> map_loader_;
+
+  // Out action server implements the ExecuteMission action
+  std::unique_ptr<ActionServer> action_server_;
+
+  // The action server callback
+  void executeMission();
+
+  // A regular, non-spinning ROS node that we can use for the Behavior Tree
+  rclcpp::Node::SharedPtr client_node_;
 };
 
 }  // namespace nav2_map_server

--- a/nav2_map_server/include/nav2_map_server/map_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_server.hpp
@@ -37,20 +37,8 @@ protected:
   nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
   nav2_util::CallbackReturn on_error(const rclcpp_lifecycle::State & state) override;
 
-  using GoalHandle = rclcpp_action::ServerGoalHandle<nav2_msgs::action::ExecuteMission>;
-  using ActionServer = nav2_util::SimpleActionServer<nav2_msgs::action::ExecuteMission>;
-
   // The map loader that will actually do the work
   std::unique_ptr<nav2_util::LifecycleHelperInterface> map_loader_;
-
-  // Out action server implements the ExecuteMission action
-  std::unique_ptr<ActionServer> action_server_;
-
-  // The action server callback
-  void executeMission();
-
-  // A regular, non-spinning ROS node that we can use for the Behavior Tree
-  rclcpp::Node::SharedPtr client_node_;
 };
 
 }  // namespace nav2_map_server

--- a/nav2_motion_primitives/include/nav2_motion_primitives/motion_primitive.hpp
+++ b/nav2_motion_primitives/include/nav2_motion_primitives/motion_primitive.hpp
@@ -114,7 +114,7 @@ protected:
     rclcpp::Rate loop_rate(10);
 
     while (rclcpp::ok()) {
-      if (action_server_->is_cancelling()) {
+      if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(node_->get_logger(), "Canceling %s", primitive_name_.c_str());
         action_server_->cancel_all();
         return;

--- a/nav2_motion_primitives/src/back_up.cpp
+++ b/nav2_motion_primitives/src/back_up.cpp
@@ -62,20 +62,18 @@ Status BackUp::onCycleUpdate()
     return Status::FAILED;
   }
 
-  geometry_msgs::msg::Twist cmd_vel;
-  cmd_vel.linear.y = 0.0;
-  cmd_vel.angular.z = 0.0;
-
   double diff_x = initial_pose_->pose.pose.position.x - current_odom_pose->pose.pose.position.x;
   double diff_y = initial_pose_->pose.pose.position.y - current_odom_pose->pose.pose.position.y;
   double distance = sqrt(diff_x * diff_x + diff_y * diff_y);
 
   if (distance >= abs(command_x_)) {
-    cmd_vel.linear.x = 0;
-    robot_->sendVelocity(cmd_vel);
+    stopRobot();
     return Status::SUCCEEDED;
   }
   // TODO(mhpanah): cmd_vel value should be passed as a parameter
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.y = 0.0;
+  cmd_vel.angular.z = 0.0;
   command_x_ < 0 ? cmd_vel.linear.x = -0.025 : cmd_vel.linear.x = 0.025;
   robot_->sendVelocity(cmd_vel);
 

--- a/nav2_motion_primitives/src/spin.cpp
+++ b/nav2_motion_primitives/src/spin.cpp
@@ -76,21 +76,18 @@ Status Spin::timedSpin()
   // Output control command
   geometry_msgs::msg::Twist cmd_vel;
 
+  // TODO(orduno) #423 fixed time
+  auto current_time = std::chrono::system_clock::now();
+  if (current_time - start_time_ >= 6s) {  // almost 180 degrees
+    stopRobot();
+    return Status::SUCCEEDED;
+  }
+
   // TODO(orduno) #423 fixed speed
   cmd_vel.linear.x = 0.0;
   cmd_vel.linear.y = 0.0;
   cmd_vel.angular.z = 0.5;
   robot_->sendVelocity(cmd_vel);
-
-  // TODO(orduno) #423 fixed time
-  auto current_time = std::chrono::system_clock::now();
-  if (current_time - start_time_ >= 6s) {  // almost 180 degrees
-    // Stop the robot
-    cmd_vel.angular.z = 0.0;
-    robot_->sendVelocity(cmd_vel);
-
-    return Status::SUCCEEDED;
-  }
 
   return Status::RUNNING;
 }
@@ -133,6 +130,7 @@ Status Spin::controlledSpin()
 
   // check if we are done
   if (dist_left >= (0.0 - goal_tolerance_angle_)) {
+    stopRobot();
     return Status::SUCCEEDED;
   }
 

--- a/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
+++ b/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
@@ -52,14 +52,13 @@ protected:
   nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
   nav2_util::CallbackReturn on_error(const rclcpp_lifecycle::State & state) override;
 
-  using GoalHandle = rclcpp_action::ServerGoalHandle<nav2_msgs::action::ComputePathToPose>;
   using ActionServer = nav2_util::SimpleActionServer<nav2_msgs::action::ComputePathToPose>;
 
   // Our action server implements the ComputePathToPose action
   std::unique_ptr<ActionServer> action_server_;
 
   // The action server callback
-  void computePathToPose(const std::shared_ptr<GoalHandle> goal_handle);
+  void computePathToPose();
 
   // Compute a plan given start and goal poses, provided in global world frame.
   bool makePlan(

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -165,7 +165,7 @@ NavfnPlanner::computePathToPose()
       planner_->setNavArr(costmap_.metadata.size_x, costmap_.metadata.size_y);
     }
 
-    if (action_server_->is_cancelling()) {
+    if (action_server_->is_cancel_requested()) {
       RCLCPP_INFO(get_logger(), "Goal was canceled. Canceling planning action.");
       action_server_->cancel_all();
       return;

--- a/nav2_tasks/include/nav2_tasks/behavior_tree_engine.hpp
+++ b/nav2_tasks/include/nav2_tasks/behavior_tree_engine.hpp
@@ -37,6 +37,7 @@ public:
   BtStatus run(
     BT::Blackboard::Ptr & blackboard,
     const std::string & behavior_tree_xml,
+    std::function<void()> onLoop,
     std::function<bool()> cancelRequested,
     std::chrono::milliseconds loopTimeout = std::chrono::milliseconds(10));
 

--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -115,23 +115,17 @@ public:
   void deactivate()
   {
     std::lock_guard<std::mutex> lock_goal_handle(update_mutex_);
-
     server_active_ = false;
 
-    // TODO(orduno) Replace with `abort_all()` once #849 is merged
-    if (current_handle_ != nullptr && current_handle_->is_active()) {
-      RCLCPP_WARN(node_->get_logger(), "Taking action server to deactive state "
-        " with an active goal. Cancelling the current goal.");
-      current_handle_->abort(std::make_shared<typename ActionT::Result>());
-      current_handle_.reset();
+    if (is_active(current_handle_)) {
+      warn_msg("Taking action server to deactive state with an active goal, will be aborted");
     }
 
-    if (new_handle_ != nullptr && new_handle_->is_active()) {
-      RCLCPP_WARN(node_->get_logger(), "Taking action server to deactive state "
-        " with a pending preemption. Cancelling the preemptive goal.");
-      new_handle_->abort(std::make_shared<typename ActionT::Result>());
-      new_handle_.reset();
+    if (is_active(pending_handle_)) {
+      warn_msg("Taking action server to deactive state with a pending preemption, will be aborted");
     }
+
+    abort_all();
   }
 
   bool serverIsActive()

--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -181,7 +181,7 @@ public:
     return current_handle_->get_goal();
   }
 
-  bool is_cancelling() const
+  bool is_cancel_requested() const
   {
     std::lock_guard<std::mutex> lock(update_mutex_);
 

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "lifecycle_msgs/msg/state.hpp"
 

--- a/nav2_util/test/test_actions.cpp
+++ b/nav2_util/test/test_actions.cpp
@@ -69,7 +69,7 @@ preempted:
 
     for (int i = 1; (i < goal->order) && rclcpp::ok(); ++i) {
       // Check if this action has been canceled
-      if (action_server_->is_cancelling()) {
+      if (action_server_->is_cancel_requested()) {
         result->sequence = sequence;
         action_server_->cancel_all(result);
         return;

--- a/nav2_util/test/test_actions.cpp
+++ b/nav2_util/test/test_actions.cpp
@@ -41,10 +41,10 @@ public:
 
   void on_init()
   {
-    action_server_ = std::make_shared<nav2_util::SimpleActionServer<Fibonacci>>(
+    action_server_ = std::make_unique<nav2_util::SimpleActionServer<Fibonacci>>(
       shared_from_this(),
       "fibonacci",
-      std::bind(&FibonacciServerNode::execute, this, std::placeholders::_1));
+      std::bind(&FibonacciServerNode::execute, this));
   }
 
   void on_term()
@@ -52,16 +52,13 @@ public:
     action_server_.reset();
   }
 
-  void execute(const std::shared_ptr<GoalHandle> goal_handle)
+  void execute()
   {
-    // The goal may be pre-empted, so keep a pointer to the current goal
-    std::shared_ptr<GoalHandle> current_goal_handle = goal_handle;
-
     rclcpp::Rate loop_rate(10);
 
 preempted:
     // Initialize the goal, feedback, and result
-    auto goal = current_goal_handle->get_goal();
+    auto goal = action_server_->get_current_goal();
     auto feedback = std::make_shared<Fibonacci::Feedback>();
     auto result = std::make_shared<Fibonacci::Result>();
 
@@ -72,15 +69,15 @@ preempted:
 
     for (int i = 1; (i < goal->order) && rclcpp::ok(); ++i) {
       // Check if this action has been canceled
-      if (current_goal_handle->is_canceling()) {
+      if (action_server_->is_cancelling()) {
         result->sequence = sequence;
-        current_goal_handle->canceled(result);
+        action_server_->cancel_all(result);
         return;
       }
 
       // Check if we've gotten an new goal, pre-empting the current one
       if (action_server_->preempt_requested()) {
-        current_goal_handle = action_server_->get_updated_goal_handle();
+        action_server_->accept_pending_goal();
         goto preempted;
       }
 
@@ -88,19 +85,19 @@ preempted:
       sequence.push_back(sequence[i] + sequence[i - 1]);
 
       // Publish feedback
-      current_goal_handle->publish_feedback(feedback);
+      action_server_->publish_feedback(feedback);
       loop_rate.sleep();
     }
 
     // Check if goal is done
     if (rclcpp::ok()) {
       result->sequence = sequence;
-      current_goal_handle->succeed(result);
+      action_server_->succeeded_current(result);
     }
   }
 
 private:
-  std::shared_ptr<nav2_util::SimpleActionServer<Fibonacci>> action_server_;
+  std::unique_ptr<nav2_util::SimpleActionServer<Fibonacci>> action_server_;
 };
 
 class RclCppFixture


### PR DESCRIPTION
## Description of contribution in a few bullet points

Extended the `SimpleActionServer` interface and improved a few other things: 

* Added additional checks to make sure we only keep the latest preempt request in the queue.
* Action server users no longer interact directly with the goal handles. Provided additional functions for aborting, canceling, etc.
* Updated `bt_navigator`, `motion_primitives`, `dwb_controller`, `navfn_planner` to use the new interface.

Here's a diagram of the states and transitions:
![SimpleActionServerStates](https://user-images.githubusercontent.com/39749557/59569861-79f84380-9044-11e9-967e-8dde48970573.png)


Refactored the DWB controller main loop:

* Changed the order of the steps to: 1) check for cancel 2) check for preempting 3) compute control 4) check if reached goal
* Made a few other small refactors.
* Added checks for handling pending preemptions after the controller has succeeded or failed.

This partially addresses #811 and possibly fix #835. Haven't been able to reproduce #835 to test.

---

## Future work that may be required in bullet points

* Fix the `SimpleActionServer` unit tests.
* Handle a pending preemption after reaching a final state on current goal #861.