### PR TITLE
Make FootprintSubscriber topic parameter a const reference

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/footprint_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/footprint_subscriber.hpp
@@ -29,17 +29,17 @@ class FootprintSubscriber
 public:
   FootprintSubscriber(
     nav2_util::LifecycleNode::SharedPtr node,
-    std::string & topic_name);
+    const std::string & topic_name);
 
   FootprintSubscriber(
     rclcpp::Node::SharedPtr node,
-    std::string & topic_name);
+    const std::string & topic_name);
 
   FootprintSubscriber(
     const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
     const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-    std::string & topic_name);
+    const std::string & topic_name);
 
   ~FootprintSubscriber() {}
 

--- a/nav2_costmap_2d/src/footprint_subscriber.cpp
+++ b/nav2_costmap_2d/src/footprint_subscriber.cpp
@@ -21,7 +21,7 @@ namespace nav2_costmap_2d
 
 FootprintSubscriber::FootprintSubscriber(
   nav2_util::LifecycleNode::SharedPtr node,
-  std::string & topic_name)
+  const std::string & topic_name)
 : FootprintSubscriber(node->get_node_base_interface(),
     node->get_node_topics_interface(),
     node->get_node_logging_interface(),
@@ -30,7 +30,7 @@ FootprintSubscriber::FootprintSubscriber(
 
 FootprintSubscriber::FootprintSubscriber(
   rclcpp::Node::SharedPtr node,
-  std::string & topic_name)
+  const std::string & topic_name)
 : FootprintSubscriber(node->get_node_base_interface(),
     node->get_node_topics_interface(),
     node->get_node_logging_interface(),
@@ -41,7 +41,7 @@ FootprintSubscriber::FootprintSubscriber(
   const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
   const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
   const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-  std::string & topic_name)
+  const std::string & topic_name)
 : node_base_(node_base),
   node_topics_(node_topics),
   node_logging_(node_logging),


### PR DESCRIPTION
Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu Bionic |
| Robotic platform tested on | None |

---

## Description of contribution in a few bullet points

The `FootprintSubscriber` constructor takes a non-const `std::string &`  for the topic name. This makes it impossible to give the topic name from a string literal. The topic name does not need to be mutable.

---

## Future work that may be required in bullet points

* I did not test this locally due to #965.

---

