### PR TITLE
Improve shutdown reliability

### DIFF
--- a/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
+++ b/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
@@ -69,6 +69,9 @@ protected:
 
   // The local planner
   std::unique_ptr<dwb_core::DWBLocalPlanner> planner_;
+
+  // An executor used to spin the costmap node
+  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> costmap_executor_;
 };
 
 }  // namespace dwb_controller

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -43,6 +43,8 @@ DwbController::DwbController()
   costmap_thread_ = std::make_unique<std::thread>(
     [&](rclcpp_lifecycle::LifecycleNode::SharedPtr node)
     {
+      // TODO(mjeronimo): Once Brian pushes his change upstream to rlcpp executors, we'll
+      // be able to provide our own executor to spin(), reducing this to a single line
       costmap_executor_->add_node(node->get_node_base_interface());
       costmap_executor_->spin();
       costmap_executor_->remove_node(node->get_node_base_interface());

--- a/nav2_world_model/include/nav2_world_model/world_model.hpp
+++ b/nav2_world_model/include/nav2_world_model/world_model.hpp
@@ -59,6 +59,9 @@ protected:
   // The frame_id and metadata layer values used in the service response message
   static constexpr const char * frame_id_{"map"};
   static constexpr const char * metadata_layer_{"Master"};
+
+  // An executor used to spin the costmap node
+  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> costmap_executor_;
 };
 
 }  // namespace nav2_world_model

--- a/nav2_world_model/src/world_model.cpp
+++ b/nav2_world_model/src/world_model.cpp
@@ -27,15 +27,23 @@ WorldModel::WorldModel()
   // The costmap node is used in the implementation of the world model
   costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
 
+  // Create an executor that will be used to spin the costmap node
+  costmap_executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+
   // Launch a thread to run the costmap node
   costmap_thread_ = std::make_unique<std::thread>(
-    [](rclcpp_lifecycle::LifecycleNode::SharedPtr node)
-    {rclcpp::spin(node->get_node_base_interface());}, costmap_ros_);
+    [&](rclcpp_lifecycle::LifecycleNode::SharedPtr node)
+    {
+      costmap_executor_->add_node(node->get_node_base_interface());
+      costmap_executor_->spin();
+      costmap_executor_->remove_node(node->get_node_base_interface());
+    }, costmap_ros_);
 }
 
 WorldModel::~WorldModel()
 {
   RCLCPP_INFO(get_logger(), "Destroying");
+  costmap_executor_->cancel();
   costmap_thread_->join();
 }
 

--- a/nav2_world_model/src/world_model.cpp
+++ b/nav2_world_model/src/world_model.cpp
@@ -34,6 +34,8 @@ WorldModel::WorldModel()
   costmap_thread_ = std::make_unique<std::thread>(
     [&](rclcpp_lifecycle::LifecycleNode::SharedPtr node)
     {
+      // TODO(mjeronimo): Once Brian pushes his change upstream to rlcpp executors, we'll
+      // be able to provide our own executor to spin(), reducing this to a single line
       costmap_executor_->add_node(node->get_node_base_interface());
       costmap_executor_->spin();
       costmap_executor_->remove_node(node->get_node_base_interface());


### PR DESCRIPTION
## Description
* Previously, the nodes that contain the costmap node (world_model and dwb_controller) relied upon the rclcpp::shutdown (checking rclcpp::ok) to exit the contained node's thread. This PR uses an executor and its cancel operation to cause the thread to exit. This eliminates a race condition that was present which occasionally caused crashes at shutdown. 

## Future work
* Either make the costmap node a full-fledged node where it is accessed through normal ROS mechanisms (topics, services, etc.) or have it _not_ be a ROS node and accept a ROS node pointer to use to create its topics, etc. We currently have it as a hybrid where it is a ROS node, but the classes that use it (world_model and dwb) access its functionality directly using method calls. 