### PR TITLE
updated deprecated setting of ros-args 

### DIFF
--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -103,7 +103,7 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   setLayout(main_layout);
 
   auto options = rclcpp::NodeOptions().arguments(
-    {"__node:=navigation_dialog_action_client"});
+    {"--ros-args --remap __node:=navigation_dialog_action_client"});
   client_node_ = std::make_shared<rclcpp::Node>("_", options);
 
   action_client_ = rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(client_node_,


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | (Ubuntu) |


---

## Description of contribution in a few bullet points
Fix for rviz complaining about deprecated params:
```'Found remap rule '__node:=navigation_dialog_action_client'. This syntax is deprecated. Use '--ros-args --remap __node:=navigation_dialog_action_client' instead.```

---