### PR TITLE
Fix the dashing 0.2.1 build on OSRF build farm.

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -51,6 +51,9 @@ add_library(nav2_costmap_2d_core SHARED
   src/clear_costmap_service.cpp
 )
 
+# prevent pluginlib from using boost
+target_compile_definitions(nav2_costmap_2d_core PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 set(dependencies
   geometry_msgs
   laser_geometry

--- a/nav2_dwb_controller/dwb_controller/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_controller/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(${library_name}
   src/progress_checker.cpp
 )
 
+target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 set(dependencies
   rclcpp
   rclcpp_action

--- a/nav2_dwb_controller/dwb_core/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_core/CMakeLists.txt
@@ -44,6 +44,10 @@ add_library(dwb_core SHARED
   src/publisher.cpp
   src/illegal_trajectory_tracker.cpp
 )
+
+# prevent pluginlib from using boost
+target_compile_definitions(dwb_core PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 ament_target_dependencies(dwb_core
   ${dependencies}
 )

--- a/nav2_dwb_controller/dwb_critics/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_critics/CMakeLists.txt
@@ -36,6 +36,9 @@ add_library(${PROJECT_NAME} SHARED
     src/twirling.cpp
 )
 
+# prevent pluginlib from using boost
+target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 set(dependencies
   angles
   nav2_costmap_2d

--- a/nav2_world_model/CMakeLists.txt
+++ b/nav2_world_model/CMakeLists.txt
@@ -27,6 +27,9 @@ add_library(${library_name} SHARED
   src/world_model.cpp
 )
 
+# prevent pluginlib from using boost
+target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 set(dependencies
   rclcpp
   nav2_util


### PR DESCRIPTION
All our builds have boost installed due to other dependencies, so
we've never run into this. The build farm must build with all other
dependencies removed somehow.


