### PR TITLE
disabling by default the debug markers for local planner

### DIFF
--- a/nav2_bringup/launch/nav2_default_view.rviz
+++ b/nav2_bringup/launch/nav2_default_view.rviz
@@ -261,7 +261,7 @@ Visualization Manager:
           Unreliable: false
           Value: true
         - Class: rviz_default_plugins/MarkerArray
-          Enabled: true
+          Enabled: false
           Name: Trajectories
           Namespaces:
             {}


### PR DESCRIPTION
The rviz config shows the set of tested DWB paths, which is nice for debug but a little TMI for typical development, just toggling it off. 