### PR TITLE
set first_map_received in amcl to false when cleaning up

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -86,7 +86,7 @@ protected:
   map_t * map_{nullptr};
   map_t * convertMap(const nav_msgs::msg::OccupancyGrid & map_msg);
   bool first_map_only_{true};
-  bool first_map_received_{false};
+  std::atomic<bool> first_map_received_{false};
   amcl_hyp_t * initial_pose_hyp_;
   std::recursive_mutex configuration_mutex_;
   rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::ConstSharedPtr map_sub_;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -285,6 +285,7 @@ AmclNode::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   // Map
   map_free(map_);
   map_ = nullptr;
+  first_map_received_ = false;
   free_space_indices.resize(0);
 
   // Transforms


### PR DESCRIPTION
Fixes amcl lifecycle node transition bug in #1121, where the `LaserReceived` callback was being called even though the map had not yet been received, causing a crash because the map was null. There was a check the that `first_map_received_` was true lest it returned, so this PR sets that flag to false when the node calls `on_cleanup`. 

This is the last bug I've seen blocking the lifecycle nodes from being transitioned via the `LifecycleManager` with `reset` and back to `startup`. 
