### PR TITLE
Fix robot model and LiDAR display in RViz config

### DIFF
--- a/nav2_bringup/launch/nav2_default_view.rviz
+++ b/nav2_bringup/launch/nav2_default_view.rviz
@@ -50,8 +50,8 @@ Visualization Manager:
       Class: rviz_default_plugins/RobotModel
       Collision Enabled: false
       Description File: ""
-      Description Source: File
-      Description Topic: /tf
+      Description Source: Topic
+      Description Topic: /robot_description
       Enabled: true
       Links:
         All Links Enabled: true
@@ -111,7 +111,7 @@ Visualization Manager:
       Size (m): 0.009999999776482582
       Style: Flat Squares
       Topic: /scan
-      Unreliable: false
+      Unreliable: true
       Use Fixed Frame: true
       Use rainbow: true
       Value: true


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora Linux |
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points
* Laser scans are published using `SensorDataQoS`, which means 'Unreliable' should be checked in RViz
* `robot_state_publisher` pushes out the model over `/robot_description`.