### PR TITLE
add tf2_geometry_msgs dependency

### DIFF
--- a/nav2_util/src/map_loader/CMakeLists.txt
+++ b/nav2_util/src/map_loader/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(map_loader SHARED
 ament_target_dependencies(map_loader
   geometry_msgs
   tf2
+  tf2_geometry_msgs
   tf2_ros
   nav_msgs
   SDL


### PR DESCRIPTION
Fixes a failing compile bug for `nav2_util` which won't compile due to a recent commit that forgot to include a dependency on `tf2_geometry_msgs`