### PR TITLE
Move install commands to subdirs where target is defined

### DIFF
--- a/nav2_util/CMakeLists.txt
+++ b/nav2_util/CMakeLists.txt
@@ -23,19 +23,6 @@ include_directories(include)
 set(library_name ${PROJECT_NAME}_core)
 add_subdirectory(src)
 
-install(TARGETS
-  ${library_name}
-  map_lib
-  pf_lib
-  sensors_lib
-  motions_lib
-  map_loader
-  lifecycle_bringup
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
-)
-
 install(DIRECTORY include/
   DESTINATION include/
 )

--- a/nav2_util/src/CMakeLists.txt
+++ b/nav2_util/src/CMakeLists.txt
@@ -28,3 +28,11 @@ add_executable(lifecycle_bringup
   lifecycle_bringup_commandline.cpp
 )
 target_link_libraries(lifecycle_bringup ${library_name})
+
+install(TARGETS
+  ${library_name}
+  lifecycle_bringup
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)

--- a/nav2_util/src/map/CMakeLists.txt
+++ b/nav2_util/src/map/CMakeLists.txt
@@ -5,3 +5,10 @@ add_library(map_lib SHARED
   map_draw.c
   map_cspace.cpp
 )
+
+install(TARGETS
+  map_lib
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)

--- a/nav2_util/src/map_loader/CMakeLists.txt
+++ b/nav2_util/src/map_loader/CMakeLists.txt
@@ -15,3 +15,10 @@ target_link_libraries(map_loader
     ${SDL_LIBRARY}
     ${SDL_IMAGE_LIBRARIES}
 )
+
+install(TARGETS
+  map_loader
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)

--- a/nav2_util/src/motion_model/CMakeLists.txt
+++ b/nav2_util/src/motion_model/CMakeLists.txt
@@ -4,3 +4,10 @@ add_library(motions_lib SHARED
   motion_model.cpp
 )
 target_link_libraries(motions_lib pf_lib)
+
+install(TARGETS
+  motions_lib
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)

--- a/nav2_util/src/pf/CMakeLists.txt
+++ b/nav2_util/src/pf/CMakeLists.txt
@@ -10,3 +10,10 @@ add_library(pf_lib SHARED
   eig3.c
   pf_draw.c
 )
+
+install(TARGETS
+  pf_lib
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)

--- a/nav2_util/src/sensors/CMakeLists.txt
+++ b/nav2_util/src/sensors/CMakeLists.txt
@@ -5,3 +5,10 @@ add_library(sensors_lib SHARED
   laser/likelihood_field_model_prob.cpp
 )
 target_link_libraries(sensors_lib pf_lib)
+
+install(TARGETS
+  sensors_lib
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #768, fixes #856  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

Moves `install` commands to the subdirectory where the library is defined to properly support CMake 3.10.2 on some systems.