### PR TITLE
Fix underlay parameter for install_overlay_dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,7 @@ executors:
       <<: *common_environment
       CACHE_NONCE: "Debug"
       OVERLAY_MIXINS: "debug ccache coverage-gcc"
-      UNDERLAY_MIXINS: "debug ccache"
+      UNDERLAY_MIXINS: "release ccache"
   release_exec:
     docker:
       - image: rosplanning/navigation2:master.release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ references:
               cat << parameters.underlay >>/checksum.txt > checksum.txt
               vcs export --exact src | \
                 (echo vcs_export && cat) >> checksum.txt
-              sha256sum checksum.txt >> checksum.txt
+              sha256sum $PWD/checksum.txt >> checksum.txt
               apt-get update
               dependencies=$(
                 rosdep install -q -y \
@@ -79,7 +79,7 @@ references:
                 tr -d \, | xargs -n1 | sort -u | xargs)
               dpkg -s $dependencies | \
                 (echo workspace_dependencies && cat) >> checksum.txt
-              sha256sum checksum.txt >> checksum.txt
+              sha256sum $PWD/checksum.txt >> checksum.txt
     setup_workspace:
       description: "Setup Workspace"
       parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ references:
       build: false
   install_overlay_dependencies: &install_overlay_dependencies
     install_dependencies:
-      underlay: /opt/ros_ws
+      underlay: /opt/underlay_ws
       workspace: /opt/overlay_ws
   setup_overlay_workspace: &setup_overlay_workspace
     setup_workspace: &setup_workspace_overlay

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,14 +177,14 @@ references:
     run:
       name: Pre Checkout
       command: |
-        mkdir -p $ROS_WS
-        ln -s /opt/ros/$ROS_DISTRO $ROS_WS/install
+        mkdir -p $ROS_WS && cd $ROS_WS
+        ln -s /opt/ros/$ROS_DISTRO install
         echo $CACHE_NONCE | \
-          (echo cache_nonce && cat) >> $ROS_WS/checksum.txt
-        sha256sum $ROS_WS/checksum.txt >> $ROS_WS/checksum.txt
+          (echo cache_nonce && cat) >> checksum.txt
+        sha256sum $PWD/checksum.txt >> checksum.txt
         TZ=utc stat -c '%y' /ros_entrypoint.sh | \
-          (echo ros_entrypoint && cat) >> $ROS_WS/checksum.txt
-        sha256sum $ROS_WS/checksum.txt >> $ROS_WS/checksum.txt
+          (echo ros_entrypoint && cat) >> checksum.txt
+        sha256sum $PWD/checksum.txt >> checksum.txt
         rm -rf $OVERLAY_WS/*
   on_checkout: &on_checkout
     checkout:

--- a/.dockerhub/debug/hooks/build
+++ b/.dockerhub/debug/hooks/build
@@ -3,7 +3,7 @@ set -ex
 
 export FROM_IMAGE=osrf/ros2:nightly
 export FAIL_ON_BUILD_FAILURE=""
-export UNDERLAY_MIXINS="debug ccache"
+export UNDERLAY_MIXINS="release ccache"
 export OVERLAY_MIXINS="debug ccache coverage-gcc"
 
 docker build \


### PR DESCRIPTION
Use `/opt/underlay_ws` as the target underlay for overlay's `install_dependencies` command, otherwise the checksum.txt for the overlay is improperly copied from `/opt/ros_ws` instead of `/opt/underlay_ws`.