### PR TITLE
Cache per packge.xml via multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@
 #   --build-arg OVERLAY_MIXINS ./
 ARG FROM_IMAGE=osrf/ros2:nightly
 
-# multi-stage build for caching
-FROM $FROM_IMAGE as cache
+# multi-stage for caching
+FROM $FROM_IMAGE AS cache
 WORKDIR /tmp
 
 # copy package manifests for caching
@@ -20,8 +20,8 @@ RUN mkdir ./cache && cd ./src && \
     find ./ -name "COLCON_IGNORE" | \
       xargs cp --parents -t ../cache
 
-# multi-stage build for compiling
-FROM $FROM_IMAGE
+# multi-stage for building
+FROM $FROM_IMAGE AS build
 
 # install CI dependencies	
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # docker build -t nav2:latest \
 #   --build-arg UNDERLAY_MIXINS \
 #   --build-arg OVERLAY_MIXINS ./
-ARG FROM_IMAGE=osrf/ros2:old-nightly
+ARG FROM_IMAGE=osrf/ros2:nightly
 FROM $FROM_IMAGE as package_cache
 
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ FROM $FROM_IMAGE as package_cache
 
 WORKDIR /tmp
 COPY ./ ./src
-RUN mkdir ./cache && \
-    cd ./src && \
+RUN mkdir ./cache && cd ./src && \
     find ./ -name "package.xml" | \
-    xargs cp --parents -t ../cache
+      xargs cp --parents -t ../cache && \
+    find ./ -name "COLCON_IGNORE" | \
+      xargs cp --parents -t ../cache
 
 FROM $FROM_IMAGE
 
@@ -73,7 +74,6 @@ COPY --from=package_cache /tmp/cache src/navigation2/
 RUN . $UNDERLAY_WS/install/setup.sh && \
     apt-get update && \
     rosdep install -q -y \
-      --verbose \
       --from-paths \
         $UNDERLAY_WS/src \
         src \


### PR DESCRIPTION
Use multistage build in Dockerfile to cache dependency install agents only the package.xml files themselves, rather than the entire build context passed to the docker daemon.  
Context: https://github.com/ros-planning/navigation2/pull/1106#issuecomment-530614144