### PR TITLE
Set preempt request to false when resetting handle

### DIFF
--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -77,6 +77,7 @@ public:
 
             pending_handle_->canceled(empty_result());
             pending_handle_.reset();
+            preempt_requested_ = false;
           }
 
           debug_msg("Setting flag so the action server can grab the preempt request.");
@@ -89,6 +90,7 @@ public:
 
             pending_handle_->canceled(empty_result());
             pending_handle_.reset();
+            preempt_requested_ = false;
           }
 
           debug_msg("Starting a thread to process the goals");
@@ -207,6 +209,7 @@ public:
       warn_msg("Cancelling a pending goal. Should check for pre-empt requests.");
       pending_handle_->canceled(result);
       pending_handle_.reset();
+      preempt_requested_ = false;
     }
   }
 
@@ -224,6 +227,7 @@ public:
       warn_msg("Aborting a pending goal. Should check for pre-empt requests.");
       pending_handle_->abort(empty_result());
       pending_handle_.reset();
+      preempt_requested_ = false;
     }
   }
 
@@ -244,6 +248,7 @@ public:
       warn_msg("A preemption request was available before succeeding on the current goal.");
       pending_handle_->canceled(empty_result());
       pending_handle_.reset();
+      preempt_requested_ = false;
     }
   }
 


### PR DESCRIPTION
This PR addresses dwb_controller crash found when there is a failure of dwb. After the `followPath` goal handle is aborted from a dwb_controller failure, on the next loop of the `followPath` it will check for a preemption request on the next `updateGlobalPath`. Currently,  the pending goal is being aborted and reset but the `preempt_requested` flag is not set to false. This supposedly causes an exception and crash when the handle is now `nullptr`. 

Here was the log info:
```
[dwb_controller-8] [ERROR] [DWBLocalPlanner]: No valid trajectories out of 398! 
[dwb_controller-8] [ERROR] [DWBLocalPlanner]: 1.00: BaseObstacle/Trajectory Hits Obstacle.
[dwb_controller-8] [ERROR] [dwb_controller]: No valid trajectories out of 398! 
[dwb_controller-8] [WARN] [dwb_controller_rclcpp_node]: [FollowPath] [ActionServer] Aborting a pending goal. Should check for pre-empt requests.
[dwb_controller-8] [INFO] [local_costmap.local_costmap]: Received request to clear entirely the local_costmap
[world_model-7] [INFO] [global_costmap.global_costmap]: Received request to clear entirely the global_costmap
[world_model-7] [INFO] [global_costmap.global_costmap]: StaticLayer: Requesting map from the map service
[map_server-5] [INFO] [map_server]: OccGridLoader: Handling map request
[motion_primitives_node-11] [INFO] [motion_primitives]: Attempting Spin
[motion_primitives_node-11] [INFO] [motion_primitives]: Currently only supported spinning by a fixed amount
[motion_primitives_node-11] [ERROR] [collision_checker]: Footprint Hits Obstacle.
[motion_primitives_node-11] [WARN] [motion_primitives]: Collision Ahead - Exiting Spin 
[motion_primitives_node-11] [INFO] [motion_primitives]: Spin completed successfully
[dwb_controller-8] [INFO] [dwb_controller]: Received a goal, begin following path
[dwb_controller-8] [INFO] [dwb_controller]: Preempting the goal. Passing the new path to the planner.
[dwb_controller-8] [ERROR] [dwb_controller_rclcpp_node]: [FollowPath] [ActionServer] Attempting to get pending goal when not available
[ERROR] [dwb_controller-8]: process has died [pid 28945, exit code -11, cmd '/home/brian/ros2_projects_ws/navigation2_ws/install/dwb_controller/lib/dwb_controller/dwb_controller __params:=/tmp/tmpymrpysik'].
```
This PR ensures that this flag is set to false every time that the pending goal handle is reset.