### PR TITLE
Update ros2_dependencies.repos

### DIFF
--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -11,11 +11,3 @@ repositories:
     type: git
     url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
     version: ros2
-  image_common:
-    type: git
-    url: https://github.com/ros-perception/image_common.git
-    version: ros2
-  vision_opencv:
-    type: git
-    url: https://github.com/ros-perception/vision_opencv.git
-    version: ros2

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -11,3 +11,7 @@ repositories:
     type: git
     url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
     version: ros2
+  vision_opencv:
+    type: git
+    url: https://github.com/ros-perception/vision_opencv.git
+    version: ros2


### PR DESCRIPTION
Remove unused dependencies image_common and vision_opencv

~~@crdelsey I think these are no longer necessary.~~
Maybe not.