### PR TITLE
Add global namespace to costmap's local namespace

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -73,11 +73,19 @@ class Costmap2DROS : public nav2_util::LifecycleNode
 {
 public:
   /**
-   * @brief  Constructor for the wrapper
-   * @param name The name for this costmap
-   * @param tf A reference to a TransformListener
+   * @brief  Constructor for the wrapper, the node will
+   * be placed in a namespace equal to the node's name
+   * @param name Name of the costmap ROS node
    */
   explicit Costmap2DROS(const std::string & name);
+
+  /**
+   * @brief  Constructor for the wrapper
+   * @param name Name of the costmap ROS node
+   * @param absolute_namespace Namespace of the costmap ROS node starting with "/"
+   */
+  explicit Costmap2DROS(const std::string & name, const std::string & absolute_namespace);
+
   ~Costmap2DROS();
 
   nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -51,11 +51,17 @@ using namespace std::chrono_literals;
 
 namespace nav2_costmap_2d
 {
-
 Costmap2DROS::Costmap2DROS(const std::string & name)
-: nav2_util::LifecycleNode(name, name, true), name_(name)
+: Costmap2DROS(name, name) {}
+
+Costmap2DROS::Costmap2DROS(const std::string & name, const std::string & absolute_namespace)
+: nav2_util::LifecycleNode(name, "", true,
+    // NodeOption arguments take precedence over the ones provided on the command line
+    // use this to make sure the node is placed on the provided namespace
+    rclcpp::NodeOptions().arguments({std::string("__ns:=") + absolute_namespace})),
+  name_(name)
 {
-  RCLCPP_INFO(get_logger(), "Creating");
+  RCLCPP_INFO(get_logger(), "Creating Costmap");
   auto options = rclcpp::NodeOptions().arguments(
     {std::string("__node:=") + get_name() + "_client"});
   client_node_ = std::make_shared<rclcpp::Node>("_", options);

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -34,7 +34,8 @@ DwbController::DwbController()
   RCLCPP_INFO(get_logger(), "Creating");
 
   // The costmap node is used in the implementation of the DWB controller
-  costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>("local_costmap");
+  costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "local_costmap", nav2_util::add_namespaces(std::string{get_namespace()}, "local_costmap"));
 
   // Create an executor that will be used to spin the costmap node
   costmap_executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();

--- a/nav2_util/include/nav2_util/node_utils.hpp
+++ b/nav2_util/include/nav2_util/node_utils.hpp
@@ -33,6 +33,14 @@ namespace nav2_util
  */
 std::string sanitize_node_name(const std::string & potential_node_name);
 
+/// Concatenate two namespaces to produce an absolute namespace
+/**
+ * \param[in] top_ns The namespace to place first
+ * \param[in] sub_ns The namespace to place after top_ns
+ * \return An absolute namespace starting with "/"
+*/
+std::string add_namespaces(const std::string & top_ns, const std::string & sub_ns = "");
+
 /// Add some random characters to a node name to ensure it is unique in the system
 /**
  * There are utility classes that create an internal private node to interact

--- a/nav2_util/src/node_utils.cpp
+++ b/nav2_util/src/node_utils.cpp
@@ -38,6 +38,19 @@ string sanitize_node_name(const string & potential_node_name)
   return node_name;
 }
 
+string add_namespaces(const string & top_ns, const string & sub_ns)
+{
+  if (!top_ns.empty() && top_ns.back() == '/') {
+    if (top_ns.front() == '/') {
+      return top_ns + sub_ns;
+    } else {
+      return "/" + top_ns + sub_ns;
+    }
+  }
+
+  return top_ns + "/" + sub_ns;
+}
+
 std::string time_to_string(size_t len)
 {
   string output(len, '0');  // prefill the string with zeros

--- a/nav2_world_model/src/world_model.cpp
+++ b/nav2_world_model/src/world_model.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "nav2_world_model/world_model.hpp"
+#include "nav2_util/node_utils.hpp"
 
 #include <memory>
 
@@ -24,10 +25,11 @@ namespace nav2_world_model
 WorldModel::WorldModel()
 : nav2_util::LifecycleNode("world_model")
 {
-  RCLCPP_INFO(get_logger(), "Creating");
+  RCLCPP_INFO(get_logger(), "Creating World Model");
 
   // The costmap node is used in the implementation of the world model
-  costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
+  costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "global_costmap", nav2_util::add_namespaces(std::string{get_namespace()}, "global_costmap"));
 
   // Create an executor that will be used to spin the costmap node
   costmap_executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #971  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo simulation of TB |

---

## Description of contribution in a few bullet points

If the nodes hosting costmaps (i.e. world map & dwb) are placed on a namespace, this PR will also put the costmaps on that namespace:

| Namespace | World Model | Global Costmap  | DWB | Local Costmap |
| ---------------- | ----------------- | ---------------------- | ------- | -------------------- |
| /      | /world_model | /global_costmap/global_costmap | /dwb_controller | /local_costmap/local_costmap |
| /robot1 | /robot1/world_model | /robot1/global_costmap/global_costmap | /robot1/dwb_controller | /robot1/local_costmap/local_costmap |

The namespace could be provided on the hosting node constructor (directly or through `rclcpp::NodeOptions`) or the launch file. Notice how the costmaps specify a namespace locally but the hosting node's namespace gets appended.

Without this PR, the behavior is:

| Namespace | World Model | Global Costmap  | DWB | Local Costmap |
| ---------------- | ----------------- | ---------------------- | ------- | -------------------- |
| /      | /world_model | /global_costmap/global_costmap | /dwb_controller | /local_costmap/local_costmap |
| /robot1 | /robot1/world_model | /robot1/global_costmap | /robot1/dwb_controller | /robot1/local_costmap |

Notice how we loose the local namespace specified on the costmaps.

This is one step towards solving #971.
