### PR TITLE
Enable deprecated warnings

### DIFF
--- a/nav2_common/cmake/nav2_package.cmake
+++ b/nav2_common/cmake/nav2_package.cmake
@@ -33,7 +33,7 @@ macro(nav2_package)
   endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations -fPIC)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC)
   endif()
 
   option(COVERAGE_ENABLED "Enable code coverage" FALSE)


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo simulation of TB3 |

---

## Description of contribution in a few bullet points

Enable deprecated warnings during build. -- we're currently getting no warnings :smiley: