### PR TITLE
Activate recovery server velocity publisher

### DIFF
--- a/nav2_recoveries/include/nav2_recoveries/recovery.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery.hpp
@@ -130,18 +130,20 @@ public:
 
   void activate() override
   {
+    vel_pub_->on_activate();
     enabled_ = true;
   }
 
   void deactivate() override
   {
+    vel_pub_->on_deactivate();
     enabled_ = false;
   }
 
 protected:
   rclcpp_lifecycle::LifecycleNode::SharedPtr node_;
   std::string recovery_name_;
-  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr vel_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr vel_pub_;
   std::shared_ptr<tf2_ros::Buffer> tf_;
   std::unique_ptr<ActionServer> action_server_;
 


### PR DESCRIPTION
The spin recovery cannot send velocity commands because the publisher is never activated. This PR activates/deactivates the publisher for the recovery plugins.