### PR TITLE
Update to latest v2 BT Library

### DIFF
--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   BehaviorTree.CPP:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: ros2
+    version: 2.5.2
   angles:
     type: git
     url: https://github.com/ros/angles.git


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | SystemTest |

---

## Description of contribution in a few bullet points

* We were tracking the ros2 branch of the BT library, however, this branch seems out of date. Grabbing the latest tagged version instead.
