### PR TITLE
Spin rclcpp node on executor and cancel

### DIFF
--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -51,7 +51,7 @@ protected:
 
   // When creating a local node, this class will launch a separate thread created to spin the node
   std::unique_ptr<std::thread> rclcpp_thread_;
-  std::atomic<bool> stop_rclcpp_thread_{false};
+  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> rclcpp_exec_;
 };
 
 }  // namespace nav2_util

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -47,17 +47,17 @@ LifecycleNode::LifecycleNode(
   use_rclcpp_node_(use_rclcpp_node)
 {
   if (use_rclcpp_node_) {
-    stop_rclcpp_thread_ = false;
     std::vector<std::string> new_args = options.arguments();
     new_args.push_back(
       std::string("__node:=") + this->get_name() + "_rclcpp_node");
     rclcpp_node_ = std::make_shared<rclcpp::Node>(
       "_", namespace_, rclcpp::NodeOptions(options).arguments(new_args));
+    rclcpp_exec_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
     rclcpp_thread_ = std::make_unique<std::thread>(
       [&](rclcpp::Node::SharedPtr node) {
-        while (!stop_rclcpp_thread_ && rclcpp::ok()) {
-          rclcpp::spin_some(node);
-        }
+        rclcpp_exec_->add_node(node);
+        rclcpp_exec_->spin();
+        rclcpp_exec_->remove_node(node);
       },
       rclcpp_node_);
   }
@@ -74,7 +74,7 @@ LifecycleNode::~LifecycleNode()
   }
 
   if (use_rclcpp_node_) {
-    stop_rclcpp_thread_ = true;
+    rclcpp_exec_->cancel();
     rclcpp_thread_->join();
   }
 }

--- a/nav2_util/test/CMakeLists.txt
+++ b/nav2_util/test/CMakeLists.txt
@@ -20,3 +20,7 @@ target_link_libraries(test_lifecycle_utils ${library_name})
 ament_add_gtest(test_actions test_actions.cpp)
 ament_target_dependencies(test_actions rclcpp_action test_msgs)
 target_link_libraries(test_actions ${library_name})
+
+ament_add_gtest(test_lifecycle_node test_lifecycle_node.cpp)
+ament_target_dependencies(test_lifecycle_node rclcpp_lifecycle)
+target_link_libraries(test_lifecycle_node ${library_name})

--- a/nav2_util/test/test_lifecycle_node.cpp
+++ b/nav2_util/test/test_lifecycle_node.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "nav2_util/lifecycle_node.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+RclCppFixture g_rclcppfixture;
+
+// For the following two tests, if the LifecycleNode doesn't shut down properly,
+// the overall test will hang since the rclcpp thread will still be running,
+// preventing the executable from exiting (the test will hang)
+
+TEST(LifecycleNode, RclcppNodeExitsCleanly)
+{
+  // Make sure the node exits cleanly when using an rclcpp_node and associated thread
+  auto node1 = std::make_shared<nav2_util::LifecycleNode>("test_node", "", true);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  SUCCEED();
+}
+
+TEST(LifecycleNode, MultipleRclcppNodesExitCleanly)
+{
+  // Try a couple nodes w/ rclcpp_node and threads
+  auto node1 = std::make_shared<nav2_util::LifecycleNode>("test_node1", "", true);
+  auto node2 = std::make_shared<nav2_util::LifecycleNode>("test_node2", "", true);
+
+  // Another one without rclcpp_node and on the stack
+  nav2_util::LifecycleNode node3("test_node3", "", false);
+
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  SUCCEED();
+}


### PR DESCRIPTION
This approach replaces #854 

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #792 |
| Primary OS tested on | Ubuntu |

---

## Description of contribution in a few bullet points
- Added executor to spin the rclcpp node in thread
- Cancel executor in destructor of nav2_util::LifecycleNode in order to stop spin in thread
---

## Future work that may be required in bullet points
- The only difference between this approach and a normal `rclcpp::spin(node)` is that we have created our own executor that we can use to cancel the spin(). Since the normal spin locally creates a `rclcpp::executors::SingleThreadedExecutor`, we could consider adding an interface such as:

```
void
rclcpp::spin(
  rclcpp::Node::SharedPtr node_ptr, 
  rclcpp::executors::SingleThreadedExecutor & exec = rclcpp::executors::SingleThreadedExecutor());
```
