### PR TITLE
Recovery using odometric poses and costmaps

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/collision_checker.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/collision_checker.hpp
@@ -43,7 +43,8 @@ public:
     CostmapSubscriber & costmap_sub,
     FootprintSubscriber & footprint_sub,
     tf2_ros::Buffer & tf,
-    std::string name = "collision_checker");
+    std::string name = "collision_checker",
+    std::string global_frame = "map");
 
   ~CollisionChecker();
 
@@ -63,6 +64,7 @@ protected:
 
   // Name used for logging
   std::string name_;
+  std::string global_frame_;
   tf2_ros::Buffer & tf_;
   CostmapSubscriber & costmap_sub_;
   FootprintSubscriber & footprint_sub_;

--- a/nav2_costmap_2d/src/collision_checker.cpp
+++ b/nav2_costmap_2d/src/collision_checker.cpp
@@ -33,8 +33,10 @@ CollisionChecker::CollisionChecker(
   CostmapSubscriber & costmap_sub,
   FootprintSubscriber & footprint_sub,
   tf2_ros::Buffer & tf,
-  std::string name)
+  std::string name,
+  std::string global_frame)
 : name_(name),
+  global_frame_(global_frame),
   tf_(tf),
   costmap_sub_(costmap_sub),
   footprint_sub_(footprint_sub)
@@ -171,7 +173,7 @@ void CollisionChecker::unorientFootprint(
   std::vector<geometry_msgs::msg::Point> & reset_footprint)
 {
   geometry_msgs::msg::PoseStamped current_pose;
-  if (!nav2_util::getCurrentPose(current_pose, tf_)) {
+  if (!nav2_util::getCurrentPose(current_pose, tf_, global_frame_)) {
     throw CollisionCheckerException("Robot pose unavailable.");
   }
 

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -143,11 +143,11 @@ Costmap2DROS::on_configure(const rclcpp_lifecycle::State & /*state*/)
       std::bind(&Costmap2DROS::setRobotFootprintPolygon, this, std::placeholders::_1));
 
   footprint_pub_ = create_publisher<geometry_msgs::msg::PolygonStamped>(
-    name_ + "/published_footprint", rclcpp::SystemDefaultsQoS());
+    "published_footprint", rclcpp::SystemDefaultsQoS());
 
   costmap_publisher_ = new Costmap2DPublisher(shared_from_this(),
       layered_costmap_->getCostmap(), global_frame_,
-      name_ + "/costmap", always_send_full_costmap_);
+      "costmap", always_send_full_costmap_);
 
   // Set the footprint
   if (use_radius_) {

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -137,11 +137,11 @@ Costmap2DROS::on_configure(const rclcpp_lifecycle::State & /*state*/)
       std::bind(&Costmap2DROS::setRobotFootprintPolygon, this, std::placeholders::_1));
 
   footprint_pub_ = create_publisher<geometry_msgs::msg::PolygonStamped>(
-    "published_footprint", rclcpp::SystemDefaultsQoS());
+    name_ + "/published_footprint", rclcpp::SystemDefaultsQoS());
 
   costmap_publisher_ = new Costmap2DPublisher(shared_from_this(),
       layered_costmap_->getCostmap(), global_frame_,
-      "costmap", always_send_full_costmap_);
+      name_ + "/costmap", always_send_full_costmap_);
 
   // Set the footprint
   if (use_radius_) {
@@ -378,7 +378,7 @@ Costmap2DROS::mapUpdateLoop(double frequency)
       if ((last_publish_ + publish_cycle_ < current_time) ||  // publish_cycle_ is due
         (current_time < last_publish_))      // time has moved backwards, probably due to a switch to sim_time // NOLINT
       {
-        RCLCPP_DEBUG(get_logger(), "Publish costmap");
+        RCLCPP_DEBUG(get_logger(), "Publish costmap at %s", name_.c_str());
         costmap_publisher_->publishCostmap();
         last_publish_ = current_time;
       }

--- a/nav2_costmap_2d/test/integration/test_collision_checker.cpp
+++ b/nav2_costmap_2d/test/integration/test_collision_checker.cpp
@@ -120,7 +120,7 @@ public:
       footprint_topic);
 
     collision_checker_ = std::make_unique<nav2_costmap_2d::CollisionChecker>(
-      *costmap_sub_, *footprint_sub_, *tf_buffer_, get_name());
+      *costmap_sub_, *footprint_sub_, *tf_buffer_, get_name(), "map");
 
     layers_ = new nav2_costmap_2d::LayeredCostmap("map", false, false);
     // Add Static Layer

--- a/nav2_recoveries/include/nav2_recoveries/recovery.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery.hpp
@@ -110,7 +110,7 @@ protected:
       node_, footprint_topic);
 
     collision_checker_ = std::make_unique<nav2_costmap_2d::CollisionChecker>(
-      *costmap_sub_, *footprint_sub_, tf_);
+      *costmap_sub_, *footprint_sub_, tf_, "odom");
 
     vel_pub_ = node_->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
   }

--- a/nav2_recoveries/src/back_up.cpp
+++ b/nav2_recoveries/src/back_up.cpp
@@ -45,7 +45,7 @@ Status BackUp::onRun(const std::shared_ptr<const BackUpAction::Goal> command)
 
   command_x_ = command->target.x;
 
-  if (!nav2_util::getCurrentPose(initial_pose_, tf_)) {
+  if (!nav2_util::getCurrentPose(initial_pose_, tf_, "odom")) {
     RCLCPP_ERROR(node_->get_logger(), "Initial robot pose is not available.");
     return Status::FAILED;
   }
@@ -56,7 +56,7 @@ Status BackUp::onRun(const std::shared_ptr<const BackUpAction::Goal> command)
 Status BackUp::onCycleUpdate()
 {
   geometry_msgs::msg::PoseStamped current_pose;
-  if (!nav2_util::getCurrentPose(current_pose, tf_)) {
+  if (!nav2_util::getCurrentPose(current_pose, tf_, "odom")) {
     RCLCPP_ERROR(node_->get_logger(), "Current robot pose is not available.");
     return Status::FAILED;
   }

--- a/nav2_recoveries/src/main.cpp
+++ b/nav2_recoveries/src/main.cpp
@@ -35,9 +35,9 @@ int main(int argc, char ** argv)
   auto tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer);
 
   recoveries_node->declare_parameter(
-    "costmap_topic", rclcpp::ParameterValue(std::string("global_costmap/costmap_raw")));
+    "costmap_topic", rclcpp::ParameterValue(std::string("local_costmap/costmap_raw")));
   recoveries_node->declare_parameter(
-    "footprint_topic", rclcpp::ParameterValue(std::string("global_costmap/published_footprint")));
+    "footprint_topic", rclcpp::ParameterValue(std::string("local_costmap/published_footprint")));
 
   auto spin = std::make_shared<nav2_recoveries::Spin>(
     recoveries_node, tf_buffer);

--- a/nav2_recoveries/src/spin.cpp
+++ b/nav2_recoveries/src/spin.cpp
@@ -50,7 +50,7 @@ Spin::~Spin()
 Status Spin::onRun(const std::shared_ptr<const SpinAction::Goal> command)
 {
   geometry_msgs::msg::PoseStamped current_pose;
-  if (!nav2_util::getCurrentPose(current_pose, tf_)) {
+  if (!nav2_util::getCurrentPose(current_pose, tf_, "odom")) {
     RCLCPP_ERROR(node_->get_logger(), "Current robot pose is not available.");
     return Status::FAILED;
   }

--- a/nav2_recoveries/src/spin.cpp
+++ b/nav2_recoveries/src/spin.cpp
@@ -57,7 +57,7 @@ Status Spin::onRun(const std::shared_ptr<const SpinAction::Goal> command)
 Status Spin::onCycleUpdate()
 {
   geometry_msgs::msg::PoseStamped current_pose;
-  if (!nav2_util::getCurrentPose(current_pose, tf_)) {
+  if (!nav2_util::getCurrentPose(current_pose, tf_, "odom")) {
     RCLCPP_ERROR(node_->get_logger(), "Current robot pose is not available.");
     return Status::FAILED;
   }

--- a/nav2_recoveries/test/test_recoveries.cpp
+++ b/nav2_recoveries/test/test_recoveries.cpp
@@ -110,9 +110,9 @@ protected:
     tf_buffer->setCreateTimerInterface(timer_interface);
     auto tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer);
     node_->declare_parameter(
-      "costmap_topic", rclcpp::ParameterValue(std::string("global_costmap/costmap_raw")));
+      "costmap_topic", rclcpp::ParameterValue(std::string("local_costmap/costmap_raw")));
     node_->declare_parameter(
-      "footprint_topic", rclcpp::ParameterValue(std::string("global_costmap/published_footprint")));
+      "footprint_topic", rclcpp::ParameterValue(std::string("local_costmap/published_footprint")));
     recovery_ = std::make_unique<DummyRecovery>(node_, tf_buffer);
 
     client_ = rclcpp_action::create_client<RecoveryAction>(node_, "Recovery");


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #994 https://github.com/ros-planning/navigation2/issues/1026  |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

* using the odometric positioning so that the recoveries are **not** effected by global localizer updates for controller outputs
* pulling local costmap at potentially higher resolution so anything controlling motors is using the same sets of information 
* correcting the frame of reference
---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

I need to test this before merging, but I'm having a hard time figuring out exactly how I plan to do that

---

<!-- OPTIONAL -->

I'd like to request maintainer: <blank> to review this PR.
