### PR TITLE
Update lifecycle_manager_client.cpp

### DIFF
--- a/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
@@ -146,7 +146,7 @@ LifecycleManagerClient::callService(uint8_t command)
   request->command = command;
 
   RCLCPP_INFO(node_->get_logger(), "Waiting for the lifecycle_manager's %s service...",
-    service_name_);
+    service_name_.c_str());
 
   while (!manager_client_->wait_for_service(std::chrono::seconds(1))) {
     if (!rclcpp::ok()) {
@@ -157,7 +157,7 @@ LifecycleManagerClient::callService(uint8_t command)
   }
 
   RCLCPP_INFO(node_->get_logger(), "send_async_request (%s) to the lifecycle_manager",
-    service_name_);
+    service_name_.c_str());
   auto future_result = manager_client_->async_send_request(request);
   rclcpp::spin_until_future_complete(node_, future_result);
   return future_result.get()->success;


### PR DESCRIPTION
Fix build error under clang:
```
--- stderr: nav2_lifecycle_manager                                                                                                
/opt/ros/master/src/ros-planning/navigation2/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp:149:5: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char>') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
    service_name_);
    ^
/opt/ros/master/src/ros-planning/navigation2/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp:160:5: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char>') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
    service_name_);
    ^
2 errors generated.
```

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Untested |
| Robotic platform tested on | Untested |

---

## Description of contribution in a few bullet points

* fix build error under Clang and runtime error