### PR TITLE
on download, rosdep all necessary items, calling on each build is redundant

### DIFF
--- a/tools/build_all.sh
+++ b/tools/build_all.sh
@@ -50,14 +50,12 @@ fi
 # Build our ROS 2 dependencies
 cd $CWD/ros2_nav_dependencies_ws
 export ROSDISTRO_INDEX_URL='https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml'
-rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO --skip-keys "catkin"
 (. $ROS2_SETUP_FILE &&
  colcon build --symlink-install)
 
 # Build our code
 cd $CWD/navigation2_ws
 export ROSDISTRO_INDEX_URL='https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml'
-rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO
 (. $ROS2_SETUP_FILE && . $CWD/ros2_nav_dependencies_ws/install/setup.bash &&
  colcon build --symlink-install)
 

--- a/tools/initial_ros_setup.sh
+++ b/tools/initial_ros_setup.sh
@@ -48,7 +48,9 @@ download_navstack() {
   else
     cd src
     git clone https://github.com/ros-planning/navigation2.git
+    cd ../
   fi
+  rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO --skip-keys "catkin"
   return_to_root_dir
 }
 
@@ -58,6 +60,7 @@ download_ros2() {
   cd ros2_ws
   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
   vcs import src < ros2.repos
+  rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO --skip-keys "catkin"
   return_to_root_dir
 }
 
@@ -66,6 +69,7 @@ download_ros2_dependencies() {
   mkdir -p ros2_nav_dependencies_ws/src
   cd ros2_nav_dependencies_ws
   vcs import src < ${CWD}/navigation2_ws/src/navigation2/tools/ros2_dependencies.repos
+  rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO --skip-keys "catkin"
   return_to_root_dir
 }
 
@@ -81,11 +85,11 @@ checkpoint() {
 }
 
 download_all() {
-  checkpoint download_navstack
-  checkpoint download_ros2_dependencies
   if [ "$ENABLE_ROS2" = true ]; then
     checkpoint download_ros2
   fi
+  checkpoint download_ros2_dependencies
+  checkpoint download_navstack
 }
 
 echo "This script will download the ROS 2 latest release workspace, the"

--- a/tools/initial_ros_setup.sh
+++ b/tools/initial_ros_setup.sh
@@ -48,7 +48,6 @@ download_navstack() {
   else
     cd src
     git clone https://github.com/ros-planning/navigation2.git
-    cd ../
   fi
   return_to_root_dir
 }

--- a/tools/initial_ros_setup.sh
+++ b/tools/initial_ros_setup.sh
@@ -50,7 +50,6 @@ download_navstack() {
     git clone https://github.com/ros-planning/navigation2.git
     cd ../
   fi
-  rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO --skip-keys "catkin"
   return_to_root_dir
 }
 
@@ -60,7 +59,6 @@ download_ros2() {
   cd ros2_ws
   wget https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
   vcs import src < ros2.repos
-  rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO --skip-keys "catkin"
   return_to_root_dir
 }
 
@@ -69,7 +67,6 @@ download_ros2_dependencies() {
   mkdir -p ros2_nav_dependencies_ws/src
   cd ros2_nav_dependencies_ws
   vcs import src < ${CWD}/navigation2_ws/src/navigation2/tools/ros2_dependencies.repos
-  rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS2_DISTRO --skip-keys "catkin"
   return_to_root_dir
 }
 
@@ -85,11 +82,15 @@ checkpoint() {
 }
 
 download_all() {
+  checkpoint download_navstack
+  checkpoint download_ros2_dependencies
   if [ "$ENABLE_ROS2" = true ]; then
     checkpoint download_ros2
   fi
-  checkpoint download_ros2_dependencies
-  checkpoint download_navstack
+}
+
+rosdep_install() {
+  rosdep install -y -r -q --from-paths . --ignore-src --rosdistro $ROS2_DISTRO --skip-keys "catkin"
 }
 
 echo "This script will download the ROS 2 latest release workspace, the"
@@ -104,6 +105,7 @@ read -r REPLY
 echo
 if [ "$REPLY" = "y" ]; then
   download_all
+  rosdep_install
   if [ "$ENABLE_BUILD" = true ]; then
     $CWD/navigation2_ws/src/navigation2/tools/build_all.sh
   fi


### PR DESCRIPTION
Also came up because the ros2_ws didn't have rosdep called over it so anything in a clean 18.04 container (or metal) didn't have alot of things installed that were necessary for a clean build on a new machine

Edit: I start out yesterday to work on recoveries... ended up battling dependency PIP vs APT nightmares for 15 hours... "Oh that's missing let me just pip install it..." *famous last words*