### PR TITLE
Remove wait for action server/service in bt_action_node and timeout send goal

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
@@ -40,6 +40,11 @@ public:
     goal_.target.y = 0.0;
     goal_.target.z = 0.0;
   }
+
+  BT::NodeStatus on_send_goal_failure() override
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -66,7 +66,7 @@ public:
 
     // Make sure the server is actually there before continuing
     RCLCPP_INFO(node_->get_logger(), "Waiting for \"%s\" action server", action_name_.c_str());
-    action_client_->wait_for_action_server();
+    // action_client_->wait_for_action_server();
 
     // Give the derive class a chance to do any initialization
     on_init();
@@ -109,10 +109,13 @@ public:
 
 new_goal_received:
     auto future_goal_handle = action_client_->async_send_goal(goal_, send_goal_options);
-    if (rclcpp::spin_until_future_complete(node_, future_goal_handle) !=
+    if (rclcpp::spin_until_future_complete(node_, future_goal_handle, std::chrono::seconds(1)) !=
       rclcpp::executor::FutureReturnCode::SUCCESS)
     {
-      throw std::runtime_error("send_goal failed");
+      RCLCPP_INFO(node_->get_logger(),
+        "Failed to send goal for \"%s\" action server", action_name_.c_str());
+      return BT::NodeStatus::FAILURE;
+      // throw std::runtime_error("send_goal failed");
     }
 
     goal_handle_ = future_goal_handle.get();

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -112,8 +112,9 @@ new_goal_received:
     if (rclcpp::spin_until_future_complete(node_, future_goal_handle, std::chrono::seconds(1)) !=
       rclcpp::executor::FutureReturnCode::SUCCESS)
     {
-      RCLCPP_INFO(node_->get_logger(),
+      RCLCPP_ERROR(node_->get_logger(),
         "Failed to send goal for \"%s\" action server", action_name_.c_str());
+      setStatus(BT::NodeStatus::IDLE);
       return BT::NodeStatus::FAILURE;
       // throw std::runtime_error("send_goal failed");
     }

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -69,7 +69,7 @@ public:
     // Make sure the server is actually there before continuing
     RCLCPP_INFO(node_->get_logger(), "Waiting for \"%s\" service",
       service_name_.c_str());
-    service_client_->wait_for_service();
+    // service_client_->wait_for_service();
 
     RCLCPP_INFO(node_->get_logger(), "\"%s\" BtServiceNode initialized",
       service_node_name_.c_str());

--- a/nav2_behavior_tree/include/nav2_behavior_tree/clear_costmap_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/clear_costmap_service.hpp
@@ -39,6 +39,11 @@ public:
   void on_init() override
   {
   }
+
+  BT::NodeStatus on_send_request_failure() override
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
@@ -40,6 +40,11 @@ public:
   {
     goal_.target_yaw = M_PI / 2;
   }
+
+  BT::NodeStatus on_send_goal_failure() override
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
@@ -45,6 +45,11 @@ public:
 
     goal_.time.sec = duration;
   }
+
+  BT::NodeStatus on_send_goal_failure() override
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_bringup/bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/bringup/launch/nav2_bringup_launch.py
@@ -119,6 +119,7 @@ def generate_launch_description():
                                     'amcl',
                                     'controller_server',
                                     'planner_server',
+                                    'recoveries_server',
                                     'bt_navigator']}])
 
     # Create the launch description and populate

--- a/nav2_bringup/bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/bringup/launch/nav2_bringup_launch.py
@@ -119,7 +119,6 @@ def generate_launch_description():
                                     'amcl',
                                     'controller_server',
                                     'planner_server',
-                                    'recoveries_server',
                                     'bt_navigator']}])
 
     # Create the launch description and populate

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -90,6 +90,8 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
   blackboard_->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", tf_);  // NOLINT
   blackboard_->set<std::chrono::milliseconds>("node_loop_timeout", std::chrono::milliseconds(10));  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>("send_goal_timeout", std::chrono::milliseconds(1000));  // NOLINT
+
   blackboard_->set<bool>("path_updated", false);  // NOLINT
   blackboard_->set<bool>("initial_pose_received", false);  // NOLINT
 


### PR DESCRIPTION
## Basic Info
| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1177  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | gazebo simulation of tb3 waffle |

## Description of contribution in a few bullet points
- Removed wait for action server and wait for service from `bt_action_node` and `bt_service_node`
- Add a timeout when spinning a send goal or service rest
- Replaced throw error with returning `BT::NodeStatus` to exit `tick` when client fails to send goal or service request
- Added override function to allow recovery behaviors to return SUCCESS when the send goal/service fails, allowing for the bt tree to attempt the next recovery action instead of exiting tree

## Future work that may be required in bullet points
- The override function `on_send_goal_failure` can be removed when we update the recovery node (currently using the sequence star control node) to allow action nodes to fail and and still proceed to the next action node
- With this change, since there is no guarantee that when the system is active and a user sends a goal pose that the services and action servers are ready and available, the navigation may possibly fail, possibly attempting any recoveries specified in the behavior tree. I think this may be acceptable behavior, but we may consider creating a bt action node or some way to check that the servers (or also transforms) are ready before proceeding to navigating. This could be an optional behavior someone uses to ensure everything is up and ready before continuing on. 