### PR TITLE
Update design for providing transform to bt nodes

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/goal_reached_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/goal_reached_condition.hpp
@@ -17,7 +17,6 @@
 
 #include <string>
 #include <memory>
-#include <thread>
 
 #include "rclcpp/rclcpp.hpp"
 #include "behaviortree_cpp/condition_node.h"

--- a/nav2_behavior_tree/include/nav2_behavior_tree/goal_reached_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/goal_reached_condition.hpp
@@ -17,13 +17,13 @@
 
 #include <string>
 #include <memory>
+#include <thread>
 
 #include "rclcpp/rclcpp.hpp"
 #include "behaviortree_cpp/condition_node.h"
 #include "nav2_util/robot_utils.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "tf2_ros/transform_listener.h"
-#include "tf2_ros/create_timer_ros.h"
+#include "tf2_ros/buffer.h"
 
 namespace nav2_behavior_tree
 {
@@ -59,12 +59,7 @@ public:
   {
     node_ = blackboard()->template get<rclcpp::Node::SharedPtr>("node");
     node_->get_parameter_or<double>("goal_reached_tol", goal_reached_tol_, 0.25);
-    tf_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
-    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-      node_->get_node_base_interface(),
-      node_->get_node_timers_interface());
-    tf_->setCreateTimerInterface(timer_interface);
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_);
+    tf_ = blackboard()->template get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
 
     initialized_ = true;
   }
@@ -74,7 +69,6 @@ public:
   {
     geometry_msgs::msg::PoseStamped current_pose;
 
-    rclcpp::spin_some(node_);
     if (!nav2_util::getCurrentPose(current_pose, *tf_)) {
       RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
       return false;
@@ -99,7 +93,6 @@ protected:
 private:
   rclcpp::Node::SharedPtr node_;
   std::shared_ptr<tf2_ros::Buffer> tf_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   geometry_msgs::msg::PoseStamped::SharedPtr goal_;
 
   bool initialized_;

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(nav2_msgs REQUIRED)
 find_package(behaviortree_cpp REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(nav2_util REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 nav2_package()
 
@@ -45,6 +46,7 @@ set(dependencies
   behaviortree_cpp
   std_srvs
   nav2_util
+  tf2_ros
 )
 
 ament_target_dependencies(${executable_name}

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -26,6 +26,8 @@
 #include "nav_msgs/msg/path.hpp"
 #include "nav2_util/simple_action_server.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
+#include "tf2_ros/transform_listener.h"
+#include "tf2_ros/create_timer_ros.h"
 
 namespace nav2_bt_navigator
 {
@@ -83,6 +85,10 @@ protected:
 
   // A regular, non-spinning ROS node that we can use for calls to the action client
   rclcpp::Node::SharedPtr client_node_;
+
+  // Spinning transform that can be used by the BT nodes
+  std::shared_ptr<tf2_ros::Buffer> tf_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 };
 
 }  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/package.xml
+++ b/nav2_bt_navigator/package.xml
@@ -7,6 +7,8 @@
   <maintainer email="michael.jeronimo@intel.com">Michael Jeronimo</maintainer>
   <license>Apache-2.0</license>
 
+  <depend>tf2_ros</depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>nav2_common</build_depend>
   <build_depend>rclcpp</build_depend>


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo simulation of TB3 |

---

## Description of contribution in a few bullet points

Fix for #1105.

* Making a transform (buffer) available on the behavior tree blackboard for nodes to pull and use.
* Updating `GoalReachedCondition` to use the blackboard provided tf.

More details here: https://github.com/ros-planning/navigation2/issues/1105#issuecomment-534203963
