### PR TITLE
Split robot specific parameters into separate yaml

### DIFF
--- a/nav2_bringup/launch/nav2_bringup_2nd_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_2nd_launch.py
@@ -8,7 +8,8 @@ def generate_launch_description():
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='false')
     params_file = launch.substitutions.LaunchConfiguration('params', default=
         [launch.substitutions.ThisLaunchFileDir(), '/nav2_params.yaml'])
-   
+    robot_params_file = launch.substitutions.LaunchConfiguration('robot_params', default=
+        [launch.substitutions.ThisLaunchFileDir(), '/turtlebot3_waffle_params.yaml'])  
     bt_navigator_install_path = get_package_prefix('nav2_bt_navigator')
     bt_navigator_xml = os.path.join(bt_navigator_install_path,
                                     'behavior_trees',
@@ -22,13 +23,13 @@ def generate_launch_description():
             package='nav2_world_model',
             node_executable='world_model',
             output='screen',
-            parameters=[params_file]),
+            parameters=[params_file, robot_params_file]),
 
         launch_ros.actions.Node(
             package='dwb_controller',
             node_executable='dwb_controller',
             output='screen',
-            parameters=[params_file]),
+            parameters=[params_file, robot_params_file]),
 
         launch_ros.actions.Node(
             package='nav2_navfn_planner',

--- a/nav2_bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/launch/nav2_bringup_launch.py
@@ -32,6 +32,7 @@ def generate_launch_description():
     map_yaml_file = launch.substitutions.LaunchConfiguration('map')
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time')
     params_file = launch.substitutions.LaunchConfiguration('params')
+    robot_params_file = launch.substitutions.LaunchConfiguration('robot_params')
     bt_xml_file = launch.substitutions.LaunchConfiguration('bt_xml_file')
     autostart = launch.substitutions.LaunchConfiguration('autostart')
 
@@ -66,6 +67,11 @@ def generate_launch_description():
         default_value=os.path.join(launch_dir, 'nav2_params.yaml'),
         description='Full path to the ROS2 parameters file to use for all launched nodes')
 
+    declare_robot_params_file_cmd = launch.actions.DeclareLaunchArgument(
+        'robot_params',
+        default_value=os.path.join(launch_dir, 'turtlebot3_waffle_params.yaml'),
+        description='Full path to the ROS2 robot parameters file')
+
     declare_autostart_cmd = launch.actions.DeclareLaunchArgument(
         'autostart', default_value='true',
         description='Automatically startup the nav2 stack')
@@ -88,19 +94,19 @@ def generate_launch_description():
         node_executable='amcl',
         node_name='amcl',
         output='screen',
-        parameters=[configured_params])
+        parameters=[configured_params, robot_params_file])
 
     start_world_model_cmd = launch_ros.actions.Node(
         package='nav2_world_model',
         node_executable='world_model',
         output='screen',
-        parameters=[configured_params])
+        parameters=[configured_params, robot_params_file])
 
     start_dwb_cmd = launch_ros.actions.Node(
         package='dwb_controller',
         node_executable='dwb_controller',
         output='screen',
-        parameters=[configured_params])
+        parameters=[configured_params, robot_params_file])
 
     start_planner_cmd = launch_ros.actions.Node(
         package='nav2_navfn_planner',
@@ -140,6 +146,7 @@ def generate_launch_description():
     ld.add_action(declare_map_yaml_cmd)
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_params_file_cmd)
+    ld.add_action(declare_robot_params_file_cmd)
     ld.add_action(declare_autostart_cmd)
     ld.add_action(declare_bt_xml_cmd)
 

--- a/nav2_bringup/launch/nav2_localization_launch.py
+++ b/nav2_bringup/launch/nav2_localization_launch.py
@@ -27,6 +27,8 @@ def generate_launch_description():
                                                             default='false')
     autostart = launch.substitutions.LaunchConfiguration('autostart')
     params_file = launch.substitutions.LaunchConfiguration('params')
+    robot_params_file = launch.substitutions.LaunchConfiguration('robot_params')
+
 
     # Create our own temporary YAML files that include substitutions
     param_substitutions = {
@@ -59,6 +61,12 @@ def generate_launch_description():
                            '/nav2_params.yaml'],
             description='Full path to the ROS2 parameters file to use'),
 
+        launch.actions.DeclareLaunchArgument(
+            'robot_params',
+            default_value=[launch.substitutions.ThisLaunchFileDir(),
+                            '/turtlebot3_waffle_params.yaml'],
+            description='Full path to the ROS2 robot parameters file'),
+
         launch_ros.actions.Node(
             package='nav2_map_server',
             node_executable='map_server',
@@ -71,7 +79,7 @@ def generate_launch_description():
             node_executable='amcl',
             node_name='amcl',
             output='screen',
-            parameters=[configured_params]),
+            parameters=[configured_params, robot_params_file]),
 
         launch_ros.actions.Node(
             package='nav2_lifecycle_manager',

--- a/nav2_bringup/launch/nav2_navigation_launch.py
+++ b/nav2_bringup/launch/nav2_navigation_launch.py
@@ -29,8 +29,8 @@ def generate_launch_description():
                                                             default='false')
     autostart = launch.substitutions.LaunchConfiguration('autostart')
     params_file = launch.substitutions.LaunchConfiguration('params')
+    robot_params_file = launch.substitutions.LaunchConfiguration('robot_params')
     bt_xml_file = launch.substitutions.LaunchConfiguration('bt_xml_file')
-
 
     # Create our own temporary YAML files that include substitutions
     param_substitutions = {
@@ -63,6 +63,12 @@ def generate_launch_description():
             description='Full path to the ROS2 parameters file to use'),
 
         launch.actions.DeclareLaunchArgument(
+            'robot_params',
+            default_value=[launch.substitutions.ThisLaunchFileDir(), 
+                            '/turtlebot3_waffle_params.yaml'],
+            description='Full path to the ROS2 robot parameters file'),
+
+        launch.actions.DeclareLaunchArgument(
             'bt_xml_file',
             default_value=os.path.join(get_package_prefix('nav2_bt_navigator'),
                 'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
@@ -72,13 +78,13 @@ def generate_launch_description():
             package='nav2_world_model',
             node_executable='world_model',
             output='screen',
-            parameters=[configured_params]),
+            parameters=[configured_params, robot_params_file]),
 
         launch_ros.actions.Node(
             package='dwb_controller',
             node_executable='dwb_controller',
             output='screen',
-            parameters=[configured_params]),
+            parameters=[configured_params, robot_params_file]),
 
         launch_ros.actions.Node(
             package='nav2_navfn_planner',

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -26,7 +26,6 @@ amcl:
     recovery_alpha_fast: 0.0
     recovery_alpha_slow: 0.0
     resample_interval: 1
-    robot_model_type: "differential"
     save_pose_rate: 0.5
     sigma_hit: 0.2
     tf_broadcast: true
@@ -55,25 +54,6 @@ dwb_controller:
   ros__parameters:
     use_sim_time: True
     debug_trajectory_details: True
-    min_vel_x: 0.0
-    min_vel_y: 0.0
-    max_vel_x: 0.26
-    max_vel_y: 0.0
-    max_vel_theta: 1.0
-    min_speed_xy: 0.0
-    max_speed_xy: 0.26
-    min_speed_theta: 0.0
-    min_x_velocity_threshold: 0.001
-    # Add high threshold velocity for turtlebot 3 issue.
-    # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
-    min_y_velocity_threshold: 0.5
-    min_theta_velocity_threshold: 0.001
-    acc_lim_x: 2.5
-    acc_lim_y: 0.0
-    acc_lim_theta: 3.2
-    decel_lim_x: -2.5
-    decel_lim_y: 0.0
-    decel_lim_theta: -3.2
     vx_samples: 20
     vy_samples: 5
     vtheta_samples: 20
@@ -100,7 +80,6 @@ local_costmap:
       width: 3
       height: 3
       resolution: 0.05
-      robot_radius: 0.22
       inflation_layer.cost_scaling_factor: 3.0
       obstacle_layer:
         enabled: True
@@ -122,7 +101,6 @@ global_costmap:
   global_costmap:
     ros__parameters:
       use_sim_time: True
-      robot_radius: 0.22
       obstacle_layer:
         enabled: True
       always_send_full_costmap: True

--- a/nav2_bringup/launch/turtlebot3_waffle_params.yaml
+++ b/nav2_bringup/launch/turtlebot3_waffle_params.yaml
@@ -1,0 +1,36 @@
+amcl:
+  ros__parameters:
+    robot_model_type: "differential"
+
+dwb_controller:
+  ros__parameters:
+    min_vel_x: 0.0
+    min_vel_y: 0.0
+    max_vel_x: 0.26
+    max_vel_y: 0.0
+    max_vel_theta: 1.0
+    min_speed_xy: 0.0
+    max_speed_xy: 0.26
+    min_speed_theta: 0.0
+    min_in_place_vel_theta: 0.4
+    min_x_velocity_threshold: 0.001
+    # Add high threshold velocity for turtlebot 3 issue.
+    # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
+    min_y_velocity_threshold: 0.5
+    min_theta_velocity_threshold: 0.001
+    acc_lim_x: 2.5
+    acc_lim_y: 0.0
+    acc_lim_theta: 3.2
+    decel_lim_x: -2.5
+    decel_lim_y: 0.0
+    decel_lim_theta: -3.2
+
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      robot_radius: 0.22
+
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      robot_radius: 0.22


### PR DESCRIPTION
This PR creates a separate yaml file for the robot-specific parameters in the navstack (e.g. specific to turtlebot3 waffle model) and integrates it alonside `nav2_params.yaml` in the launch files. For different robot yaml files, they can be specified at command line via `robot_params:=/path/to/robot_params.yaml`.

I've left out changes to the `nav2_simulation_launch.py` since it is currently incurring run-time failures due to ExecuteProcess and rosargs for params.

#### Future work:
- Simplify and clean up launch files (too many and redundant)

