### PR TITLE
Un-block costmap activate transition: move transform check to map update thread

### DIFF
--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -185,6 +185,8 @@ PlannerServer::computePathToPose()
 
     geometry_msgs::msg::PoseStamped start;
     if (!nav2_util::getCurrentPose(start, *tf_)) {
+      RCLCPP_INFO(get_logger(), "Start pose unavailable. Canceling planning action.");
+      action_server_->terminate_goals();
       return;
     }
 


### PR DESCRIPTION
Right now the navigation2 stack is brought up sequentially such that the `controller_server` and `planner_server`, which contain the costmap_2d_ros node, are blocked in the `on_activate` transition due to the costmap's dependence on the transform between global frame and robot base frame to be available before successfully completing the lifecycle transition. For the global costmap, this transform is broadcast from amcl when the initial pose is set.

This PR moves the transform check to the map update thread in the costmap, so that the `on_activate` lifecycle transition is unblocked.  Part of my goal here is to remove external dependencies from the lifecycle transition of the node. When the pose is eventually provided, the thread will proceed to updating the costmap.

Notes:
While the thread is awaiting the transform to be available, if someone requests a `NavigateToPose` action, the planner will now fail and the recovery behaviors will start and eventually fail, failing the navigation. If executing recovery behaviors is undesirable, we can add a `isTransformAvailable` check as a bt condition node to fail the stop the tree if the transform is unavailable.