### PR TITLE
Enable global planner tester

### DIFF
--- a/nav2_system_tests/CMakeLists.txt
+++ b/nav2_system_tests/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(nav_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(gazebo_ros_pkgs REQUIRED)
 find_package(nav2_amcl REQUIRED)
 find_package(nav2_lifecycle_manager REQUIRED)
@@ -30,6 +31,7 @@ set(dependencies
   gazebo_ros_pkgs
   geometry_msgs
   std_msgs
+  tf2_geometry_msgs
   rclpy
 )
 

--- a/nav2_system_tests/CMakeLists.txt
+++ b/nav2_system_tests/CMakeLists.txt
@@ -40,7 +40,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
 
-  # add_subdirectory(src/planning)
+  add_subdirectory(src/planning)
   add_subdirectory(src/localization)
   add_subdirectory(src/system)
   add_subdirectory(src/updown)

--- a/nav2_system_tests/package.xml
+++ b/nav2_system_tests/package.xml
@@ -22,6 +22,7 @@
   <build_depend>launch_testing</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>gazebo_ros_pkgs</build_depend>
   <build_depend>launch_ros</build_depend>
   <build_depend>launch_testing</build_depend>
@@ -38,6 +39,7 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nav2_amcl</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>gazebo_ros_pkgs</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch_testing</exec_depend>

--- a/nav2_system_tests/src/planning/CMakeLists.txt
+++ b/nav2_system_tests/src/planning/CMakeLists.txt
@@ -7,7 +7,7 @@ ament_target_dependencies(test_planner_node
   ${dependencies}
 )
 
-ament_add_test(test_planner_node
+ament_add_test(test_planner
   GENERATE_RESULT_FOR_RETURN_CODE_ZERO
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_planner_launch.py"
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -18,6 +18,8 @@
 #include <utility>
 #include <memory>
 #include <chrono>
+#include <sstream>
+#include <iomanip>
 
 #include "planner_tester.hpp"
 #include "geometry_msgs/msg/twist.hpp"
@@ -25,7 +27,7 @@
 #include "nav2_msgs/msg/costmap_meta_data.hpp"
 
 using namespace std::chrono_literals;
-using namespace std::chrono;
+using namespace std::chrono;  // NOLINT
 using nav2_util::Costmap;
 using nav2_util::TestCostmap;
 
@@ -273,7 +275,7 @@ bool PlannerTester::defaultPlannerRandomTests(
   std::mt19937 generator(random_device());
 
   // Obtain random positions within map
-  std::uniform_int_distribution<> distribution_x(1, costmap_->get_properties().size_x - 1 );
+  std::uniform_int_distribution<> distribution_x(1, costmap_->get_properties().size_x - 1);
   std::uniform_int_distribution<> distribution_y(1, costmap_->get_properties().size_y - 1);
 
   auto generate_random = [&]() mutable -> std::pair<int, int> {
@@ -493,12 +495,17 @@ bool PlannerTester::sendCancel()
 
 void PlannerTester::printPath(const ComputePathToPoseResult & path) const
 {
-  int index = 0;
+  auto index = 0;
+  auto ss = std::stringstream{};
+
   for (auto pose : path.poses) {
-    RCLCPP_INFO(get_logger(), "  point %u x: %0.2f, y: %0.2f",
-      index, pose.position.x, pose.position.y);
+    ss << "   point #" << index << " with"  <<
+      " x: " << std::setprecision(3)  << pose.position.x <<
+      " y: " << std::setprecision(3)  << pose.position.y << '\n';
     ++index;
   }
+
+  RCLCPP_INFO(get_logger(), ss.str().c_str());
 }
 
 void PlannerTester::waitForPlanner()

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -369,9 +369,9 @@ TaskStatus PlannerTester::sendRequest(
   auto future_goal_handle = planner_client_->async_send_goal(action_goal);
 
   RCLCPP_DEBUG(this->get_logger(), "Waiting for goal acceptance");
-  auto status_request = future_goal_handle.wait_for(seconds(1));
+  auto status_request = future_goal_handle.wait_for(seconds(5));
   if (status_request != std::future_status::ready) {
-    RCLCPP_ERROR(this->get_logger(), "Failed sending the goal");
+    RCLCPP_ERROR(this->get_logger(), "Failed to send the goal");
     return TaskStatus::FAILED;
   }
 
@@ -384,8 +384,9 @@ TaskStatus PlannerTester::sendRequest(
   auto future_result = planner_client_->async_get_result(goal_handle);
 
   RCLCPP_DEBUG(this->get_logger(), "Wait for the server to be done with the action");
-  auto status_result = future_result.wait_for(seconds(5));
+  auto status_result = future_result.wait_for(seconds(10));
   if (status_result != std::future_status::ready) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to get a plan within the allowed time");
     return TaskStatus::FAILED;
   }
 

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -384,7 +384,7 @@ TaskStatus PlannerTester::sendRequest(
   auto future_result = planner_client_->async_get_result(goal_handle);
 
   RCLCPP_DEBUG(this->get_logger(), "Wait for the server to be done with the action");
-  auto status_result = future_result.wait_for(seconds(1));
+  auto status_result = future_result.wait_for(seconds(5));
   if (status_result != std::future_status::ready) {
     return TaskStatus::FAILED;
   }
@@ -499,7 +499,7 @@ void PlannerTester::waitForPlanner()
 {
   RCLCPP_DEBUG(this->get_logger(), "Waiting for ComputePathToPose action server");
 
-  if (!planner_client_ || !planner_client_->wait_for_action_server(4s)) {
+  if (!planner_client_ || !planner_client_->wait_for_action_server(10s)) {
     RCLCPP_ERROR(this->get_logger(), "Planner not running");
     throw std::runtime_error("Planner not running");
   }

--- a/nav2_system_tests/src/planning/planner_tester.hpp
+++ b/nav2_system_tests/src/planning/planner_tester.hpp
@@ -21,20 +21,32 @@
 #include <thread>
 
 #include "rclcpp/rclcpp.hpp"
-#include "nav2_behavior_tree/compute_path_to_pose_task.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+#include "nav2_msgs/action/compute_path_to_pose.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
 #include "nav2_msgs/srv/get_costmap.hpp"
+#include "nav2_msgs/srv/get_robot_pose.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 #include "nav2_util/costmap.hpp"
-#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
 
 namespace nav2_system_tests
 {
 
+enum class TaskStatus : int8_t
+{
+  SUCCEEDED = 1,
+  FAILED = 2,
+  RUNNING = 3,
+};
+
 class PlannerTester : public rclcpp::Node, public ::testing::Test
 {
 public:
+  using ComputePathToPoseCommand = geometry_msgs::msg::PoseStamped;
+  using ComputePathToPoseResult = nav2_msgs::msg::Path;
+
   PlannerTester();
   ~PlannerTester();
 
@@ -51,15 +63,15 @@ public:
   // TODO(orduno): #443 Assuming a robot the size of a costmap cell
   bool plannerTest(
     const geometry_msgs::msg::Point & robot_position,
-    const nav2_behavior_tree::ComputePathToPoseCommand::SharedPtr & goal,
-    nav2_behavior_tree::ComputePathToPoseResult::SharedPtr & path);
+    const ComputePathToPoseCommand & goal,
+    ComputePathToPoseResult & path);
 
   // Sends the request to the planner and gets the result.
   // Uses the default map or preloaded costmaps.
   // Success criteria is a collision free path and a deviation to a
   // reference path smaller than a tolerance.
   bool defaultPlannerTest(
-    nav2_behavior_tree::ComputePathToPoseResult::SharedPtr & path,
+    ComputePathToPoseResult & path,
     const double deviation_tolerance = 1.0);
 
   bool defaultPlannerRandomTests(
@@ -72,28 +84,29 @@ public:
 private:
   void setCostmap();
 
-  void startCostmapServer(std::string serviceName);
+  void startRobotPoseServer();
+  void startCostmapServer();
 
-  nav2_behavior_tree::TaskStatus sendRequest(
-    const nav2_behavior_tree::ComputePathToPoseCommand::SharedPtr & goal,
-    nav2_behavior_tree::ComputePathToPoseResult::SharedPtr & path
+  TaskStatus sendRequest(
+    const ComputePathToPoseCommand & goal,
+    ComputePathToPoseResult & path
   );
 
-  bool isCollisionFree(const nav2_behavior_tree::ComputePathToPoseResult & path);
+  bool isCollisionFree(const ComputePathToPoseResult & path);
 
   bool isWithinTolerance(
     const geometry_msgs::msg::Point & robot_position,
-    const nav2_behavior_tree::ComputePathToPoseCommand & goal,
-    const nav2_behavior_tree::ComputePathToPoseResult & path) const;
+    const ComputePathToPoseCommand & goal,
+    const ComputePathToPoseResult & path) const;
 
   bool isWithinTolerance(
     const geometry_msgs::msg::Point & robot_position,
-    const nav2_behavior_tree::ComputePathToPoseCommand & goal,
-    const nav2_behavior_tree::ComputePathToPoseResult & path,
+    const ComputePathToPoseCommand & goal,
+    const ComputePathToPoseResult & path,
     const double deviationTolerance,
-    const nav2_behavior_tree::ComputePathToPoseResult & reference_path) const;
+    const ComputePathToPoseResult & reference_path) const;
 
-  void printPath(const nav2_behavior_tree::ComputePathToPoseResult & path) const;
+  void printPath(const ComputePathToPoseResult & path) const;
 
   // The static map
   std::shared_ptr<nav_msgs::msg::OccupancyGrid> map_;
@@ -102,15 +115,17 @@ private:
   std::unique_ptr<nav2_util::Costmap> costmap_;
 
   // The interface to the global planner
-  std::unique_ptr<nav2_behavior_tree::ComputePathToPoseTaskClient> planner_client_;
+  std::shared_ptr<rclcpp_action::Client<nav2_msgs::action::ComputePathToPose>> planner_client_;
   std::string plannerName_;
+  void waitForPlanner();
 
-  // Server for providing a costmap
+  // The tester must provide these services
   rclcpp::Service<nav2_msgs::srv::GetCostmap>::SharedPtr costmap_server_;
+  rclcpp::Service<nav2_msgs::srv::GetRobotPose>::SharedPtr get_robot_pose_server_;
 
-  // Publisher of the robot position
-  rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_pub_;
-  void publishRobotPosition(const geometry_msgs::msg::Point & position) const;
+  geometry_msgs::msg::PoseStamped robot_pose_;
+  mutable std::mutex update_robot_pose_;
+  void updateRobotPosition(const geometry_msgs::msg::Point & position);
 
   // Occupancy grid publisher for visualization
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_pub_;
@@ -133,7 +148,7 @@ private:
   // A thread for spinning the ROS node
   void spinThread();
   std::thread * spin_thread_;
-  std::atomic<bool> spinning_ok_;
+  rclcpp::executors::SingleThreadedExecutor executor_;
 };
 
 }  // namespace nav2_system_tests

--- a/nav2_system_tests/src/planning/planner_tester.hpp
+++ b/nav2_system_tests/src/planning/planner_tester.hpp
@@ -26,10 +26,11 @@
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
 #include "nav2_msgs/srv/get_costmap.hpp"
-#include "nav2_msgs/srv/get_robot_pose.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 #include "nav2_util/costmap.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "tf2_msgs/msg/tf_message.hpp"
 
 namespace nav2_system_tests
 {
@@ -84,7 +85,7 @@ public:
 private:
   void setCostmap();
 
-  void startRobotPoseServer();
+  void startRobotPoseProvider();
   void startCostmapServer();
 
   TaskStatus sendRequest(
@@ -119,12 +120,12 @@ private:
   std::string plannerName_;
   void waitForPlanner();
 
-  // The tester must provide these services
+  // The tester must provide the costmap service
   rclcpp::Service<nav2_msgs::srv::GetCostmap>::SharedPtr costmap_server_;
-  rclcpp::Service<nav2_msgs::srv::GetRobotPose>::SharedPtr get_robot_pose_server_;
 
-  geometry_msgs::msg::PoseStamped robot_pose_;
-  mutable std::mutex update_robot_pose_;
+  // The tester must provide the robot pose through a transform
+  rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr transform_publisher_;
+
   void updateRobotPosition(const geometry_msgs::msg::Point & position);
 
   // Occupancy grid publisher for visualization

--- a/nav2_system_tests/src/planning/test_planner_launch.py
+++ b/nav2_system_tests/src/planning/test_planner_launch.py
@@ -29,11 +29,17 @@ from launch_testing.legacy import LaunchTestService
 def main(argv=sys.argv[1:]):
     testExecutable = os.getenv('TEST_EXECUTABLE')
 
-    ld = LaunchDescription([launch_ros.actions.Node(
+    run_navfn = launch_ros.actions.Node(
         package='nav2_navfn_planner',
         node_executable='navfn_planner',
-        output='screen'),
-    ])
+        output='screen')
+    run_lifecycle_manager = launch_ros.actions.Node(
+        package='nav2_lifecycle_manager',
+        node_executable='lifecycle_manager',
+        node_name='lifecycle_manager',
+        output='screen',
+        parameters=[{'node_names': ['navfn_planner']}, {'autostart': True}])
+    ld = LaunchDescription([run_navfn, run_lifecycle_manager])
 
     test1_action = ExecuteProcess(
         cmd=[testExecutable],
@@ -41,16 +47,8 @@ def main(argv=sys.argv[1:]):
         output='screen'
     )
 
-    run_lifecycle_manager = launch_ros.actions.Node(
-        package='nav2_lifecycle_manager',
-        node_executable='lifecycle_manager',
-        node_name='lifecycle_manager',
-        output='screen',
-        parameters=[{'node_names': ['navfn_planner']}, {'autostart': True}])
-
     lts = LaunchTestService()
     lts.add_test_action(ld, test1_action)
-    lts.add_test_action(ld, run_lifecycle_manager)
     ls = LaunchService(argv=argv)
     ls.include_launch_description(ld)
     return lts.run(ls)

--- a/nav2_system_tests/src/planning/test_planner_node.cpp
+++ b/nav2_system_tests/src/planning/test_planner_node.cpp
@@ -20,8 +20,12 @@
 #include "planner_tester.hpp"
 
 using namespace std::chrono_literals;
+
 using nav2_system_tests::PlannerTester;
 using nav2_util::TestCostmap;
+
+using ComputePathToPoseCommand = geometry_msgs::msg::PoseStamped;
+using ComputePathToPoseResult = nav2_msgs::msg::Path;
 
 // rclcpp::init can only be called once per process, so this needs to be a global variable
 class RclCppFixture
@@ -44,7 +48,7 @@ TEST_F(PlannerTester, testSimpleCostmaps)
     TestCostmap::maze2
   };
 
-  auto result = std::make_shared<nav2_behavior_tree::ComputePathToPoseResult>();
+  ComputePathToPoseResult result;
 
   for (auto costmap : costmaps) {
     loadSimpleCostmap(costmap);
@@ -55,13 +59,12 @@ TEST_F(PlannerTester, testSimpleCostmaps)
 TEST_F(PlannerTester, testWithOneFixedEndpoint)
 {
   loadDefaultMap();
-  auto result = std::make_shared<nav2_behavior_tree::ComputePathToPoseResult>();
+  ComputePathToPoseResult result;
   EXPECT_EQ(true, defaultPlannerTest(result));
 }
 
 TEST_F(PlannerTester, testWithHundredRandomEndPoints)
 {
   loadDefaultMap();
-  auto result = std::make_shared<nav2_behavior_tree::ComputePathToPoseResult>();
   EXPECT_EQ(true, defaultPlannerRandomTests(100, 0.1));
 }

--- a/nav2_system_tests/src/planning/test_planner_node.cpp
+++ b/nav2_system_tests/src/planning/test_planner_node.cpp
@@ -56,13 +56,6 @@ TEST_F(PlannerTester, testSimpleCostmaps)
   }
 }
 
-TEST_F(PlannerTester, testWithOneFixedEndpoint)
-{
-  loadDefaultMap();
-  ComputePathToPoseResult result;
-  EXPECT_EQ(true, defaultPlannerTest(result));
-}
-
 TEST_F(PlannerTester, testWithHundredRandomEndPoints)
 {
   loadDefaultMap();

--- a/tools/run_test_suite.bash
+++ b/tools/run_test_suite.bash
@@ -23,5 +23,6 @@ colcon test --packages-select nav2_system_tests --ctest-args --exclude-regex "te
 colcon test-result --verbose
 
 $SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_localization$
+$SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_planner$
 $SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_bt_navigator$
 $SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_bt_navigator_with_dijkstra$


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #586 |
| Primary OS tested on | Ubuntu 18.0 |
| Robotic platform tested on | N/A |

---

## Description of contribution in a few bullet points

* Made a few upgrades, including using the ROS2 actions interface.
* Enabling the planner tests on CI. Ran the tests on my machine 100 times with two failures -- planning service was not available on both.