### PR TITLE
Add getFootprint() overload that returns time stamp

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/footprint_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/footprint_subscriber.hpp
@@ -50,6 +50,10 @@ public:
   // This frame is assumed to be known out of band, but typically it is "map".
   bool getFootprint(std::vector<geometry_msgs::msg::Point> & footprint);
 
+  // Returns an oriented robot footprint.
+  // The second parameter is the time the fooptrint was at this orientation.
+  bool getFootprint(std::vector<geometry_msgs::msg::Point> & footprint, rclcpp::Time & stamp);
+
 protected:
   // Interfaces used for logging and creating publishers and subscribers
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/footprint_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/footprint_subscriber.hpp
@@ -44,6 +44,10 @@ public:
 
   ~FootprintSubscriber() {}
 
+  // Returns an oriented robot footprint.
+  // The footprint received by the subscriber has already been transformed
+  // such that all points are in the global frame.
+  // This frame is assumed to be known out of band, but typically it is "map".
   bool getFootprint(std::vector<geometry_msgs::msg::Point> & footprint);
 
 protected:

--- a/nav2_costmap_2d/src/footprint_subscriber.cpp
+++ b/nav2_costmap_2d/src/footprint_subscriber.cpp
@@ -55,7 +55,7 @@ FootprintSubscriber::FootprintSubscriber(
 }
 
 bool
-FootprintSubscriber::getFootprint(std::vector<geometry_msgs::msg::Point> & footprint)
+FootprintSubscriber::getFootprint(std::vector<geometry_msgs::msg::Point> & footprint, rclcpp::Time & stamp)
 {
   if (!footprint_received_) {
     return false;
@@ -63,7 +63,15 @@ FootprintSubscriber::getFootprint(std::vector<geometry_msgs::msg::Point> & footp
 
   footprint = toPointVector(
     std::make_shared<geometry_msgs::msg::Polygon>(footprint_->polygon));
+  stamp = footprint_->header.stamp;
   return true;
+}
+
+bool
+FootprintSubscriber::getFootprint(std::vector<geometry_msgs::msg::Point> & footprint)
+{
+  rclcpp::Time temp;
+  return getFootprint(footprint, temp);
 }
 
 void


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  |

---

## Description of contribution in a few bullet points


* Documents `FootprintSubscriber:getFootprint()`
  * is this documentation correct?
* Add overloaded method that returns time
  * Without the time stamp, I'm uncertain about how to get the footprint in the base frame. If I un-orient using the latest position, the result would be incorrect if the robot has moved since the footprint was published.

---

## Future work that may be required in bullet points

* I haven't actually tried to build this patch. This PR is both a contribution and a question to make sure I understand the footprint subscriber.
