### PR TITLE
Fix spin cpu (fixes #792)

### DIFF
--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -54,8 +54,8 @@ protected:
   // When creating a local node, this class will launch a separate thread created to spin the node
   std::unique_ptr<std::thread> rclcpp_thread_;
 
-  std::condition_variable cv_;
-  std::mutex m_;
+  std::condition_variable should_exit_cv_;
+  std::mutex mutex_;
 };
 
 }  // namespace nav2_util

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -15,7 +15,9 @@
 #ifndef NAV2_UTIL__LIFECYCLE_NODE_HPP_
 #define NAV2_UTIL__LIFECYCLE_NODE_HPP_
 
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 
@@ -51,7 +53,9 @@ protected:
 
   // When creating a local node, this class will launch a separate thread created to spin the node
   std::unique_ptr<std::thread> rclcpp_thread_;
-  std::atomic<bool> stop_rclcpp_thread_{false};
+
+  std::condition_variable cv_;
+  std::mutex m_;
 };
 
 }  // namespace nav2_util

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -33,11 +33,13 @@ namespace nav2_util
 //     https://github.com/ros2/geometry2/issues/94
 //     https://github.com/ros2/geometry2/issues/70
 //
-// Until then, this class can provide a normal ROS node that has a thread
-// that processes the node's messages. If a derived class needs to interface
-// to one of these classes - MessageFilter, etc. - that don't yet support
-// lifecycle nodes, it can simply set the use_rclcpp_node flag in the constructor
-// and then provide the rclcpp_node_ to the helper classes, like MessageFilter.
+// Until we get the required support in ROS2 and then utilize the updated
+// interfaces, this class will provide a bridging solution. This class provides
+// an optional normal ROS node an automatically launches a thread that processes
+// the node's messages. If a derived class needs to interface to one of these classes
+// like MessageFilter that don't yet support lifecycle nodes, it can simply set the
+//  use_rclcpp_node flag in the constructor and then provide the rclcpp_node_ to the
+//  helper classes, like MessageFilter.
 //
 
 LifecycleNode::LifecycleNode(
@@ -49,41 +51,50 @@ LifecycleNode::LifecycleNode(
   use_rclcpp_node_(use_rclcpp_node)
 {
   if (use_rclcpp_node_) {
-    // Create a non-lifecycle node to use to interface to ROS2 functionality that is
-    // not yet lifecycle enabled
+    // If requested, create a non-lifecycle node (an "rclcpp_node") to use to interface
+    // to ROS2 functionality that is not yet lifecycle enabled
     rclcpp_node_ = std::make_shared<rclcpp::Node>(node_name + "_rclcpp_node", namespace_);
 
-    // The lambda function for this thread will efficiently spin the node
+    // Create a lambda function to efficiently spin the node
     auto f = [this](rclcpp::Node::SharedPtr node) {
-      std::shared_future<void> future_result = std::async(std::launch::async,
-        [this]{ 
-          std::unique_lock<std::mutex> lk(m_); 
-          cv_.wait(lk); 
-        }); 
+        // Create an async task w/ a shared_future so that we can use this with
+        // spin_until_future_complete. The task simply waits until the condition variable
+        // is signaled. This happens when the LifecycleNode is destructed.
+        std::shared_future<void> future_result = std::async(std::launch::async,
+            [this] {
+              std::unique_lock<std::mutex> lk(mutex_);
+              should_exit_cv_.wait(lk);
+            });
 
-      // Wait for the result
-      rclcpp::spin_until_future_complete(node, future_result);
-    };
+        // Process messages for this thread until the future result is complete, which,
+        // in our case, indicates that that the lifecycle node is exiting
+        rclcpp::spin_until_future_complete(node, future_result);
+      };
 
-    // Create the thread to spin this node
+    // Create the thread to spin this node, providing the above lambda function
     rclcpp_thread_ = std::make_unique<std::thread>(f, rclcpp_node_);
   }
 }
 
 LifecycleNode::~LifecycleNode()
 {
-  // In case this lifecycle node wasn't properly shut down, do it here
+  // In case this lifecycle node wasn't properly shut down, manually execute the
+  // state transitions
   if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
     on_deactivate(get_current_state());
     on_cleanup(get_current_state());
   }
 
   if (use_rclcpp_node_) {
-    cv_.notify_one();
+    // If we're using an rclcpp_node, notify that thread so that it can terminate
+    should_exit_cv_.notify_one();
 
-    auto timer_callback = [this]() -> void {RCLCPP_INFO(this->get_logger(), "Hello, world!");};
-    auto timer_ = rclcpp_node_->create_wall_timer(1ms, timer_callback);
+    // Make sure there is at least one item on the node's input queue so that it will
+    // break out of the spin_until_future_complete
+    auto timer_ =
+      rclcpp_node_->create_wall_timer(1ms, [](rclcpp::TimerBase & timer) {timer.cancel();});
 
+    // Then, join with that thread before continuing
     rclcpp_thread_->join();
   }
 }

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -57,9 +57,9 @@ LifecycleNode::LifecycleNode(
     auto f = [this](rclcpp::Node::SharedPtr node) {
       std::shared_future<void> future_result = std::async(std::launch::async,
         [this]{ 
-		  std::unique_lock<std::mutex> lk(m_); 
-		  cv_.wait(lk); 
-		}); 
+          std::unique_lock<std::mutex> lk(m_); 
+          cv_.wait(lk); 
+        }); 
 
       // Wait for the result
       rclcpp::spin_until_future_complete(node, future_result);
@@ -81,8 +81,8 @@ LifecycleNode::~LifecycleNode()
   if (use_rclcpp_node_) {
     cv_.notify_one();
 
-	auto timer_callback = [this]() -> void {RCLCPP_INFO(this->get_logger(), "Hello, world!");};
-    auto timer_ = create_wall_timer(1ms, timer_callback);
+    auto timer_callback = [this]() -> void {RCLCPP_INFO(this->get_logger(), "Hello, world!");};
+    auto timer_ = rclcpp_node_->create_wall_timer(1ms, timer_callback);
 
     rclcpp_thread_->join();
   }

--- a/nav2_util/test/CMakeLists.txt
+++ b/nav2_util/test/CMakeLists.txt
@@ -20,3 +20,7 @@ target_link_libraries(test_lifecycle_utils ${library_name})
 ament_add_gtest(test_actions test_actions.cpp)
 ament_target_dependencies(test_actions rclcpp_action test_msgs)
 target_link_libraries(test_actions ${library_name})
+
+ament_add_gtest(test_lifecycle_node test_lifecycle_node.cpp)
+ament_target_dependencies(test_lifecycle_node rclcpp_lifecycle)
+target_link_libraries(test_lifecycle_node ${library_name})

--- a/nav2_util/test/test_lifecycle_node.cpp
+++ b/nav2_util/test/test_lifecycle_node.cpp
@@ -26,6 +26,10 @@ public:
 };
 RclCppFixture g_rclcppfixture;
 
+// For the following two tests, if the LifecycleNode doesn't shut down properly,
+// the overall test will hang since the rclcpp thread will still be running,
+// preventing the executable from exiting (the test will hang)
+
 TEST(LifecycleNode, RclcppNodeExitsCleanly)
 {
   // Make sure the node exits cleanly when using an rclcpp_node and associated thread

--- a/nav2_util/test/test_lifecycle_node.cpp
+++ b/nav2_util/test/test_lifecycle_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
 #include "gtest/gtest.h"
 #include "nav2_util/lifecycle_node.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -24,10 +26,23 @@ public:
 };
 RclCppFixture g_rclcppfixture;
 
-TEST(LifecycleNode, CreateAndDestroy)
+TEST(LifecycleNode, RclcppNodeExitsCleanly)
 {
+  // Make sure the node exits cleanly when using an rclcpp_node and associated thread
   auto node1 = std::make_shared<nav2_util::LifecycleNode>("test_node", "", true);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  SUCCEED();
+}
 
-  std::this_thread::sleep_for(std::chrono::seconds(2));
+TEST(LifecycleNode, MultipleRclcppNodesExitCleanly)
+{
+  // Try a couple nodes w/ rclcpp_node and threads
+  auto node1 = std::make_shared<nav2_util::LifecycleNode>("test_node1", "", true);
+  auto node2 = std::make_shared<nav2_util::LifecycleNode>("test_node2", "", true);
+
+  // Another one without rclcpp_node and on the stack
+  nav2_util::LifecycleNode node3("test_node3", "", false);
+
+  std::this_thread::sleep_for(std::chrono::seconds(1));
   SUCCEED();
 }

--- a/nav2_util/test/test_lifecycle_node.cpp
+++ b/nav2_util/test/test_lifecycle_node.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "nav2_util/lifecycle_node.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+RclCppFixture g_rclcppfixture;
+
+TEST(LifecycleNode, CreateAndDestroy)
+{
+  auto node1 = std::make_shared<nav2_util::LifecycleNode>("test_node", "", true);
+
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  SUCCEED();
+}


### PR DESCRIPTION
## Description

We have a temporary solution in place where our lifecycle nodes can optionally create a normal ROS2 node and automatically create a thread to spin this node. These "rclcpp_nodes" are used to interface to functionality in ROS2 that is not yet lifecycle enabled. As such, the rclcpp_nodes are temporary and will be removed fairly soon.

To spin these rclcpp_nodes, the code for nav2_util::LifecycleNode previously used rclcpp::spin_some and then, in the destructor, checked the status of a boolean variable to know when to exit this thread used for spinning the rclcpp_node. This resulted in high CPU utilization (issue #792 was reported for DWB, but this is true for all of our lifecycle nodes that request an rclcpp node) because there is no efficient wait; spin_some was being called in a tight loop.

This PR uses spin_until_future_complete to efficiently process input messages, which also checking a condition variable to know when to exit the thread. One difficulty with this approach is that it will only work if there are messages on the input queue for the node. This is normally the case, but may not be true in testing scenarios, for example. So, to ensure that there is at least one message on the queue, when a nav2_util::LifecycleNode is terminating, it puts a timer event on the queue. This ensures that this message will be processed and then the spin_until_future_complete will evaluate the future and exit since the future is indeed complete.  

## Future work that may be required
* Instead of using a timer event, we can define a custom waitable, such as a "null waitable" that we could put on the queue instead of the timer event
* There are similar situations in ROS2 code, such as the TransformListener that need to have this issue addressed. 