### PR TITLE
Dont republish map

### DIFF
--- a/nav2_bringup/bringup/rviz/nav2_default_view.rviz
+++ b/nav2_bringup/bringup/rviz/nav2_default_view.rviz
@@ -117,7 +117,7 @@ Visualization Manager:
         Depth: 5
         Durability Policy: Volatile
         History Policy: Keep Last
-        Reliability Policy: Reliable
+        Reliability Policy: Best Effort
         Value: /scan
       Use Fixed Frame: true
       Use rainbow: true
@@ -150,7 +150,7 @@ Visualization Manager:
         Depth: 5
         Durability Policy: Volatile
         History Policy: Keep Last
-        Reliability Policy: Reliable
+        Reliability Policy: Best Effort
         Value: /mobile_base/sensors/bumper_pointcloud
       Use Fixed Frame: true
       Use rainbow: true
@@ -198,8 +198,8 @@ Visualization Manager:
           Enabled: true
           Name: Global Costmap
           Topic:
-            Depth: 5
-            Durability Policy: Volatile
+            Depth: 1
+            Durability Policy: Transient Local
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /global_costmap/costmap
@@ -255,8 +255,8 @@ Visualization Manager:
           Enabled: true
           Name: Local Costmap
           Topic:
-            Depth: 5
-            Durability Policy: Volatile
+            Depth: 1
+            Durability Policy: Transient Local
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /local_costmap/costmap

--- a/nav2_bringup/bringup/rviz/nav2_default_view.rviz
+++ b/nav2_bringup/bringup/rviz/nav2_default_view.rviz
@@ -186,7 +186,7 @@ Visualization Manager:
         Depth: 5
         Durability Policy: Volatile
         History Policy: Keep Last
-        Reliability Policy: Reliable
+        Reliability Policy: Best Effort
         Value: /particlecloud
       Value: true
     - Class: rviz_common/Group

--- a/nav2_bringup/bringup/rviz/nav2_default_view.rviz
+++ b/nav2_bringup/bringup/rviz/nav2_default_view.rviz
@@ -51,7 +51,12 @@ Visualization Manager:
       Collision Enabled: false
       Description File: ""
       Description Source: Topic
-      Description Topic: /robot_description
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
       Enabled: false
       Links:
         All Links Enabled: true
@@ -61,7 +66,6 @@ Visualization Manager:
         Link Tree Style: ""
       Name: RobotModel
       TF Prefix: ""
-      Unreliable: false
       Update Interval: 0
       Value: true
       Visual Enabled: true
@@ -105,13 +109,16 @@ Visualization Manager:
       Min Intensity: 0
       Name: LaserScan
       Position Transformer: XYZ
-      Queue Size: 10
       Selectable: true
       Size (Pixels): 3
       Size (m): 0.009999999776482582
       Style: Flat Squares
-      Topic: /scan
-      Unreliable: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /scan
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
@@ -135,13 +142,16 @@ Visualization Manager:
       Min Intensity: 0
       Name: Bumper Hit
       Position Transformer: ""
-      Queue Size: 10
       Selectable: true
       Size (Pixels): 3
       Size (m): 0.07999999821186066
       Style: Spheres
-      Topic: /mobile_base/sensors/bumper_pointcloud
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /mobile_base/sensors/bumper_pointcloud
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
@@ -151,8 +161,12 @@ Visualization Manager:
       Draw Behind: true
       Enabled: true
       Name: Map
-      Topic: /map
-      Unreliable: false
+      Topic:
+        Depth: 1
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /map
       Use Timestamp: false
       Value: true
     - Alpha: 1
@@ -168,8 +182,12 @@ Visualization Manager:
       Shaft Length: 0.23000000417232513
       Shaft Radius: 0.009999999776482582
       Shape: Arrow (Flat)
-      Topic: /particlecloud
-      Unreliable: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /particlecloud
       Value: true
     - Class: rviz_common/Group
       Displays:
@@ -179,8 +197,12 @@ Visualization Manager:
           Draw Behind: false
           Enabled: true
           Name: Global Costmap
-          Topic: /global_costmap/costmap
-          Unreliable: false
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /global_costmap/costmap
           Use Timestamp: false
           Value: false
         - Alpha: 1
@@ -203,16 +225,24 @@ Visualization Manager:
           Radius: 0.029999999329447746
           Shaft Diameter: 0.004999999888241291
           Shaft Length: 0.019999999552965164
-          Topic: /plan
-          Unreliable: false
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /plan
           Value: true
         - Alpha: 1
           Class: rviz_default_plugins/Polygon
           Color: 25; 255; 0
           Enabled: false
           Name: Polygon
-          Topic: /global_costmap/published_footprint
-          Unreliable: false
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /global_costmap/published_footprint
           Value: false
       Enabled: true
       Name: Global Planner
@@ -224,8 +254,12 @@ Visualization Manager:
           Draw Behind: false
           Enabled: true
           Name: Local Costmap
-          Topic: /local_costmap/costmap
-          Unreliable: false
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /local_costmap/costmap
           Use Timestamp: false
           Value: true
         - Alpha: 1
@@ -248,25 +282,36 @@ Visualization Manager:
           Radius: 0.029999999329447746
           Shaft Diameter: 0.10000000149011612
           Shaft Length: 0.10000000149011612
-          Topic: /local_plan
-          Unreliable: false
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /local_plan
           Value: true
         - Class: rviz_default_plugins/MarkerArray
           Enabled: false
           Name: Trajectories
           Namespaces:
             {}
-          Queue Size: 10
-          Topic: /marker
-          Unreliable: false
-          Value: true
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /marker
+          Value: false
         - Alpha: 1
           Class: rviz_default_plugins/Polygon
           Color: 25; 255; 0
           Enabled: true
           Name: Polygon
-          Topic: /local_costmap/published_footprint
-          Unreliable: false
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /local_costmap/published_footprint
           Value: true
       Enabled: true
       Name: Local Planner
@@ -283,10 +328,20 @@ Visualization Manager:
     - Class: rviz_default_plugins/Measure
       Line color: 128; 128; 0
     - Class: rviz_default_plugins/SetInitialPose
-      Topic: /initialpose
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
     - Class: rviz_default_plugins/PublishPoint
       Single click: true
-      Topic: /clicked_point
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
     - Class: nav2_rviz_plugins/GoalTool
   Transformation:
     Current:
@@ -318,7 +373,7 @@ Window Geometry:
   Hide Right Dock: true
   Navigation 2:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000338fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002d0000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb00000018004e0061007600690067006100740069006f006e002000320100000313000000620000006200ffffff000000010000010f00000338fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000338000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000004990000033800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000338fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002c4000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb00000018004e0061007600690067006100740069006f006e0020003201000003070000006e0000006e00ffffff000000010000010f00000338fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000338000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000004990000033800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Tool Properties:

--- a/nav2_bringup/bringup/rviz/nav2_namespaced_view.rviz
+++ b/nav2_bringup/bringup/rviz/nav2_namespaced_view.rviz
@@ -5,6 +5,7 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /Global Options1
+        - /RobotModel1/Status1
         - /TF1/Frames1
         - /TF1/Tree1
         - /Global Planner1/Global Costmap1
@@ -50,7 +51,12 @@ Visualization Manager:
       Collision Enabled: false
       Description File: ""
       Description Source: Topic
-      Description Topic: <robot_namespace>/robot_description
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: <robot_namespace>/robot_description
       Enabled: false
       Links:
         All Links Enabled: true
@@ -60,41 +66,14 @@ Visualization Manager:
         Link Tree Style: Links in Alphabetic Order
       Name: RobotModel
       TF Prefix: ""
-      Unreliable: false
       Update Interval: 0
-      Value: false
+      Value: true
       Visual Enabled: true
     - Class: rviz_default_plugins/TF
       Enabled: true
       Frame Timeout: 15
       Frames:
         All Enabled: false
-        base_footprint:
-          Value: true
-        base_link:
-          Value: true
-        base_scan:
-          Value: true
-        camera_depth_frame:
-          Value: true
-        camera_depth_optical_frame:
-          Value: true
-        camera_link:
-          Value: true
-        camera_rgb_frame:
-          Value: true
-        camera_rgb_optical_frame:
-          Value: true
-        caster_back_left_link:
-          Value: true
-        caster_back_right_link:
-          Value: true
-        imu_link:
-          Value: true
-        wheel_left_link:
-          Value: true
-        wheel_right_link:
-          Value: true
       Marker Scale: 1
       Name: TF
       Show Arrows: true
@@ -124,13 +103,16 @@ Visualization Manager:
       Min Intensity: 0
       Name: LaserScan
       Position Transformer: XYZ
-      Queue Size: 10
       Selectable: true
       Size (Pixels): 3
       Size (m): 0.009999999776482582
       Style: Flat Squares
-      Topic: <robot_namespace>/scan
-      Unreliable: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: <robot_namespace>/scan
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
@@ -154,13 +136,16 @@ Visualization Manager:
       Min Intensity: 0
       Name: Bumper Hit
       Position Transformer: ""
-      Queue Size: 10
       Selectable: true
       Size (Pixels): 3
       Size (m): 0.07999999821186066
       Style: Spheres
-      Topic: <robot_namespace>/mobile_base/sensors/bumper_pointcloud
-      Unreliable: false
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: <robot_namespace>/mobile_base/sensors/bumper_pointcloud
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
@@ -170,8 +155,12 @@ Visualization Manager:
       Draw Behind: true
       Enabled: true
       Name: Map
-      Topic: <robot_namespace>/map
-      Unreliable: false
+      Topic:
+        Depth: 1
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: <robot_namespace>/map
       Use Timestamp: false
       Value: true
     - Alpha: 1
@@ -187,8 +176,12 @@ Visualization Manager:
       Shaft Length: 0.23000000417232513
       Shaft Radius: 0.009999999776482582
       Shape: Arrow (Flat)
-      Topic: <robot_namespace>/particlecloud
-      Unreliable: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: <robot_namespace>/particlecloud
       Value: true
     - Class: rviz_common/Group
       Displays:
@@ -198,10 +191,14 @@ Visualization Manager:
           Draw Behind: false
           Enabled: true
           Name: Global Costmap
-          Topic: <robot_namespace>/global_costmap/costmap
-          Unreliable: false
+          Topic:
+            Depth: 1
+            Durability Policy: Transient Local
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: <robot_namespace>/global_costmap/costmap
           Use Timestamp: false
-          Value: false
+          Value: true
         - Alpha: 1
           Buffer Length: 1
           Class: rviz_default_plugins/Path
@@ -222,16 +219,24 @@ Visualization Manager:
           Radius: 0.029999999329447746
           Shaft Diameter: 0.004999999888241291
           Shaft Length: 0.019999999552965164
-          Topic: <robot_namespace>/plan
-          Unreliable: false
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: <robot_namespace>/plan
           Value: true
         - Alpha: 1
           Class: rviz_default_plugins/Polygon
           Color: 25; 255; 0
           Enabled: false
           Name: Polygon
-          Topic: <robot_namespace>/global_costmap/published_footprint
-          Unreliable: false
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: <robot_namespace>/global_costmap/published_footprint
           Value: false
       Enabled: true
       Name: Global Planner
@@ -243,8 +248,12 @@ Visualization Manager:
           Draw Behind: false
           Enabled: true
           Name: Local Costmap
-          Topic: <robot_namespace>/local_costmap/costmap
-          Unreliable: false
+          Topic:
+            Depth: 1
+            Durability Policy: Transient Local
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: <robot_namespace>/local_costmap/costmap
           Use Timestamp: false
           Value: true
         - Alpha: 1
@@ -267,25 +276,36 @@ Visualization Manager:
           Radius: 0.029999999329447746
           Shaft Diameter: 0.10000000149011612
           Shaft Length: 0.10000000149011612
-          Topic: <robot_namespace>/local_plan
-          Unreliable: false
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: <robot_namespace>/local_plan
           Value: true
         - Class: rviz_default_plugins/MarkerArray
           Enabled: false
           Name: Trajectories
           Namespaces:
             {}
-          Queue Size: 10
-          Topic: <robot_namespace>/marker
-          Unreliable: false
-          Value: true
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: <robot_namespace>/marker
+          Value: false
         - Alpha: 1
           Class: rviz_default_plugins/Polygon
           Color: 25; 255; 0
           Enabled: true
           Name: Polygon
-          Topic: <robot_namespace>/local_costmap/published_footprint
-          Unreliable: false
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: <robot_namespace>/local_costmap/published_footprint
           Value: true
       Enabled: true
       Name: Local Planner
@@ -302,11 +322,12 @@ Visualization Manager:
     - Class: rviz_default_plugins/Measure
       Line color: 128; 128; 0
     - Class: rviz_default_plugins/SetInitialPose
-      Topic: <robot_namespace>/initialpose
-    - Class: rviz_default_plugins/PublishPoint
-      Single click: true
-      Topic: <robot_namespace>/clicked_point
-    - Class: nav2_rviz_plugins/GoalTool
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: <robot_namespace>/initialpose
   Transformation:
     Current:
       Class: rviz_default_plugins/TF
@@ -337,7 +358,7 @@ Window Geometry:
   Hide Right Dock: true
   Navigation 2:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000338fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002d0000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb00000018004e0061007600690067006100740069006f006e002000320100000313000000620000004300ffffff000000010000010f00000338fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000338000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000004990000033800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000338fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002c4000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb00000018004e0061007600690067006100740069006f006e0020003201000003070000006e0000006200ffffff000000010000010f00000338fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000338000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000004990000033800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Tool Properties:
@@ -345,5 +366,5 @@ Window Geometry:
   Views:
     collapsed: true
   Width: 1545
-  X: 295
-  Y: 238
+  X: 186
+  Y: 117

--- a/nav2_map_server/src/occ_grid_loader.cpp
+++ b/nav2_map_server/src/occ_grid_loader.cpp
@@ -183,10 +183,6 @@ nav2_util::CallbackReturn OccGridLoader::on_activate(const rclcpp_lifecycle::Sta
   occ_pub_->on_activate();
   occ_pub_->publish(*msg_);
 
-  // due to timing / discovery issues, need to republish map
-  auto timer_callback = [this]() -> void {occ_pub_->publish(*msg_);};
-  timer_ = node_->create_wall_timer(2s, timer_callback);
-
   return nav2_util::CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #867 , #331  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Turtlebot3 simulation |

---

## Description of contribution in a few bullet points
* removes timer thread from map_server that republishes map every 2s
* updates the Rviz config file to add new QOS settings
* sets Rviz QOS settings for map topics (map, local & global costmaps) to use transient_local with depth of 1
* sets Rviz QOS settings for sensor topics (scan, pointcloud) to use default sensor settings (Best Effort reliability)

---

## Future work that may be required in bullet points
I grepped through the code to look for any other non-default QOS settings, couldn't find any others, but if anyone notices that something no longer shows up in Rviz, this PR could be the culprit

My testing looked good, I think it shouldn't be an issue