### PR TITLE
Set init_pose yaw component in AMCL

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1214,7 +1214,7 @@ AmclNode::initOdometry()
   // When pausing and resuming, remember the last robot pose so we don't start at 0:0 again
   init_pose_[0] = last_published_pose_.pose.pose.position.x;
   init_pose_[1] = last_published_pose_.pose.pose.position.y;
-  init_pose_[2] = last_published_pose_.pose.pose.position.z;
+  init_pose_[2] = tf2::getYaw(last_published_pose_.pose.pose.orientation);
 
   if (!initial_pose_is_known_) {
     init_cov_[0] = 0.5 * 0.5;


### PR DESCRIPTION
The `init_pose` double array is intended to be for (x,y, yaw), not (x,y,z) as erroneously thought before, causing the yaw to be initialized incorrectly every time the stack was reset. This PR fixes this by setting the last known orientation. 