### PR TITLE
Dashing Slam fix

### DIFF
--- a/nav2_bringup/launch/nav2_navigation_launch.py
+++ b/nav2_bringup/launch/nav2_navigation_launch.py
@@ -36,7 +36,6 @@ def generate_launch_description():
         'use_sim_time': use_sim_time,
         'bt_xml_filename': bt_xml_file,
         'autostart': autostart,
-        'map_subscribe_transient_local': 'False'
     }
 
     configured_params = RewrittenYaml(

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -139,6 +139,7 @@ StaticLayer::getParameters()
 
   // Enforce bounds
   lethal_threshold_ = std::max(std::min(temp_lethal_threshold, 100), 0);
+  map_received_ = false;
 }
 
 void
@@ -241,6 +242,9 @@ StaticLayer::incomingMap(const nav_msgs::msg::OccupancyGrid::SharedPtr new_map)
 {
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   processMap(*new_map);
+  if (!map_received_) {
+    map_received_ = true;
+  }
 }
 
 void


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info
The upstream ros2/cartographer changed to use transient_local, so now we can use transient local in the nav2_navigation_launch.py 

Also, during back-port of the previous change, another change was needed to set the "map_received" flag to true in the static layer after it is received. This change was already existing in the master branch, but not backported.

IF it's not too late, we should release these changes with the newest release (0.2.5 -> 0.2.6)
