### PR TITLE
Costmap subscriber const topic

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
@@ -30,17 +30,17 @@ class CostmapSubscriber
 public:
   CostmapSubscriber(
     nav2_util::LifecycleNode::SharedPtr node,
-    std::string & topic_name);
+    const std::string & topic_name);
 
   CostmapSubscriber(
     rclcpp::Node::SharedPtr node,
-    std::string & topic_name);
+    const std::string & topic_name);
 
   CostmapSubscriber(
     const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
     const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-    std::string & topic_name);
+    const std::string & topic_name);
 
   ~CostmapSubscriber() {}
 

--- a/nav2_costmap_2d/src/costmap_subscriber.cpp
+++ b/nav2_costmap_2d/src/costmap_subscriber.cpp
@@ -21,7 +21,7 @@ namespace nav2_costmap_2d
 
 CostmapSubscriber::CostmapSubscriber(
   nav2_util::LifecycleNode::SharedPtr node,
-  std::string & topic_name)
+  const std::string & topic_name)
 : CostmapSubscriber(node->get_node_base_interface(),
     node->get_node_topics_interface(),
     node->get_node_logging_interface(),
@@ -30,7 +30,7 @@ CostmapSubscriber::CostmapSubscriber(
 
 CostmapSubscriber::CostmapSubscriber(
   rclcpp::Node::SharedPtr node,
-  std::string & topic_name)
+  const std::string & topic_name)
 : CostmapSubscriber(node->get_node_base_interface(),
     node->get_node_topics_interface(),
     node->get_node_logging_interface(),
@@ -41,7 +41,7 @@ CostmapSubscriber::CostmapSubscriber(
   const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
   const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
   const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-  std::string & topic_name)
+  const std::string & topic_name)
 : node_base_(node_base),
   node_topics_(node_topics),
   node_logging_(node_logging),


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on |  |
| Robotic platform tested on | |

---

## Description of contribution in a few bullet points

* Similar to #1011 
* Non-const reference to topic prevents passing string literals like `"costmap"`
* This PR makes the parameter a const reference

---

## Future work that may be required in bullet points

* I did not build locally due to #965 
