### PR TITLE
adding recoveries XML to simulation launch file

### DIFF
--- a/nav2_bringup/launch/nav2_simulation_launch.py
+++ b/nav2_bringup/launch/nav2_simulation_launch.py
@@ -60,7 +60,7 @@ def generate_launch_description():
         'bt',
         default_value=os.path.join(
             get_package_prefix('nav2_bt_navigator'),
-            'behavior_trees/navigate_w_replanning.xml'),
+            'behavior_trees/navigate_w_replanning_and_recovery.xml'),
         description='Full path to the Behavior Tree XML file to use for the BT navigator')
 
     declare_map_yaml_cmd = launch.actions.DeclareLaunchArgument(

--- a/nav2_recoveries/include/nav2_recoveries/recovery.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery.hpp
@@ -110,7 +110,7 @@ protected:
       node_, footprint_topic);
 
     collision_checker_ = std::make_unique<nav2_costmap_2d::CollisionChecker>(
-      *costmap_sub_, *footprint_sub_, tf_, "odom");
+      *costmap_sub_, *footprint_sub_, tf_, node_->get_name(), "odom");
 
     vel_pub_ = node_->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
   }


### PR DESCRIPTION
Adding the `..._and_recovery` XML file for the simulation launch file so we can have the recovery behaviors running in the simulation. There were a few issues I resolved that likely would have been seen earlier if it were default. 