### PR TITLE
Rviz panel autostart fix

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -25,6 +25,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/empty.hpp"
 #include "nav2_msgs/srv/manage_lifecycle_nodes.hpp"
+#include "std_srvs/srv/trigger.hpp"
 
 namespace nav2_lifecycle_manager
 {
@@ -43,11 +44,17 @@ protected:
 
   // The services provided by this node
   rclcpp::Service<ManageLifecycleNodes>::SharedPtr manager_srv_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr is_active_srv_;
 
   void managerCallback(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<ManageLifecycleNodes::Request> request,
     std::shared_ptr<ManageLifecycleNodes::Response> response);
+
+  void activeCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
   // Support functions for the service calls
   bool startup();
@@ -85,6 +92,8 @@ protected:
 
   // Whether to automatically start up the system
   bool autostart_;
+
+  bool system_active_{false};
 };
 
 }  // namespace nav2_lifecycle_manager

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -51,7 +51,7 @@ protected:
     const std::shared_ptr<ManageLifecycleNodes::Request> request,
     std::shared_ptr<ManageLifecycleNodes::Response> response);
 
-  void activeCallback(
+  void isActiveCallback(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
     std::shared_ptr<std_srvs::srv::Trigger::Response> response);

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
@@ -25,6 +25,7 @@
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "std_srvs/srv/empty.hpp"
 #include "nav2_msgs/srv/manage_lifecycle_nodes.hpp"
+#include "std_srvs/srv/trigger.hpp"
 
 namespace nav2_lifecycle_manager
 {
@@ -40,6 +41,7 @@ public:
   bool pause();
   bool resume();
   bool reset();
+  bool is_active();
 
   // A couple convenience methods to facilitate scripting tests
   void set_initial_pose(double x, double y, double theta);
@@ -55,6 +57,7 @@ protected:
   rclcpp::Node::SharedPtr node_;
 
   rclcpp::Client<ManageLifecycleNodes>::SharedPtr manager_client_;
+  rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr is_active_client_;
   std::string service_name_{"lifecycle_manager/manage_nodes"};
 
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
@@ -30,6 +30,8 @@
 namespace nav2_lifecycle_manager
 {
 
+enum class SystemStatus {ACTIVE, INACTIVE, TIMEOUT};
+
 class LifecycleManagerClient
 {
 public:
@@ -41,7 +43,7 @@ public:
   bool pause();
   bool resume();
   bool reset();
-  bool is_active();
+  SystemStatus is_active(const std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
 
   // A couple convenience methods to facilitate scripting tests
   void set_initial_pose(double x, double y, double theta);
@@ -58,7 +60,8 @@ protected:
 
   rclcpp::Client<ManageLifecycleNodes>::SharedPtr manager_client_;
   rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr is_active_client_;
-  std::string service_name_{"lifecycle_manager/manage_nodes"};
+  std::string manage_service_name_{"lifecycle_manager/manage_nodes"};
+  std::string active_service_name_{"lifecycle_manager/is_active"};
 
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -52,7 +52,7 @@ LifecycleManager::LifecycleManager()
       std::bind(&LifecycleManager::managerCallback, this, _1, _2, _3));
 
   is_active_srv_ = create_service<std_srvs::srv::Trigger>("lifecycle_manager/is_active",
-      std::bind(&LifecycleManager::activeCallback, this, _1, _2, _3));
+      std::bind(&LifecycleManager::isActiveCallback, this, _1, _2, _3));
 
   auto options = rclcpp::NodeOptions().arguments(
     {"--ros-args", "-r", std::string("__node:=") + get_name() + "service_client", "--"});
@@ -110,9 +110,9 @@ LifecycleManager::managerCallback(
 }
 
 void
-LifecycleManager::activeCallback(
+LifecycleManager::isActiveCallback(
   const std::shared_ptr<rmw_request_id_t>/*request_header*/,
-  const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+  const std::shared_ptr<std_srvs::srv::Trigger::Request>/*request*/,
   std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
   response->success = system_active_;

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -203,7 +203,7 @@ LifecycleManager::shutdown()
   shutdownAllNodes();
   destroyLifecycleServiceClients();
   message("Managed nodes have been shut down");
-  system_active_ = false;  
+  system_active_ = false;
   return true;
 }
 
@@ -231,7 +231,7 @@ LifecycleManager::pause()
     return false;
   }
   message("Managed nodes have been paused");
-  system_active_ = false;  
+  system_active_ = false;
   return true;
 }
 
@@ -244,7 +244,7 @@ LifecycleManager::resume()
     return false;
   }
   message("Managed nodes are active");
-  system_active_ = true;  
+  system_active_ = true;
   return true;
 }
 

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -51,6 +51,9 @@ LifecycleManager::LifecycleManager()
   manager_srv_ = create_service<ManageLifecycleNodes>("lifecycle_manager/manage_nodes",
       std::bind(&LifecycleManager::managerCallback, this, _1, _2, _3));
 
+  is_active_srv_ = create_service<std_srvs::srv::Trigger>("lifecycle_manager/is_active",
+      std::bind(&LifecycleManager::activeCallback, this, _1, _2, _3));
+
   auto options = rclcpp::NodeOptions().arguments(
     {"--ros-args", "-r", std::string("__node:=") + get_name() + "service_client", "--"});
   service_client_node_ = std::make_shared<rclcpp::Node>("_", options);
@@ -104,6 +107,15 @@ LifecycleManager::managerCallback(
       response->success = resume();
       break;
   }
+}
+
+void
+LifecycleManager::activeCallback(
+  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+  const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  response->success = system_active_;
 }
 
 void
@@ -180,6 +192,7 @@ LifecycleManager::startup()
     return false;
   }
   message("Managed nodes are active");
+  system_active_ = true;
   return true;
 }
 
@@ -190,6 +203,7 @@ LifecycleManager::shutdown()
   shutdownAllNodes();
   destroyLifecycleServiceClients();
   message("Managed nodes have been shut down");
+  system_active_ = false;  
   return true;
 }
 
@@ -204,6 +218,7 @@ LifecycleManager::reset()
     return false;
   }
   message("Managed nodes have been reset");
+  system_active_ = false;
   return true;
 }
 
@@ -216,6 +231,7 @@ LifecycleManager::pause()
     return false;
   }
   message("Managed nodes have been paused");
+  system_active_ = false;  
   return true;
 }
 
@@ -228,6 +244,7 @@ LifecycleManager::resume()
     return false;
   }
   message("Managed nodes are active");
+  system_active_ = true;  
   return true;
 }
 

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -78,8 +78,6 @@ private:
   nav2_msgs::action::NavigateToPose::Goal goal_;
   GoalHandle::SharedPtr goal_handle_;
 
-  // A timer used to check on the completion status of the action
-
   // The client used to control the nav2 stack
   nav2_lifecycle_manager::LifecycleManagerClient client_;
 
@@ -104,12 +102,14 @@ private:
 class InitialThread : public QThread
 {
   Q_OBJECT
+
 public:
-  InitialThread(nav2_lifecycle_manager::LifecycleManagerClient & client)
+  explicit InitialThread(nav2_lifecycle_manager::LifecycleManagerClient & client)
   : client_(client)
   {}
 
-  void run() override {
+  void run() override
+  {
     auto response = client_.is_active();
     if (response) {
       emit activeSystem();
@@ -125,7 +125,6 @@ signals:
 private:
   nav2_lifecycle_manager::LifecycleManagerClient client_;
 };
-
 
 }  // namespace nav2_rviz_plugins
 

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -87,6 +87,7 @@ private:
 
   QStateMachine state_machine_;
 
+  QState * pre_initial_{nullptr};
   QState * initial_{nullptr};
   QState * idle_{nullptr};
   QState * stopping_{nullptr};
@@ -99,6 +100,32 @@ private:
   QState * running_{nullptr};
   QState * canceled_{nullptr};
 };
+
+class InitialThread : public QThread
+{
+  Q_OBJECT
+public:
+  InitialThread(nav2_lifecycle_manager::LifecycleManagerClient & client)
+  : client_(client)
+  {}
+
+  void run() override {
+    auto response = client_.is_active();
+    if (response) {
+      emit activeSystem();
+    } else {
+      emit inactiveSystem();
+    }
+  }
+
+signals:
+  void activeSystem();
+  void inactiveSystem();
+
+private:
+  nav2_lifecycle_manager::LifecycleManagerClient client_;
+};
+
 
 }  // namespace nav2_rviz_plugins
 

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -104,14 +104,19 @@ class InitialThread : public QThread
   Q_OBJECT
 
 public:
+  using SystemStatus = nav2_lifecycle_manager::SystemStatus;
+
   explicit InitialThread(nav2_lifecycle_manager::LifecycleManagerClient & client)
   : client_(client)
   {}
 
   void run() override
   {
-    auto response = client_.is_active();
-    if (response) {
+    SystemStatus status = SystemStatus::TIMEOUT;
+    while (status == SystemStatus::TIMEOUT) {
+      status = client_.is_active(std::chrono::seconds(1));
+    }
+    if (status == SystemStatus::ACTIVE) {
       emit activeSystem();
     } else {
       emit inactiveSystem();

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -96,11 +96,13 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   InitialThread * initialThread = new InitialThread(client_);
   connect(initialThread, &InitialThread::finished, initialThread, &QObject::deleteLater);
 
-  QSignalTransition * activeSignal = new QSignalTransition(initialThread, &InitialThread::activeSystem);
+  QSignalTransition * activeSignal = new QSignalTransition(initialThread,
+      &InitialThread::activeSystem);
   activeSignal->setTargetState(idle_);
   pre_initial_->addTransition(activeSignal);
 
-  QSignalTransition * inactiveSignal = new QSignalTransition(initialThread, &InitialThread::inactiveSystem);
+  QSignalTransition * inactiveSignal = new QSignalTransition(initialThread,
+      &InitialThread::inactiveSystem);
   inactiveSignal->setTargetState(initial_);
   pre_initial_->addTransition(inactiveSignal);
 

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -44,10 +44,16 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   const char * shutdown_msg = "Deactivate, cleanup, and shutdown all nav2 lifecycle nodes";
   const char * cancel_msg = "Cancel navigation";
 
+  pre_initial_ = new QState();
+  pre_initial_->setObjectName("pre_initial");
+  pre_initial_->assignProperty(start_stop_button_, "text", "Startup");
+  pre_initial_->assignProperty(start_stop_button_, "enabled", false);
+
   initial_ = new QState();
   initial_->setObjectName("initial");
   initial_->assignProperty(start_stop_button_, "text", "Startup");
   initial_->assignProperty(start_stop_button_, "toolTip", startup_msg);
+  initial_->assignProperty(start_stop_button_, "enabled", true);
 
   // State entered when NavigateToPose is not active
   idle_ = new QState();
@@ -87,13 +93,25 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   runningTransition->setTargetState(idle_);
   running_->addTransition(runningTransition);
 
+  InitialThread * initialThread = new InitialThread(client_);
+  connect(initialThread, &InitialThread::finished, initialThread, &QObject::deleteLater);
+
+  QSignalTransition * activeSignal = new QSignalTransition(initialThread, &InitialThread::activeSystem);
+  activeSignal->setTargetState(idle_);
+  pre_initial_->addTransition(activeSignal);
+
+  QSignalTransition * inactiveSignal = new QSignalTransition(initialThread, &InitialThread::inactiveSystem);
+  inactiveSignal->setTargetState(initial_);
+  pre_initial_->addTransition(inactiveSignal);
+
+  state_machine_.addState(pre_initial_);
   state_machine_.addState(initial_);
   state_machine_.addState(idle_);
   state_machine_.addState(stopping_);
   state_machine_.addState(running_);
   state_machine_.addState(canceled_);
 
-  state_machine_.setInitialState(initial_);
+  state_machine_.setInitialState(pre_initial_);
   state_machine_.start();
 
   // Lay out the items in the panel
@@ -112,6 +130,8 @@ Nav2Panel::Nav2Panel(QWidget * parent)
 
   QObject::connect(&GoalUpdater, SIGNAL(updateGoal(double,double,double,QString)),  // NOLINT
     this, SLOT(onNewGoal(double,double,double,QString)));  // NOLINT
+
+  initialThread->start();
 }
 
 Nav2Panel::~Nav2Panel()

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -60,6 +60,7 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   idle_->setObjectName("idle");
   idle_->assignProperty(start_stop_button_, "text", "Shutdown");
   idle_->assignProperty(start_stop_button_, "toolTip", shutdown_msg);
+  idle_->assignProperty(start_stop_button_, "enabled", true);
 
   // State entered after NavigateToPose has been canceled
   canceled_ = new QState();


### PR DESCRIPTION
This PR enables the `Nav2Panel` to transition states properly whether the navstack has been autostart enabled or not

| Info |  |
| ------ | ----------- |
| Ticket(s) this addresses   | #1067 |
| Primary OS tested on | Ubuntu 18.04) |

## Description of contribution in a few bullet points
- adds `is_active_srv` and `is_active_client` to lifecycle manager and its client
- sets active flag  if lifecycle manager `startup` was successful
- adds `InitialThread` QThread which starts in the `Nav2Panel` constructor and requests active state, sends signal to button state, and terminates when finished
- Creates new `pre_initial` state that waits for the lifecycle manager to respond before transitioning to either `initial` or `completed` (should probably rename this state)

