### PR TITLE
Halt method in the recovery node is not being called after successfull navigation

### DIFF
--- a/nav2_behavior_tree/src/recovery_node.cpp
+++ b/nav2_behavior_tree/src/recovery_node.cpp
@@ -92,6 +92,7 @@ BT::NodeStatus RecoveryNode::tick()
           {
             current_child_idx_--;
             retry_count_ = 0;
+            halt();
             return BT::NodeStatus::FAILURE;
           }
           break;
@@ -109,6 +110,7 @@ BT::NodeStatus RecoveryNode::tick()
     }
   }  // end while loop
   retry_count_ = 0;
+  halt();
   return BT::NodeStatus::FAILURE;
 }
 

--- a/nav2_behavior_tree/src/recovery_node.cpp
+++ b/nav2_behavior_tree/src/recovery_node.cpp
@@ -49,6 +49,7 @@ BT::NodeStatus RecoveryNode::tick()
         case BT::NodeStatus::SUCCESS:
           {
             retry_count_ = 0;
+            halt();
             return BT::NodeStatus::SUCCESS;
           }
           break;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#1179) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (Gazebo + TB3) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

---
As a temporary quick fix I am calling the Halt method when recovery node returns success. We need to dive deeper to find out why the parent node is not calling the halt method.
