### PR TITLE
Move scan parameters under obstacle layer namespace

### DIFF
--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -112,15 +112,15 @@ local_costmap:
       inflation_layer.cost_scaling_factor: 3.0
       obstacle_layer:
         enabled: True
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
       static_layer:
         map_subscribe_transient_local: True
       always_send_full_costmap: True
       observation_sources: scan
-      scan:
-        topic: /scan
-        max_obstacle_height: 2.0
-        clearing: True
-        marking: True
   local_costmap_client:
     ros__parameters:
       use_sim_time: True
@@ -135,15 +135,15 @@ global_costmap:
       robot_radius: 0.22
       obstacle_layer:
         enabled: True
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
       static_layer:
         map_subscribe_transient_local: True
       always_send_full_costmap: True
       observation_sources: scan
-      scan:
-        topic: /scan
-        max_obstacle_height: 2.0
-        clearing: True
-        marking: True
   global_costmap_client:
     ros__parameters:
       use_sim_time: True


### PR DESCRIPTION
The scan parameters were not being set from the yaml because the `declareParameter` was expecting the parameters to be under the 'obstacle_layer' namespace, e.g. `obstacle_layer.scan.topic'.  Therefore, the obstacle layer was never receiving scan callbacks, causing the robot to ram into obstacles since the costmap was not updated.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1208 |
---

## Description of contribution in a few bullet points
- moves parameters for the scan observations to the obstacle layer namespace in the `nav2_params.yaml`
