### PR TITLE
Fix rviz panel initialization race

### DIFF
--- a/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
@@ -76,14 +76,14 @@ LifecycleManagerClient::is_active(const std::chrono::nanoseconds timeout)
 {
   auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
 
-  RCLCPP_INFO(node_->get_logger(), "Waiting for the lifecycle_manager's %s service...",
+  RCLCPP_INFO(node_->get_logger(), "Waiting for the %s service...",
     active_service_name_.c_str());
 
   if (!is_active_client_->wait_for_service(timeout)) {
     return SystemStatus::TIMEOUT;
   }
 
-  RCLCPP_INFO(node_->get_logger(), "send_async_request (%s) to the lifecycle_manager",
+  RCLCPP_INFO(node_->get_logger(), "Sending %s request",
     active_service_name_.c_str());
   auto future_result = is_active_client_->async_send_request(request);
 
@@ -175,7 +175,7 @@ LifecycleManagerClient::callService(uint8_t command)
   auto request = std::make_shared<ManageLifecycleNodes::Request>();
   request->command = command;
 
-  RCLCPP_INFO(node_->get_logger(), "Waiting for the lifecycle_manager's %s service...",
+  RCLCPP_INFO(node_->get_logger(), "Waiting for the %s service...",
     manage_service_name_.c_str());
 
   while (!manager_client_->wait_for_service(std::chrono::seconds(1))) {
@@ -186,7 +186,7 @@ LifecycleManagerClient::callService(uint8_t command)
     RCLCPP_INFO(node_->get_logger(), "Waiting for service to appear...");
   }
 
-  RCLCPP_INFO(node_->get_logger(), "send_async_request (%s) to the lifecycle_manager",
+  RCLCPP_INFO(node_->get_logger(), "Sending %s request",
     manage_service_name_.c_str());
   auto future_result = manager_client_->async_send_request(request);
   rclcpp::spin_until_future_complete(node_, future_result);

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -35,6 +35,8 @@ class QPushButton;
 namespace nav2_rviz_plugins
 {
 
+class InitialThread;
+
 /// Panel to interface to the nav2 stack
 class Nav2Panel : public rviz_common::Panel
 {
@@ -51,6 +53,7 @@ public:
   void save(rviz_common::Config config) const override;
 
 private Q_SLOTS:
+  void startThread();
   void onStartup();
   void onShutdown();
   void onCancel();
@@ -87,6 +90,7 @@ private:
   QPushButton * pause_resume_button_{nullptr};
 
   QStateMachine state_machine_;
+  InitialThread * initial_thread_;
 
   QState * pre_initial_{nullptr};
   QState * initial_{nullptr};

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -159,10 +159,10 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   state_machine_.addState(resumed_);
 
   state_machine_.setInitialState(pre_initial_);
-  state_machine_.start();
 
   // delay starting initial thread until state machine has started or a race occurs
   QObject::connect(&state_machine_, SIGNAL(started()), this, SLOT(startThread()));
+  state_machine_.start();
 
   // Lay out the items in the panel
   QVBoxLayout * main_layout = new QVBoxLayout;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1200  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | gazebo simulation of turtlebot3 |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
This fixes the bug (#1200) where the nav2 rviz panel wasn't working with cyclonedds.

There was a race condition during initialization between:

1. the start of the state machine in the panel which tracks the state of the system and updates the buttons
2. the thread which retrieves the system status via the lifecycle_manager/is_active service. 

If the thread received a response too fast and it emitted the signal back to the state machine before the state machine had asynchronously started, the state machine didn't receive the signal at all. 

This fixes that by using the state machine's `started()` signal to then start the thread, so that the sequence is guaranteed not to race.

Also, I added a slight change to the messages that are displayed when the "is_active" is being called. It was previously redundant and confusing

---

## Future work that may be required in bullet points
NA