### PR TITLE
Fix ExecuteProcess actions to use new parameter format.

### DIFF
--- a/nav2_bringup/launch/nav2_simulation_launch.py
+++ b/nav2_bringup/launch/nav2_simulation_launch.py
@@ -116,7 +116,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_share_directory('turtlebot3_description'),
                 'urdf', 'turtlebot3_waffle.urdf'),
-            ['__params:=', configured_params]],
+            '--ros-args', '--params-file', configured_params],
         cwd=[launch_dir], output='screen')
 
     start_rviz_cmd = launch.actions.ExecuteProcess(
@@ -134,7 +134,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_map_server'),
                 'lib/nav2_map_server/map_server'),
-            ['__params:=', configured_params]],
+            '--ros-args', '--params-file', configured_params],
         cwd=[launch_dir], output='screen')
 
     start_localizer_cmd = launch.actions.ExecuteProcess(
@@ -142,7 +142,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_amcl'),
                 'lib/nav2_amcl/amcl'),
-            ['__params:=', configured_params]],
+            '--ros-args', '--params-file', configured_params],
         cwd=[launch_dir], output='screen')
 
     start_planner_cmd = launch.actions.ExecuteProcess(
@@ -150,7 +150,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_navfn_planner'),
                 'lib/nav2_navfn_planner/navfn_planner'),
-            ['__params:=', configured_params]],
+            '--ros-args', '--params-file', configured_params],
         cwd=[launch_dir], output='screen')
 
     start_dwb_cmd = launch.actions.ExecuteProcess(
@@ -158,7 +158,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('dwb_controller'),
                 'lib/dwb_controller/dwb_controller'),
-            ['__params:=', configured_params]],
+            '--ros-args', '--params-file', configured_params],
         cwd=[launch_dir], output='screen')
 
     start_navigator_cmd = launch.actions.ExecuteProcess(
@@ -166,7 +166,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_bt_navigator'),
                 'lib/nav2_bt_navigator/bt_navigator'),
-            ['__params:=', configured_params]],
+            '--ros-args', '--params-file', configured_params],
         cwd=[launch_dir], output='screen')
 
     start_recovery_cmd = launch.actions.ExecuteProcess(
@@ -174,7 +174,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_recoveries'),
                 'lib/nav2_recoveries/recoveries_node'),
-            ['__params:=', configured_params]],
+            '--ros-args', '--params-file', configured_params],
         cwd=[launch_dir], output='screen')
 
     start_lifecycle_manager_cmd = launch.actions.ExecuteProcess(
@@ -182,7 +182,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_lifecycle_manager'),
                 'lib/nav2_lifecycle_manager/lifecycle_manager'),
-            ['__params:=', configured_params]],
+            '--ros-args', '--params-file', configured_params],
         cwd=[launch_dir], output='screen')
 
     # Create the launch description and populate

--- a/nav2_system_tests/src/updown/test_updown_launch.py
+++ b/nav2_system_tests/src/updown/test_updown_launch.py
@@ -51,7 +51,7 @@ def generate_launch_description():
     start_gazebo_cmd = launch.actions.ExecuteProcess(
         cmd=['gzserver', '-s', 'libgazebo_ros_init.so',
              world,
-             '--ros-args', ['__params:=', params_file]],
+             '--ros-args', '--params-file', params_file],
         cwd=[launch_dir], output='screen')
 
     start_robot_state_publisher_cmd = launch.actions.ExecuteProcess(
@@ -60,7 +60,7 @@ def generate_launch_description():
                 get_package_prefix('robot_state_publisher'),
                 'lib/robot_state_publisher/robot_state_publisher'),
             urdf,
-            '--ros-args', ['__params:=', params_file]],
+            '--ros-args', '--params-file', params_file],
         cwd=[launch_dir], output='screen')
 
     start_map_server_cmd = launch.actions.ExecuteProcess(
@@ -68,7 +68,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_map_server'),
                 'lib/nav2_map_server/map_server'),
-            '--ros-args', ['__params:=', params_file]],
+            '--ros-args', '--params-file', params_file],
         cwd=[launch_dir], output='screen')
 
     start_localizer_cmd = launch.actions.ExecuteProcess(
@@ -76,7 +76,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_amcl'),
                 'lib/nav2_amcl/amcl'),
-            '--ros-args', ['__params:=', params_file]],
+            '--ros-args', '--params-file', params_file],
         cwd=[launch_dir], output='screen')
 
     start_dwb_cmd = launch.actions.ExecuteProcess(
@@ -84,7 +84,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('dwb_controller'),
                 'lib/dwb_controller/dwb_controller'),
-            '--ros-args', ['__params:=', params_file]],
+            '--ros-args', '--params-file', params_file],
         cwd=[launch_dir], output='screen')
 
     start_planner_cmd = launch.actions.ExecuteProcess(
@@ -92,7 +92,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_navfn_planner'),
                 'lib/nav2_navfn_planner/navfn_planner'),
-            '--ros-args', ['__params:=', params_file]],
+            '--ros-args', '--params-file', params_file],
         cwd=[launch_dir], output='screen')
 
     start_navigator_cmd = launch.actions.ExecuteProcess(
@@ -100,7 +100,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_bt_navigator'),
                 'lib/nav2_bt_navigator/bt_navigator'),
-            '--ros-args', ['__params:=', params_file]],
+            '--ros-args', '--params-file', params_file],
         cwd=[launch_dir], output='screen')
 
     start_controller_cmd = launch.actions.ExecuteProcess(
@@ -108,7 +108,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_lifecycle_manager'),
                 'lib/nav2_lifecycle_manager/lifecycle_manager'),
-            '--ros-args', ['__params:=', params_file]],
+            '--ros-args', '--params-file', params_file],
         cwd=[launch_dir], output='screen')
 
     startup_cmd = launch.actions.ExecuteProcess(
@@ -116,7 +116,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_prefix('nav2_system_tests'),
                 'lib/nav2_system_tests/test_updown'),
-            '--ros-args', ['__params:=', params_file]],
+            '--ros-args', '--params-file', params_file],
         cwd=[launch_dir], output='screen')
 
     startup_exit_event_handler = launch.actions.RegisterEventHandler(


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

* there are two launch files that still use ExecuteProcess instead of the ros Node action to launch nav2 components. They are currently broken due to the new command line parameter format. This PR is a quick fix to get them working again. Replacing them with Node actions is being done as part of the multi-robot fixes.