### PR TITLE
Fixed a bug to be able to reset recovery node internal states

### DIFF
--- a/nav2_bt_navigator/include/nav2_bt_navigator/recovery_node.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/recovery_node.hpp
@@ -51,6 +51,7 @@ private:
   unsigned int number_of_retries_;
   unsigned int retry_count_;
   BT::NodeStatus tick() override;
+  void halt() override;
 };
 }  // namespace nav2_bt_navigator
 

--- a/nav2_bt_navigator/src/recovery_node.cpp
+++ b/nav2_bt_navigator/src/recovery_node.cpp
@@ -23,6 +23,13 @@ RecoveryNode::RecoveryNode(const std::string & name, const BT::NodeParameters & 
   getParam<unsigned int>("number_of_retries", number_of_retries_);
 }
 
+void RecoveryNode::halt()
+{
+  ControlNode::halt();
+  current_child_idx_ = 0;
+  retry_count_ = 0;
+}
+
 BT::NodeStatus RecoveryNode::tick()
 {
   const unsigned children_count = children_nodes_.size();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#939) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (Gazebo simulation) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
- This PR partially fixes #939.
- The halt() method needed to be overwritten in the recovery node to be able to reset the internal variable states of the recovery node.  Without this fix, if the tree is canceled, the reset method will invoke the halt but the states of the recovery node will not get reset. Thus, if the recovery node was ticking its second child during execution when cancel is called, the tree will remain in that state forever. 
---
