### PR TITLE
Fix for TEB local planner buildable

### DIFF
--- a/nav2_dwb_controller/dwb_controller/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_controller/CMakeLists.txt
@@ -72,5 +72,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
+ament_export_libraries(${library_name})
 
 ament_package()


### PR DESCRIPTION
It is dependency of [this PR(port TEB to ROS2)](https://github.com/rst-tu-dortmund/teb_local_planner/pull/159).

Signed-off-by: vinnamkim <vinnam.kim@gmail.com>