### PR TITLE
Use relative namespace for clear costmap services

### DIFF
--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
@@ -11,13 +11,13 @@
             <GoalReached/>
             <RecoveryNode number_of_retries="1" name="ComputePath">
               <ComputePathToPose goal="${goal}" path="${path}"/>
-              <ClearEntireCostmap service_name="/global_costmap/clear_entirely_global_costmap"/>
+              <ClearEntireCostmap service_name="global_costmap/clear_entirely_global_costmap"/>
             </RecoveryNode>
           </Fallback>
         </RateController>
         <RecoveryNode number_of_retries="1" name="FollowPath">
           <FollowPath path="${path}"/>
-          <ClearEntireCostmap service_name="/local_costmap/clear_entirely_local_costmap"/>
+          <ClearEntireCostmap service_name="local_costmap/clear_entirely_local_costmap"/>
         </RecoveryNode>
       </Sequence>
       <SequenceStar name="RecoveryActions">


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | # |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo simulation of TB3 |

---

## Description of contribution in a few bullet points

Clear costmap services should be placed on relative namespaces.