### PR TITLE
Removing service client nodes from navfn

### DIFF
--- a/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
+++ b/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
@@ -43,8 +43,7 @@ public:
   NavfnPlanner();
   ~NavfnPlanner();
 
-  // Provides the executor (with the node added) for spinning
-  std::unique_ptr<rclcpp::executor::Executor> get_executor();
+  bool has_nested_service_requests() {return has_nested_client_;}
 
 protected:
   // Implement the lifecycle interface
@@ -56,6 +55,12 @@ protected:
   nav2_util::CallbackReturn on_error(const rclcpp_lifecycle::State & state) override;
 
   using ActionServer = nav2_util::SimpleActionServer<nav2_msgs::action::ComputePathToPose>;
+
+  // Whether this node has one or more clients performing service requests within service callbacks
+  bool has_nested_client_;
+
+  // Callback group of the service clients which are invoked within callbacks
+  std::shared_ptr<rclcpp::callback_group::CallbackGroup> nested_client_group_;
 
   // Our action server implements the ComputePathToPose action
   std::unique_ptr<ActionServer> action_server_;
@@ -137,9 +142,6 @@ protected:
   // Service clients for getting the costmap and robot pose
   std::unique_ptr<nav2_util::CostmapServiceClient> costmap_client_;
   std::unique_ptr<nav2_util::GetRobotPoseClient> get_robot_pose_client_;
-
-  // Callback group of the service clients, these will be asynchronous
-  std::shared_ptr<rclcpp::callback_group::CallbackGroup> async_services_group_;
 
   // Publishers for the path and endpoints
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr plan_publisher_;

--- a/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
+++ b/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
@@ -43,6 +43,9 @@ public:
   NavfnPlanner();
   ~NavfnPlanner();
 
+  // Provides the executor (with the node added) for spinning
+  std::unique_ptr<rclcpp::executor::Executor> get_executor();
+
 protected:
   // Implement the lifecycle interface
   nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
@@ -131,9 +134,12 @@ protected:
   // Planner based on ROS1 NavFn algorithm
   std::unique_ptr<NavFn> planner_;
 
-  // Service client for getting the costmap
-  nav2_util::CostmapServiceClient costmap_client_{"navfn_planner"};
-  nav2_util::GetRobotPoseClient get_robot_pose_client_{"navfn_planner"};
+  // Service clients for getting the costmap and robot pose
+  std::unique_ptr<nav2_util::CostmapServiceClient> costmap_client_;
+  std::unique_ptr<nav2_util::GetRobotPoseClient> get_robot_pose_client_;
+
+  // Callback group of the service clients, these will be asynchronous
+  std::shared_ptr<rclcpp::callback_group::CallbackGroup> async_services_group_;
 
   // Publishers for the path and endpoints
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr plan_publisher_;

--- a/nav2_navfn_planner/src/main.cpp
+++ b/nav2_navfn_planner/src/main.cpp
@@ -15,7 +15,7 @@
 #include <memory>
 
 #include "nav2_navfn_planner/navfn_planner.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include "nav2_util/executors.hpp"
 
 int main(int argc, char ** argv)
 {
@@ -27,7 +27,8 @@ int main(int argc, char ** argv)
   // <FEEDBACK REQUEST> I'm open to suggestions but I'd rather not expose we're using
   // a multithreaded executor due to some implementation detail. Can you think of a better pattern?
   // Also consider we'll have to revist this once we start composing nodes.
-  auto exec = planner->get_executor();
+  auto exec = nav2_util::get_executor(planner->has_nested_service_requests());
+  exec->add_node(planner->get_node_base_interface());
   exec->spin();
 
   rclcpp::shutdown();

--- a/nav2_navfn_planner/src/main.cpp
+++ b/nav2_navfn_planner/src/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char ** argv)
 {
-  using namespace rclcpp::executors;
-  using namespace rclcpp::executor;
-
   rclcpp::init(argc, argv);
 
   auto planner = std::make_shared<nav2_navfn_planner::NavfnPlanner>();

--- a/nav2_navfn_planner/src/main.cpp
+++ b/nav2_navfn_planner/src/main.cpp
@@ -19,10 +19,20 @@
 
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
-  auto node = std::make_shared<nav2_navfn_planner::NavfnPlanner>();
-  rclcpp::spin(node->get_node_base_interface());
-  rclcpp::shutdown();
+  using namespace rclcpp::executors;
+  using namespace rclcpp::executor;
 
+  rclcpp::init(argc, argv);
+
+  auto planner = std::make_shared<nav2_navfn_planner::NavfnPlanner>();
+
+  // The planner needs a special executor
+  // <FEEDBACK REQUEST> I'm open to suggestions but I'd rather not expose we're using
+  // a multithreaded executor due to some implementation detail. Can you think of a better pattern?
+  // Also consider we'll have to revist this once we start composing nodes.
+  auto exec = planner->get_executor();
+  exec->spin();
+
+  rclcpp::shutdown();
   return 0;
 }

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
 #include "builtin_interfaces/msg/duration.hpp"
 #include "geometry_msgs/msg/point.hpp"
@@ -72,14 +73,13 @@ std::unique_ptr<rclcpp::executor::Executor> NavfnPlanner::get_executor()
   //              for a single node. Replace the double-threaded executor with a custom
   //              async service executor.
 
-  using namespace rclcpp::executors;
-  using namespace rclcpp::executor;
-
   const bool yield_before_execute = true;
   const unsigned number_of_threads = 2;
 
-  auto exec = std::make_unique<MultiThreadedExecutor>(ExecutorArgs(),
+  auto exec = std::make_unique<rclcpp::executors::MultiThreadedExecutor>(
+    rclcpp::executor::ExecutorArgs(),
     number_of_threads, yield_before_execute);
+
   exec->add_node(this->get_node_base_interface());
 
   return std::move(exec);
@@ -100,9 +100,9 @@ NavfnPlanner::on_configure(const rclcpp_lifecycle::State & /*state*/)
     rclcpp::callback_group::CallbackGroupType::Reentrant);
 
   costmap_client_ = std::make_unique<nav2_util::CostmapServiceClient>(node,
-    async_services_group_);
+      async_services_group_);
   get_robot_pose_client_ = std::make_unique<nav2_util::GetRobotPoseClient>(node,
-    async_services_group_);
+      async_services_group_);
 
   // Create a planner based on the new costmap size
   getCostmap(costmap_);

--- a/nav2_util/include/nav2_util/costmap_service_client.hpp
+++ b/nav2_util/include/nav2_util/costmap_service_client.hpp
@@ -26,13 +26,15 @@ namespace nav2_util
 class CostmapServiceClient : public ServiceClient<nav2_msgs::srv::GetCostmap>
 {
 public:
-  explicit CostmapServiceClient(rclcpp::Node::SharedPtr node,
+  explicit CostmapServiceClient(
+    rclcpp::Node::SharedPtr node,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
   : ServiceClient<nav2_msgs::srv::GetCostmap>("GetCostmap", node, group)
   {
   }
 
-  explicit CostmapServiceClient(rclcpp_lifecycle::LifecycleNode::SharedPtr node,
+  explicit CostmapServiceClient(
+    rclcpp_lifecycle::LifecycleNode::SharedPtr node,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
   : ServiceClient<nav2_msgs::srv::GetCostmap>("GetCostmap", node, group)
   {

--- a/nav2_util/include/nav2_util/costmap_service_client.hpp
+++ b/nav2_util/include/nav2_util/costmap_service_client.hpp
@@ -26,20 +26,20 @@ namespace nav2_util
 class CostmapServiceClient : public ServiceClient<nav2_msgs::srv::GetCostmap>
 {
 public:
-  explicit CostmapServiceClient(const std::string & parent_node_name)
-  : ServiceClient<nav2_msgs::srv::GetCostmap>("GetCostmap", parent_node_name)
+  explicit CostmapServiceClient(rclcpp::Node::SharedPtr node,
+    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
+  : ServiceClient<nav2_msgs::srv::GetCostmap>("GetCostmap", node, group)
   {
   }
 
-  explicit CostmapServiceClient(rclcpp::Node::SharedPtr & node)
-  : ServiceClient<nav2_msgs::srv::GetCostmap>("GetCostmap", node)
+  explicit CostmapServiceClient(rclcpp_lifecycle::LifecycleNode::SharedPtr node,
+    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
+  : ServiceClient<nav2_msgs::srv::GetCostmap>("GetCostmap", node, group)
   {
   }
 
-  using CostmapServiceRequest =
-    ServiceClient<nav2_msgs::srv::GetCostmap>::RequestType;
-  using CostmapServiceResponse =
-    ServiceClient<nav2_msgs::srv::GetCostmap>::ResponseType;
+  using CostmapServiceRequest = ServiceClient<nav2_msgs::srv::GetCostmap>::RequestType;
+  using CostmapServiceResponse = ServiceClient<nav2_msgs::srv::GetCostmap>::ResponseType;
 };
 
 }  // namespace nav2_util

--- a/nav2_util/include/nav2_util/executors.hpp
+++ b/nav2_util/include/nav2_util/executors.hpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_UTIL__EXECUTORS_HPP_
+#define NAV2_UTIL__EXECUTORS_HPP_
+
+#include <utility>
+#include <memory>
+
+#include "rclcpp/executors/multi_threaded_executor.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/node_interfaces/node_base.hpp"
+
+namespace nav2_util
+{
+
+// Some nav2 nodes perform service requests within service callbacks. This becomes a problem if
+// the node is spinning on a single-threaded executor, since waiting for the service response
+// blocks further spinning of the node. The request is sent asynchronously, but the response
+// comes on an executable waiting on the queue, and nested spinning is currently not supported.
+
+// There is an open issue to address this upstream:
+// https://github.com/ros2/rclcpp/issues/773
+
+// The current solution is to use a multi-threaded executor. A second thread will process the
+// service response, if service client is assigned to a `Reentrant` callback group.
+
+std::unique_ptr<rclcpp::executor::Executor>
+get_executor(const bool service_requests_on_callbacks)
+{
+  if (service_requests_on_callbacks) {
+    // TODO(orduno) It's not required to have two threads processing executables all the time
+    //              for a single node. Replace the double-threaded executor with one that
+    //              executes callbacks with internal service requests on a separate thread
+    //              i.e., an async service executor.
+
+    const unsigned number_of_threads = 2;
+    const bool yield_thread_before_execute = false;
+
+    return std::move(
+      std::make_unique<rclcpp::executors::MultiThreadedExecutor>(
+        rclcpp::executor::ExecutorArgs(),
+        number_of_threads, yield_thread_before_execute));
+  }
+
+  return std::move(std::make_unique<rclcpp::executors::SingleThreadedExecutor>());
+}
+
+std::shared_ptr<rclcpp::callback_group::CallbackGroup>
+create_nested_request_group(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> nb)
+{
+  return nb->create_callback_group(rclcpp::callback_group::CallbackGroupType::Reentrant);
+}
+
+}  // namespace nav2_util
+
+#endif  // NAV2_UTIL__EXECUTORS_HPP_

--- a/nav2_util/include/nav2_util/get_robot_pose_client.hpp
+++ b/nav2_util/include/nav2_util/get_robot_pose_client.hpp
@@ -15,6 +15,8 @@
 #ifndef NAV2_UTIL__GET_ROBOT_POSE_CLIENT_HPP_
 #define NAV2_UTIL__GET_ROBOT_POSE_CLIENT_HPP_
 
+#include <string>
+
 #include "nav2_util/service_client.hpp"
 #include "nav2_msgs/srv/get_robot_pose.hpp"
 
@@ -29,13 +31,15 @@ public:
   {
   }
 
-  explicit GetRobotPoseClient(rclcpp::Node::SharedPtr node,
+  explicit GetRobotPoseClient(
+    rclcpp::Node::SharedPtr node,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
   : ServiceClient<nav2_msgs::srv::GetRobotPose>("GetRobotPose", node, group)
   {
   }
 
-  explicit GetRobotPoseClient(rclcpp_lifecycle::LifecycleNode::SharedPtr node,
+  explicit GetRobotPoseClient(
+    rclcpp_lifecycle::LifecycleNode::SharedPtr node,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
   : ServiceClient<nav2_msgs::srv::GetRobotPose>("GetRobotPose", node, group)
   {
@@ -47,6 +51,6 @@ public:
     ServiceClient<nav2_msgs::srv::GetRobotPose>::ResponseType;
 };
 
-}  // namespace nav2_tasks
+}  // namespace nav2_util
 
 #endif  // NAV2_UTIL__GET_ROBOT_POSE_CLIENT_HPP_

--- a/nav2_util/include/nav2_util/get_robot_pose_client.hpp
+++ b/nav2_util/include/nav2_util/get_robot_pose_client.hpp
@@ -29,8 +29,15 @@ public:
   {
   }
 
-  explicit GetRobotPoseClient(rclcpp::Node::SharedPtr & node)
-  : ServiceClient<nav2_msgs::srv::GetRobotPose>("GetRobotPose", node)
+  explicit GetRobotPoseClient(rclcpp::Node::SharedPtr node,
+    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
+  : ServiceClient<nav2_msgs::srv::GetRobotPose>("GetRobotPose", node, group)
+  {
+  }
+
+  explicit GetRobotPoseClient(rclcpp_lifecycle::LifecycleNode::SharedPtr node,
+    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
+  : ServiceClient<nav2_msgs::srv::GetRobotPose>("GetRobotPose", node, group)
   {
   }
 

--- a/nav2_util/include/nav2_util/service_client.hpp
+++ b/nav2_util/include/nav2_util/service_client.hpp
@@ -16,6 +16,7 @@
 #define NAV2_UTIL__SERVICE_CLIENT_HPP_
 
 #include <string>
+#include <memory>
 
 #include "nav2_util/node_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -23,31 +24,90 @@
 namespace nav2_util
 {
 
+// Create a service client with a given type from node interfaces.
+// TODO(orduno) rclcpp is missing a similar method, remove once it's added:
+//              https://github.com/ros2/rclcpp/issues/768
+template<typename ServiceT>
+typename std::shared_ptr<rclcpp::Client<ServiceT>>
+create_client(
+  std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base,
+  std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface> node_graph,
+  std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface> node_services,
+  const std::string & service_name,
+  const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
+  std::shared_ptr<rclcpp::callback_group::CallbackGroup> group = nullptr)
+{
+  rcl_client_options_t options = rcl_client_get_default_options();
+  options.qos = qos_profile;
+
+  using rclcpp::Client;
+  using rclcpp::ClientBase;
+
+  auto cli = Client<ServiceT>::make_shared(
+    node_base.get(),
+    node_graph,
+    // TODO(orduno) Extend name with sub-namespace, see rclcpp::Node::create_client()
+    service_name,
+    options);
+
+  auto cli_base_ptr = std::dynamic_pointer_cast<ClientBase>(cli);
+  node_services->add_client(cli_base_ptr, group);
+  return cli;
+}
+
 template<class ServiceT>
 class ServiceClient
 {
 public:
+  // When possible, provide a spinning node to avoid creating additional internal nodes
+  template<typename NodeT = rclcpp::Node>
   explicit ServiceClient(
     const std::string & service_name,
-    const rclcpp::Node::SharedPtr & provided_node = rclcpp::Node::SharedPtr())
+    const std::shared_ptr<NodeT> & provided_node = std::shared_ptr<NodeT>(),
+    std::shared_ptr<rclcpp::callback_group::CallbackGroup> group = nullptr)
   : service_name_(service_name)
   {
     if (provided_node) {
-      node_ = provided_node;
+      set_interfaces_from_node<NodeT>(provided_node);
     } else {
-      node_ = generate_internal_node(service_name + "_Node");
+      // TODO(orduno) Remove usage of internally generated nodes
+      RCLCPP_WARN(
+        node_logging_->get_logger(), "%s service client: using an internally generated node",
+        service_name_.c_str());
+      auto node = generate_internal_node(service_name + "_Node");
+      set_interfaces_from_node<rclcpp::Node>(generate_internal_node(service_name + "_Node"));
     }
-    client_ = node_->create_client<ServiceT>(service_name);
+
+    client_ = nav2_util::create_client<ServiceT>(
+      node_base_, node_graph_, node_services_, service_name,
+      rmw_qos_profile_services_default, group);
   }
 
-  ServiceClient(const std::string & service_name, const std::string & parent_name)
+  // TODO(orduno) Remove this constructor which relies on generating an internal node
+  [[deprecated("use alternative constructors")]]
+  explicit ServiceClient(const std::string & service_name, const std::string & parent_name)
   : service_name_(service_name)
   {
     auto options = rclcpp::NodeOptions().arguments(
       {"__node:=" + parent_name + std::string("_") + service_name +
         "_client"});
-    node_ = rclcpp::Node::make_shared("_", options);
-    client_ = node_->create_client<ServiceT>(service_name);
+    auto node = rclcpp::Node::make_shared("_", options);
+
+    set_interfaces_from_node<rclcpp::Node>(node);
+
+    client_ = nav2_util::create_client<ServiceT>(
+      node_base_, node_graph_, node_services_, service_name);
+  }
+
+  ServiceClient() = delete;
+
+  template<typename NodeT>
+  void set_interfaces_from_node(const std::shared_ptr<NodeT> & node)
+  {
+    node_base_ = node->get_node_base_interface();
+    node_graph_ = node->get_node_graph_interface();
+    node_services_ = node->get_node_services_interface();
+    node_logging_ = node->get_node_logging_interface();
   }
 
   using RequestType = typename ServiceT::Request;
@@ -63,18 +123,25 @@ public:
                 service_name_ + " service client: interrupted while waiting for service");
       }
       RCLCPP_INFO(
-        node_->get_logger(), "%s service client: waiting for service to appear...",
+        node_logging_->get_logger(), "%s service client: waiting for service to appear...",
         service_name_.c_str());
     }
 
-    RCLCPP_DEBUG(node_->get_logger(), "%s service client: send async request",
+    RCLCPP_DEBUG(node_logging_->get_logger(), "%s service client: send async request",
       service_name_.c_str());
     auto future_result = client_->async_send_request(request);
 
-    if (rclcpp::spin_until_future_complete(node_, future_result, timeout) !=
-      rclcpp::executor::FutureReturnCode::SUCCESS)
-    {
-      throw std::runtime_error(service_name_ + " service client: async_send_request failed");
+    if (!nodeIsSpinable()) {
+      auto status = future_result.wait_for(timeout);
+      if (status != std::future_status::ready) {
+        throw std::runtime_error(service_name_ + " service client: async_send_request failed");
+      }
+    } else {
+      if (rclcpp::spin_until_future_complete(node_base_, future_result, timeout) !=
+        rclcpp::executor::FutureReturnCode::SUCCESS)
+      {
+        throw std::runtime_error(service_name_ + " service client: async_send_request failed");
+      }
     }
 
     return future_result.get();
@@ -82,7 +149,8 @@ public:
 
   bool invoke(
     typename RequestType::SharedPtr & request,
-    typename ResponseType::SharedPtr & response)
+    typename ResponseType::SharedPtr & response,
+    const std::chrono::seconds timeout = std::chrono::seconds::max())
   {
     while (!client_->wait_for_service(std::chrono::seconds(1))) {
       if (!rclcpp::ok()) {
@@ -90,25 +158,33 @@ public:
                 service_name_ + " service client: interrupted while waiting for service");
       }
       RCLCPP_INFO(
-        node_->get_logger(), "%s service client: waiting for service to appear...",
+        node_logging_->get_logger(), "%s service client: waiting for service to appear...",
         service_name_.c_str());
     }
 
-    RCLCPP_DEBUG(node_->get_logger(), "%s service client: send async request",
+    RCLCPP_DEBUG(node_logging_->get_logger(), "%s service client: send async request",
       service_name_.c_str());
     auto future_result = client_->async_send_request(request);
 
-    if (rclcpp::spin_until_future_complete(node_, future_result) !=
-      rclcpp::executor::FutureReturnCode::SUCCESS)
-    {
-      return false;
+    if (!nodeIsSpinable()) {
+      auto status = future_result.wait_for(timeout);
+      if (status != std::future_status::ready) {
+        return false;
+      }
+    } else {
+      if (rclcpp::spin_until_future_complete(node_base_, future_result, timeout) !=
+        rclcpp::executor::FutureReturnCode::SUCCESS)
+      {
+        return false;
+      }
     }
 
     response = future_result.get();
     return response.get();
   }
 
-  void wait_for_service(const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::max())
+  void wait_for_service(
+    const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::max()) const
   {
     while (!client_->wait_for_service(timeout)) {
       if (!rclcpp::ok()) {
@@ -118,10 +194,22 @@ public:
     }
   }
 
+  bool nodeIsSpinable() const
+  {
+    // Nodes can only be added to one executor. If it hasn't, then it can be spinned
+    return !static_cast<bool>(node_base_->get_associated_with_executor_atomic());
+  }
+
 protected:
   std::string service_name_;
-  rclcpp::Node::SharedPtr node_;
-  typename rclcpp::Client<ServiceT>::SharedPtr client_;
+
+  // Interfaces used for logging and creating the service client
+  std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_;
+  std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface> node_graph_;
+  std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface> node_services_;
+  std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface> node_logging_;
+
+  typename std::shared_ptr<rclcpp::Client<ServiceT>> client_;
 };
 
 }  // namespace nav2_util

--- a/nav2_util/src/map/map_cspace.cpp
+++ b/nav2_util/src/map/map_cspace.cpp
@@ -67,7 +67,7 @@ public:
 bool operator<(const CellData & a, const CellData & b)
 {
   return a.map_->cells[MAP_INDEX(a.map_, a.i_,
-           a.j_)].occ_dist > a.map_->cells[MAP_INDEX(b.map_, b.i_, b.j_)].occ_dist;
+         a.j_)].occ_dist > a.map_->cells[MAP_INDEX(b.map_, b.i_, b.j_)].occ_dist;
 }
 
 CachedDistanceMap *

--- a/nav2_util/test/test_service_client.cpp
+++ b/nav2_util/test/test_service_client.cpp
@@ -37,8 +37,8 @@ public:
     const rclcpp::Node::SharedPtr & provided_node = rclcpp::Node::SharedPtr())
   : ServiceClient(name, provided_node) {}
 
-  string name() {return node_->get_name();}
-  const rclcpp::Node::SharedPtr & getNode() {return node_;}
+  string name() {return node_base_->get_name();}
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & getBaseNode() {return node_base_;}
 };
 
 TEST(ServiceClient, are_non_alphanumerics_removed)
@@ -53,6 +53,6 @@ TEST(ServiceClient, can_ServiceClient_use_passed_in_node)
 {
   auto node = rclcpp::Node::make_shared("test_node");
   TestServiceClient t("bar", node);
-  ASSERT_EQ(t.getNode(), node);
+  ASSERT_EQ(t.getBaseNode(), node->get_node_base_interface());
   ASSERT_EQ(t.name(), "test_node");
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #816   |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | gazebo simulation of turtlebot 3 |

---

## Description of contribution in a few bullet points
 
As described in #816, several nodes are created and used solely for interfacing to services. This PR proposes an approach for removing such nodes.

* Several improvements to `ServiceClient`. It will no longer create a node for interfacing with services if one is provided.
* Updated `GetRobotPoseClient` and `CostmapServiceClient` to use improved `ServiceClient`.
* Updated `Navfn` to use new clients. For obtaining async service responses, it requires a multi-threaded executor.

Once we agree on the model, which I'm using `navfn` as an example, I can propagate the changes to the rest of the nodes on a separate PR.

---

## Future work that may be required in bullet points

* Remove service nodes from amcl, costmaps, bt navigator and lifecycle.
* Replace the multi-threaded executor with a custom async service executor.
