### PR TITLE
Handle map messages even if there is no initial pose

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1073,7 +1073,7 @@ AmclNode::handleMapMessage(const nav_msgs::msg::OccupancyGrid & msg)
       msg.header.frame_id.c_str(),
       global_frame_id_.c_str());
   }
-
+  freeMapDependentMemory();
   map_ = convertMap(msg);
 
 #if NEW_UNIFORM_SAMPLING

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1053,10 +1053,8 @@ AmclNode::mapReceived(const nav_msgs::msg::OccupancyGrid::SharedPtr msg)
   if (first_map_only_ && first_map_received_) {
     return;
   }
-  if (initial_pose_is_known_) {
-    handleMapMessage(*msg);
-    first_map_received_ = true;
-  }
+  handleMapMessage(*msg);
+  first_map_received_ = true;
 }
 
 void
@@ -1076,31 +1074,12 @@ AmclNode::handleMapMessage(const nav_msgs::msg::OccupancyGrid & msg)
       global_frame_id_.c_str());
   }
 
-  freeMapDependentMemory();
-  // Clear queued laser objects because they hold pointers to the existing
-  // map, #5202.
-  lasers_.clear();
-  lasers_update_.clear();
-  frame_to_laser_.clear();
-
   map_ = convertMap(msg);
 
 #if NEW_UNIFORM_SAMPLING
   createFreeSpaceVector();
 #endif
-  // Create the particle filter
-  initParticleFilter();
-  // resample_count = 0 is extra
 
-  // Instantiate the sensor objects
-  motion_model_.reset();
-  motion_model_ = std::unique_ptr<nav2_amcl::MotionModel>(nav2_amcl::MotionModel::createMotionModel(
-        robot_model_type_, alpha1_, alpha2_, alpha3_, alpha4_, alpha5_));
-
-  // Laser
-  lasers_.clear();
-
-  handleInitialPose(last_published_pose_);
 }
 
 void
@@ -1125,17 +1104,11 @@ AmclNode::freeMapDependentMemory()
     map_ = NULL;
   }
 
-  if (pf_ != NULL) {
-    pf_free(pf_);
-    pf_ = NULL;
-  }
-
-  motion_model_.reset();
-  motion_model_ = std::unique_ptr<nav2_amcl::MotionModel>(nav2_amcl::MotionModel::createMotionModel(
-        robot_model_type_, alpha1_, alpha2_, alpha3_, alpha4_, alpha5_));
-
-  // Laser
+  // Clear queued laser objects because they hold pointers to the existing
+  // map, #5202.
   lasers_.clear();
+  lasers_update_.clear();
+  frame_to_laser_.clear();
 }
 
 // Convert an OccupancyGrid map message into the internal representation. This function


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (Gazebo + TB3 simulation) |

---

## Description of contribution in a few bullet points
- Initial pose is not needed to save map messages. We need to be able to save map data even when the callback is called only once.
- When map messages are being published periodically and `first_map_only_` flag is set to false, we are resetting pf every time the map callback is called.  This can cause divergence. To fix this issue, every-time we get a map update, I only clear the map and laser data without re-initializing pf every time. 


---