### PR TITLE
Add current workspace to the rosdep install command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ references:
               dependencies=$(
                 rosdep install -q -y \
                   --from-paths \
-                    $UNDERLAY_WS/src \
+                    $UNDERLAY_WS/src src \
                   --ignore-src \
                   --verbose | \
                 awk '$1 ~ /^resolution\:/' | \


### PR DESCRIPTION
# Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | This PR addresses the issue noted here https://github.com/ros-planning/navigation2/pull/1107#issuecomment-530652301 |
| Primary OS tested on |   |
| Robotic platform tested on |  |

---

## Description of contribution in a few bullet points

* CircleCI is currently only running rosdep on the underlay(navstack dependencies) workspace, and not the nav2 workspace. This PR adds the current workspace to the rosdep command.
* When the CircleCI `install_dependencies` command is run on the underlay, the two paths will collapse to the same directory and should be harmless but redundant. When the `install_dependencies` command is run on the overlay (nav2) workspace, then underlay and overlay will be scanned for dependencies as desired.
* Once https://github.com/ros-infrastructure/rosdep/pull/699 is released, the `$UNDERLAY_WS/src` component can be removed and the redundancy can be eliminated.