### PR TITLE
Install Behavior Trees in correct location

### DIFF
--- a/nav2_bringup/bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/bringup/launch/nav2_bringup_launch.py
@@ -14,7 +14,7 @@
 
 import os
 
-from ament_index_python.packages import get_package_prefix, get_package_share_directory
+from ament_index_python.packages import get_package_share_directory
 
 from nav2_common.launch import Node
 
@@ -74,7 +74,7 @@ def generate_launch_description():
     declare_bt_xml_cmd = DeclareLaunchArgument(
         'bt_xml_file',
         default_value=os.path.join(
-            get_package_prefix('nav2_bt_navigator'),
+            get_package_share_directory('nav2_bt_navigator'),
             'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
         description='Full path to the behavior tree xml file to use')
 

--- a/nav2_bringup/bringup/launch/nav2_multi_tb3_simulation_launch.py
+++ b/nav2_bringup/bringup/launch/nav2_multi_tb3_simulation_launch.py
@@ -18,7 +18,6 @@
 
 import os
 
-from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import get_package_share_directory
 
 from nav2_common.launch import ReplaceString
@@ -76,7 +75,7 @@ def generate_launch_description():
     declare_bt_xml_cmd = DeclareLaunchArgument(
         'bt_xml_file',
         default_value=os.path.join(
-            get_package_prefix('nav2_bt_navigator'),
+            get_package_share_directory('nav2_bt_navigator'),
             'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
         description='Full path to the behavior tree xml file to use')
 

--- a/nav2_bringup/bringup/launch/nav2_navigation_launch.py
+++ b/nav2_bringup/bringup/launch/nav2_navigation_launch.py
@@ -14,7 +14,7 @@
 
 import os
 
-from ament_index_python.packages import get_package_prefix, get_package_share_directory
+from ament_index_python.packages import get_package_share_directory
 
 from nav2_common.launch import RewrittenYaml
 from nav2_common.launch import Node
@@ -85,7 +85,7 @@ def generate_launch_description():
 
         DeclareLaunchArgument(
             'bt_xml_file',
-            default_value=os.path.join(get_package_prefix('nav2_bt_navigator'),
+            default_value=os.path.join(get_package_share_directory('nav2_bt_navigator'),
                 'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
             description='Full path to the behavior tree xml file to use'),
 

--- a/nav2_bringup/bringup/launch/nav2_tb3_simulation_launch.py
+++ b/nav2_bringup/bringup/launch/nav2_tb3_simulation_launch.py
@@ -84,7 +84,7 @@ def generate_launch_description():
     declare_bt_xml_cmd = DeclareLaunchArgument(
         'bt_xml_file',
         default_value=os.path.join(
-            get_package_prefix('nav2_bt_navigator'),
+            get_package_share_directory('nav2_bt_navigator'),
             'behavior_trees', 'navigate_w_replanning_and_recovery.xml'),
         description='Full path to the behavior tree xml file to use')
 

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -69,9 +69,7 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
-install(DIRECTORY behavior_trees/
-  DESTINATION behavior_trees/
-)
+install(DIRECTORY behavior_trees DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -18,7 +18,6 @@ import os
 import sys
 
 
-from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch import LaunchService
@@ -34,7 +33,7 @@ def generate_launch_description():
     bringup_package = get_package_share_directory('nav2_bringup')
     params_file = os.path.join(bringup_package, 'params/nav2_params.yaml')
     astar = (os.getenv('ASTAR').lower() == 'true')
-    bt_navigator_install_path = get_package_prefix('nav2_bt_navigator')
+    bt_navigator_install_path = get_package_share_directory('nav2_bt_navigator')
     bt_navigator_xml = os.path.join(bt_navigator_install_path,
                                     'behavior_trees',
                                     os.getenv('BT_NAVIGATOR_XML'))


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #1090 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | TB 3 in Gazebo |

---

## Description of contribution in a few bullet points

* Install behavior trees in `/opt/ros/dashing/share/nav2_bt_navigator/behavior_trees` instead of `/opt/ros/dashing/behavior_trees`