### PR TITLE
Fixing bugs with action cancellations

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -49,7 +49,7 @@ def generate_launch_description():
     configured_params = RewrittenYaml(
         source_file=params_file, rewrites=param_substitutions,
         convert_types=True)
-    
+
     # Declare the launch arguments
     declare_map_yaml_cmd = launch.actions.DeclareLaunchArgument(
         'map',

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -171,7 +171,7 @@ BtNavigator::navigateToPose()
   auto is_canceling = [this]() {return action_server_->is_cancel_requested();};
 
   auto on_loop = [this]() {
-      if (action_server_->preempt_requested()) {
+      if (action_server_->is_preempt_requested()) {
         RCLCPP_INFO(get_logger(), "Received goal preemption request");
         action_server_->accept_pending_goal();
         initializeGoalPose();
@@ -189,12 +189,12 @@ BtNavigator::navigateToPose()
 
     case nav2_behavior_tree::BtStatus::FAILED:
       RCLCPP_ERROR(get_logger(), "Navigation failed");
-      action_server_->abort_all();
+      action_server_->terminate_goals();
       break;
 
     case nav2_behavior_tree::BtStatus::CANCELED:
       RCLCPP_INFO(get_logger(), "Navigation canceled");
-      action_server_->cancel_all();
+      action_server_->terminate_goals();
       // Reset the BT so that it can be run again in the future
       bt_->resetTree(tree_->root_node);
       break;

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -150,8 +150,8 @@ void DwbController::followPath()
     rclcpp::Rate loop_rate(100ms);
     while (rclcpp::ok()) {
       if (action_server_->is_cancel_requested()) {
-        RCLCPP_INFO(get_logger(), "Goal was canceled. Cancelling and stopping.");
-        action_server_->cancel_all();
+        RCLCPP_INFO(get_logger(), "Goal was canceled. Stopping the robot.");
+        action_server_->terminate_goals();
         publishZeroVelocity();
         return;
       }
@@ -170,7 +170,7 @@ void DwbController::followPath()
   } catch (nav_core2::PlannerException & e) {
     RCLCPP_ERROR(this->get_logger(), e.what());
     publishZeroVelocity();
-    action_server_->abort_all();
+    action_server_->terminate_goals();
     return;
   }
 
@@ -213,7 +213,7 @@ void DwbController::computeAndPublishVelocity()
 
 void DwbController::updateGlobalPath()
 {
-  if (action_server_->preempt_requested()) {
+  if (action_server_->is_preempt_requested()) {
     RCLCPP_INFO(get_logger(), "Preempting the goal. Passing the new path to the planner.");
     setPlannerPath(action_server_->accept_pending_goal()->path);
   }

--- a/nav2_motion_primitives/include/nav2_motion_primitives/motion_primitive.hpp
+++ b/nav2_motion_primitives/include/nav2_motion_primitives/motion_primitive.hpp
@@ -129,7 +129,7 @@ protected:
 
     if (onRun(action_server_->get_current_goal()) != Status::SUCCEEDED) {
       RCLCPP_INFO(node_->get_logger(), "Initial checks failed for %s", primitive_name_.c_str());
-      action_server_->abort_all();
+      action_server_->terminate_goals();
       return;
     }
 
@@ -142,17 +142,17 @@ protected:
     while (rclcpp::ok()) {
       if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(node_->get_logger(), "Canceling %s", primitive_name_.c_str());
-        action_server_->cancel_all();
+        action_server_->terminate_goals();
         return;
       }
 
       // TODO(orduno) #868 Enable preempting a motion primitive on-the-fly without stopping
-      if (action_server_->preempt_requested()) {
+      if (action_server_->is_preempt_requested()) {
         RCLCPP_ERROR(node_->get_logger(), "Received a preemption request for %s,"
           " however feature is currently not implemented. Aborting and stopping.",
           primitive_name_.c_str());
         stopRobot();
-        action_server_->abort_all();
+        action_server_->terminate_goals();
         return;
       }
 
@@ -164,7 +164,7 @@ protected:
 
         case Status::FAILED:
           RCLCPP_WARN(node_->get_logger(), "%s failed", primitive_name_.c_str());
-          action_server_->abort_all();
+          action_server_->terminate_goals();
           return;
 
         case Status::RUNNING:

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -167,11 +167,11 @@ NavfnPlanner::computePathToPose()
 
     if (action_server_->is_cancel_requested()) {
       RCLCPP_INFO(get_logger(), "Goal was canceled. Canceling planning action.");
-      action_server_->cancel_all();
+      action_server_->terminate_goals();
       return;
     }
 
-    if (action_server_->preempt_requested()) {
+    if (action_server_->is_preempt_requested()) {
       RCLCPP_INFO(get_logger(), "Preempting the goal pose.");
       goal = action_server_->accept_pending_goal();
     }
@@ -187,7 +187,7 @@ NavfnPlanner::computePathToPose()
       RCLCPP_WARN(get_logger(), "Planning algorithm failed to generate a valid"
         " path to (%.2f, %.2f)", goal->pose.pose.position.x, goal->pose.pose.position.y);
       // TODO(orduno): define behavior if a preemption is available
-      action_server_->abort_all();
+      action_server_->terminate_goals();
       return;
     }
 
@@ -211,14 +211,14 @@ NavfnPlanner::computePathToPose()
 
     // TODO(orduno): provide information about fail error to parent task,
     //               for example: couldn't get costmap update
-    action_server_->abort_all();
+    action_server_->terminate_goals();
     return;
   } catch (...) {
     RCLCPP_WARN(get_logger(), "Plan calculation failed");
 
     // TODO(orduno): provide information about the failure to the parent task,
     //               for example: couldn't get costmap update
-    action_server_->abort_all();
+    action_server_->terminate_goals();
     return;
   }
 }

--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -197,13 +197,6 @@ public:
     return current_handle_->is_canceling();
   }
 
-  // <PR FEEDBACK REQUEST> I'm trying to simplify even further how the user of the action server
-  //                       takes the goals (current and preemption) to a terminal state
-  //                       (and communicates that back to the client).
-  //                       On a simple action server, perhaps there is no need for the user to
-  //                       differentiate between cancelling and aborting. In addition, we are
-  //                       accepting all goal cancellation requests, so those goals
-  //                       should probably terminate with a canceled call (not abort).
   void terminate_goals(
     typename std::shared_ptr<typename ActionT::Result> result =
     std::make_shared<typename ActionT::Result>())

--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -58,6 +58,8 @@ public:
     auto handle_cancel =
       [this](std::shared_ptr<rclcpp_action::ServerGoalHandle<ActionT>>)
       {
+        std::lock_guard<std::mutex> lock(update_mutex_);
+        // TODO(orduno) could goal handle be aborted (and on a terminal state) before reaching here?
         debug_msg("Received request for goal cancellation");
         return rclcpp_action::CancelResponse::ACCEPT;
       };
@@ -73,9 +75,9 @@ public:
 
           if (is_active(pending_handle_)) {
             debug_msg("The pending slot is occupied."
-              " The pending goal will be canceled and replaced.");
+              " The previous pending goal will be aborted and replaced.");
 
-            pending_handle_->canceled(empty_result());
+            pending_handle_->abort(empty_result());
             pending_handle_.reset();
             preempt_requested_ = false;
           }
@@ -86,9 +88,9 @@ public:
         } else {
           if (is_active(pending_handle_)) {
             // Shouldn't reach a state with a pending goal but no current one.
-            error_msg("Forgot to handle a preemption. Cancelling the pending goal.");
+            error_msg("Forgot to handle a preemption. Aborting the pending goal.");
 
-            pending_handle_->canceled(empty_result());
+            pending_handle_->abort(empty_result());
             pending_handle_.reset();
             preempt_requested_ = false;
           }
@@ -120,23 +122,23 @@ public:
     server_active_ = false;
 
     if (is_active(current_handle_)) {
-      warn_msg("Taking action server to deactive state with an active goal, will be aborted");
+      warn_msg("Taking action server to deactive state with an active goal.");
     }
 
     if (is_active(pending_handle_)) {
-      warn_msg("Taking action server to deactive state with a pending preemption, will be aborted");
+      warn_msg("Taking action server to deactive state with a pending preemption.");
     }
 
-    abort_all();
+    terminate_goals();
   }
 
-  bool serverIsActive()
+  bool is_server_active()
   {
     std::lock_guard<std::mutex> lock(update_mutex_);
     return server_active_;
   }
 
-  bool preempt_requested() const
+  bool is_preempt_requested() const
   {
     std::lock_guard<std::mutex> lock(update_mutex_);
     return preempt_requested_;
@@ -181,6 +183,8 @@ public:
   {
     std::lock_guard<std::mutex> lock(update_mutex_);
 
+    // A cancel request is assumed if either handle is canceled by the client.
+
     if (current_handle_ == nullptr) {
       error_msg("Checking for cancel but current goal is not available");
       return false;
@@ -193,41 +197,45 @@ public:
     return current_handle_->is_canceling();
   }
 
-  void cancel_all(
+  // <PR FEEDBACK REQUEST> I'm trying to simplify even further how the user of the action server
+  //                       takes the goals (current and preemption) to a terminal state
+  //                       (and communicates that back to the client).
+  //                       On a simple action server, perhaps there is no need for the user to
+  //                       differentiate between cancelling and aborting. In addition, we are
+  //                       accepting all goal cancellation requests, so those goals
+  //                       should probably terminate with a canceled call (not abort).
+  void terminate_goals(
     typename std::shared_ptr<typename ActionT::Result> result =
     std::make_shared<typename ActionT::Result>())
   {
     std::lock_guard<std::mutex> lock(update_mutex_);
 
-    if (current_handle_ != nullptr) {
-      debug_msg("Cancelling the current goal.");
-      current_handle_->canceled(result);
-      current_handle_.reset();
+    if (is_active(current_handle_)) {
+      if (current_handle_->is_canceling()) {
+        debug_msg("Client requested to cancel the current goal. Cancelling.");
+        current_handle_->canceled(result);
+        current_handle_.reset();
+      } else {
+        debug_msg("Aborting the current goal.");
+        current_handle_->abort(result);
+        current_handle_.reset();
+      }
     }
 
-    if (pending_handle_ != nullptr) {
-      warn_msg("Cancelling a pending goal. Should check for pre-empt requests.");
-      pending_handle_->canceled(result);
-      pending_handle_.reset();
-      preempt_requested_ = false;
-    }
-  }
-
-  void abort_all()
-  {
-    std::lock_guard<std::mutex> lock(update_mutex_);
-
-    if (current_handle_ != nullptr) {
-      debug_msg("Aborting the current goal.");
-      current_handle_->abort(empty_result());
-      current_handle_.reset();
-    }
-
-    if (pending_handle_ != nullptr) {
-      warn_msg("Aborting a pending goal. Should check for pre-empt requests.");
-      pending_handle_->abort(empty_result());
-      pending_handle_.reset();
-      preempt_requested_ = false;
+    if (is_active(pending_handle_)) {
+      if (pending_handle_->is_canceling()) {
+        warn_msg("Client requested to cancel the pending goal."
+          " Cancelling. Should check for pre-empt requests before terminating the goal.");
+        pending_handle_->canceled(result);
+        pending_handle_.reset();
+        preempt_requested_ = false;
+      } else {
+        warn_msg("Aborting a pending goal. "
+          " Should check for pre-empt requests before terminating the goal.");
+        pending_handle_->abort(result);
+        pending_handle_.reset();
+        preempt_requested_ = false;
+      }
     }
   }
 
@@ -243,10 +251,9 @@ public:
       current_handle_.reset();
     }
 
-    // TODO(orduno) Cancelling any pending goal. Get consensus on policy.
     if (is_active(pending_handle_)) {
       warn_msg("A preemption request was available before succeeding on the current goal.");
-      pending_handle_->canceled(empty_result());
+      pending_handle_->abort(empty_result());
       pending_handle_.reset();
       preempt_requested_ = false;
     }

--- a/nav2_util/test/test_actions.cpp
+++ b/nav2_util/test/test_actions.cpp
@@ -71,12 +71,12 @@ preempted:
       // Check if this action has been canceled
       if (action_server_->is_cancel_requested()) {
         result->sequence = sequence;
-        action_server_->cancel_all(result);
+        action_server_->terminate_goals(result);
         return;
       }
 
       // Check if we've gotten an new goal, pre-empting the current one
-      if (action_server_->preempt_requested()) {
+      if (action_server_->is_preempt_requested()) {
         action_server_->accept_pending_goal();
         goto preempted;
       }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #911 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Turtlebot3 gazebo |

---

## Description of contribution in a few bullet points
Made a few improvements to `SimpleActionServer`, mainly to address #911:
* Check if the goal is active before canceling or aborting.
* Cancel only if the client has requested so, otherwise abort.
* Remove separate `cancel` and `abort` methods, instead have one `terminate_goals` which calls the appropriate method depending on the state of the goal.

---

## Future work that may be required in bullet points