### PR TITLE
[nav2_costmap_2d] remove unnecessary CMake code to remove warning

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -30,9 +30,7 @@ nav2_package()
 
 include_directories(
   include
-  ${ament_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
-  ${laser_geometry_INCLUDE_DIRS}
 )
 
 add_definitions(${EIGEN3_DEFINITIONS})


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | (Ubuntu Bionic) |
| Robotic platform tested on | (NA) |

---

## Description of contribution in a few bullet points
Removes CMake unused or duplicated variables

- `ament_INCLUDE_DIRS`: CMake complains that this variable is uninitialized. I believe this is a leftover from ROS 1 port (catkin_INCLUDE_DIRS was bundling all the found ROS packages include dirs but `ament_cmake` doesn't)
- `laser_geometry_INCLUDE_DIRS`: laser_geometry is in the list of dependencies passed to `ament_target_dependencies` so its presence in `include_directories` is redundant
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>