### PR TITLE
Set environment variables so logging comes out in order

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -81,6 +81,9 @@ def generate_launch_description():
         cmd=[simulator, '-s', 'libgazebo_ros_init.so', world],
         cwd=[launch_dir], output='screen')
 
+    stdout_linebuf_envvar = launch.actions.SetEnvironmentVariable(
+        'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1')
+
     start_robot_state_publisher_cmd = launch.actions.ExecuteProcess(
         cmd=[
             os.path.join(
@@ -170,6 +173,9 @@ def generate_launch_description():
     ld.add_action(declare_world_cmd)
     ld.add_action(declare_params_file_cmd)
     ld.add_action(declare_rviz_config_file_cmd)
+
+    # Set environment variables
+    ld.add_action(stdout_linebuf_envvar)
 
     # Add any actions to launch in simulation (conditioned on 'use_simulation')
     ld.add_action(start_gazebo_cmd)

--- a/nav2_bringup/launch/nav2_simulation_launch.py
+++ b/nav2_bringup/launch/nav2_simulation_launch.py
@@ -99,6 +99,9 @@ def generate_launch_description():
                                    'worlds/turtlebot3_worlds/waffle.model'),
         description='Full path to world file to load')
 
+    stdout_linebuf_envvar = launch.actions.SetEnvironmentVariable(
+        'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1')
+
     # Specify the actions
     start_gazebo_cmd = launch.actions.ExecuteProcess(
         condition=IfCondition(use_simulation),
@@ -203,6 +206,9 @@ def generate_launch_description():
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_use_simulation_cmd)
     ld.add_action(declare_world_cmd)
+
+    # Set environment variables
+    ld.add_action(stdout_linebuf_envvar)
 
     # Add any actions to launch in simulation (conditioned on 'use_simulation')
     ld.add_action(start_gazebo_cmd)


### PR DESCRIPTION
When launched with launch_ros, executables can withhold logging output at log level "INFO" until termination.
So RCLCPP_WARN will get output immediately, but you won't see RCLCPP_INFO until the program terminates.
Explicitly make stdout line-buffered so this doesn't happen.

Better solution than PR #852 