### PR TITLE
Use proper exception rethrow for DWB critic init error

### DIFF
--- a/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
@@ -180,7 +180,7 @@ DWBLocalPlanner::loadCritics()
       plugin->initialize(node_, plugin_name, costmap_ros_);
     } catch (const std::exception & e) {
       RCLCPP_ERROR(node_->get_logger(), "Couldn't initialize critic plugin!");
-      throw e;
+      throw;
     }
     RCLCPP_INFO(node_->get_logger(), "Critic plugin initialized");
   }


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora Linux |
| Robotic platform tested on | hardware turtlebot3 waffle |

---

## Description of contribution in a few bullet points
* This change makes critic initialization error messages display properly.
   Without this change:
   ```
   [dwb_controller-7] [ERROR] [dwb_controller]: Couldn't initialize critic plugin!
   [dwb_controller-7] [ERROR] [dwb_controller]: Couldn't load critics! Caught exception: std::exception
   ```