### PR TITLE
prevent dwb controller from missing changes to the global path (#1160)

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -129,7 +129,9 @@ new_goal_received:
 
         // We can handle a new goal if we're still executing
         auto status = goal_handle_->get_status();
-        if (goal_updated_ && (status == action_msgs::msg::GoalStatus::STATUS_EXECUTING)) {
+        if (goal_updated_ && (status == action_msgs::msg::GoalStatus::STATUS_EXECUTING ||
+          status == action_msgs::msg::GoalStatus::STATUS_ACCEPTED ))
+        {
           goal_updated_ = false;
           goto new_goal_received;
         }


### PR DESCRIPTION
this fixes rare cases where my dwb controller isn't picking up changes to the global path.