### PR TITLE
Change system test back to using /move_base_simple/goal

### DIFF
--- a/nav2_system_tests/src/system/test_system_node.py
+++ b/nav2_system_tests/src/system/test_system_node.py
@@ -31,7 +31,7 @@ class NavTester(Node):
         super().__init__('nav2_tester')
         self.initial_pose_pub = self.create_publisher(PoseWithCovarianceStamped,
                                                       '/initialpose')
-        self.goal_pub = self.create_publisher(PoseStamped, '/goal_pose')
+        self.goal_pub = self.create_publisher(PoseStamped, '/move_base_simple/goal')
 
         self.model_pose_sub = self.create_subscription(PoseWithCovarianceStamped,
                                                        '/amcl_pose', self.poseCallback)


### PR DESCRIPTION
## Description of contribution in a few bullet points
The bt_navigator and bt_navigator_dykstra system tests won't pass on dashing, since they are using the wrong topic "/goal_pose". This changes it back to using "/move_base_simple/goal"

NOTE: THIS IS A PR DIRECTLY TO THE DASHING BRANCH
