### PR TITLE
Reverse order of shutdown nodes

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -67,7 +67,7 @@ protected:
   bool changeStateForNode(const std::string & node_name, std::uint8_t transition);
 
   // For each node in the map, transition to the new target state
-  bool changeStateForAllNodes(std::uint8_t transition);
+  bool changeStateForAllNodes(std::uint8_t transition, bool reverse_order = false);
 
   // Convenience function to highlight the output on the console
   void message(const std::string & msg);

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -126,11 +126,20 @@ LifecycleManager::changeStateForNode(const std::string & node_name, std::uint8_t
 }
 
 bool
-LifecycleManager::changeStateForAllNodes(std::uint8_t transition)
+LifecycleManager::changeStateForAllNodes(std::uint8_t transition, bool reverse_order)
 {
-  for (const auto & kv : node_map_) {
-    if (!changeStateForNode(kv.first, transition)) {
-      return false;
+  if (!reverse_order) {
+    for (auto & node_name : node_names_) {
+      if (!changeStateForNode(node_name, transition)) {
+        return false;
+      }
+    }
+  } else {
+    std::vector<std::string>::reverse_iterator rit;
+    for (rit = node_names_.rbegin(); rit != node_names_.rend(); ++rit) {
+      if (!changeStateForNode(*rit, transition)) {
+        return false;
+      }
     }
   }
 
@@ -154,9 +163,9 @@ void
 LifecycleManager::shutdownAllNodes()
 {
   message("Deactivate, cleanup, and shutdown nodes");
-  changeStateForAllNodes(Transition::TRANSITION_DEACTIVATE);
-  changeStateForAllNodes(Transition::TRANSITION_CLEANUP);
-  changeStateForAllNodes(Transition::TRANSITION_UNCONFIGURED_SHUTDOWN);
+  changeStateForAllNodes(Transition::TRANSITION_DEACTIVATE, true);
+  changeStateForAllNodes(Transition::TRANSITION_CLEANUP, true);
+  changeStateForAllNodes(Transition::TRANSITION_UNCONFIGURED_SHUTDOWN, true);
 }
 
 void


### PR DESCRIPTION
This PR aims to address _part_ of the issue concerning clean shutdown of nodes even while the robot is navigating

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #883  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo simulation turtlebot3 |



## Description of contribution in a few bullet points
- reversed order of shutting down nodes  (reverse of bringup)


## Future work that may be required in bullet points
- the `changeStateForAllNodes` function is only being used by the `shutdownAllNodes` call. I think we could refactor/clean up the code either by consolidating those functions or by using the former elsewhere during bringup. Instead of bringing up each node with configure and activate back to back, we could transition all nodes to configure first, and then transition them all to activate next. 

