### PR TITLE
reset AMCL initial pose with last known pose covariances

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -136,7 +136,7 @@ protected:
     std::shared_ptr<std_srvs::srv::Empty::Response> response);
 
   // Nomotion update control. Used to temporarily let amcl update samples even when no motion occurs
-  bool force_update_{false};
+  std::atomic<bool> force_update_{false};
 
   // Odometry
   void initOdometry();
@@ -202,6 +202,7 @@ protected:
   bool init_pose_received_on_inactive{false};
   bool initial_pose_is_known_{false};
   bool set_initial_pose_{false};
+  bool always_reset_initial_pose_;
   double initial_pose_x_;
   double initial_pose_y_;
   double initial_pose_z_;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -231,10 +231,6 @@ AmclNode::on_activate(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Activating");
 
-  if (always_reset_initial_pose_) {
-    initial_pose_is_known_ = false;
-  }
-
   // Lifecycle publishers must be explicitly activated
   pose_pub_->on_activate();
   particlecloud_pub_->on_activate();
@@ -1043,6 +1039,10 @@ AmclNode::initParameters()
     RCLCPP_WARN(get_logger(), "You've set min_particles to be greater than max particles,"
       " this isn't allowed so max_particles will be set to min_particles.");
     max_particles_ = min_particles_;
+  }
+
+  if (always_reset_initial_pose_) {
+    initial_pose_is_known_ = false;
   }
 }
 


### PR DESCRIPTION
By default, we have the last known pose being initialized as the initial pose when AMCL is reset. However, when re-configuring and re-activating AMCL, the particle filter was being cleared and the covariances from the last known pose were not re-initialized even if the pose position itself was being re-initialized, causing poorer initialization after a reset. Also, if pose is set via parameter, the original initial pose parameters are being set even after AMCL is reset. Lastly, in the case that the robot does move (robot kidnapping) between resetting and starting up again, there should be an option to require that the user provide a new initial pose.

This PR addresses these issues via the following:
- forces update of particle filter when started after `on_cleanup` is called
- sets the initial pose parameters  to the last known pose if  `set_initial_pose` is true
- sets the initial covariance of particle filter to last known pose covariance
- adds a new parameter flag `always_reset_initial_pose` which will require the user provide a new topic pose for the initial estimate when resetting AMCL (if `set_initial_pose` is true, it will still use the  pose from the parameter)