### PR TITLE
Use platform-independent library paths for DWB plugins

### DIFF
--- a/nav2_dwb_controller/dwb_critics/default_critics.xml
+++ b/nav2_dwb_controller/dwb_critics/default_critics.xml
@@ -1,5 +1,5 @@
 <class_libraries>
-  <library path="lib/libdwb_critics">
+  <library path="dwb_critics">
     <class type="dwb_critics::PreferForwardCritic" base_class_type="dwb_core::TrajectoryCritic">
       <description>Penalize trajectories with move backwards and/or turn too much</description>
     </class>

--- a/nav2_dwb_controller/dwb_plugins/plugins.xml
+++ b/nav2_dwb_controller/dwb_plugins/plugins.xml
@@ -1,10 +1,10 @@
 <class_libraries>
-  <library path="lib/libsimple_goal_checker">
+  <library path="simple_goal_checker">
     <class type="dwb_plugins::SimpleGoalChecker" base_class_type="dwb_core::GoalChecker">
       <description></description>
     </class>
   </library>
-  <library path="lib/libstandard_traj_generator">
+  <library path="standard_traj_generator">
     <class type="dwb_plugins::StandardTrajectoryGenerator" base_class_type="dwb_core::TrajectoryGenerator">
       <description></description>
     </class>
@@ -12,7 +12,7 @@
       <description></description>
     </class>
   </library>
-  <library path="lib/libstopped_goal_checker">
+  <library path="stopped_goal_checker">
     <class type="dwb_plugins::StoppedGoalChecker" base_class_type="dwb_core::GoalChecker">
       <description></description>
     </class>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora Linux |
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points

* Resolves the following runtime warnings:
   ```
   [dwb_controller-8] [WARN] [pluginlib.ClassLoader]: given plugin name 'lib/libstandard_traj_generator' should be '/libstandard_traj_generator' for better portability
   [dwb_controller-8] [WARN] [pluginlib.ClassLoader]: given plugin name 'lib/libsimple_goal_checker' should be '/libsimple_goal_checker' for better portability
   [dwb_controller-8] [WARN] [pluginlib.ClassLoader]: given plugin name 'lib/libdwb_critics' should be '/libdwb_critics' for better portability
   ```
* This aligns the DWB plugins with costmap, where this is already correct:
  https://github.com/ros-planning/navigation2/blob/549c69a6619dccb6344a96919e5c830aa9078a9d/nav2_costmap_2d/costmap_plugins.xml#L2
  https://github.com/ros-planning/navigation2/blob/549c69a6619dccb6344a96919e5c830aa9078a9d/nav2_costmap_2d/CMakeLists.txt#L79
