### PR TITLE
Allow parameters in WaitAction

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
@@ -28,8 +28,8 @@ namespace nav2_behavior_tree
 class WaitAction : public BtActionNode<nav2_msgs::action::Wait>
 {
 public:
-  explicit WaitAction(const std::string & action_name)
-  : BtActionNode<nav2_msgs::action::Wait>(action_name)
+  explicit WaitAction(const std::string & action_name, const BT::NodeParameters & params)
+  : BtActionNode<nav2_msgs::action::Wait>(action_name, params)
   {
   }
 
@@ -44,6 +44,13 @@ public:
     }
 
     goal_.time.sec = duration;
+  }
+
+  // Any BT node that accepts parameters must provide a requiredNodeParameters method
+  static const BT::NodeParameters & requiredNodeParameters()
+  {
+    static BT::NodeParameters params = {{"wait_duration", "1"}};
+    return params;
   }
 };
 


### PR DESCRIPTION
The current WaitAction does not work properly because it does not accept parameter arguments from the behavior tree xml, making the duration 0 seconds. There was also a bug upon reset and startup of the recovery plugins such that the call to sleep for the duration hangs which this PR apparently fixes too. 

For reference, bt nodes which accept parameters must pass in the `BT::NodeParameters` in the constructor and implement the static method `requiredNodeParameters()`