### PR TITLE
remove reset of costmap_ros shared ptr

### DIFF
--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -140,7 +140,6 @@ PlannerServer::on_cleanup(const rclcpp_lifecycle::State & state)
   plan_publisher_.reset();
   tf_.reset();
   costmap_ros_->on_cleanup(state);
-  costmap_ros_.reset();
   planner_->cleanup();
   planner_.reset();
 


### PR DESCRIPTION
Part of addressing fixes in #1121 . `costmap_ros_` is being created in the constructor of the planner, therefore we shouldn't be resetting it during the `on_cleanup` call, as this will crash the node when attempting to call `on_configure` again.
