### PR TITLE
nav2 rviz plugin action server timeout fix

### DIFF
--- a/nav2_rviz_plugins/src/navigation_dialog.cpp
+++ b/nav2_rviz_plugins/src/navigation_dialog.cpp
@@ -114,7 +114,12 @@ NavigationDialog::startNavigation(double x, double y, double theta, std::string 
   pose.pose.position.z = 0.0;
   pose.pose.orientation = orientationAroundZAxis(theta);
 
-  action_client_->wait_for_action_server();
+  auto is_action_server_ready = action_client_->wait_for_action_server(std::chrono::seconds(5));
+
+  if (!is_action_server_ready){
+    RCLCPP_ERROR(client_node_->get_logger(), "Action server is not available");
+    return;
+  }
 
   // Send the goal pose
   goal_.pose = pose;

--- a/nav2_rviz_plugins/src/navigation_dialog.cpp
+++ b/nav2_rviz_plugins/src/navigation_dialog.cpp
@@ -115,10 +115,9 @@ NavigationDialog::startNavigation(double x, double y, double theta, std::string 
   pose.pose.orientation = orientationAroundZAxis(theta);
 
   auto is_action_server_ready = action_client_->wait_for_action_server(std::chrono::seconds(5));
-  if (!is_action_server_ready)
-  {
+  if (!is_action_server_ready) {
     RCLCPP_ERROR(client_node_->get_logger(), "NavigateToPose action server is not available."
-      "Is the initial pose set?");
+      " Is the initial pose set?");
     return;
   }
 

--- a/nav2_rviz_plugins/src/navigation_dialog.cpp
+++ b/nav2_rviz_plugins/src/navigation_dialog.cpp
@@ -115,10 +115,11 @@ NavigationDialog::startNavigation(double x, double y, double theta, std::string 
   pose.pose.orientation = orientationAroundZAxis(theta);
 
   auto is_action_server_ready = action_client_->wait_for_action_server(std::chrono::seconds(5));
-
-  if (!is_action_server_ready){
-    RCLCPP_ERROR(client_node_->get_logger(), "NavigateToPose action server is not available. "
-        "Is the initial pose set?");
+  if (!is_action_server_ready)
+  {
+    RCLCPP_ERROR(client_node_->get_logger(), "NavigateToPose action server is not available."
+      "Is the initial pose set?");
+    return;
   }
 
   // Send the goal pose

--- a/nav2_rviz_plugins/src/navigation_dialog.cpp
+++ b/nav2_rviz_plugins/src/navigation_dialog.cpp
@@ -117,8 +117,8 @@ NavigationDialog::startNavigation(double x, double y, double theta, std::string 
   auto is_action_server_ready = action_client_->wait_for_action_server(std::chrono::seconds(5));
 
   if (!is_action_server_ready){
-    RCLCPP_ERROR(client_node_->get_logger(), "Action server is not available");
-    return;
+    RCLCPP_ERROR(client_node_->get_logger(), "NavigateToPose action server is not available. "
+        "Is the initial pose set?");
   }
 
   // Send the goal pose


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#901 ) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (Gazebo simulation of TB3 Burger, RVIZ) |

---

## Added a timeout to wait_for_action_server(). Previously, it was causing RVIZ to crash if the action server never gets available. It usually happens if the initial pose is not set or Gazebo is not running. Now, it waits for the action server to be available for 5 seconds and than if it is not available it prints an error message and return. If the action sever is not available, this will cause RVIZ to freeze for 5 seconds, but at least RVIZ doesn't crash and works as expected.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

<!-- OPTIONAL -->

I'd like to request maintainer: <blank> to review this PR.
