### PR TITLE
Update behavior tree with local and global planner recoveries

### DIFF
--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
@@ -4,15 +4,21 @@
 -->
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
-    <RecoveryNode number_of_retries="6">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
       <Sequence name="NavigateWithReplanning">
         <RateController hz="1.0">
-          <Fallback>
+          <Fallback name="GoalReached">
             <GoalReached/>
-             <ComputePathToPose goal="${goal}" path="${path}"/>
+            <RecoveryNode number_of_retries="1" name="ComputePath">
+              <ComputePathToPose goal="${goal}" path="${path}"/>
+              <ClearEntireCostmap service_name="/global_costmap/clear_entirely_global_costmap"/>
+            </RecoveryNode>
           </Fallback>
         </RateController>
-        <FollowPath path="${path}"/>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="${path}"/>
+          <ClearEntireCostmap service_name="/local_costmap/clear_entirely_local_costmap"/>
+        </RecoveryNode>
       </Sequence>
       <SequenceStar name="RecoveryActions">
         <ClearEntireCostmap service_name="local_costmap/clear_entirely_local_costmap"/>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 simulation |

---

## Description of contribution in a few bullet points
When running the system test 1000 times, I often saw this (12/1000):
```
12: [test_system_node-11] [INFO] [nav2_tester]: Distance from goal is: 1.6401835582713067
12: [navfn_planner-7] [WARN] [navfn_planner]: Planning algorithm failed to generate a valid path to (0.00, 2.00)
12: [dwb_controller-6] [INFO] [local_costmap.local_costmap]: Received request to clear entirely the local_costmap
12: [navfn_planner-7] [INFO] [global_costmap.navfn_planner]: Received request to clear entirely the global_costmap
12: [navfn_planner-7] [INFO] [global_costmap.navfn_planner]: Subscribing to the map topic (/map) with transient local durability
12: [recoveries_node-8] [INFO] [recoveries]: Attempting Spin
12: [recoveries_node-8] [INFO] [recoveries]: Turning -1.57 for spin recovery.
```

After this the system would get into a state where it would not be able to recover, it would keep retrying and eventually fail. 

We had some discussion on this, and the simplest thing to try was to have the global planner clear the global costmap and try again. Likewise for the local_planner.

This PR adds a recovery for the global planner of clearing the costmap, then retrying ONCE. If it fails, then it will still fall back to the previous system recoveries (including spin, clear costmaps). 

Likewise, it does the same thing for the local planner, clearing the local costmap first, then retrying before going to the global recoveries.

I tested this change, and running 500 times, I never saw the failure above. 

## Future work that may be required in bullet points
More work can obviously be done to improve the BT, such as potentially just ignoring a failure by the global planner if there is already an active plan in progress. 

*Edit - fixed formatting