### PR TITLE
Parameter dumping utility

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -59,8 +59,30 @@ AmclNode::AmclNode()
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
-  declare_parameter("alpha1", rclcpp::ParameterValue(0.2));
-  declare_parameter("alpha2", rclcpp::ParameterValue(0.2));
+  auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
+
+  descriptor.name = "alpha1";
+  descriptor.description = "This is the alpha1 parameter";
+  descriptor.additional_constraints = "These are additional constraints";
+  descriptor.read_only = false;
+  descriptor.floating_point_range.resize(1);
+  descriptor.floating_point_range[0].from_value = 0.0;
+  descriptor.floating_point_range[0].to_value = 1.0;
+  descriptor.floating_point_range[0].step = 0.1;
+  descriptor.integer_range.resize(0);
+  declare_parameter(descriptor.name, rclcpp::ParameterValue(0.2), descriptor);
+
+  descriptor.name = "alpha2";
+  descriptor.description = "This is the alpha2 parameter";
+  descriptor.additional_constraints = "These are additional constraints for alpha2";
+  descriptor.read_only = false;
+  descriptor.floating_point_range.resize(0);
+  descriptor.integer_range.resize(1);
+  descriptor.integer_range[0].from_value = 0;
+  descriptor.integer_range[0].to_value = 100;
+  descriptor.integer_range[0].step = 1;
+  declare_parameter(descriptor.name, rclcpp::ParameterValue(0.2), descriptor);
+
   declare_parameter("alpha3", rclcpp::ParameterValue(0.2));
   declare_parameter("alpha4", rclcpp::ParameterValue(0.2));
   declare_parameter("alpha5", rclcpp::ParameterValue(0.2));

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -59,64 +59,69 @@ AmclNode::AmclNode()
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
-  auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
+  add_parameter("alpha1", rclcpp::ParameterValue(0.2),
+    "This is the alpha1 parameter", "These are additional constraints for alpha1", {0.0, 1.0, 0.1});
 
-  descriptor.name = "alpha1";
-  descriptor.description = "This is the alpha1 parameter";
-  descriptor.additional_constraints = "These are additional constraints";
-  descriptor.read_only = false;
-  descriptor.floating_point_range.resize(1);
-  descriptor.floating_point_range[0].from_value = 0.0;
-  descriptor.floating_point_range[0].to_value = 1.0;
-  descriptor.floating_point_range[0].step = 0.1;
-  descriptor.integer_range.resize(0);
-  declare_parameter(descriptor.name, rclcpp::ParameterValue(0.2), descriptor);
+  add_parameter("alpha2", rclcpp::ParameterValue(0.2),
+    "This is the alpha2 parameter", "These are additional constraints for alpha2");
 
-  descriptor.name = "alpha2";
-  descriptor.description = "This is the alpha2 parameter";
-  descriptor.additional_constraints = "These are additional constraints for alpha2";
-  descriptor.read_only = false;
-  descriptor.floating_point_range.resize(0);
-  descriptor.integer_range.resize(1);
-  descriptor.integer_range[0].from_value = 0;
-  descriptor.integer_range[0].to_value = 100;
-  descriptor.integer_range[0].step = 1;
-  declare_parameter(descriptor.name, rclcpp::ParameterValue(0.2), descriptor);
+  add_parameter("alpha3", rclcpp::ParameterValue(0.2),
+    "This is the alpha3 parameter", "These are additional constraints for alpha3");
 
-  declare_parameter("alpha3", rclcpp::ParameterValue(0.2));
-  declare_parameter("alpha4", rclcpp::ParameterValue(0.2));
-  declare_parameter("alpha5", rclcpp::ParameterValue(0.2));
-  declare_parameter("base_frame_id", rclcpp::ParameterValue(std::string("base_footprint")));
-  declare_parameter("beam_skip_distance", rclcpp::ParameterValue(0.5));
-  declare_parameter("beam_skip_error_threshold", rclcpp::ParameterValue(0.9));
-  declare_parameter("beam_skip_threshold", rclcpp::ParameterValue(0.3));
-  declare_parameter("do_beamskip", rclcpp::ParameterValue(false));
-  declare_parameter("global_frame_id", rclcpp::ParameterValue(std::string("map")));
-  declare_parameter("lambda_short", rclcpp::ParameterValue(0.1));
-  declare_parameter("laser_likelihood_max_dist", rclcpp::ParameterValue(2.0));
-  declare_parameter("laser_max_range", rclcpp::ParameterValue(100.0));
-  declare_parameter("laser_min_range", rclcpp::ParameterValue(-1.0));
-  declare_parameter("laser_model_type", rclcpp::ParameterValue(std::string("likelihood_field")));
-  declare_parameter("max_beams", rclcpp::ParameterValue(60));
-  declare_parameter("max_particles", rclcpp::ParameterValue(2000));
-  declare_parameter("min_particles", rclcpp::ParameterValue(500));
-  declare_parameter("odom_frame_id", rclcpp::ParameterValue(std::string("odom")));
-  declare_parameter("pf_err", rclcpp::ParameterValue(0.05));
-  declare_parameter("pf_z", rclcpp::ParameterValue(0.99));
-  declare_parameter("recovery_alpha_fast", rclcpp::ParameterValue(0.0));
-  declare_parameter("recovery_alpha_slow", rclcpp::ParameterValue(0.0));
-  declare_parameter("resample_interval", rclcpp::ParameterValue(1));
-  declare_parameter("robot_model_type", rclcpp::ParameterValue(std::string("differential")));
-  declare_parameter("save_pose_rate", rclcpp::ParameterValue(0.5));
-  declare_parameter("sigma_hit", rclcpp::ParameterValue(0.2));
-  declare_parameter("tf_broadcast", rclcpp::ParameterValue(true));
-  declare_parameter("transform_tolerance", rclcpp::ParameterValue(1.0));
-  declare_parameter("update_min_a", rclcpp::ParameterValue(0.2));
-  declare_parameter("update_min_d", rclcpp::ParameterValue(0.25));
-  declare_parameter("z_hit", rclcpp::ParameterValue(0.5));
-  declare_parameter("z_max", rclcpp::ParameterValue(0.05));
-  declare_parameter("z_rand", rclcpp::ParameterValue(0.5));
-  declare_parameter("z_short", rclcpp::ParameterValue(0.05));
+  add_parameter("alpha4", rclcpp::ParameterValue(0.2),
+    "This is the alpha4 parameter", "These are additional constraints for alpha4");
+
+  add_parameter("alpha5", rclcpp::ParameterValue(0.2),
+    "This is the alpha5 parameter", "These are additional constraints for alpha5");
+
+  add_parameter("base_frame_id", rclcpp::ParameterValue(std::string("base_footprint")),
+    "Which frame to use for the robot base");
+
+  add_parameter("beam_skip_distance", rclcpp::ParameterValue(0.5));
+  add_parameter("beam_skip_error_threshold", rclcpp::ParameterValue(0.9));
+  add_parameter("beam_skip_threshold", rclcpp::ParameterValue(0.3));
+  add_parameter("do_beamskip", rclcpp::ParameterValue(false));
+
+  add_parameter("global_frame_id", rclcpp::ParameterValue(std::string("map")),
+    "The name of the coordinate frame published by the localization system");
+
+  add_parameter("lambda_short", rclcpp::ParameterValue(0.1));
+  add_parameter("laser_likelihood_max_dist", rclcpp::ParameterValue(2.0));
+  add_parameter("laser_max_range", rclcpp::ParameterValue(100.0));
+  add_parameter("laser_min_range", rclcpp::ParameterValue(-1.0));
+  add_parameter("laser_model_type", rclcpp::ParameterValue(std::string("likelihood_field")));
+
+  add_parameter("max_beams", rclcpp::ParameterValue(60),
+    "How many evenly-spaced beams in each scan to be used when updating the filter");
+
+  add_parameter("max_particles", rclcpp::ParameterValue(2000),
+    "Minimum allowed number of particles");
+
+  add_parameter("min_particles", rclcpp::ParameterValue(500),
+    "Maximum allowed number of particles");
+
+  add_parameter("odom_frame_id", rclcpp::ParameterValue(std::string("odom")),
+    "Which frame to use for odometry");
+
+  add_parameter("pf_err", rclcpp::ParameterValue(0.05));
+  add_parameter("pf_z", rclcpp::ParameterValue(0.99));
+  add_parameter("recovery_alpha_fast", rclcpp::ParameterValue(0.0));
+  add_parameter("recovery_alpha_slow", rclcpp::ParameterValue(0.0));
+  add_parameter("resample_interval", rclcpp::ParameterValue(1));
+  add_parameter("robot_model_type", rclcpp::ParameterValue(std::string("differential")));
+  add_parameter("save_pose_rate", rclcpp::ParameterValue(0.5));
+  add_parameter("sigma_hit", rclcpp::ParameterValue(0.2));
+  add_parameter("tf_broadcast", rclcpp::ParameterValue(true));
+  add_parameter("transform_tolerance", rclcpp::ParameterValue(1.0));
+
+  add_parameter("update_min_a", rclcpp::ParameterValue(0.2),
+    "Rotational movement required before performing a filter update");
+
+  add_parameter("update_min_d", rclcpp::ParameterValue(0.25));
+  add_parameter("z_hit", rclcpp::ParameterValue(0.5));
+  add_parameter("z_max", rclcpp::ParameterValue(0.05));
+  add_parameter("z_rand", rclcpp::ParameterValue(0.5));
+  add_parameter("z_short", rclcpp::ParameterValue(0.05));
 }
 
 AmclNode::~AmclNode()

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -60,7 +60,7 @@ AmclNode::AmclNode()
   RCLCPP_INFO(get_logger(), "Creating");
 
   add_parameter("alpha1", rclcpp::ParameterValue(0.2),
-    "This is the alpha1 parameter", "These are additional constraints for alpha1", {0.0, 1.0, 0.1});
+    "This is the alpha1 parameter", "These are additional constraints for alpha1");
 
   add_parameter("alpha2", rclcpp::ParameterValue(0.2),
     "This is the alpha2 parameter", "These are additional constraints for alpha2");
@@ -85,11 +85,23 @@ AmclNode::AmclNode()
   add_parameter("global_frame_id", rclcpp::ParameterValue(std::string("map")),
     "The name of the coordinate frame published by the localization system");
 
-  add_parameter("lambda_short", rclcpp::ParameterValue(0.1));
-  add_parameter("laser_likelihood_max_dist", rclcpp::ParameterValue(2.0));
-  add_parameter("laser_max_range", rclcpp::ParameterValue(100.0));
-  add_parameter("laser_min_range", rclcpp::ParameterValue(-1.0));
-  add_parameter("laser_model_type", rclcpp::ParameterValue(std::string("likelihood_field")));
+  add_parameter("lambda_short", rclcpp::ParameterValue(0.1),
+    "Exponential decay parameter for z_short part of model");
+
+  add_parameter("laser_likelihood_max_dist", rclcpp::ParameterValue(2.0),
+    "Maximum distance to do obstacle inflation on map, for use in likelihood_field model");
+
+  add_parameter("laser_max_range", rclcpp::ParameterValue(100.0),
+    "Maximum scan range to be considered",
+    "-1.0 will cause the laser's reported maximum range to be used");
+
+  add_parameter("laser_min_range", rclcpp::ParameterValue(-1.0),
+    "Minimum scan range to be considered",
+    "-1.0 will cause the laser's reported minimum range to be used");
+
+  add_parameter("laser_model_type", rclcpp::ParameterValue(std::string("likelihood_field")),
+    "Which model to use, either beam, likelihood_field, or likelihood_field_prob",
+    "Ssame as likelihood_field but incorporates the beamskip feature, if enabled");
 
   add_parameter("max_beams", rclcpp::ParameterValue(60),
     "How many evenly-spaced beams in each scan to be used when updating the filter");
@@ -105,19 +117,44 @@ AmclNode::AmclNode()
 
   add_parameter("pf_err", rclcpp::ParameterValue(0.05));
   add_parameter("pf_z", rclcpp::ParameterValue(0.99));
-  add_parameter("recovery_alpha_fast", rclcpp::ParameterValue(0.0));
-  add_parameter("recovery_alpha_slow", rclcpp::ParameterValue(0.0));
-  add_parameter("resample_interval", rclcpp::ParameterValue(1));
+
+  add_parameter("recovery_alpha_fast", rclcpp::ParameterValue(0.0),
+    "Exponential decay rate for the fast average weight filter, used in deciding when to recover "
+    "by adding random poses",
+    "A good value might be 0.1");
+
+  add_parameter("recovery_alpha_slow", rclcpp::ParameterValue(0.0),
+    "Exponential decay rate for the slow average weight filter, used in deciding when to recover "
+    "by adding random poses",
+    "A good value might be 0.001");
+
+  add_parameter("resample_interval", rclcpp::ParameterValue(1),
+    "Number of filter updates required before resampling");
+
   add_parameter("robot_model_type", rclcpp::ParameterValue(std::string("differential")));
-  add_parameter("save_pose_rate", rclcpp::ParameterValue(0.5));
+
+  add_parameter("save_pose_rate", rclcpp::ParameterValue(0.5),
+    "Maximum rate (Hz) at which to store the last estimated pose and covariance to the parameter "
+    "server, in the variables ~initial_pose_* and ~initial_cov_*. This saved pose will be used "
+    "on subsequent runs to initialize the filter",
+    "-1.0 to disable");
+
   add_parameter("sigma_hit", rclcpp::ParameterValue(0.2));
-  add_parameter("tf_broadcast", rclcpp::ParameterValue(true));
-  add_parameter("transform_tolerance", rclcpp::ParameterValue(1.0));
+
+  add_parameter("tf_broadcast", rclcpp::ParameterValue(true),
+    "Set this to false to prevent amcl from publishing the transform between the global frame and "
+    "the odometry frame");
+
+  add_parameter("transform_tolerance", rclcpp::ParameterValue(1.0),
+    "Time with which to post-date the transform that is published, to indicate that this transform "
+    "is valid into the future");
 
   add_parameter("update_min_a", rclcpp::ParameterValue(0.2),
     "Rotational movement required before performing a filter update");
 
-  add_parameter("update_min_d", rclcpp::ParameterValue(0.25));
+  add_parameter("update_min_d", rclcpp::ParameterValue(0.25),
+    "Translational movement required before performing a filter update");
+
   add_parameter("z_hit", rclcpp::ParameterValue(0.5));
   add_parameter("z_max", rclcpp::ParameterValue(0.05));
   add_parameter("z_rand", rclcpp::ParameterValue(0.5));

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -41,6 +41,71 @@ public:
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   virtual ~LifecycleNode();
 
+  typedef struct {
+    double from_value;
+    double to_value;
+    double step;
+  } floating_point_range;
+
+  typedef struct {
+    int from_value;
+    int to_value;
+    int step;
+  } integer_range;
+
+  // Declare a parameter that has no integer or floating point range constraints
+  void add_parameter(const std::string & name, const rclcpp::ParameterValue & default_value,
+    const std::string & description = "", const std::string & additional_constraints = "",
+    bool read_only = false)
+  {
+    auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
+
+    descriptor.name = name;
+    descriptor.description = description;
+    descriptor.additional_constraints = additional_constraints;
+    descriptor.read_only = read_only;
+
+    declare_parameter(descriptor.name, default_value, descriptor);
+  }
+
+  // Declare a parameter that has a floating point range constraint
+  void add_parameter(const std::string & name, const rclcpp::ParameterValue & default_value,
+    const std::string & description, const std::string & additional_constraints,
+    const floating_point_range fp_range, bool read_only = false)
+  {
+    auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
+
+    descriptor.name = name;
+    descriptor.description = description;
+    descriptor.additional_constraints = additional_constraints;
+    descriptor.read_only = read_only;
+    descriptor.floating_point_range.resize(1);
+    descriptor.floating_point_range[0].from_value = fp_range.from_value;
+    descriptor.floating_point_range[0].from_value = fp_range.to_value;
+    descriptor.floating_point_range[0].step = fp_range.step;
+
+    declare_parameter(descriptor.name, default_value, descriptor);
+  }
+
+  // Declare a parameter that has an integer range constraint
+  void add_parameter(const std::string & name, const rclcpp::ParameterValue & default_value,
+    const std::string & description, const std::string & additional_constraints,
+    const integer_range int_range, bool read_only)
+  {
+    auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
+
+    descriptor.name = name;
+    descriptor.description = description;
+    descriptor.additional_constraints = additional_constraints;
+    descriptor.read_only = read_only;
+    descriptor.integer_range.resize(1);
+    descriptor.integer_range[0].from_value = int_range.from_value;
+    descriptor.integer_range[0].from_value = int_range.to_value;
+    descriptor.integer_range[0].step = int_range.step;
+
+    declare_parameter(descriptor.name, default_value, descriptor);
+  }
+
 protected:
   // Whether or not to create a local rclcpp::Node which can be used for ROS2 classes that don't
   // yet support lifecycle nodes

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -70,8 +70,9 @@ public:
 
   // Declare a parameter that has a floating point range constraint
   void add_parameter(const std::string & name, const rclcpp::ParameterValue & default_value,
-    const std::string & description, const std::string & additional_constraints,
-    const floating_point_range fp_range, bool read_only = false)
+    const floating_point_range fp_range,
+    const std::string & description = "", const std::string & additional_constraints = "",
+    bool read_only = false)
   {
     auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
 
@@ -81,7 +82,7 @@ public:
     descriptor.read_only = read_only;
     descriptor.floating_point_range.resize(1);
     descriptor.floating_point_range[0].from_value = fp_range.from_value;
-    descriptor.floating_point_range[0].from_value = fp_range.to_value;
+    descriptor.floating_point_range[0].to_value = fp_range.to_value;
     descriptor.floating_point_range[0].step = fp_range.step;
 
     declare_parameter(descriptor.name, default_value, descriptor);
@@ -89,8 +90,9 @@ public:
 
   // Declare a parameter that has an integer range constraint
   void add_parameter(const std::string & name, const rclcpp::ParameterValue & default_value,
-    const std::string & description, const std::string & additional_constraints,
-    const integer_range int_range, bool read_only)
+    const integer_range int_range,
+    const std::string & description = "", const std::string & additional_constraints = "",
+    bool read_only = false)
   {
     auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
 
@@ -100,7 +102,7 @@ public:
     descriptor.read_only = read_only;
     descriptor.integer_range.resize(1);
     descriptor.integer_range[0].from_value = int_range.from_value;
-    descriptor.integer_range[0].from_value = int_range.to_value;
+    descriptor.integer_range[0].to_value = int_range.to_value;
     descriptor.integer_range[0].step = int_range.step;
 
     declare_parameter(descriptor.name, default_value, descriptor);

--- a/nav2_util/src/CMakeLists.txt
+++ b/nav2_util/src/CMakeLists.txt
@@ -29,9 +29,19 @@ add_executable(lifecycle_bringup
 )
 target_link_libraries(lifecycle_bringup ${library_name})
 
+find_package(Boost REQUIRED COMPONENTS program_options)
+
+add_executable(dump_params dump_params.cpp)
+ament_target_dependencies(dump_params rclcpp)
+
+target_include_directories(dump_params PUBLIC ${Boost_INCLUDE_DIRS})
+
+target_link_libraries(dump_params ${Boost_PROGRAM_OPTIONS_LIBRARY})
+
 install(TARGETS
   ${library_name}
   lifecycle_bringup
+  dump_params
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}

--- a/nav2_util/src/doit
+++ b/nav2_util/src/doit
@@ -1,9 +1,0 @@
-
-../../build/nav2_util/src/dump_params --node_names="map_server,amcl,world_model,dwb_controller,navfn_planner,local_costmap/local_costmap,global_costmap/global_costmap,lifecycle_manager" --format=yaml > 1.yaml
-
-../../build/nav2_util/src/dump_params --node_names="map_server,amcl,world_model,dwb_controller,navfn_planner,local_costmap/local_costmap,global_costmap/global_costmap,lifecycle_manager" --format=yaml --verbose > 2.yaml
-
-../../build/nav2_util/src/dump_params --node_names="map_server,amcl,world_model,dwb_controller,navfn_planner,local_costmap/local_costmap,global_costmap/global_costmap,lifecycle_manager" --format=md > 1.md
-
-../../build/nav2_util/src/dump_params --node_names="map_server,amcl,world_model,dwb_controller,navfn_planner,local_costmap/local_costmap,global_costmap/global_costmap,lifecycle_manager" --format=md --verbose > 2.md
-

--- a/nav2_util/src/doit
+++ b/nav2_util/src/doit
@@ -1,0 +1,9 @@
+
+../../build/nav2_util/src/dump_params --node_names="map_server,amcl,world_model,dwb_controller,navfn_planner,local_costmap/local_costmap,global_costmap/global_costmap,lifecycle_manager" --format=yaml > 1.yaml
+
+../../build/nav2_util/src/dump_params --node_names="map_server,amcl,world_model,dwb_controller,navfn_planner,local_costmap/local_costmap,global_costmap/global_costmap,lifecycle_manager" --format=yaml --verbose > 2.yaml
+
+../../build/nav2_util/src/dump_params --node_names="map_server,amcl,world_model,dwb_controller,navfn_planner,local_costmap/local_costmap,global_costmap/global_costmap,lifecycle_manager" --format=md > 1.md
+
+../../build/nav2_util/src/dump_params --node_names="map_server,amcl,world_model,dwb_controller,navfn_planner,local_costmap/local_costmap,global_costmap/global_costmap,lifecycle_manager" --format=md --verbose > 2.md
+

--- a/nav2_util/src/dump_params.cpp
+++ b/nav2_util/src/dump_params.cpp
@@ -1,0 +1,420 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "boost/program_options.hpp"
+#include "boost/tokenizer.hpp"
+#include "boost/foreach.hpp"
+#include "boost/algorithm/algorithm.hpp"
+#include "boost/algorithm/string/split.hpp"
+#include "boost/algorithm/string/classification.hpp"
+#include "rcl_interfaces/srv/list_parameters.hpp"
+#include "rcl_interfaces/srv/get_parameters.hpp"
+#include "rcl_interfaces/msg/parameter_value.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace po = boost::program_options;
+namespace alg = boost::algorithm;
+
+static std::vector<std::string>
+get_param_names_for_node(rclcpp::Node::SharedPtr node, std::string node_name)
+{
+  auto client = node->create_client<rcl_interfaces::srv::ListParameters>(
+    node_name + "/list_parameters");
+
+  while (!client->wait_for_service(std::chrono::seconds(1))) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(node->get_logger(), "client interrupted while waiting for service to appear.");
+      return std::vector<std::string>();
+    }
+    RCLCPP_INFO(node->get_logger(), "waiting for service to appear...");
+  }
+
+  auto request = std::make_shared<rcl_interfaces::srv::ListParameters::Request>();
+  auto result_future = client->async_send_request(request);
+
+  if (rclcpp::spin_until_future_complete(node, result_future) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_ERROR(node->get_logger(), "service call failed :(");
+    return std::vector<std::string>();
+  }
+  auto result = result_future.get();
+  return result->result.names;
+}
+
+static std::vector<rcl_interfaces::msg::ParameterValue>
+get_param_values_for_node(
+  rclcpp::Node::SharedPtr node, std::string node_name,
+  std::vector<std::string> & param_names)
+{
+  auto client = node->create_client<rcl_interfaces::srv::GetParameters>(
+    node_name + "/get_parameters");
+
+  while (!client->wait_for_service(std::chrono::seconds(1))) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(node->get_logger(), "client interrupted while waiting for service to appear.");
+      return std::vector<rcl_interfaces::msg::ParameterValue>();
+    }
+    RCLCPP_INFO(node->get_logger(), "waiting for service to appear...");
+  }
+
+  auto request = std::make_shared<rcl_interfaces::srv::GetParameters::Request>();
+  request->names = param_names;
+
+  auto result_future = client->async_send_request(request);
+
+  if (rclcpp::spin_until_future_complete(node, result_future) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_ERROR(node->get_logger(), "service call failed :(");
+    return std::vector<rcl_interfaces::msg::ParameterValue>();
+  }
+  auto result = result_future.get();
+  return result->values;
+}
+
+static std::vector<rcl_interfaces::msg::ParameterDescriptor>
+get_param_descriptors_for_node(
+  rclcpp::Node::SharedPtr node, std::string node_name,
+  std::vector<std::string> & param_names)
+{
+  auto client = node->create_client<rcl_interfaces::srv::DescribeParameters>(
+    node_name + "/describe_parameters");
+
+  while (!client->wait_for_service(std::chrono::seconds(1))) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(node->get_logger(), "client interrupted while waiting for service to appear.");
+      return std::vector<rcl_interfaces::msg::ParameterDescriptor>();
+    }
+    RCLCPP_INFO(node->get_logger(), "waiting for service to appear...");
+  }
+
+  auto request = std::make_shared<rcl_interfaces::srv::DescribeParameters::Request>();
+  request->names = param_names;
+
+  auto result_future = client->async_send_request(request);
+
+  if (rclcpp::spin_until_future_complete(node, result_future) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_ERROR(node->get_logger(), "service call failed :(");
+    return std::vector<rcl_interfaces::msg::ParameterDescriptor>();
+  }
+  auto result = result_future.get();
+  return result->descriptors;
+}
+
+static void
+print_yaml(
+  std::string node_name, std::vector<std::string> & param_names,
+  std::vector<rcl_interfaces::msg::ParameterValue> & param_values,
+  std::vector<rcl_interfaces::msg::ParameterDescriptor> & param_descriptors, bool verbose)
+{
+  std::cout << node_name << ":" << std::endl;
+  std::cout << "  ros__parameters:" << std::endl;
+
+  for (unsigned i = 0; i < param_names.size(); i++) {
+    if (verbose) {
+      // Use a field width wide enough for all of the headers
+      auto fw = 24;
+      std::cout << "\n";
+      std::cout << "    # " << std::left << std::setw(fw) << "description: " <<
+        param_descriptors[i].description << "\n";
+      std::cout << "    # " << std::left << std::setw(fw) << "additional_constraints: " <<
+        param_descriptors[i].additional_constraints << "\n";
+      std::cout << "    # " << std::left << std::setw(fw) << "read_only: " <<
+      (param_descriptors[i].read_only ? "True" : "False") << "\n";
+
+      if (param_descriptors[i].floating_point_range.size()) {
+        auto range = param_descriptors[i].floating_point_range[0];
+        std::cout << "    # " << std::left << std::setw(fw) << "Floating point range: ";
+        std::cout << range.from_value << ";"
+          << range.to_value << ";"
+          << range.step << "\n";
+      } else if (param_descriptors[i].integer_range.size()) {
+        auto range = param_descriptors[i].integer_range[0];
+        std::cout << "    # " << std::left << std::setw(fw) << "Integer range: ";
+        std::cout << range.from_value << ";"
+          << range.to_value << ";"
+          << range.step << "\n";
+      }
+    }
+
+    std::function<std::string(void)> pf;
+
+    switch (param_values[i].type) {
+      case rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET:
+        pf = []() {return "NOT_SET";};
+        break;
+
+      case rcl_interfaces::msg::ParameterType::PARAMETER_BOOL:            // bool
+        pf = [param_values, i]() {return param_values[i].bool_value ? "True" : "False";};
+        break;
+
+      case rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER:            // int64
+        pf = [param_values, i]() {return std::to_string(param_values[i].integer_value);};
+        break;
+
+      case rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE:            // float64
+        pf = [param_values, i]() {return std::to_string(param_values[i].double_value);};
+        break;
+
+      case rcl_interfaces::msg::ParameterType::PARAMETER_STRING:            // string
+        pf = [param_values, i]() {
+            return std::string("\"") + param_values[i].string_value + std::string("\"");
+          };
+        break;
+
+      case rcl_interfaces::msg::ParameterType::PARAMETER_BYTE_ARRAY:        // byte[]
+      case rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY:        // bool[]
+      case rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY:    // int64[]
+      case rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY:    // float64[]
+      case rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY:    // string[]
+        pf = [param_values, i]() {
+            std::stringstream stream;
+            stream << "[";
+            auto num_items = param_values[i].string_array_value.size();
+            for (unsigned j = 0; j < num_items; j++) {
+              switch (param_values[i].type) {
+                case rcl_interfaces::msg::ParameterType::PARAMETER_BYTE_ARRAY:
+                  stream << param_values[i].byte_array_value[j];
+                  break;
+                case rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY:
+                  stream << (param_values[i].bool_array_value[j] ? "True" : "False");
+                  break;
+                case rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY:
+                  stream << param_values[i].integer_array_value[j];
+                  break;
+                case rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY:
+                  stream << param_values[i].double_array_value[j];
+                  break;
+                case rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY:
+                  stream << "\"" << param_values[i].string_array_value[j] << "\"";
+                  break;
+              }
+
+              if (j != num_items - 1) {
+                stream << ", ";
+              }
+            }
+            stream << "]";
+            return stream.str();
+          };
+        break;
+    }
+
+    std::cout << "    " << param_names[i] << ": " << pf() << "\n";
+  }
+
+  std::cout << std::endl;
+}
+
+static void
+print_markdown(
+  std::string node_name, std::vector<std::string> & param_names,
+  std::vector<rcl_interfaces::msg::ParameterValue> & param_values,
+  std::vector<rcl_interfaces::msg::ParameterDescriptor> & param_descriptors,
+  bool verbose)
+{
+  std::cout << "## " << node_name << " Parameters" << "\n";
+
+  if (verbose) {
+    std::cout << "|Parameter|Default Value|Description|Additional Constraints|Read Only|Range|" 
+      << "\n";
+    std::cout << "|---|---|---|---|---|---|" << "\n";
+  } else {
+    std::cout << "|Parameter|Default Value|" << "\n";
+    std::cout << "|---|---|" << "\n";
+  }
+
+  for (unsigned i = 0; i < param_names.size(); i++) {
+    std::function<std::string(void)> pf;
+
+    switch (param_values[i].type) {
+      case rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET:
+        pf = []() {return "NOT_SET";};
+        break;
+
+      case rcl_interfaces::msg::ParameterType::PARAMETER_BOOL:            // bool
+        pf = [param_values, i]() {return param_values[i].bool_value ? "True" : "False";};
+        break;
+
+      case rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER:            // int64
+        pf = [param_values, i]() {return std::to_string(param_values[i].integer_value);};
+        break;
+
+      case rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE:            // float64
+        pf = [param_values, i]() {return std::to_string(param_values[i].double_value);};
+        break;
+
+      case rcl_interfaces::msg::ParameterType::PARAMETER_STRING:            // string
+        pf = [param_values, i]() {
+            return std::string("\"") + param_values[i].string_value + std::string("\"");
+          };
+        break;
+
+      case rcl_interfaces::msg::ParameterType::PARAMETER_BYTE_ARRAY:        // byte[]
+      case rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY:        // bool[]
+      case rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY:    // int64[]
+      case rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY:    // float64[]
+      case rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY:    // string[]
+        pf = [param_values, i]() {
+            std::stringstream stream;
+            stream << "[";
+            auto num_items = param_values[i].string_array_value.size();
+            for (unsigned j = 0; j < num_items; j++) {
+              switch (param_values[i].type) {
+                case rcl_interfaces::msg::ParameterType::PARAMETER_BYTE_ARRAY:
+                  stream << param_values[i].byte_array_value[j];
+                  break;
+                case rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY:
+                  stream << (param_values[i].bool_array_value[j] ? "True" : "False");
+                  break;
+                case rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY:
+                  stream << param_values[i].integer_array_value[j];
+                  break;
+                case rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY:
+                  stream << param_values[i].double_array_value[j];
+                  break;
+                case rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY:
+                  stream << "\"" << param_values[i].string_array_value[j] << "\"";
+                  break;
+              }
+
+              if (j != num_items - 1) {
+                stream << ", ";
+              }
+            }
+            stream << "]";
+            return stream.str();
+          };
+        break;
+    }
+
+    std::cout << "|" << param_names[i] << "|" << pf();
+
+    if (verbose) {
+      std::cout << "|" <<
+        param_descriptors[i].description << "|" <<
+        param_descriptors[i].additional_constraints << "|" <<
+      (param_descriptors[i].read_only ? "True" : "False");
+
+      if (param_descriptors[i].floating_point_range.size()) {
+        auto range = param_descriptors[i].floating_point_range[0];
+        std::cout << "|"
+          << range.from_value << ";"
+          << range.to_value << ";"
+          << range.step;
+      } else if (param_descriptors[i].integer_range.size()) {
+        auto range = param_descriptors[i].integer_range[0];
+        std::cout << "|"
+          << range.from_value << ";"
+          << range.to_value << ";"
+          << range.step;
+      }
+    }
+
+    std::cout << "|\n";
+  }
+
+  std::cout << std::endl;
+}
+
+template<typename T>
+struct option_sequence
+{
+  std::vector<T> values;
+};
+
+template<typename T>
+void
+validate(
+  boost::any & v, const std::vector<std::string> & values,
+  option_sequence<T> * /*target_type*/, int)
+{
+  std::vector<T> result;
+  typedef std::vector<std::string> strings;
+  for (strings::const_iterator iter = values.begin(); iter != values.end(); ++iter) {
+    strings tks;
+    alg::split(tks, *iter, alg::is_any_of(","));
+    for (strings::const_iterator tk = tks.begin(); tk != tks.end(); ++tk) {
+      result.push_back(boost::lexical_cast<T>(*tk));
+    }
+  }
+  v = option_sequence<T>();
+  boost::any_cast<option_sequence<T> &>(v).values.swap(result);
+}
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto dump_params_node = rclcpp::Node::make_shared("dump_params");
+
+  try {
+    po::options_description desc("Options");
+    desc.add_options()("help,h", "Print help message")
+      // ("all,a", "Dump parameters for all nodes")
+      ("node_names,n", po::value<option_sequence<std::string>>(),
+      "A list of comma-separated node names")("format,f", po::value<std::string>(),
+      "The format to dump ('yaml' or 'markdown')")("verbose,v", "Verbose option")
+    ;
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help") || !vm.count("node_names")) {
+      std::cout << "Usage: " << basename(argv[0]) << "\n";
+      std::cout << desc << "\n";
+      return 1;
+    }
+
+    auto node_names = vm["node_names"].as<option_sequence<std::string>>().values;
+    bool verbose = vm.count("verbose");
+
+    for (std::string target_node_name : node_names) {
+      auto param_names = get_param_names_for_node(dump_params_node, target_node_name);
+      auto param_values =
+        get_param_values_for_node(dump_params_node, target_node_name, param_names);
+      auto param_descriptors = get_param_descriptors_for_node(dump_params_node, target_node_name,
+          param_names);
+
+      if (!vm.count("format")) {
+        // Default to YAML if the format hasn't been specified
+        print_yaml(target_node_name, param_names, param_values, param_descriptors, verbose);
+      } else {
+        auto format = vm["format"].as<std::string>();
+        if (format == "md" || format == "markdown") {
+          print_markdown(target_node_name, param_names, param_values, param_descriptors, verbose);
+        } else {
+          if (format != "yaml") {
+            std::cerr << "Unknown output format specified, defaulting to 'yaml'" << std::endl;
+          }
+          print_yaml(target_node_name, param_names, param_values, param_descriptors, verbose);
+        }
+      }
+    }
+  } catch (po::error &) {
+    // TODO(mjeronimo): output message
+  }
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/nav2_util/src/dump_params.cpp
+++ b/nav2_util/src/dump_params.cpp
@@ -135,9 +135,9 @@ static std::string to_string(const T a_value)
 
 static void
 print_yaml(
-  std::string node_name, std::vector<std::string> & param_names,
-  std::vector<rcl_interfaces::msg::ParameterValue> & param_values,
-  std::vector<rcl_interfaces::msg::ParameterDescriptor> & param_descriptors, bool verbose)
+  const std::string node_name, std::vector<std::string> & param_names,
+  const std::vector<rcl_interfaces::msg::ParameterValue> & param_values,
+  const std::vector<rcl_interfaces::msg::ParameterDescriptor> & param_descriptors, bool verbose)
 {
   std::cout << node_name << ":" << std::endl;
   std::cout << "  ros__parameters:" << std::endl;
@@ -247,9 +247,9 @@ print_yaml(
 
 static void
 print_markdown(
-  std::string node_name, std::vector<std::string> & param_names,
-  std::vector<rcl_interfaces::msg::ParameterValue> & param_values,
-  std::vector<rcl_interfaces::msg::ParameterDescriptor> & param_descriptors,
+  const std::string node_name, std::vector<std::string> & param_names,
+  const std::vector<rcl_interfaces::msg::ParameterValue> & param_values,
+  const std::vector<rcl_interfaces::msg::ParameterDescriptor> & param_descriptors,
   bool verbose)
 {
   std::cout << "## " << node_name << " Parameters" << "\n";


### PR DESCRIPTION
## Description 
This is a utility that will dump all of the parameters for one or more running nodes. It can be used to document the default node parameters. The intention is to automatically generate markdown and/or yaml such that the output is derived from the code so that we don't have to manually keep the docs in sync with the code. 

```
Usage: dump_params
Options:
  -h [ --help ]           Print help message
  -n [ --node_names ] arg A list of comma-separated node names
  -f [ --format ] arg     The format to dump ('yaml' or 'markdown')
  -v [ --verbose ]        Verbose option
```

### Examples:
The following will dump parameters for all nodes currently running, defaulting to the concise yaml format (parameter name and value):

`dump_params`

The following will create yaml output with a verbose listing (including all of the parameter descriptor values) for the map_server and amcl_nodes:

`dump_params --node_names "map_server,amcl" --format yaml --verbose`

The following will create a markdown table that has node parameters and values for all of the parameters for map_server, amcl, and dwb_controller:

`dump_params --node_names "map_server,amcl,dwb_controller" --format markdown`

The PR adds utility functions to the nav2_util::lifecycle_node class that provide a simplified interfaces to the user to specify the various parameter and parameter descriptor information. 

## Future work

* We could embed some additional information into the "additional constraints" field. For example, whether or not a parameter should be presented to the end user. This field could be used to filter the output. Another example: specify the lifecycle state a node needs to be in to update the parameter.
* This utilility could potentially be upstreamed into the "ros2 param" sub-function. We could write the equivalent functionality in Python and provide an interface something like this:

`ros2 param dump "map_server,amcl" yaml verbose`

* There might be other output formats that are convenient (XML, for example)