### PR TITLE
Check goal handle status before canceling

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -182,8 +182,9 @@ protected:
   {
     // Shut the node down if it is currently running
     if (status() != BT::NodeStatus::RUNNING) {
-        return false;
+      return false;
     }
+
     rclcpp::spin_some(node_);
     auto status = goal_handle_->get_status();
 
@@ -191,7 +192,7 @@ protected:
     if (status == action_msgs::msg::GoalStatus::STATUS_ACCEPTED ||
       status == action_msgs::msg::GoalStatus::STATUS_EXECUTING)
     {
-        return true;
+      return true;
     }
 
     return false;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #904 |
---

## Description of contribution in a few bullet points
- Checks that a goal is either `action_msgs::msg::GoalStatus::STATUS_ACCEPTED ` or `action_msgs::msg::GoalStatus::STATUS_EXECUTING` before attempting to cancel when `halt()` is called for `BtActionNode`
- fixes crash seen in #904 due to race condition between aborting a goal on server side and sending a cancel on client 
- removes redundant cancel goal 
