### PR TITLE
Add Pause, Resume, and Reset rviz panel buttons

### DIFF
--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -54,6 +54,8 @@ private Q_SLOTS:
   void onStartup();
   void onShutdown();
   void onCancel();
+  void onPause();
+  void onResume();
   void onNewGoal(double x, double y, double theta, QString frame);
 
 private:
@@ -82,6 +84,7 @@ private:
   nav2_lifecycle_manager::LifecycleManagerClient client_;
 
   QPushButton * start_stop_button_{nullptr};
+  QPushButton * pause_resume_button_{nullptr};
 
   QStateMachine state_machine_;
 
@@ -97,6 +100,8 @@ private:
   // but do nothing upon entrance.
   QState * running_{nullptr};
   QState * canceled_{nullptr};
+  QState * pausing_{nullptr};
+  QState * resuming_{nullptr};
 };
 
 class InitialThread : public QThread

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -83,7 +83,7 @@ private:
   // The client used to control the nav2 stack
   nav2_lifecycle_manager::LifecycleManagerClient client_;
 
-  QPushButton * start_stop_button_{nullptr};
+  QPushButton * start_reset_button_{nullptr};
   QPushButton * pause_resume_button_{nullptr};
 
   QStateMachine state_machine_;
@@ -91,17 +91,15 @@ private:
   QState * pre_initial_{nullptr};
   QState * initial_{nullptr};
   QState * idle_{nullptr};
-  QState * stopping_{nullptr};
-  // The following states are added to allow for the state of the button to only expose shutdown
+  QState * reset_{nullptr};
+  QState * paused_{nullptr};
+  QState * resumed_{nullptr};
+  // The following states are added to allow for the state of the button to only expose reset
   // while the NavigateToPose action is not active. While running, the user will be allowed to
   // cancel the action. The ROSActionTransition allows for the state of the action to be detected
-  // and the button state to change automatically. The additional states canceled_ and
-  // completed_ support the transitions from running into states that can transition to shutdown
-  // but do nothing upon entrance.
+  // and the button state to change automatically.
   QState * running_{nullptr};
   QState * canceled_{nullptr};
-  QState * pausing_{nullptr};
-  QState * resuming_{nullptr};
 };
 
 class InitialThread : public QThread

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -47,43 +47,33 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   const char * pause_msg = "Deactivate all nav2 lifecycle nodes";
   const char * resume_msg = "Activate all nav2 lifecycle nodes";
 
-<<<<<<< HEAD
   pre_initial_ = new QState();
   pre_initial_->setObjectName("pre_initial");
-  pre_initial_->assignProperty(start_stop_button_, "text", "Startup");
-  pre_initial_->assignProperty(start_stop_button_, "enabled", false);
+  pre_initial_->assignProperty(start_reset_button_, "text", "Startup");
+  pre_initial_->assignProperty(start_reset_button_, "enabled", false);
 
-  initial_ = new QState();
-  initial_->setObjectName("initial");
-  initial_->assignProperty(start_stop_button_, "text", "Startup");
-  initial_->assignProperty(start_stop_button_, "toolTip", startup_msg);
-  initial_->assignProperty(start_stop_button_, "enabled", true);
-=======
-  // Initial state before system is activated
+  pre_initial_->assignProperty(pause_resume_button_, "text", "Pause");
+  pre_initial_->assignProperty(pause_resume_button_, "enabled", false);
+
   initial_ = new QState();
   initial_->setObjectName("initial");
   initial_->assignProperty(start_reset_button_, "text", "Startup");
   initial_->assignProperty(start_reset_button_, "toolTip", startup_msg);
+  initial_->assignProperty(start_reset_button_, "enabled", true);
 
   initial_->assignProperty(pause_resume_button_, "text", "Pause");
   initial_->assignProperty(pause_resume_button_, "enabled", false);
->>>>>>> 5176099e... add pause, resume, and repeat button transitions
 
   // State entered when NavigateToPose is not active
   idle_ = new QState();
   idle_->setObjectName("idle");
-<<<<<<< HEAD
-  idle_->assignProperty(start_stop_button_, "text", "Shutdown");
-  idle_->assignProperty(start_stop_button_, "toolTip", shutdown_msg);
-  idle_->assignProperty(start_stop_button_, "enabled", true);
-=======
   idle_->assignProperty(start_reset_button_, "text", "Reset");
   idle_->assignProperty(start_reset_button_, "toolTip", shutdown_msg);
+  idle_->assignProperty(start_reset_button_, "enabled", true);
 
   idle_->assignProperty(pause_resume_button_, "text", "Pause");
   idle_->assignProperty(pause_resume_button_, "enabled", true);
   idle_->assignProperty(pause_resume_button_, "toolTip", pause_msg);
->>>>>>> 5176099e... add pause, resume, and repeat button transitions
 
   // State entered to cancel the NavigateToPose action
   canceled_ = new QState();


### PR DESCRIPTION
This PR is based off refactoring done in PR #1098 

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #818  |
| Primary OS tested on | Ubuntu |


## Description of contribution in a few bullet points
- Replaced `shutdown` with `reset`, allowing users to `startup` again
- Added second button for `pause` and `resume`, which will deactivate and activate the navstack lifecycle nodes

State diagram:
![Rviz Panel state diagram](https://user-images.githubusercontent.com/22353511/64806417-f6b59380-d547-11e9-95e0-38a3129ce35f.png)


## Future work that may be required in bullet points
- Fix bugs to allow `startup` to work again properly after system has been `reset`
- This is an old problem, but perhaps the button states should fail transitioning if the lifecycle nodes were unsuccesfully transitioned? Right now the calls are asynchronous and the states will transition regardless of the outcome

