### PR TITLE
spin up thread for goal tool to not block frontend

### DIFF
--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/goal_tool.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/goal_tool.hpp
@@ -18,6 +18,7 @@
 #include <QObject>
 
 #include <memory>
+#include <thread>
 
 #include "rviz_default_plugins/tools/pose/pose_tool.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
@@ -49,9 +50,11 @@ public:
 
 protected:
   void onPoseSet(double x, double y, double theta) override;
+  void onPoseSetImpl(double x, double y, double theta);
 
 private:
   std::unique_ptr<NavigationDialog> navigation_dialog_;
+  std::unique_ptr<std::thread> execution_thread_;
 };
 
 }  // namespace nav2_rviz_plugins


### PR DESCRIPTION
https://github.com/ros-planning/navigation2/issues/1002

Makes it so RVIZ doesnt lag when you use the action server interface