### PR TITLE
Add support for running nav2 with cartographer

### DIFF
--- a/nav2_bringup/launch/nav2_navigation_launch.py
+++ b/nav2_bringup/launch/nav2_navigation_launch.py
@@ -31,12 +31,12 @@ def generate_launch_description():
     params_file = launch.substitutions.LaunchConfiguration('params')
     bt_xml_file = launch.substitutions.LaunchConfiguration('bt_xml_file')
 
-
     # Create our own temporary YAML files that include substitutions
     param_substitutions = {
         'use_sim_time': use_sim_time,
         'bt_xml_filename': bt_xml_file,
-        'autostart': autostart
+        'autostart': autostart,
+        'map_subscribe_transient_local': 'False'
     }
 
     configured_params = RewrittenYaml(

--- a/nav2_bringup/launch/nav2_params.yaml
+++ b/nav2_bringup/launch/nav2_params.yaml
@@ -104,6 +104,8 @@ local_costmap:
       inflation_layer.cost_scaling_factor: 3.0
       obstacle_layer:
         enabled: True
+      static_layer:
+        map_subscribe_transient_local: True
       always_send_full_costmap: True
       observation_sources: scan
       scan:
@@ -125,6 +127,8 @@ global_costmap:
       robot_radius: 0.22
       obstacle_layer:
         enabled: True
+      static_layer:
+        map_subscribe_transient_local: True
       always_send_full_costmap: True
       observation_sources: scan
       scan:

--- a/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
@@ -109,7 +109,7 @@ private:
   unsigned char lethal_threshold_;
   unsigned char unknown_cost_value_;
   bool trinary_costmap_;
-  bool map_received_;
+  bool map_received_{false};
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -72,12 +72,14 @@ StaticLayer::onInitialize()
 
   getParameters();
 
-  rclcpp::QoS map_qos(1);
+  rclcpp::QoS map_qos(10); // initialize to default
   if (map_subscribe_transient_local_) {
     map_qos.transient_local();
+    map_qos.reliable();
+    map_qos.keep_last(1);
   }
 
-  RCLCPP_DEBUG(node_->get_logger(),
+  RCLCPP_INFO(node_->get_logger(),
     "Subscribing to the map topic (%s) with %s durability",
     map_topic_.c_str(),
     map_subscribe_transient_local_ ? "transient local" : "volatile");

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -335,7 +335,7 @@ StaticLayer::updateCosts(
     // throttle warning down to only 1/10 message rate
     if (++count == 10) {
       RCLCPP_WARN(node_->get_logger(), "Can't update static costmap layer, no map received");
-      count=0;
+      count = 0;
     }
     return;
   }

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -331,7 +331,12 @@ StaticLayer::updateCosts(
     return;
   }
   if (!map_received_) {
-    RCLCPP_WARN(node_->get_logger(), "Can't update static costmap layer, no map received");
+    static int count = 0;
+    // throttle warning down to only 1/10 message rate
+    if (++count == 10) {
+      RCLCPP_WARN(node_->get_logger(), "Can't update static costmap layer, no map received");
+      count=0;
+    }
     return;
   }
 

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -327,7 +327,11 @@ StaticLayer::updateCosts(
   nav2_costmap_2d::Costmap2D & master_grid,
   int min_i, int min_j, int max_i, int max_j)
 {
-  if (!enabled_ || !map_received_) {
+  if (!enabled_) {
+    return;
+  }
+  if (!map_received_) {
+    RCLCPP_WARN(node_->get_logger(), "Can't update static costmap layer, no map received");
     return;
   }
 

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -373,7 +373,12 @@ Costmap2DROS::mapUpdateLoop(double frequency)
 
     // Measure the execution time of the updateMap method
     timer.start();
-    updateMap();
+    try {
+      updateMap();
+    }
+    catch (const char* e) {
+      RCLCPP_ERROR(get_logger(), e);
+    }
     timer.end();
 
     RCLCPP_DEBUG(get_logger(), "Map update time: %.9f", timer.elapsed_time_in_seconds());

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -373,12 +373,7 @@ Costmap2DROS::mapUpdateLoop(double frequency)
 
     // Measure the execution time of the updateMap method
     timer.start();
-    try {
-      updateMap();
-    }
-    catch (const char* e) {
-      RCLCPP_ERROR(get_logger(), e);
-    }
+    updateMap();
     timer.end();
 
     RCLCPP_DEBUG(get_logger(), "Map update time: %.9f", timer.elapsed_time_in_seconds());

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -83,9 +83,14 @@ void CostmapLayer::updateWithTrueOverwrite(
   int max_i,
   int max_j)
 {
-  if (!enabled_ || costmap_ == nullptr) {
+  if (!enabled_) {
     return;
   }
+
+  if (costmap_ == nullptr) {
+    throw "Can't update costmap layer. It has't been initilized yet. Check if /map topic is published.";
+  }
+
   unsigned char * master = master_grid.getCharMap();
   unsigned int span = master_grid.getSizeInCellsX();
 

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -1,5 +1,5 @@
 #include <nav2_costmap_2d/costmap_layer.hpp>
-
+#include <stdexcept>
 #include <algorithm>
 
 namespace nav2_costmap_2d
@@ -88,7 +88,7 @@ void CostmapLayer::updateWithTrueOverwrite(
   }
 
   if (costmap_ == nullptr) {
-    throw "Can't update costmap layer. It has't been initilized yet. Check if /map topic is published.";
+    throw std::runtime_error("Can't update costmap layer: It has't been initilized yet!");
   }
 
   unsigned char * master = master_grid.getCharMap();

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -83,7 +83,7 @@ void CostmapLayer::updateWithTrueOverwrite(
   int max_i,
   int max_j)
 {
-  if (!enabled_) {
+  if (!enabled_ || costmap_ == nullptr) {
     return;
   }
   unsigned char * master = master_grid.getCharMap();

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -88,7 +88,7 @@ void CostmapLayer::updateWithTrueOverwrite(
   }
 
   if (costmap_ == nullptr) {
-    throw std::runtime_error("Can't update costmap layer: It has't been initilized yet!");
+    throw std::runtime_error("Can't update costmap layer: It has't been initialized yet!");
   }
 
   unsigned char * master = master_grid.getCharMap();


### PR DESCRIPTION
This PR includes changes for using Navigation 2 and Slam together. These changes are tested using Navigation 2 (Dashing-Devel), Cartographer and real robot (Turtlebot 3).

- set map_subscribe_transient_local parameter in the launch file to False when launching Navigation 2 without AMCL and Map Server. The default value for this parameter is True.  This parameter is used to set the QoS settings.

- Set QoS Keep_last to 1 or 10.

- added if costmap_ == nullptr. If for any reason costmap_ is nullptr, wrold model will stop working. this problem occurs when the QoS settings are not right.