### PR TITLE
Declare if not declared parameters

### DIFF
--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -75,11 +75,11 @@ void ObstacleLayer::onInitialize()
   std::string topics_string;
 
   // TODO(mjeronimo): these four are candidates for dynamic update
-  node_->declare_parameter(name_ + "." + "enabled", rclcpp::ParameterValue(true));
-  node_->declare_parameter(name_ + "." + "footprint_clearing_enabled",
+  declareParameter("enabled", rclcpp::ParameterValue(true));
+  declareParameter("footprint_clearing_enabled",
     rclcpp::ParameterValue(true));
-  node_->declare_parameter(name_ + "." + "max_obstacle_height", rclcpp::ParameterValue(2.0));
-  node_->declare_parameter(name_ + "." + "combination_method", rclcpp::ParameterValue(1));
+  declareParameter("max_obstacle_height", rclcpp::ParameterValue(2.0));
+  declareParameter("combination_method", rclcpp::ParameterValue(1));
 
   node_->get_parameter(name_ + "." + "enabled", enabled_);
   node_->get_parameter(name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_);
@@ -114,31 +114,31 @@ void ObstacleLayer::onInitialize()
     std::string topic, sensor_frame, data_type;
     bool inf_is_valid, clearing, marking;
 
-    node_->declare_parameter(source + "." + "topic", rclcpp::ParameterValue(source));
-    node_->declare_parameter(source + "." + "sensor_frame",
-      rclcpp::ParameterValue(std::string("")));
-    node_->declare_parameter(source + "." + "observation_persistence", rclcpp::ParameterValue(0.0));
-    node_->declare_parameter(source + "." + "expected_update_rate", rclcpp::ParameterValue(0.0));
-    node_->declare_parameter(source + "." + "data_type",
-      rclcpp::ParameterValue(std::string("LaserScan")));
-    node_->declare_parameter(source + "." + "min_obstacle_height", rclcpp::ParameterValue(0.0));
-    node_->declare_parameter(source + "." + "max_obstacle_height", rclcpp::ParameterValue(0.0));
-    node_->declare_parameter(source + "." + "inf_is_valid", rclcpp::ParameterValue(false));
-    node_->declare_parameter(source + "." + "marking", rclcpp::ParameterValue(true));
-    node_->declare_parameter(source + "." + "clearing", rclcpp::ParameterValue(false));
-    node_->declare_parameter(source + "." + "obstacle_range", rclcpp::ParameterValue(2.5));
-    node_->declare_parameter(source + "." + "raytrace_range", rclcpp::ParameterValue(3.0));
+    declareParameter(source + "." + "topic", rclcpp::ParameterValue(source));
+    declareParameter(source + "." + "sensor_frame", rclcpp::ParameterValue(std::string("")));
+    declareParameter(source + "." + "observation_persistence", rclcpp::ParameterValue(0.0));
+    declareParameter(source + "." + "expected_update_rate", rclcpp::ParameterValue(0.0));
+    declareParameter(source + "." + "data_type", rclcpp::ParameterValue(std::string("LaserScan")));
+    declareParameter(source + "." + "min_obstacle_height", rclcpp::ParameterValue(0.0));
+    declareParameter(source + "." + "max_obstacle_height", rclcpp::ParameterValue(0.0));
+    declareParameter(source + "." + "inf_is_valid", rclcpp::ParameterValue(false));
+    declareParameter(source + "." + "marking", rclcpp::ParameterValue(true));
+    declareParameter(source + "." + "clearing", rclcpp::ParameterValue(false));
+    declareParameter(source + "." + "obstacle_range", rclcpp::ParameterValue(2.5));
+    declareParameter(source + "." + "raytrace_range", rclcpp::ParameterValue(3.0));
 
-    node_->get_parameter(source + "." + "topic", topic);
-    node_->get_parameter(source + "." + "sensor_frame", sensor_frame);
-    node_->get_parameter(source + "." + "observation_persistence", observation_keep_time);
-    node_->get_parameter(source + "." + "expected_update_rate", expected_update_rate);
-    node_->get_parameter(source + "." + "data_type", data_type);
-    node_->get_parameter(source + "." + "min_obstacle_height", min_obstacle_height);
-    node_->get_parameter(source + "." + "max_obstacle_height", max_obstacle_height);
-    node_->get_parameter(source + "." + "inf_is_valid", inf_is_valid);
-    node_->get_parameter(source + "." + "marking", marking);
-    node_->get_parameter(source + "." + "clearing", clearing);
+    node_->get_parameter(name_ + "." + source + "." + "topic", topic);
+    node_->get_parameter(name_ + "." + source + "." + "sensor_frame", sensor_frame);
+    node_->get_parameter(name_ + "." + source + "." + "observation_persistence",
+      observation_keep_time);
+    node_->get_parameter(name_ + "." + source + "." + "expected_update_rate",
+      expected_update_rate);
+    node_->get_parameter(name_ + "." + source + "." + "data_type", data_type);
+    node_->get_parameter(name_ + "." + source + "." + "min_obstacle_height", min_obstacle_height);
+    node_->get_parameter(name_ + "." + source + "." + "max_obstacle_height", max_obstacle_height);
+    node_->get_parameter(name_ + "." + source + "." + "inf_is_valid", inf_is_valid);
+    node_->get_parameter(name_ + "." + source + "." + "marking", marking);
+    node_->get_parameter(name_ + "." + source + "." + "clearing", clearing);
 
     if (!(data_type == "PointCloud2" || data_type == "LaserScan")) {
       RCLCPP_FATAL(node_->get_logger(),
@@ -149,11 +149,11 @@ void ObstacleLayer::onInitialize()
 
     // get the obstacle range for the sensor
     double obstacle_range;
-    node_->get_parameter(source + "." + "obstacle_range", obstacle_range);
+    node_->get_parameter(name_ + "." + source + "." + "obstacle_range", obstacle_range);
 
     // get the raytrace range for the sensor
     double raytrace_range;
-    node_->get_parameter(source + "." + "raytrace_range", raytrace_range);
+    node_->get_parameter(name_ + "." + source + "." + "raytrace_range", raytrace_range);
 
     RCLCPP_DEBUG(node_->get_logger(),
       "Creating an observation buffer for source %s, topic %s, frame %s",

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -121,8 +121,7 @@ StaticLayer::getParameters()
 
   declareParameter("enabled", rclcpp::ParameterValue(true));
   declareParameter("subscribe_to_updates", rclcpp::ParameterValue(false));
-  declareParameter("map_subscribe_transient_local",
-    rclcpp::ParameterValue(true));
+  declareParameter("map_subscribe_transient_local", rclcpp::ParameterValue(true));
 
   node_->get_parameter(name_ + "." + "enabled", enabled_);
   node_->get_parameter(name_ + "." + "subscribe_to_updates", subscribe_to_updates_);

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -59,17 +59,16 @@ void VoxelLayer::onInitialize()
 {
   ObstacleLayer::onInitialize();
 
-  node_->declare_parameter(name_ + "." + "enabled", rclcpp::ParameterValue(true));
-  node_->declare_parameter(name_ + "." + "footprint_clearing_enabled",
-    rclcpp::ParameterValue(true));
-  node_->declare_parameter(name_ + "." + "max_obstacle_height", rclcpp::ParameterValue(2.0));
-  node_->declare_parameter(name_ + "." + "z_voxels", rclcpp::ParameterValue(10));
-  node_->declare_parameter(name_ + "." + "origin_z", rclcpp::ParameterValue(0.0));
-  node_->declare_parameter(name_ + "." + "z_resolution", rclcpp::ParameterValue(0.2));
-  node_->declare_parameter(name_ + "." + "unknown_threshold", rclcpp::ParameterValue(15));
-  node_->declare_parameter(name_ + "." + "mark_threshold", rclcpp::ParameterValue(0));
-  node_->declare_parameter(name_ + "." + "combination_method", rclcpp::ParameterValue(1));
-  node_->declare_parameter(name_ + "." + "publish_voxel_map", rclcpp::ParameterValue(false));
+  declareParameter("enabled", rclcpp::ParameterValue(true));
+  declareParameter("footprint_clearing_enabled", rclcpp::ParameterValue(true));
+  declareParameter("max_obstacle_height", rclcpp::ParameterValue(2.0));
+  declareParameter("z_voxels", rclcpp::ParameterValue(10));
+  declareParameter("origin_z", rclcpp::ParameterValue(0.0));
+  declareParameter("z_resolution", rclcpp::ParameterValue(0.2));
+  declareParameter("unknown_threshold", rclcpp::ParameterValue(15));
+  declareParameter("mark_threshold", rclcpp::ParameterValue(0));
+  declareParameter("combination_method", rclcpp::ParameterValue(1));
+  declareParameter("publish_voxel_map", rclcpp::ParameterValue(false));
 
   node_->get_parameter(name_ + "." + "enabled", enabled_);
   node_->get_parameter(name_ + "." + "footprint_clearing_enabled", footprint_clearing_enabled_);

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -38,9 +38,6 @@ ClearCostmapService::ClearCostmapService(
 {
   reset_value_ = costmap_.getCostmap()->getDefaultValue();
 
-  std::vector<std::string> clearable_layers{"obstacle_layer"};
-  node_->declare_parameter("clearable_layers", rclcpp::ParameterValue(clearable_layers));
-
   node_->get_parameter("clearable_layers", clearable_layers_);
 
   clear_except_service_ = node_->create_service<ClearExceptRegion>(

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -70,6 +70,7 @@ Costmap2DROS::Costmap2DROS(const std::string & name, const std::string & absolut
   std::vector<std::string> plugin_names{"static_layer", "obstacle_layer", "inflation_layer"};
   std::vector<std::string> plugin_types{"nav2_costmap_2d::StaticLayer",
     "nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::InflationLayer"};
+  std::vector<std::string> clearable_layers{"obstacle_layer"};
 
   declare_parameter("always_send_full_costmap", rclcpp::ParameterValue(false));
   declare_parameter("footprint_padding", rclcpp::ParameterValue(0.01f));
@@ -95,6 +96,7 @@ Costmap2DROS::Costmap2DROS(const std::string & name, const std::string & absolut
   declare_parameter("update_frequency", rclcpp::ParameterValue(5.0));
   declare_parameter("use_maximum", rclcpp::ParameterValue(false));
   declare_parameter("width", rclcpp::ParameterValue(10));
+  declare_parameter("clearable_layers", rclcpp::ParameterValue(clearable_layers));
 }
 
 Costmap2DROS::~Costmap2DROS()

--- a/nav2_costmap_2d/src/layer.cpp
+++ b/nav2_costmap_2d/src/layer.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <vector>
+#include "nav2_util/node_utils.hpp"
 
 namespace nav2_costmap_2d
 {
@@ -71,7 +72,7 @@ Layer::declareParameter(
   const std::string & param_name, const rclcpp::ParameterValue & value)
 {
   local_params_.insert(param_name);
-  node_->declare_parameter(getFullName(param_name), value);
+  nav2_util::declare_parameter_if_not_declared(node_, getFullName(param_name), value);
 }
 
 bool

--- a/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
+++ b/nav2_dwb_controller/dwb_controller/src/dwb_controller.cpp
@@ -76,7 +76,7 @@ DwbController::on_configure(const rclcpp_lifecycle::State & state)
   get_parameter("controller_frequency", controller_frequency_);
   RCLCPP_INFO(get_logger(), "Controller frequency set to %.4fHz", controller_frequency_);
 
-  odom_sub_ = std::make_shared<nav_2d_utils::OdomSubscriber>(*this);
+  odom_sub_ = std::make_shared<nav_2d_utils::OdomSubscriber>(node);
   vel_publisher_ = create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", 1);
 
   // Create the action server that we implement with our followPath method

--- a/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
@@ -47,7 +47,10 @@
 #include "nav_2d_utils/parameters.hpp"
 #include "nav_2d_utils/tf_help.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "pluginlib/class_list_macros.hpp"
+
+using nav2_util::declare_parameter_if_not_declared;
 
 namespace dwb_core
 {
@@ -62,16 +65,17 @@ DWBLocalPlanner::DWBLocalPlanner(
   goal_checker_loader_("dwb_core", "dwb_core::GoalChecker"),
   critic_loader_("dwb_core", "dwb_core::TrajectoryCritic")
 {
-  node_->declare_parameter("critics");
-  node_->declare_parameter("prune_plan", rclcpp::ParameterValue(true));
-  node_->declare_parameter("prune_distance", rclcpp::ParameterValue(1.0));
-  node_->declare_parameter("debug_trajectory_details", rclcpp::ParameterValue(false));
-  node_->declare_parameter("trajectory_generator_name",
+  declare_parameter_if_not_declared(node_, "critics");
+  declare_parameter_if_not_declared(node_, "prune_plan", rclcpp::ParameterValue(true));
+  declare_parameter_if_not_declared(node_, "prune_distance", rclcpp::ParameterValue(1.0));
+  declare_parameter_if_not_declared(node_, "debug_trajectory_details",
+    rclcpp::ParameterValue(false));
+  declare_parameter_if_not_declared(node_, "trajectory_generator_name",
     rclcpp::ParameterValue(std::string("dwb_plugins::StandardTrajectoryGenerator")));
-  node_->declare_parameter("goal_checker_name",
+  declare_parameter_if_not_declared(node_, "goal_checker_name",
     rclcpp::ParameterValue(std::string("dwb_plugins::SimpleGoalChecker")));
-  node_->declare_parameter("use_dwa", rclcpp::ParameterValue(false));
-  node_->declare_parameter("transform_tolerance", rclcpp::ParameterValue(0.1));
+  declare_parameter_if_not_declared(node_, "use_dwa", rclcpp::ParameterValue(false));
+  declare_parameter_if_not_declared(node_, "transform_tolerance", rclcpp::ParameterValue(0.1));
 }
 
 nav2_util::CallbackReturn
@@ -173,7 +177,8 @@ DWBLocalPlanner::loadCritics()
     std::string plugin_name = critic_names[i];
     std::string plugin_class;
 
-    node_->declare_parameter(plugin_name + "/class", rclcpp::ParameterValue(plugin_name));
+    declare_parameter_if_not_declared(node_, plugin_name + "/class",
+      rclcpp::ParameterValue(plugin_name));
     node_->get_parameter(plugin_name + "/class", plugin_class);
 
     plugin_class = resolveCriticClassName(plugin_class);
@@ -211,18 +216,18 @@ DWBLocalPlanner::loadBackwardsCompatibleParameters()
                                                 //   (local) goal, based on wave propagation
   node_->set_parameters({rclcpp::Parameter("critics", critic_names)});
 
-  node_->declare_parameter("path_distance_bias");
-  node_->declare_parameter("goal_distance_bias");
-  node_->declare_parameter("occdist_scale");
-  node_->declare_parameter("max_scaling_factor");
-  node_->declare_parameter("scaling_speed");
-  node_->declare_parameter("PathAlign.scale");
-  node_->declare_parameter("GoalAlign.scale");
-  node_->declare_parameter("PathDist.scale");
-  node_->declare_parameter("GoalDist.scale");
-  node_->declare_parameter("ObstacleFootprint.scale");
-  node_->declare_parameter("ObstacleFootprint.max_scaling_factor");
-  node_->declare_parameter("ObstacleFootprint.scaling_speed");
+  declare_parameter_if_not_declared(node_, "path_distance_bias");
+  declare_parameter_if_not_declared(node_, "goal_distance_bias");
+  declare_parameter_if_not_declared(node_, "occdist_scale");
+  declare_parameter_if_not_declared(node_, "max_scaling_factor");
+  declare_parameter_if_not_declared(node_, "scaling_speed");
+  declare_parameter_if_not_declared(node_, "PathAlign.scale");
+  declare_parameter_if_not_declared(node_, "GoalAlign.scale");
+  declare_parameter_if_not_declared(node_, "PathDist.scale");
+  declare_parameter_if_not_declared(node_, "GoalDist.scale");
+  declare_parameter_if_not_declared(node_, "ObstacleFootprint.scale");
+  declare_parameter_if_not_declared(node_, "ObstacleFootprint.max_scaling_factor");
+  declare_parameter_if_not_declared(node_, "ObstacleFootprint.scaling_speed");
 
   /* *INDENT-OFF* */
   nav_2d_utils::moveParameter(node_, "path_distance_bias", "PathAlign.scale", 32.0, false);

--- a/nav2_dwb_controller/dwb_core/src/publisher.cpp
+++ b/nav2_dwb_controller/dwb_core/src/publisher.cpp
@@ -40,12 +40,14 @@
 #include <vector>
 
 #include "nav_2d_utils/conversions.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 
 using std::max;
 using std::string;
+using nav2_util::declare_parameter_if_not_declared;
 
 namespace dwb_core
 {
@@ -53,12 +55,13 @@ namespace dwb_core
 DWBPublisher::DWBPublisher(nav2_util::LifecycleNode::SharedPtr node)
 : node_(node)
 {
-  node_->declare_parameter("publish_evaluation", rclcpp::ParameterValue(true));
-  node_->declare_parameter("publish_global_plan", rclcpp::ParameterValue(true));
-  node_->declare_parameter("publish_transformed_plan", rclcpp::ParameterValue(true));
-  node_->declare_parameter("publish_local_plan", rclcpp::ParameterValue(true));
-  node_->declare_parameter("publish_trajectories", rclcpp::ParameterValue(true));
-  node_->declare_parameter("publish_cost_grid_pc", rclcpp::ParameterValue(false));
+  declare_parameter_if_not_declared(node_, "publish_evaluation", rclcpp::ParameterValue(true));
+  declare_parameter_if_not_declared(node_, "publish_global_plan", rclcpp::ParameterValue(true));
+  declare_parameter_if_not_declared(node_, "publish_transformed_plan",
+    rclcpp::ParameterValue(true));
+  declare_parameter_if_not_declared(node_, "publish_local_plan", rclcpp::ParameterValue(true));
+  declare_parameter_if_not_declared(node_, "publish_trajectories", rclcpp::ParameterValue(true));
+  declare_parameter_if_not_declared(node_, "publish_cost_grid_pc", rclcpp::ParameterValue(false));
 }
 
 nav2_util::CallbackReturn

--- a/nav2_dwb_controller/dwb_critics/src/base_obstacle.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/base_obstacle.cpp
@@ -36,6 +36,7 @@
 #include "dwb_core/exceptions.hpp"
 #include "pluginlib/class_list_macros.hpp"
 #include "nav2_costmap_2d/cost_values.hpp"
+#include "nav2_util/node_utils.hpp"
 
 PLUGINLIB_EXPORT_CLASS(dwb_critics::BaseObstacleCritic, dwb_core::TrajectoryCritic)
 
@@ -46,7 +47,8 @@ void BaseObstacleCritic::onInit()
 {
   costmap_ = costmap_ros_->getCostmap();
 
-  nh_->declare_parameter(name_ + ".sum_scores", rclcpp::ParameterValue(false));
+  nav2_util::declare_parameter_if_not_declared(nh_,
+    name_ + ".sum_scores", rclcpp::ParameterValue(false));
   nh_->get_parameter(name_ + ".sum_scores", sum_scores_);
 }
 

--- a/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
@@ -39,6 +39,7 @@
 #include <memory>
 #include "dwb_core/exceptions.hpp"
 #include "nav2_costmap_2d/cost_values.hpp"
+#include "nav2_util/node_utils.hpp"
 
 using std::abs;
 using costmap_queue::CellData;
@@ -60,7 +61,8 @@ void MapGridCritic::onInit()
   // Always set to true, but can be overriden by subclasses
   stop_on_failure_ = true;
 
-  nh_->declare_parameter(name_ + ".aggregation_type", rclcpp::ParameterValue(std::string("last")));
+  nav2_util::declare_parameter_if_not_declared(nh_,
+    name_ + ".aggregation_type", rclcpp::ParameterValue(std::string("last")));
 
   std::string aggro_str;
   nh_->get_parameter(name_ + ".aggregation_type", aggro_str);

--- a/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
@@ -38,6 +38,7 @@
 #include <string>
 #include <vector>
 #include "nav_2d_utils/parameters.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "dwb_core/exceptions.hpp"
 #include "pluginlib/class_list_macros.hpp"
 
@@ -96,7 +97,8 @@ void OscillationCritic::onInit()
   oscillation_reset_time_ = rclcpp::Duration::from_seconds(
     nav_2d_utils::searchAndGetParam(nh_, "oscillation_reset_time", -1.0));
 
-  nh_->declare_parameter(name_ + ".x_only_threshold", rclcpp::ParameterValue(0.05));
+  nav2_util::declare_parameter_if_not_declared(nh_,
+    name_ + ".x_only_threshold", rclcpp::ParameterValue(0.05));
 
   /**
    * Historical Parameter Loading

--- a/nav2_dwb_controller/dwb_critics/src/prefer_forward.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/prefer_forward.cpp
@@ -35,18 +35,21 @@
 #include "dwb_critics/prefer_forward.hpp"
 #include <math.h>
 #include "pluginlib/class_list_macros.hpp"
+#include "nav2_util/node_utils.hpp"
 
 PLUGINLIB_EXPORT_CLASS(dwb_critics::PreferForwardCritic, dwb_core::TrajectoryCritic)
+
+using nav2_util::declare_parameter_if_not_declared;
 
 namespace dwb_critics
 {
 
 void PreferForwardCritic::onInit()
 {
-  nh_->declare_parameter(name_ + ".penalty", rclcpp::ParameterValue(1.0));
-  nh_->declare_parameter(name_ + ".strafe_x", rclcpp::ParameterValue(0.1));
-  nh_->declare_parameter(name_ + ".strafe_theta", rclcpp::ParameterValue(0.2));
-  nh_->declare_parameter(name_ + ".theta_scale", rclcpp::ParameterValue(10.0));
+  declare_parameter_if_not_declared(nh_, name_ + ".penalty", rclcpp::ParameterValue(1.0));
+  declare_parameter_if_not_declared(nh_, name_ + ".strafe_x", rclcpp::ParameterValue(0.1));
+  declare_parameter_if_not_declared(nh_, name_ + ".strafe_theta", rclcpp::ParameterValue(0.2));
+  declare_parameter_if_not_declared(nh_, name_ + ".theta_scale", rclcpp::ParameterValue(10.0));
 
   nh_->get_parameter(name_ + ".penalty", penalty_);
   nh_->get_parameter(name_ + ".strafe_x", strafe_x_);

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -39,10 +39,12 @@
 #include <string>
 
 #include "nav_2d_utils/parameters.hpp"
+#include "nav2_util/node_utils.hpp"
 
 using std::fabs;
-
+using nav2_util::declare_parameter_if_not_declared;
 using nav_2d_utils::moveDeprecatedParameter;
+
 namespace dwb_plugins
 {
 
@@ -58,20 +60,20 @@ void KinematicParameters::initialize(const nav2_util::LifecycleNode::SharedPtr &
   moveDeprecatedParameter<double>(nh, "max_speed_xy", "max_trans_vel");
   moveDeprecatedParameter<double>(nh, "min_speed_theta", "min_rot_vel");
 
-  nh->declare_parameter("min_vel_x", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("min_vel_y", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("max_vel_x", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("max_vel_y", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("max_vel_theta", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("min_speed_xy", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("max_speed_xy", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("min_speed_theta", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("acc_lim_x", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("acc_lim_y", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("acc_lim_theta", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("decel_lim_x", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("decel_lim_y", rclcpp::ParameterValue(0.0));
-  nh->declare_parameter("decel_lim_theta", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "min_vel_x", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "min_vel_y", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "max_vel_x", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "max_vel_y", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "max_vel_theta", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "min_speed_xy", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "max_speed_xy", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "min_speed_theta", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "acc_lim_x", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "acc_lim_y", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "acc_lim_theta", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "decel_lim_x", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "decel_lim_y", rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, "decel_lim_theta", rclcpp::ParameterValue(0.0));
 
   nh->get_parameter("min_vel_x", min_vel_x_);
   nh->get_parameter("min_vel_y", min_vel_y_);

--- a/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -38,6 +38,7 @@
 #include "nav_2d_utils/parameters.hpp"
 #include "pluginlib/class_list_macros.hpp"
 #include "dwb_core/exceptions.hpp"
+#include "nav2_util/node_utils.hpp"
 
 namespace dwb_plugins
 {
@@ -46,7 +47,7 @@ void LimitedAccelGenerator::initialize(const nav2_util::LifecycleNode::SharedPtr
 {
   StandardTrajectoryGenerator::initialize(nh);
 
-  nh->declare_parameter("sim_period");
+  nav2_util::declare_parameter_if_not_declared(nh, "sim_period");
 
   if (nh->get_parameter("sim_period", acceleration_time_)) {
   } else {

--- a/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
@@ -36,6 +36,7 @@
 #include <memory>
 #include "pluginlib/class_list_macros.hpp"
 #include "angles/angles.h"
+#include "nav2_util/node_utils.hpp"
 
 namespace dwb_plugins
 {
@@ -47,8 +48,10 @@ SimpleGoalChecker::SimpleGoalChecker()
 
 void SimpleGoalChecker::initialize(const nav2_util::LifecycleNode::SharedPtr & nh)
 {
-  nh->declare_parameter("xy_goal_tolerance", rclcpp::ParameterValue(0.25));
-  nh->declare_parameter("yaw_goal_tolerance", rclcpp::ParameterValue(0.25));
+  nav2_util::declare_parameter_if_not_declared(nh,
+    "xy_goal_tolerance", rclcpp::ParameterValue(0.25));
+  nav2_util::declare_parameter_if_not_declared(nh,
+    "yaw_goal_tolerance", rclcpp::ParameterValue(0.25));
 
   nh->get_parameter("xy_goal_tolerance", xy_goal_tolerance_);
   nh->get_parameter("yaw_goal_tolerance", yaw_goal_tolerance_);

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -41,6 +41,7 @@
 #include "nav_2d_utils/parameters.hpp"
 #include "pluginlib/class_list_macros.hpp"
 #include "dwb_core/exceptions.hpp"
+#include "nav2_util/node_utils.hpp"
 
 using nav_2d_utils::loadParameterWithDeprecation;
 
@@ -53,8 +54,9 @@ void StandardTrajectoryGenerator::initialize(const nav2_util::LifecycleNode::Sha
   kinematics_->initialize(nh);
   initializeIterator(nh);
 
-  nh->declare_parameter("sim_time", rclcpp::ParameterValue(1.7));
-  nh->declare_parameter("discretize_by_time", rclcpp::ParameterValue(false));
+  nav2_util::declare_parameter_if_not_declared(nh, "sim_time", rclcpp::ParameterValue(1.7));
+  nav2_util::declare_parameter_if_not_declared(nh,
+    "discretize_by_time", rclcpp::ParameterValue(false));
 
   nh->get_parameter("sim_time", sim_time_);
   checkUseDwaParam(nh);

--- a/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
@@ -36,6 +36,7 @@
 #include <cmath>
 #include <memory>
 #include "pluginlib/class_list_macros.hpp"
+#include "nav2_util/node_utils.hpp"
 
 using std::fabs;
 
@@ -51,8 +52,10 @@ void StoppedGoalChecker::initialize(const nav2_util::LifecycleNode::SharedPtr & 
 {
   SimpleGoalChecker::initialize(nh);
 
-  nh->declare_parameter("rot_stopped_velocity", rclcpp::ParameterValue(0.25));
-  nh->declare_parameter("trans_stopped_velocity", rclcpp::ParameterValue(0.25));
+  nav2_util::declare_parameter_if_not_declared(nh,
+    "rot_stopped_velocity", rclcpp::ParameterValue(0.25));
+  nav2_util::declare_parameter_if_not_declared(nh,
+    "trans_stopped_velocity", rclcpp::ParameterValue(0.25));
 
   nh->get_parameter("rot_stopped_velocity", rot_stopped_velocity_);
   nh->get_parameter("trans_stopped_velocity", trans_stopped_velocity_);

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -35,6 +35,7 @@
 #include "dwb_plugins/xy_theta_iterator.hpp"
 #include <memory>
 #include "nav_2d_utils/parameters.hpp"
+#include "nav2_util/node_utils.hpp"
 
 namespace dwb_plugins
 {
@@ -44,8 +45,8 @@ void XYThetaIterator::initialize(
 {
   kinematics_ = kinematics;
 
-  nh->declare_parameter("vx_samples", rclcpp::ParameterValue(20));
-  nh->declare_parameter("vy_samples", rclcpp::ParameterValue(5));
+  nav2_util::declare_parameter_if_not_declared(nh, "vx_samples", rclcpp::ParameterValue(20));
+  nav2_util::declare_parameter_if_not_declared(nh, "vy_samples", rclcpp::ParameterValue(5));
 
   nh->get_parameter("vx_samples", vx_samples_);
   nh->get_parameter("vy_samples", vy_samples_);

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
@@ -43,6 +43,7 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "nav2_util/node_utils.hpp"
 
 namespace nav_2d_utils
 {
@@ -60,22 +61,27 @@ public:
    * @param nh NodeHandle for creating subscriber
    * @param default_topic Name of the topic that will be loaded of the odom_topic param is not set.
    */
-  explicit OdomSubscriber(nav2_util::LifecycleNode & nh, std::string default_topic = "odom")
+  explicit OdomSubscriber(
+    nav2_util::LifecycleNode::SharedPtr & nh,
+    std::string default_topic = "odom")
   {
     std::string odom_topic;
-    nh.get_parameter_or("odom_topic", odom_topic, default_topic);
+    nh->get_parameter_or("odom_topic", odom_topic, default_topic);
     odom_sub_ =
-      nh.create_subscription<nav_msgs::msg::Odometry>(odom_topic,
+      nh->create_subscription<nav_msgs::msg::Odometry>(odom_topic,
         rclcpp::SystemDefaultsQoS(),
         std::bind(&OdomSubscriber::odomCallback, this, std::placeholders::_1));
 
-    nh.declare_parameter("min_x_velocity_threshold", rclcpp::ParameterValue(0.0001));
-    nh.declare_parameter("min_y_velocity_threshold", rclcpp::ParameterValue(0.0001));
-    nh.declare_parameter("min_theta_velocity_threshold", rclcpp::ParameterValue(0.0001));
+    nav2_util::declare_parameter_if_not_declared(nh,
+      "min_x_velocity_threshold", rclcpp::ParameterValue(0.0001));
+    nav2_util::declare_parameter_if_not_declared(nh,
+      "min_y_velocity_threshold", rclcpp::ParameterValue(0.0001));
+    nav2_util::declare_parameter_if_not_declared(nh,
+      "min_theta_velocity_threshold", rclcpp::ParameterValue(0.0001));
 
-    nh.get_parameter("min_x_velocity_threshold", min_x_velocity_threshold_);
-    nh.get_parameter("min_y_velocity_threshold", min_y_velocity_threshold_);
-    nh.get_parameter("min_theta_velocity_threshold", min_theta_velocity_threshold_);
+    nh->get_parameter("min_x_velocity_threshold", min_x_velocity_threshold_);
+    nh->get_parameter("min_y_velocity_threshold", min_y_velocity_threshold_);
+    nh->get_parameter("min_theta_velocity_threshold", min_theta_velocity_threshold_);
   }
 
   inline nav_2d_msgs::msg::Twist2D getTwist() {return odom_vel_.velocity;}

--- a/nav2_util/include/nav2_util/node_utils.hpp
+++ b/nav2_util/include/nav2_util/node_utils.hpp
@@ -80,6 +80,19 @@ std::string time_to_string(size_t len);
 rclcpp::NodeOptions
 get_node_options_default(bool allow_undeclared = true, bool declare_initial_params = true);
 
+template<typename NodeT>
+void declare_parameter_if_not_declared(
+  NodeT node,
+  const std::string & param_name,
+  const rclcpp::ParameterValue & default_value,
+  const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor =
+  rcl_interfaces::msg::ParameterDescriptor())
+{
+  if(!node->has_parameter(param_name)) {
+    node->declare_parameter(param_name, default_value, parameter_descriptor);
+  }
+}
+
 }  // namespace nav2_util
 
 #endif  // NAV2_UTIL__NODE_UTILS_HPP_

--- a/nav2_util/include/nav2_util/node_utils.hpp
+++ b/nav2_util/include/nav2_util/node_utils.hpp
@@ -84,11 +84,11 @@ template<typename NodeT>
 void declare_parameter_if_not_declared(
   NodeT node,
   const std::string & param_name,
-  const rclcpp::ParameterValue & default_value,
+  const rclcpp::ParameterValue & default_value = rclcpp::ParameterValue(),
   const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor =
   rcl_interfaces::msg::ParameterDescriptor())
 {
-  if(!node->has_parameter(param_name)) {
+  if (!node->has_parameter(param_name)) {
     node->declare_parameter(param_name, default_value, parameter_descriptor);
   }
 }


### PR DESCRIPTION
Adds a `declare_if_not_declared` template function and integrates throughout the stack to allow nodes (and particularly plugins) to be reset (unconfigured and configured again) without causing run-time errors for a parameter that has already been declared. 

Related to #714