### PR TITLE
Shutdown nodes cleanly

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -168,7 +168,19 @@ BtNavigator::navigateToPose()
 {
   initializeGoalPose();
 
-  auto is_canceling = [this]() {return action_server_->is_cancel_requested();};
+  auto is_canceling = [this]() {
+      if (action_server_ == nullptr) {
+        RCLCPP_DEBUG(get_logger(), "Action server unavailable. Canceling.");
+        return true;
+      }
+
+      if (!action_server_->is_server_active()) {
+        RCLCPP_DEBUG(get_logger(), "Action server is inactive. Canceling.");
+        return true;
+      }
+
+      return action_server_->is_cancel_requested();
+    };
 
   auto on_loop = [this]() {
       if (action_server_->is_preempt_requested()) {

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -88,6 +88,7 @@ DwbController::on_activate(const rclcpp_lifecycle::State & state)
 {
   RCLCPP_INFO(get_logger(), "Activating");
 
+  action_server_->activate();
   planner_->on_activate(state);
   costmap_ros_->on_activate(state);
   vel_pub_->on_activate();

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -88,10 +88,10 @@ DwbController::on_activate(const rclcpp_lifecycle::State & state)
 {
   RCLCPP_INFO(get_logger(), "Activating");
 
-  action_server_->activate();
   planner_->on_activate(state);
   costmap_ros_->on_activate(state);
   vel_pub_->on_activate();
+  action_server_->activate();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }
@@ -120,10 +120,10 @@ DwbController::on_cleanup(const rclcpp_lifecycle::State & state)
   costmap_ros_->on_cleanup(state);
 
   // Release any allocated resources
+  action_server_.reset();
   planner_.reset();
   odom_sub_.reset();
   vel_pub_.reset();
-  action_server_.reset();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -111,6 +111,7 @@ NavfnPlanner::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
 
   plan_publisher_->on_deactivate();
   plan_marker_publisher_->on_deactivate();
+  action_server_->deactivate();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }
@@ -163,6 +164,16 @@ NavfnPlanner::computePathToPose()
       current_costmap_size_[0] = costmap_.metadata.size_x;
       current_costmap_size_[1] = costmap_.metadata.size_y;
       planner_->setNavArr(costmap_.metadata.size_x, costmap_.metadata.size_y);
+    }
+
+    if (action_server_ == nullptr) {
+      RCLCPP_DEBUG(get_logger(), "Action server unavailable. Stopping.");
+      return;
+    }
+
+    if (!action_server_->is_server_active()) {
+      RCLCPP_DEBUG(get_logger(), "Action server is inactive. Stopping.");
+      return;
     }
 
     if (action_server_->is_cancel_requested()) {

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -100,6 +100,7 @@ NavfnPlanner::on_activate(const rclcpp_lifecycle::State & /*state*/)
 
   plan_publisher_->on_activate();
   plan_marker_publisher_->on_activate();
+  action_server_->activate();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }

--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -118,7 +118,6 @@ public:
 
   void deactivate()
   {
-    std::lock_guard<std::mutex> lock_goal_handle(update_mutex_);
     server_active_ = false;
 
     if (is_active(current_handle_)) {


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #883 |
| Primary OS tested on | Ubuntu 18.04 |

---

## Description of contribution in a few bullet points
- deactivate action server in DwbController and NavfnPlanner
- check and return if action server is unavailable or inactive
- stop robot when deactivating DwbController

## Future work
- Enable and test pause, resume, and reset 
  - `pause` can deactivate system
  - `resume` can activate system
  - `reset` can take system to unconfigured state (but not shutdown since it is terminal)


