### PR TITLE
Re-add republishing of map every 2 sec

### DIFF
--- a/nav2_map_server/include/nav2_map_server/occ_grid_loader.hpp
+++ b/nav2_map_server/include/nav2_map_server/occ_grid_loader.hpp
@@ -77,6 +77,9 @@ protected:
 
   // The name of the service for getting a map
   static constexpr const char * service_name_{"map"};
+
+  // Timer for republishing map
+  rclcpp::TimerBase::SharedPtr timer_;
 };
 
 }  // namespace nav2_map_server

--- a/nav2_map_server/src/occ_grid_loader.cpp
+++ b/nav2_map_server/src/occ_grid_loader.cpp
@@ -182,6 +182,10 @@ OccGridLoader::on_activate(const rclcpp_lifecycle::State & /*state*/)
   occ_pub_->on_activate();
   occ_pub_->publish(*msg_);
 
+  // due to timing / discovery issues, need to republish map
+  auto timer_callback = [this]() -> void {occ_pub_->publish(*msg_);};
+  timer_ = node_->create_wall_timer(2s, timer_callback);
+
   return nav2_util::CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Description of contribution in a few bullet points

When running with autostart = True, I don't see a map appear in RViz. I'm not sure why but I don't believe that the latching is working correctly for the /map topic. However, when I re-publish the map topic every 2 seconds, then the map appears in RViz. This is consistent with what we were doing before we moved to lifecycle nodes.


---

## Future work that may be required in bullet points

Debug why this is required. It may be that the QOS settings for the map need to be changed in RViz to 'transient local', 'reliable' which is what we're using for publishing the /map topic.

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

---

