### PR TITLE
Build tools - Run build_all.sh from any nested repo workspace & rename dependencies workspace for "nav" autocomplete

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -56,7 +56,7 @@ Most work will be done in the `navigation2` workspace, so just building that wil
 To build just `navigation2`,
 ```sh
 cd <directory_for_workspaces>/navigation2_ws
-source ../navstack_dependencies_ws/install/setup.sh
+source ../ros2_nav_dependencies_ws/install/setup.sh
 colcon build --symlink-install
 ```
 
@@ -75,6 +75,6 @@ Instead, it would be better to do an initial download of all the source and depe
 Then the CI tool can monitor the `navigation2` repo, update it as necessary, and rebuild using either the `<directory_for_workspaces>/navigation2_ws/src/navigation2/tools/build_all.sh` script or by running
 ```sh
 cd <directory_for_workspaces>/navigation2_ws/src/navigation2
-source ../navstack_dependencies_ws/install/setup.sh
+source ../ros2_nav_dependencies_ws/install/setup.sh
 colcon build --symlink-install
 ```

--- a/tools/build_all.sh
+++ b/tools/build_all.sh
@@ -16,7 +16,7 @@ fi
 
 set -e
 
-# so youc an call from anywhere in the navigation2_ws, ros2_ws, or deps branches
+# so you can call from anywhere in the navigation2_ws, ros2_ws, or deps branches
 while [[ "$PWD" =~ ros2_ws ]]; do
   cd ../
 done

--- a/tools/build_all.sh
+++ b/tools/build_all.sh
@@ -21,7 +21,7 @@ while [[ "$PWD" =~ ros2_ws ]]; do
   cd ../
 done
 
-while [[ "$PWD" =~ navstack_dependencies_ws ]]; do
+while [[ "$PWD" =~ ros2_nav_dependencies_ws ]]; do
   cd ../
 done
 
@@ -48,7 +48,7 @@ if [ "$ENABLE_ROS2" = true ]; then
 fi
 
 # Build our ROS 2 dependencies
-cd $CWD/navstack_dependencies_ws
+cd $CWD/ros2_nav_dependencies_ws
 export ROSDISTRO_INDEX_URL='https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml'
 rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO --skip-keys "catkin"
 (. $ROS2_SETUP_FILE &&
@@ -58,7 +58,7 @@ rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO -
 cd $CWD/navigation2_ws
 export ROSDISTRO_INDEX_URL='https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml'
 rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO
-(. $ROS2_SETUP_FILE && . $CWD/navstack_dependencies_ws/install/setup.bash &&
+(. $ROS2_SETUP_FILE && . $CWD/ros2_nav_dependencies_ws/install/setup.bash &&
  colcon build --symlink-install)
 
 # Update the ROS1 bridge

--- a/tools/build_all.sh
+++ b/tools/build_all.sh
@@ -16,6 +16,19 @@ fi
 
 set -e
 
+# so youc an call from anywhere in the navigation2_ws, ros2_ws, or deps branches
+while [[ "$PWD" =~ ros2_ws ]]; do
+  cd ../
+done
+
+while [[ "$PWD" =~ navstack_dependencies_ws ]]; do
+  cd ../
+done
+
+while [[ "$PWD" =~ navigation2_ws ]]; do
+  cd ../
+done
+
 CWD=`pwd`
 
 # Determine which repos to build. If ROS 2 base directories are

--- a/tools/initial_ros_setup.sh
+++ b/tools/initial_ros_setup.sh
@@ -63,8 +63,8 @@ download_ros2() {
 
 download_ros2_dependencies() {
   echo "Downloading the dependencies workspace"
-  mkdir -p navstack_dependencies_ws/src
-  cd navstack_dependencies_ws
+  mkdir -p ros2_nav_dependencies_ws/src
+  cd ros2_nav_dependencies_ws
   vcs import src < ${CWD}/navigation2_ws/src/navigation2/tools/ros2_dependencies.repos
   return_to_root_dir
 }


### PR DESCRIPTION
Build tool improvements

- Check if we're in the `navigation2_ws`, `ros2_ws`, or `ros_nav_dependencies_ws` and then cd out into root before running. Now you can run the build tool from any where that navigation2 touches

- rename `navstack_dependencies_ws` to `ros2_nav_dependencies_ws` so that auto complete for "nav" will bring you to the workspace you *actually* wanted to go to. 