### PR TITLE
Fixing up paths for codecov.io report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "src/navigation2/::"


### PR DESCRIPTION


## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

* adding a config file for codecov.io so that it can find our source files to include in the report.
* The actual code coverage data records the path relative to the top of the workspace eg src/navigation2/nav2_amcl/src/main.cpp. Codecov.io needs the file names relative to the root of the repo. So we just tell codecov.io to drop the src/navigation2 part of the path