### PR TITLE
Set GoalAlign & PathAlign critics scale to 0

### DIFF
--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -83,8 +83,8 @@ dwb_controller:
     transform_tolerance: 0.2
     critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
     BaseObstacle.scale: 0.02
-    PathAlign.scale: 32.0
-    GoalAlign.scale: 24.0
+    PathAlign.scale: 0.0
+    GoalAlign.scale: 0.0
     PathDist.scale: 32.0
     GoalDist.scale: 24.0
     RotateToGoal.scale: 32.0


### PR DESCRIPTION
The navigation and obstacle avoidance perform less than ideal when the PathAlign and GoalAlign critics are being used. In the local planners from the ROS1 navigation stack, these align critics weren't used, so this PR sets the scale to 0 until we can further investigate why we were receiving poor obstacle avoidance using these critics. Removing their influence for now has led to better performance so far.

## Description of contribution in a few bullet points
- Sets PathAlign and GoalAlign critcs scale to 0


## Future work that may be required in bullet points
- Tune and test critics scaling


