### PR TITLE
Clear recovery plugins on cleanup

### DIFF
--- a/nav2_recoveries/src/recovery_server.cpp
+++ b/nav2_recoveries/src/recovery_server.cpp
@@ -123,6 +123,10 @@ RecoveryServer::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
     (*iter)->cleanup();
   }
 
+  recoveries_.clear();
+  transform_listener_.reset();
+  tf_.reset();
+
   return nav2_util::CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
There is a bug when cleaning up the recovery plugins in the `recoveries_server` where the plugins are cleaned up but the plugin instances are never cleared from the vector. This causes an issue when the plugins are loaded again in the `on_configure` call, since duplicate plugins are added to the vector without removing the old ones.

This PR clears the recoveries vector `on_cleanup`. For consistency with the stack, I'm also resetting the tf buffer and tf listener. 