### PR TITLE
Enforce costmap to retain its node name

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -68,7 +68,7 @@ Costmap2DROS::Costmap2DROS(
     rclcpp::NodeOptions().arguments({
     "--ros-args", "-r", std::string("__ns:=") +
     nav2_util::add_namespaces(parent_namespace, local_namespace),
-    "--ros-args", "-r", std::string("__node:=") + name
+    "--ros-args", "-r", name + ":" + std::string("__node:=") + name
   })),
   name_(name), parent_namespace_(parent_namespace)
 {

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -65,8 +65,11 @@ Costmap2DROS::Costmap2DROS(
     // use this to make sure the node is placed on the provided namespace
     // TODO(orduno) Pass a sub-node instead of creating a new node for better handling
     //              of the namespaces
-    rclcpp::NodeOptions().arguments({"--ros-args", "-r", std::string("__ns:=") +
-      nav2_util::add_namespaces(parent_namespace, local_namespace)})),
+    rclcpp::NodeOptions().arguments({
+    "--ros-args", "-r", std::string("__ns:=") +
+    nav2_util::add_namespaces(parent_namespace, local_namespace),
+    "--ros-args", "-r", std::string("__node:=") + name
+  })),
   name_(name), parent_namespace_(parent_namespace)
 {
   RCLCPP_INFO(get_logger(), "Creating Costmap");


### PR DESCRIPTION
This PR is a fix for the global costmap node not receiving parameters from the `nav2_params.yaml`. The issue is that the launch file [mechanism to remap the node name](https://github.com/ros-planning/navigation2/blob/master/nav2_bringup/bringup/launch/nav2_navigation_launch.py#L115)  in the planner server node in the `nav2_navigation_launch.py` has a bug that also overwrites the name of the `Costmap2DROS` node that is created in its constructor. The name of the costmap node becomes 'global_costmap/planner_server', which doesn't align with the node specified in the yaml as 'global_costmap/global_costmap', thus the yaml parameters are not being set. 

This PR resolves this by adding the `__node` remapping to the node options in the costmap in order to enforce that the costmap node keeps its node name being passed via its constructor. This also fixes the full global costmap showing up in rviz since the `always_send_full_costmap` parameter is now being set to true from the yaml.

Some thoughts to consider:
- Adding the `__node` remapping argument into the `rclcpp::NodeOptions().arguments` seems to have a bug that creates a duplicate costmap when you call `ros2 node list`. This didn't seem to cause any error or problems in running the stack, but seems an issue that needs further investigation
- I originally wanted to rename the costmaps to be `/planner_server/global_costmap' and '/controller_server/local_costmap' in order to namespace them under their host node, however I found that the parameters set in the yaml weren't being set on the node. Perhaps there is a bug that doesn't allow a node name to _also_ be used as a namespace in the yaml, i.e.
```
planner_server:
  global_costmap:
    ros_parameters:
      ...
```
- One alternative solution would be to remove the node name remapping from the launch file. I'm not sure if this would be a preferred solution since we wouldn't be able to remap the planner_server name (it's default in the code is `nav2_planner` which could be changed). Please comment if you think this is preferred.
- Another alternative would be to leave the naming as is and change the params file to be:
```
global_costmap:
  planner_server:
    ros_parameters:
      ...
```
Not sure if this is preferred given the awkward naming (and the bug that made this name), though