### PR TITLE
Fix params file path for nav2_params in the system tests

### DIFF
--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -32,7 +32,7 @@ def generate_launch_description():
     map_yaml_file = os.getenv('TEST_MAP')
     world = os.getenv('TEST_WORLD')
     bringup_package = get_package_share_directory('nav2_bringup')
-    params_file = os.path.join(bringup_package, 'launch/nav2_params.yaml')
+    params_file = os.path.join(bringup_package, 'params/nav2_params.yaml')
     astar = (os.getenv('ASTAR').lower() == 'true')
     bt_navigator_install_path = get_package_prefix('nav2_bt_navigator')
     bt_navigator_xml = os.path.join(bt_navigator_install_path,


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Set correct path for params file |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | (Ubuntu 18.4) |

---

## Description of contribution in a few bullet points
changed nav2_params.yaml file path from ```/nav2_bringup/launch/``` to ```/nav2_bringup/params/```

---

