### PR TITLE
Simplify Nav2Panel button state transitions

### DIFF
--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -88,7 +88,7 @@ private:
   QStateMachine state_machine_;
 
   QState * initial_{nullptr};
-  QState * starting_{nullptr};
+  QState * idle_{nullptr};
   QState * stopping_{nullptr};
   // The following states are added to allow for the state of the button to only expose shutdown
   // while the NavigateToPose action is not active. While running, the user will be allowed to
@@ -98,7 +98,6 @@ private:
   // but do nothing upon entrance.
   QState * running_{nullptr};
   QState * canceled_{nullptr};
-  QState * completed_{nullptr};
 };
 
 }  // namespace nav2_rviz_plugins


### PR DESCRIPTION
This is a small cleanup of the QStates for the `Nav2Panel`. Whereas previously, there were new added states for `starting_`, `canceled`, and `completed`, this PR removes a state and simplifies the logic. The new `canceled` state is a kind of a short-circuit back to the `idle` state.

Here's the new state diagram:
![Rviz Panel state diagram](https://user-images.githubusercontent.com/22353511/64376266-be103a00-cfdc-11e9-9684-7d529437936e.png)


Compare with the old one:
![Rviz Panel state diagram](https://user-images.githubusercontent.com/22353511/64376093-50640e00-cfdc-11e9-8a50-60d685a000a3.png)
