### PR TITLE
create action server on BtNavigator node

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -43,7 +43,6 @@ nav2_util::CallbackReturn
 BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Configuring");
-  auto node = shared_from_this();
 
   auto options = rclcpp::NodeOptions().arguments(
     {"--ros-args",
@@ -55,14 +54,17 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   self_client_ = rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(
     client_node_, "NavigateToPose");
 
-  goal_sub_ = rclcpp_node_->create_subscription<geometry_msgs::msg::PoseStamped>(
+  goal_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
     "/goal_pose",
     rclcpp::SystemDefaultsQoS(),
     std::bind(&BtNavigator::onGoalPoseReceived, this, std::placeholders::_1));
 
-  // Create an action server that we implement with our navigateToPose method
-  action_server_ = std::make_unique<ActionServer>(rclcpp_node_, "NavigateToPose",
-      std::bind(&BtNavigator::navigateToPose, this), false);
+  action_server_ = std::make_unique<ActionServer>(
+    get_node_base_interface(),
+    get_node_clock_interface(),
+    get_node_logging_interface(),
+    get_node_waitables_interface(),
+    "NavigateToPose", std::bind(&BtNavigator::navigateToPose, this), false);
 
   // Create the class that registers our custom nodes and executes the BT
   bt_ = std::make_unique<nav2_behavior_tree::BehaviorTreeEngine>();


### PR DESCRIPTION
Fixes (at least in my several local tests) `bt_navigator` bug in #1121 on re-configuring after reset. This PR creates the `SimpleActionServer` on the `BtNavigator` lifecycle node as opposed to the `rclcpp_node`. Added new constructor in `SimpleActionServer` to support node interfaces. In any case, not sure if there was a good reason not to have the goal subscription and action server on the `BtNavigator` node itself. 

Before, we were getting crashes in `bt_navigator` dealing with creation of action server on the `rclcpp_node`.  Current theory is that the `rclcpp_node` still had ownership to a shared pointer to the first action server even though the SimpleActionServer was destructed.

```
[bt_navigator-10] 2019-09-18 15:21:13.370 [PARTICIPANT Error] Type : action_msgs::srv::dds_::CancelGoal_Request_ Not Registered -> Function createSubscriber
[ERROR] [bt_navigator-10]: process has died [pid 22624, exit code -11, cmd '/home/brian/ros2_projects_ws/navigation2_ws/install/nav2_bt_navigator/lib/nav2_bt_navigator/bt_navigator --ros-args -r __node:=bt_navigator __params:=/tmp/tmp25obzljr'].

```

