### PR TITLE
Remove set sim time

### DIFF
--- a/nav2_system_tests/package.xml
+++ b/nav2_system_tests/package.xml
@@ -30,7 +30,6 @@
   <exec_depend>launch_testing</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>ros2param</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>
   <exec_depend>nav2_util</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>

--- a/nav2_system_tests/src/system/test_system_node.py
+++ b/nav2_system_tests/src/system/test_system_node.py
@@ -83,16 +83,6 @@ class NavTester(Node):
         self.get_logger().info('Distance from goal is: ' + str(distance))
         return distance
 
-    def setSimTime(self):
-        self.get_logger().info('Setting transforms to use sim time from gazebo')
-        from subprocess import call
-        # loop through the problematic nodes
-        for nav2_node in ('/static_transform_publisher', '/map_server',
-                          '/global_costmap/global_costmap', '/local_costmap/local_costmap'):
-            while (call(['ros2', 'param', 'set', nav2_node, 'use_sim_time', 'True'])):
-                self.get_logger().error("Error couldn't set use_sim_time param on: " +
-                                        nav2_node + ' retrying...')
-
     def wait_for_node_active(self, node):
         # wait for the bt_navigator to be in active state
         node_service = '/' + node + '/get_state'
@@ -161,7 +151,6 @@ def test_all(test_robot):
         test_robot.wait_for_node_active('amcl')
         result = test_InitialPose(test_robot, timeout=1, retries=10)
     if (result):
-        test_robot.setSimTime()  # needed for nodes to become active
         test_robot.wait_for_node_active('bt_navigator')
     if (result):
         result = test_RobotMovesToGoal(test_robot)


### PR DESCRIPTION
Previously on Crystal, the system test had to set 'use_sim_time' dynamically for some composed nodes like /global_costmap/global_costmap. That's not necessary anymore. This removes that code. 

Let's see if it passes CI before reviewing. 
