### PR TITLE
Consolidate related parameter sections under a single namespace heading

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -103,13 +103,9 @@ local_costmap:
         max_obstacle_height: 2.0
         clearing: True
         marking: True
-
-local_costmap:
   local_costmap_client:
     ros__parameters:
       use_sim_time: True
-
-local_costmap:
   local_costmap_rclcpp_node:
     ros__parameters:
       use_sim_time: True
@@ -128,13 +124,9 @@ global_costmap:
         max_obstacle_height: 2.0
         clearing: True
         marking: True
-
-global_costmap:
   global_costmap_client:
     ros__parameters:
       use_sim_time: True
-
-global_costmap:
   global_costmap_rclcpp_node:
     ros__parameters:
       use_sim_time: True


### PR DESCRIPTION
The navigation2 launch implements rewriting of the input parameter file in
order to change some values, such as use_sim_time, based on command line
input. This is currently required to work around some node renaming that
occurs if we use the Node class in the launch system.

The input nav2_params.yaml file had separate sections for nodes under
the global_costmap and local costmap namespaces. This caused some issues
for our parameter rewriting code (see example below). So, to work around
this problem and to use what is probably a better organization anyways,
this PR puts the nodes under the same namespace section.

**To demonstate the current issue:**

Example input section:

```
local_costmap:
  local_costmap:
    ros__parameters:
      use_sim_time: True
      robot_radius: 0.17
      inflation_layer.cost_scaling_factor: 3.0
      obstacle_layer:
        enabled: True
      always_send_full_costmap: True
      observation_sources: scan
      scan:
        topic: /scan
        max_obstacle_height: 2.0
        clearing: True
        marking: True

local_costmap:
  local_costmap_client:
    ros__parameters:
      use_sim_time: True

local_costmap:
  local_costmap_rclcpp_node:
    ros__parameters:
      use_sim_time: True
```

Example resulting output:

```
local_costmap:
  local_costmap_rclcpp_node:
    ros__parameters: {use_sim_time: true}
```
The result is that use_sim_time is not set for local_costmap.local_costmap or local_costmap.local_costmap_client.

