### PR TITLE
map_loader: add SDL include directories

### DIFF
--- a/nav2_util/src/map_loader/CMakeLists.txt
+++ b/nav2_util/src/map_loader/CMakeLists.txt
@@ -12,6 +12,11 @@ ament_target_dependencies(map_loader
   SDL_image
 )
 
+target_include_directories(map_loader PRIVATE
+    ${SDL_INCLUDE_DIR}
+    ${SDL_IMAGE_INCLUDE_DIRS}
+)
+
 target_link_libraries(map_loader
     ${SDL_LIBRARY}
     ${SDL_IMAGE_LIBRARIES}


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | NixOS (Linux) |
| Robotic platform tested on | none |

---

## Description of contribution in a few bullet points

`nav2_util` fails to build on Nix (https://github.com/lopsided98/nix-ros-overlay) with the following error:
```
In file included from /build/navigation2-release-release-dashing-nav2_util-0.2.3-1/src/map_loader/map_loader.cpp:36:0:
/nix/store/snzbjcqvacn5i4y96i8wan4zvkaybdbn-SDL_image-1.2.12/include/SDL/SDL_image.h:27:10: fatal error: SDL.h: No such file or directory
 #include "SDL.h"
          ^~~~~~~
compilation terminated.
```
Nix uses non-standard installation paths, which is probably why this bug did not show up on other platforms.

This PR adds the SDL include directories to the `map_loader` target.