### PR TITLE
Re-enable test_collision_checker

### DIFF
--- a/nav2_costmap_2d/test/integration/CMakeLists.txt
+++ b/nav2_costmap_2d/test/integration/CMakeLists.txt
@@ -43,15 +43,15 @@ target_link_libraries(obstacle_tests_exec
   layers
 )
 
-#ament_add_test(test_collision_checker
-#  GENERATE_RESULT_FOR_RETURN_CODE_ZERO
-#  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/costmap_tests_launch.py"
-#  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-#  ENV
-#    TEST_MAP=${TEST_MAP_DIR}/TenByTen.yaml
-#    TEST_LAUNCH_DIR=${TEST_LAUNCH_DIR}
-#    TEST_EXECUTABLE=$<TARGET_FILE:test_collision_checker_exec>
-#)
+ament_add_test(test_collision_checker
+  GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/costmap_tests_launch.py"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  ENV
+    TEST_MAP=${TEST_MAP_DIR}/TenByTen.yaml
+    TEST_LAUNCH_DIR=${TEST_LAUNCH_DIR}
+    TEST_EXECUTABLE=$<TARGET_FILE:test_collision_checker_exec>
+)
 
 ament_add_test(footprint_tests
   GENERATE_RESULT_FOR_RETURN_CODE_ZERO

--- a/nav2_costmap_2d/test/integration/test_collision_checker.cpp
+++ b/nav2_costmap_2d/test/integration/test_collision_checker.cpp
@@ -179,6 +179,7 @@ public:
     setPose(x, y, theta);
     publishFootprint();
     publishCostmap();
+    rclcpp::sleep_for(std::chrono::milliseconds(50));
     return collision_checker_->isCollisionFree(pose);
   }
 

--- a/tools/run_test_suite.bash
+++ b/tools/run_test_suite.bash
@@ -5,10 +5,7 @@ set -ex
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"  # gets the directory of this script
 
 # Skip flaky tests. Nav2 system tests will be run later.
-colcon test --packages-skip nav2_system_tests nav2_dynamic_params nav2_recoveries
-
-# run the stable tests in nav2_dynamic_params
-colcon test --packages-select nav2_dynamic_params --ctest-args --exclude-regex "test_dynamic_params_client"
+colcon test --packages-skip nav2_system_tests nav2_recoveries
 
 # run the stable tests in nav2_recoveries
 colcon test --packages-select nav2_recoveries --ctest-args --exclude-regex "test_recoveries"


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1030  |
| Primary OS tested on | Ubuntu |
---

## Description of contribution in a few bullet points
- Added sleep after broadcasting tf transform in  `test_collision_checker.cpp` to fix race condition when collision checker tries to get the pose off the tf transform immediately after it's been sent
- re-enable `test_collision_checker_exec` in CMakeLists
- for cleanup, removed nav2_dynamic_params from the `test_suite.bash` since that package has now been completely removed

