### PR TITLE
Disable displaying RobotModel in Rviz by default

### DIFF
--- a/nav2_bringup/launch/nav2_default_view.rviz
+++ b/nav2_bringup/launch/nav2_default_view.rviz
@@ -52,7 +52,7 @@ Visualization Manager:
       Description File: ""
       Description Source: Topic
       Description Topic: /robot_description
-      Enabled: true
+      Enabled: false
       Links:
         All Links Enabled: true
         Expand Joint Details: false


### PR DESCRIPTION
Temporal fix for #1000, let's just disable displaying the RobotModel by default.