### PR TITLE
Add ctest loop script

### DIFF
--- a/nav2_system_tests/README.md
+++ b/nav2_system_tests/README.md
@@ -30,3 +30,4 @@ Test the integration of several components and subsystems.
 
 ## 3. System Testing
 Test the integration of all subsystems.
+ - [System Test](src/system/README.md)

--- a/nav2_system_tests/scripts/ctest_loop.bash
+++ b/nav2_system_tests/scripts/ctest_loop.bash
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+#
+# Simple bash script to loop over the navigation2 "bt_navigator" system test
+#
+# options:
+# -c <#> - number of times to loop
+# -o <file> - name of summary output file
+# -l <file> - name to use for failing log files
+# -d <dds> - name of DDS implementation to use (ex: rmw_fastrtps_cpp)
+
+failcount=0
+loopcount=1
+
+while getopts c:o:l:d: option
+  do
+    case "$option"
+    in
+      c) loopcount=$OPTARG;;
+      o) outfile=$OPTARG;;
+      l) logfile=$OPTARG;;
+      d) dds=$OPTARG;;
+    esac
+  done
+
+echo "Total loop count = " $loopcount
+export RMW_IMPLEMENTATION=$dds
+
+for ((i=1; i<=$loopcount; i++))
+  do
+    echo "******************************"
+    echo "Loop number: " $i
+    echo "Running with DDS: " $dds
+    echo "******************************"
+
+    ctest -V -R test_bt_navigator$ -O $logfile
+    result=$?
+    echo "RESULT =" $result
+    if [ "$result" != "0" ]
+    then
+      ((failcount+=1))
+      echo "TEST $i FAILED" >> $outfile
+      mv $logfile $logfile.$i.fail
+    fi
+    echo $i "TESTS COMPLETED"
+    echo $failcount "TOTAL FAILURES"
+  done
+echo $failcount " FAILURES / " $loopcount
+echo $failcount " FAILURES / " $loopcount >> $outfile
+

--- a/nav2_system_tests/src/system/README.md
+++ b/nav2_system_tests/src/system/README.md
@@ -3,23 +3,40 @@
 This is a 'top level' system test which will use Gazebo to simulate a Robot moving from an known initial starting position to a goal pose. 
 
 ## To run the test
-First, build the package
+First, remove the COLCON_IGNORE; this exists so the system tests won't be in the debian release package
+```
+rm nav2_system_tests/COLCON_IGNORE
+```
+Then, you must build navigation2 including this package:
 ```
 colcon build --symlink-install
 ```
-Then you can run the test:
+Then you can run all the system tests:
 ```
 colcon test --packages-select nav2_system_tests
 ```
 Output results will go to the screen, and will be logged to the "log/latest_test/nav2_system_tests/" path relative to where colcon test was run.
 
-## Notes: (Dec 18 Crystal release)
+To run just the bt_navigator test:
+```
+cd build/nav2_system_tests
+ctest -V bt_navigator$
+```
+
+To loop over the bt_navigator test, a script has been provided:
+```
+nav2_system_tests/scripts/ctest_loop.bash -c <# loops> -o <path/to/summary/filename.txt> -l <path/to/store/failing/logfiles.log> -d <dds to use>
+```
+
+Example (loop 100 times using fastrtps):
+```
+nav2_system_tests/scripts/getopt_ctest_loop.bash -c 100 -o /home/robot/data/results.txt -l /home/robot/data/results.log -d rmw_fastrtps_cpp
+```
+
+## Notes: (updated Aug 2019)
  * This currently uses a turtlebot3 robot model, world and map.
  * The test normally takes 1-2 minutes to run, with a timeout of 2 minutes
- * Due to current issues with the Navigation2 initialization, the bringup can sometimes require a retry, so the test automatically internally retries sending an initial pose and goal pose if it doesn't reach the goal within a default 30 second time from when the goal pose was sent
- * The test is currently using the 'simple_navigator' controller
- 
+
 ## Future Work
- * Add an additional test for the 'bt_navigator' controller
  * Add additional goal poses if the first one successfully passes
  * Remove the dependency on the turtlebot3 model and map by adding a simple / dummy robot and creating a world and map

--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -40,6 +40,8 @@ def generate_launch_description():
                                     os.getenv('BT_NAVIGATOR_XML'))
 
     return LaunchDescription([
+        launch.actions.SetEnvironmentVariable('RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1'),
+
         # Launch gazebo server for simulation
         launch.actions.ExecuteProcess(
             cmd=['gzserver', '-s', 'libgazebo_ros_init.so',


### PR DESCRIPTION
## Description of contribution in a few bullet points
Adds a script to the system tests directory for looping the bt_navigator system test. Useful for reliability testing. 

Also updates the README files with instructions

---

## Future work that may be required in bullet points
N/A
