### PR TITLE
enabling closed-loop control in spin

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
@@ -38,11 +38,7 @@ public:
 
   void on_init() override
   {
-    // TODO(orduno) #423 Fixed spin angle
-    // Rotate 90deg CCW
-    tf2::Quaternion quaternion;
-    quaternion.setRPY(0, 0, M_PI / 2);  // yaw, pitch and roll are rotation in z, y, x respectively
-    goal_.target.quaternion = tf2::toMsg(quaternion);
+    goal_.target_yaw = M_PI / 2;
   }
 };
 

--- a/nav2_msgs/action/Spin.action
+++ b/nav2_msgs/action/Spin.action
@@ -1,5 +1,5 @@
 #goal definition
-geometry_msgs/QuaternionStamped target
+float32 target_yaw
 ---
 #result definition
 std_msgs/Empty result

--- a/nav2_recoveries/include/nav2_recoveries/spin.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/spin.hpp
@@ -41,11 +41,10 @@ protected:
   double min_rotational_vel_;
   double max_rotational_vel_;
   double rotational_acc_lim_;
-  double goal_tolerance_angle_;
-
-  geometry_msgs::msg::Pose initial_pose_;
-  double start_yaw_;
-  double command_yaw_;
+  double cmd_yaw_;
+  double prev_yaw_;
+  double delta_yaw_;
+  double relative_yaw_;
 };
 
 }  // namespace nav2_recoveries

--- a/nav2_recoveries/include/nav2_recoveries/spin.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/spin.hpp
@@ -43,13 +43,9 @@ protected:
   double rotational_acc_lim_;
   double goal_tolerance_angle_;
 
+  geometry_msgs::msg::Pose initial_pose_;
   double start_yaw_;
-
-  std::chrono::system_clock::time_point start_time_;
-
-  Status timedSpin();
-
-  Status controlledSpin();
+  double command_yaw_;
 };
 
 }  // namespace nav2_recoveries

--- a/nav2_recoveries/src/spin.cpp
+++ b/nav2_recoveries/src/spin.cpp
@@ -49,50 +49,50 @@ Spin::~Spin()
 
 Status Spin::onRun(const std::shared_ptr<const SpinAction::Goal> command)
 {
-  double yaw, pitch, roll;
-  tf2::getEulerYPR(command->target.quaternion, yaw, pitch, roll);
+  double pitch, roll;
+  tf2::getEulerYPR(command->target.quaternion, command_yaw_, pitch, roll);
 
   if (roll != 0.0 || pitch != 0.0) {
-    RCLCPP_INFO(node_->get_logger(), "Spinning on Y and X not supported, "
-      "will only spin in Z.");
+    RCLCPP_INFO(node_->get_logger(), "Spinning around Y and X axes are not supported, "
+      "will only spin around Z axis.");
   }
 
-  RCLCPP_INFO(node_->get_logger(), "Currently only supported spinning by a fixed amount");
+  if (!getRobotPose(initial_pose_)) {
+    RCLCPP_ERROR(node_->get_logger(), "initial robot pose is not available.");
+    return Status::FAILED;
+  }
 
-  start_time_ = std::chrono::system_clock::now();
+  start_yaw_ = tf2::getYaw(initial_pose_.orientation);
 
   return Status::SUCCEEDED;
 }
 
 Status Spin::onCycleUpdate()
 {
-  // Currently only an open-loop time-based controller is implemented
-  // The closed-loop version 'controlledSpin()' has not been fully tested
-  return timedSpin();
-}
-
-Status Spin::timedSpin()
-{
-  // Output control command
-  geometry_msgs::msg::Twist cmd_vel;
-
-  // TODO(orduno) #423 fixed time
-  auto current_time = std::chrono::system_clock::now();
-  if (current_time - start_time_ >= 6s) {  // almost 180 degrees
-    stopRobot();
-    return Status::SUCCEEDED;
-  }
-
-  // TODO(orduno) #423 fixed speed
-  cmd_vel.linear.x = 0.0;
-  cmd_vel.linear.y = 0.0;
-  cmd_vel.angular.z = 0.5;
-
   geometry_msgs::msg::Pose current_pose;
   if (!getRobotPose(current_pose)) {
     RCLCPP_ERROR(node_->get_logger(), "Current robot pose is not available.");
     return Status::FAILED;
   }
+
+  const double current_yaw = tf2::getYaw(current_pose.orientation);
+  const double yaw_diff = start_yaw_ - current_yaw;
+
+  geometry_msgs::msg::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.linear.y = 0.0;
+  cmd_vel.angular.z = 0.0;
+
+  if (abs(yaw_diff) >= abs(command_yaw_)) {
+    stopRobot();
+    return Status::SUCCEEDED;
+  }
+
+
+  double vel = sqrt(2 * rotational_acc_lim_ * abs(yaw_diff));
+  vel = std::min(std::max(vel, min_rotational_vel_), max_rotational_vel_);
+
+  command_yaw_ < 0 ? cmd_vel.angular.z = -vel : cmd_vel.angular.z = vel;
 
   geometry_msgs::msg::Pose2D pose2d;
   pose2d.x = current_pose.position.x;
@@ -107,51 +107,6 @@ Status Spin::timedSpin()
   }
 
   vel_publisher_->publishCommand(cmd_vel);
-
-  return Status::RUNNING;
-}
-
-Status Spin::controlledSpin()
-{
-  // TODO(orduno) #423 Test and tune controller
-  //              check it doesn't abruptly start and stop
-  //              or cause massive wheel slippage when accelerating
-
-  // Get current robot orientation
-  auto current_pose = std::make_shared<geometry_msgs::msg::PoseWithCovarianceStamped>();
-  if (!robot_state_->getCurrentPose(current_pose)) {
-    RCLCPP_ERROR(node_->get_logger(), "Current robot pose is not available.");
-    return Status::FAILED;
-  }
-
-  double current_yaw = tf2::getYaw(current_pose->pose.pose.orientation);
-
-  double current_angle = current_yaw - start_yaw_;
-
-  double dist_left = M_PI - current_angle;
-
-  // TODO(orduno) #379 forward simulation to check if future position is feasible
-
-  // compute the velocity that will let us stop by the time we reach the goal
-  // v_f^2 == v_i^2 + 2 * a * d
-  // solving for v_i if v_f = 0
-  double vel = sqrt(2 * rotational_acc_lim_ * dist_left);
-
-  // limit velocity
-  vel = std::min(std::max(vel, min_rotational_vel_), max_rotational_vel_);
-
-  geometry_msgs::msg::Twist cmd_vel;
-  cmd_vel.linear.x = 0.0;
-  cmd_vel.linear.y = 0.0;
-  cmd_vel.angular.z = vel;
-
-  vel_publisher_->publishCommand(cmd_vel);
-
-  // check if we are done
-  if (dist_left >= (0.0 - goal_tolerance_angle_)) {
-    stopRobot();
-    return Status::SUCCEEDED;
-  }
 
   return Status::RUNNING;
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (fixes #423 ) |
| Primary OS tested on | (Ubuntu 18.02) |
| Robotic platform tested on | (Gazebo sim) |

---

## Description of contribution in a few bullet points

A closed-loop controller similar to backup is added. 
Since for this task, we don't care how close we get to the setpoint, a simple on-off controller was implemented and overshoot is expected.  The faster the robot moves and the slower the loop rate gets, the higher the overshoot.


## Future work that may be required in bullet points
Parameterize the angle and speed.  Currently, the angle is set to `pi/2` in `spin_action.hpp`
We should be able to change the angle from BT.  For example:

```xml
<Spin theta="180"/>
```
Should make the robot to rotate 180 degrees CW
```xml
<Spin theta="-180"/>
```
Should make the robot to rotate 180 degrees CCW

---

