### PR TITLE
Fix backwards compabile parameters

### DIFF
--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
@@ -99,7 +99,9 @@ public:
     name_ = name;
     costmap_ros_ = costmap_ros;
     nh_ = nh;
-    nh_->declare_parameter(name_ + ".scale", rclcpp::ParameterValue(1.0));
+    if (!nh_->has_parameter(name_ + ".scale")) {
+      nh_->declare_parameter(name_ + ".scale", rclcpp::ParameterValue(1.0));
+    }
     nh_->get_parameter(name_ + ".scale", scale_);
     onInit();
   }

--- a/nav2_dwb_controller/dwb_critics/src/twirling.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/twirling.cpp
@@ -39,7 +39,9 @@ namespace dwb_critics
 {
 void TwirlingCritic::onInit()
 {
-  nh_->declare_parameter(name_ + ".scale", rclcpp::ParameterValue(0.0));
+  if (!nh_->has_parameter(name_ + ".scale")) {
+    nh_->declare_parameter(name_ + ".scale", rclcpp::ParameterValue(0.0));
+  }
 
   // Scale is set to 0 by default, so if it was not set otherwise, set to 0
   nh_->get_parameter(name_ + ".scale", scale_);

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
@@ -143,18 +143,15 @@ void moveParameter(
 {
   param_t value;
   if (nh->get_parameter(current_name, value)) {
-    // TODO(crdelsey): What's the ROS 2 equivalent of deleteParam?
-    // if (should_delete)
-    //   nh->deleteParam(old_name);
+    if (should_delete) {nh->undeclare_parameter(old_name);}
     return;
   }
   if (nh->get_parameter(old_name, value)) {
-    // TODO(crdelsey): What's the ROS 2 equivalent of deleteParam?
-    // if (should_delete) nh->deleteParam(old_name);
+    if (should_delete) {nh->undeclare_parameter(old_name);}
   } else {
     value = default_value;
   }
-  nh->set_parameters({rclcpp::Parameter(current_name, value)});
+  nh->set_parameter(rclcpp::Parameter(current_name, value));
 }
 
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Fedora Linux |
| Robotic platform tested on | hardware turtlebot3 waffle |

---

## Description of contribution in a few bullet points
* Without these changes, I've been seeing 'foo has already been declared' errors.
* This doesn't appear to be covered by tests, but repro's when the `critics` parameter isn't set, triggering the following code path:
   https://github.com/ros-planning/navigation2/blob/5fe3d4ecc2a5abd7abcdb622ec34f05721da3268/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp#L190-L230

---

## Future work that may be required in bullet points
* When a backwards compatible parameter is set and moved, it is deleted. However, if neither the supported nor backwards compatible parameters are set, they're both left declared. I'm not sure what the desired behavior here is, but it seems inconsistent.

I'd like to request maintainer: @crdelsey to review this PR.