### PR TITLE
Fix python yaml loader

### DIFF
--- a/nav2_common/nav2_common/launch/rewritten_yaml.py
+++ b/nav2_common/nav2_common/launch/rewritten_yaml.py
@@ -47,7 +47,7 @@ class RewrittenYaml(launch.Substitution):
     yaml_filename = launch.utilities.perform_substitutions(context, self.name)
     rewritten_yaml = tempfile.NamedTemporaryFile(mode='w', delete=False)
     resolved_rewrites = self.resolve_rewrites(context)
-    data = yaml.load(open(yaml_filename, 'r'))
+    data = yaml.safe_load(open(yaml_filename, 'r'))
     self.substitute_values(data, resolved_rewrites)
     yaml.dump(data, rewritten_yaml)
     rewritten_yaml.close()


### PR DESCRIPTION
## Description of contribution in a few bullet points

Fixes the feature deprecated warning we get during runtime on `rewritten_yaml.py` -- more on this [here](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)

```bash
rewritten_yaml.py:56: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details
```