### PR TITLE
Adding RecoveryNode to Behavior Tree

### DIFF
--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -33,6 +33,7 @@ set(library_name ${executable_name}_core)
 add_library(${library_name} SHARED
   src/bt_navigator.cpp
   src/navigate_to_pose_behavior_tree.cpp
+  src/recovery_node.cpp
 )
 
 set(dependencies

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
@@ -5,7 +5,7 @@
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <RecoveryNode number_of_retries="6">
-      <Sequence name="NavigateWReplanning">
+      <Sequence name="NavigateWithReplanning">
         <RateController hz="1.0">
           <Fallback>
             <GoalReached/>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
@@ -4,25 +4,21 @@
 -->
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
-    <RetryUntilSuccesful name="retry_navigate" num_attempts="6">
-      <Fallback>
-        <Sequence>
-          <RateController hz="1.0">
-            <Fallback>
-              <GoalReached/>
-              <ComputePathToPose goal="${goal}" path="${path}"/>
-            </Fallback>
-          </RateController>
-          <FollowPath path="${path}"/>
-        </Sequence>
-        <ForceFailure>
-          <SequenceStar name="recovery">
-            <clearEntirelyCostmapServiceRequest service_name="/local_costmap/clear_entirely_local_costmap"/>
-            <clearEntirelyCostmapServiceRequest service_name="/global_costmap/clear_entirely_global_costmap"/>
-            <Spin/>
-          </SequenceStar>
-        </ForceFailure>
-      </Fallback>
-    </RetryUntilSuccesful>
+    <RecoveryNode num_of_retries="6">
+      <Sequence name="NavigateWReplanning">
+        <RateController hz="1.0">
+          <Fallback>
+            <GoalReached/>
+             <ComputePathToPose goal="${goal}" path="${path}"/>
+          </Fallback>
+        </RateController>
+        <FollowPath path="${path}"/>
+      </Sequence>
+      <SequenceStar name="RecoveryActions">
+        <clearEntirelyCostmapServiceRequest service_name="/local_costmap/clear_entirely_local_costmap"/>
+        <clearEntirelyCostmapServiceRequest service_name="/global_costmap/clear_entirely_global_costmap"/>
+        <Spin/>
+      </SequenceStar>
+    </RecoveryNode>
   </BehaviorTree>
 </root>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
@@ -4,7 +4,7 @@
 -->
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
-    <RecoveryNode num_of_retries="6">
+    <RecoveryNode number_of_retries="6">
       <Sequence name="NavigateWReplanning">
         <RateController hz="1.0">
           <Fallback>

--- a/nav2_bt_navigator/include/nav2_bt_navigator/recovery_node.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/recovery_node.hpp
@@ -42,13 +42,13 @@ public:
   // Any BT node that accepts parameters must provide a requiredNodeParameters method
   static const BT::NodeParameters & requiredNodeParameters()
   {
-    static BT::NodeParameters params = {{"num_of_retries", "1"}};
+    static BT::NodeParameters params = {{"number_of_retries", "1"}};
     return params;
   }
 
 private:
   unsigned int current_child_idx_;
-  unsigned int num_of_retries_;
+  unsigned int number_of_retries_;
   unsigned int retry_count_;
   BT::NodeStatus tick() override;
 };

--- a/nav2_bt_navigator/include/nav2_bt_navigator/recovery_node.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/recovery_node.hpp
@@ -49,6 +49,7 @@ public:
 private:
   unsigned int current_child_idx_;
   unsigned int num_of_retries_;
+  unsigned int retry_count_;
   BT::NodeStatus tick() override;
 };
 }  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/include/nav2_bt_navigator/recovery_node.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/recovery_node.hpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_BT_NAVIGATOR__RECOVERY_NODE_HPP_
+#define NAV2_BT_NAVIGATOR__RECOVERY_NODE_HPP_
+
+#include <string>
+#include "behaviortree_cpp/control_node.h"
+
+namespace nav2_bt_navigator
+{
+/**
+ * @brief The RecoveryNode has only two children and returns SUCCESS if and only if the first child
+ * returns SUCCESS.
+ *
+ * - If the first child returns FAILURE, the second child will be executed.  After that the first
+ * child is executed again if the second child returns SUCCESS.
+ *
+ * - If the first or second child returns RUNNING, this node returns RUNNING.
+ *
+ * - If the second child returns FAILURE, this control node will stop the loop and returns FAILURE.
+ *
+ */
+class RecoveryNode : public BT::ControlNode
+{
+public:
+  RecoveryNode(const std::string & name, const BT::NodeParameters & params);
+
+  ~RecoveryNode() override = default;
+
+  // Any BT node that accepts parameters must provide a requiredNodeParameters method
+  static const BT::NodeParameters & requiredNodeParameters()
+  {
+    static BT::NodeParameters params = {{"num_of_retries", "1"}};
+    return params;
+  }
+
+private:
+  unsigned int current_child_idx_;
+  unsigned int num_of_retries_;
+  BT::NodeStatus tick() override;
+};
+}  // namespace nav2_bt_navigator
+
+#endif  // NAV2_BT_NAVIGATOR__RECOVERY_NODE_HPP_

--- a/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
+++ b/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "nav2_bt_navigator/navigate_to_pose_behavior_tree.hpp"
+#include "nav2_bt_navigator/recovery_node.hpp"
 
 #include <memory>
 #include <string>
@@ -51,6 +52,9 @@ NavigateToPoseBehaviorTree::NavigateToPoseBehaviorTree()
 
   // Register our custom decorator nodes
   factory_.registerNodeType<nav2_tasks::RateController>("RateController");
+
+  // Register our custom Recovery nodes
+  factory_.registerNodeType<nav2_bt_navigator::RecoveryNode>("RecoveryNode");
 
   // Register our simple action nodes
   factory_.registerSimpleAction("globalLocalizationServiceRequest",

--- a/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
+++ b/nav2_bt_navigator/src/navigate_to_pose_behavior_tree.cpp
@@ -53,7 +53,7 @@ NavigateToPoseBehaviorTree::NavigateToPoseBehaviorTree()
   // Register our custom decorator nodes
   factory_.registerNodeType<nav2_tasks::RateController>("RateController");
 
-  // Register our custom Recovery nodes
+  // Register our custom control nodes
   factory_.registerNodeType<nav2_bt_navigator::RecoveryNode>("RecoveryNode");
 
   // Register our simple action nodes

--- a/nav2_bt_navigator/src/recovery_node.cpp
+++ b/nav2_bt_navigator/src/recovery_node.cpp
@@ -20,20 +20,20 @@ namespace nav2_bt_navigator
 RecoveryNode::RecoveryNode(const std::string & name, const BT::NodeParameters & params)
 : BT::ControlNode::ControlNode(name, params), current_child_idx_(0), retry_count_(0)
 {
-  getParam<unsigned int>("num_of_retries", num_of_retries_);
+  getParam<unsigned int>("number_of_retries", number_of_retries_);
 }
 
 BT::NodeStatus RecoveryNode::tick()
 {
   const unsigned children_count = children_nodes_.size();
 
-  if (children_count > 2) {
+  if (children_count != 2) {
     throw BT::BehaviorTreeException("Recovery Node '" + name() + "' must only have 2 children.");
   }
 
   setStatus(BT::NodeStatus::RUNNING);
 
-  while (current_child_idx_ < children_count && retry_count_ < num_of_retries_) {
+  while (current_child_idx_ < children_count && retry_count_ < number_of_retries_) {
     TreeNode * child_node = children_nodes_[current_child_idx_];
     const BT::NodeStatus child_status = child_node->executeTick();
 
@@ -49,7 +49,7 @@ BT::NodeStatus RecoveryNode::tick()
         case BT::NodeStatus::FAILURE:
           {
             // tick second child
-            if (retry_count_ <= num_of_retries_) {
+            if (retry_count_ <= number_of_retries_) {
               current_child_idx_++;
               break;
             } else {
@@ -64,6 +64,7 @@ BT::NodeStatus RecoveryNode::tick()
             return BT::NodeStatus::RUNNING;
           }
           break;
+
         default:
           {
           }
@@ -92,6 +93,7 @@ BT::NodeStatus RecoveryNode::tick()
             return BT::NodeStatus::RUNNING;
           }
           break;
+
         default:
           {
           }

--- a/nav2_bt_navigator/src/recovery_node.cpp
+++ b/nav2_bt_navigator/src/recovery_node.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include "nav2_bt_navigator/recovery_node.hpp"
+
+namespace nav2_bt_navigator
+{
+RecoveryNode::RecoveryNode(const std::string & name, const BT::NodeParameters & params)
+: BT::ControlNode::ControlNode(name, params), current_child_idx_(0)
+{
+  getParam<unsigned int>("num_of_retries", num_of_retries_);
+}
+
+BT::NodeStatus RecoveryNode::tick()
+{
+  const unsigned children_count = children_nodes_.size();
+
+  if (children_count > 2) {
+    throw BT::BehaviorTreeException("Recovery Node '" + name() + "' must only have 2 children.");
+  }
+
+  unsigned int retry_count = 0;
+  setStatus(BT::NodeStatus::RUNNING);
+
+  while (current_child_idx_ < children_count && retry_count < num_of_retries_) {
+    TreeNode * child_node = children_nodes_[current_child_idx_];
+    const BT::NodeStatus child_status = child_node->executeTick();
+
+    switch (child_status) {
+      case BT::NodeStatus::SUCCESS:
+        {
+          if (current_child_idx_ == 0) {
+            haltChildren(0);
+            return BT::NodeStatus::SUCCESS;
+          }
+          if (current_child_idx_ == 1) {
+            retry_count++;
+            current_child_idx_--;   //  retry first child
+            haltChildren(1);   // Is this necessary?
+          }
+        }
+        break;
+
+      case BT::NodeStatus::FAILURE:
+        {
+          if (current_child_idx_ == 0) {
+            if (retry_count <= num_of_retries_) {
+              current_child_idx_++;
+              break;
+            } else {
+              haltChildren(0);
+              return BT::NodeStatus::FAILURE;
+            }
+          }
+          if (current_child_idx_ == 1) {
+            ControlNode::halt();
+            return BT::NodeStatus::FAILURE;
+          }
+        }
+        break;
+
+      case BT::NodeStatus::RUNNING:
+        {
+          return BT::NodeStatus::RUNNING;  // Is this necessary?
+        }
+        break;
+
+      default:
+        {
+          // throw?
+        }
+    }  // end switch
+  }  // end while loop
+  return BT::NodeStatus::FAILURE;
+}
+
+}  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/src/recovery_node.cpp
+++ b/nav2_bt_navigator/src/recovery_node.cpp
@@ -41,6 +41,7 @@ BT::NodeStatus RecoveryNode::tick()
       case BT::NodeStatus::SUCCESS:
         {
           if (current_child_idx_ == 0) {
+            retry_count_ = 0;
             haltChildren(0);
             return BT::NodeStatus::SUCCESS;
           }
@@ -65,6 +66,7 @@ BT::NodeStatus RecoveryNode::tick()
           }
           if (current_child_idx_ == 1) {
             ControlNode::halt();
+            // retry_count_ = 0;
             return BT::NodeStatus::FAILURE;
           }
         }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (fixes #832 ) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (Gazebo + TB3) |

---

## Description of contribution in a few bullet points

- Added recovery node to nav2_bt_navigator (#832)
- Updated our existing `parallel_planning_w_recovery` tree to utilize the new recovery node

<a href="https://user-images.githubusercontent.com/39755151/59474267-fdbeef80-8dfa-11e9-8806-b114aca05982.png"><img src="https://user-images.githubusercontent.com/39755151/59474267-fdbeef80-8dfa-11e9-8806-b114aca05982.png" width="300"/></a>

<a href="https://user-images.githubusercontent.com/39755151/59530510-a53e2f80-8e98-11e9-9c7d-f91dce831876.jpg"><img src="https://user-images.githubusercontent.com/39755151/59530510-a53e2f80-8e98-11e9-9c7d-f91dce831876.jpg" width="600"/></a>


## Future work that may be required in bullet points

-  By utilizing the new RecoveryNode, implement local and global recovery actions.

<a href="https://user-images.githubusercontent.com/39755151/59537546-be041080-8eab-11e9-968f-8dc4bc524679.jpg"><img src="https://user-images.githubusercontent.com/39755151/59537546-be041080-8eab-11e9-968f-8dc4bc524679.jpg" width="400"/></a>

