### PR TITLE
[WIP] Change retry count to 100 for system tests

### DIFF
--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -40,6 +40,9 @@ def generate_launch_description():
                                     os.getenv('BT_NAVIGATOR_XML'))
 
     return LaunchDescription([
+        launch.actions.SetEnvironmentVariable(
+          'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1'),
+
         # Launch gazebo server for simulation
         launch.actions.ExecuteProcess(
             cmd=['gzserver', '-s', 'libgazebo_ros_init.so',

--- a/nav2_system_tests/src/system/test_system_node.py
+++ b/nav2_system_tests/src/system/test_system_node.py
@@ -30,11 +30,11 @@ class NavTester(Node):
     def __init__(self):
         super().__init__('nav2_tester')
         self.initial_pose_pub = self.create_publisher(PoseWithCovarianceStamped,
-                                                      '/initialpose')
-        self.goal_pub = self.create_publisher(PoseStamped, '/move_base_simple/goal')
+                                                      '/initialpose', 10)
+        self.goal_pub = self.create_publisher(PoseStamped, '/move_base_simple/goal', 10)
 
         self.model_pose_sub = self.create_subscription(PoseWithCovarianceStamped,
-                                                       '/amcl_pose', self.poseCallback)
+                                                       '/amcl_pose', self.poseCallback, 10)
         self.initial_pose_received = False
 
     def setInitialPose(self, pose):

--- a/tools/run_test_suite.bash
+++ b/tools/run_test_suite.bash
@@ -22,6 +22,6 @@ colcon test --packages-select nav2_system_tests --ctest-args --exclude-regex "te
 # that happened in any of the `colcon test` lines above.
 colcon test-result --verbose
 
-$SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_localization$
-$SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_bt_navigator$
-$SCRIPT_DIR/ctest_retry.bash -r 3 -d build/nav2_system_tests -t test_bt_navigator_with_dijkstra$
+$SCRIPT_DIR/ctest_retry.bash -r 100 -d build/nav2_system_tests -t test_localization$
+$SCRIPT_DIR/ctest_retry.bash -r 100 -d build/nav2_system_tests -t test_bt_navigator$
+$SCRIPT_DIR/ctest_retry.bash -r 100 -d build/nav2_system_tests -t test_bt_navigator_with_dijkstra$


### PR DESCRIPTION
This changes the retry count to 100 for the system tests. 

It would never actually reach 100 before the CI times out but this arbitrarily high number is to see if it can be made to pass at all while we're debugging stability issues.

Marking this as WIP and 'do not merge' until it is passing CI, at which point we can decide whether to merge it or not.
