### PR TITLE
removing unnecessary smart pointers that dont effect lifecycle

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -198,7 +198,7 @@ protected:
     const std::vector<amcl_hyp_t> & hyps,
     const int & max_weight_hyp);
   void sendMapToOdomTransform(const tf2::TimePoint & transform_expiration);
-  void handleInitialPose(geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
+  void handleInitialPose(geometry_msgs::msg::PoseWithCovarianceStamped & msg);
   bool init_pose_received_on_inactive{false};
   bool initial_pose_is_known_{false};
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -290,7 +290,7 @@ protected:
   std::vector<geometry_msgs::msg::Point> unpadded_footprint_;
   std::vector<geometry_msgs::msg::Point> padded_footprint_;
 
-  std::shared_ptr<ClearCostmapService> clear_costmap_service_;
+  std::unique_ptr<ClearCostmapService> clear_costmap_service_;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -152,7 +152,7 @@ Costmap2DROS::on_configure(const rclcpp_lifecycle::State & /*state*/)
   }
 
   // Add cleaning service
-  clear_costmap_service_ = std::make_shared<ClearCostmapService>(shared_from_this(), *this);
+  clear_costmap_service_ = std::make_unique<ClearCostmapService>(shared_from_this(), *this);
 
   return nav2_util::CallbackReturn::SUCCESS;
 }

--- a/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
+++ b/nav2_dwb_controller/dwb_controller/include/dwb_controller/dwb_controller.hpp
@@ -76,7 +76,7 @@ protected:
   std::unique_ptr<dwb_core::DWBLocalPlanner> planner_;
 
   // An executor used to spin the costmap node
-  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> costmap_executor_;
+  rclcpp::executors::SingleThreadedExecutor costmap_executor_;
 
   std::unique_ptr<ProgressChecker> progress_checker_;
 

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -38,25 +38,22 @@ DwbController::DwbController()
   // The costmap node is used in the implementation of the DWB controller
   costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>("local_costmap");
 
-  // Create an executor that will be used to spin the costmap node
-  costmap_executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
-
   // Launch a thread to run the costmap node
   costmap_thread_ = std::make_unique<std::thread>(
     [&](rclcpp_lifecycle::LifecycleNode::SharedPtr node)
     {
       // TODO(mjeronimo): Once Brian pushes his change upstream to rlcpp executors, we'll
       // be able to provide our own executor to spin(), reducing this to a single line
-      costmap_executor_->add_node(node->get_node_base_interface());
-      costmap_executor_->spin();
-      costmap_executor_->remove_node(node->get_node_base_interface());
+      costmap_executor_.add_node(node->get_node_base_interface());
+      costmap_executor_.spin();
+      costmap_executor_.remove_node(node->get_node_base_interface());
     }, costmap_ros_);
 }
 
 DwbController::~DwbController()
 {
   RCLCPP_INFO(get_logger(), "Destroying");
-  costmap_executor_->cancel();
+  costmap_executor_.cancel();
   costmap_thread_->join();
 }
 

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -51,7 +51,7 @@ protected:
 
   // When creating a local node, this class will launch a separate thread created to spin the node
   std::unique_ptr<std::thread> rclcpp_thread_;
-  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> rclcpp_exec_;
+  rclcpp::executors::SingleThreadedExecutor rclcpp_exec_;
 };
 
 }  // namespace nav2_util

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -53,12 +53,11 @@ LifecycleNode::LifecycleNode(
       std::string("__node:=") + this->get_name() + "_rclcpp_node");
     rclcpp_node_ = std::make_shared<rclcpp::Node>(
       "_", namespace_, rclcpp::NodeOptions(options).arguments(new_args));
-    rclcpp_exec_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
     rclcpp_thread_ = std::make_unique<std::thread>(
       [&](rclcpp::Node::SharedPtr node) {
-        rclcpp_exec_->add_node(node);
-        rclcpp_exec_->spin();
-        rclcpp_exec_->remove_node(node);
+        rclcpp_exec_.add_node(node);
+        rclcpp_exec_.spin();
+        rclcpp_exec_.remove_node(node);
       },
       rclcpp_node_);
   }
@@ -75,7 +74,7 @@ LifecycleNode::~LifecycleNode()
   }
 
   if (use_rclcpp_node_) {
-    rclcpp_exec_->cancel();
+    rclcpp_exec_.cancel();
     rclcpp_thread_->join();
   }
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/950 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

* first step in auditing pointers
* removing any pointers that don't fill a purpose, and not effecting lifecycle bringup

---

## Future work that may be required in bullet points

* convert more of the code to lifecycle so we can remove even more tiny configurable chunks of code from pointers
* understand better our style interest in lifecycle - some places we configure parameters or create pub/sub/clients in the constructor and in other places we do so in the configure state. Get an answer for what we want to do and I can homologate them.

Phase 2 of this looks like:
- Things that are purely pointers because they configure things on creation and no other substantive reasons, turn them to lifecycle so then the lifecycle nodes calling them can control them & have them be member objects. Lots of things fall into this category, especially things in `nav2_utils`
- **OR** initialize these objects in constructors of their parent objects if we're not trying to be too strict on the lifecycle thing -- which I might suggest for simplicity 

---

