### PR TITLE
Migrate to Behavior Tree V3.

### DIFF
--- a/nav2_behavior_tree/CMakeLists.txt
+++ b/nav2_behavior_tree/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
-find_package(behaviortree_cpp REQUIRED)
+find_package(behaviortree_cpp_v3 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -38,7 +38,7 @@ set(dependencies
   geometry_msgs
   nav2_msgs
   nav_msgs
-  behaviortree_cpp
+  behaviortree_cpp_v3
   tf2
   tf2_ros
   tf2_geometry_msgs

--- a/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
@@ -28,10 +28,10 @@ namespace nav2_behavior_tree
 class BackUpAction : public BtActionNode<nav2_msgs::action::BackUp>
 {
 public:
-  explicit BackUpAction(
+  BackUpAction(
     const std::string & action_name,
-    const BT::NodeConfiguration & params)
-  : BtActionNode<nav2_msgs::action::BackUp>(action_name, params)
+    const BT::NodeConfiguration & conf)
+  : BtActionNode<nav2_msgs::action::BackUp>(action_name, conf)
   {
     double dist;
     getInput("backup_dist", dist);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
@@ -30,7 +30,7 @@ class BackUpAction : public BtActionNode<nav2_msgs::action::BackUp>
 public:
   explicit BackUpAction(
     const std::string & action_name,
-    const BT::NodeParameters & params)
+    const BT::NodeConfiguration & params)
   : BtActionNode<nav2_msgs::action::BackUp>(action_name, params)
   {
   }
@@ -38,9 +38,9 @@ public:
   void on_init() override
   {
     double dist;
-    getParam<double>("backup_dist", dist);
+    getInput<double>("backup_dist", dist);
     double speed;
-    getParam<double>("backup_speed", speed);
+    getInput<double>("backup_speed", speed);
 
     // silently fix, vector direction determined by distance sign
     if (speed < 0.0) {
@@ -54,11 +54,12 @@ public:
     goal_.speed = speed;
   }
 
-  static const BT::NodeParameters & requiredNodeParameters()
+  static BT::PortsList providedPorts()
   {
-    static BT::NodeParameters params = {
-      {"backup_dist", "-0.15"}, {"backup_speed", "0.025"}};
-    return params;
+    return {
+      BT::InputPort<double>("backup_dist", -0.15, "Distance to backup"),
+      BT::InputPort<double>("backup_speed", 0.025, "Speed at which to backup")
+    };
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
@@ -33,14 +33,10 @@ public:
     const BT::NodeConfiguration & params)
   : BtActionNode<nav2_msgs::action::BackUp>(action_name, params)
   {
-  }
-
-  void on_init() override
-  {
     double dist;
-    getInput<double>("backup_dist", dist);
+    getInput("backup_dist", dist);
     double speed;
-    getInput<double>("backup_speed", speed);
+    getInput("backup_speed", speed);
 
     // silently fix, vector direction determined by distance sign
     if (speed < 0.0) {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
@@ -46,7 +46,9 @@ public:
     std::function<bool()> cancelRequested,
     std::chrono::milliseconds loopTimeout = std::chrono::milliseconds(10));
 
-  BT::Tree buildTreeFromText(std::string & xml_string, BT::Blackboard::Ptr blackboard);
+  BT::Tree buildTreeFromText(
+    const std::string & xml_string,
+    BT::Blackboard::Ptr blackboard);
 
   void haltAllActions(BT::TreeNode * root_node)
   {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
@@ -19,7 +19,6 @@
 #include <string>
 
 #include "behaviortree_cpp/behavior_tree.h"
-#include "behaviortree_cpp/blackboard/blackboard_local.h"
 #include "behaviortree_cpp/bt_factory.h"
 #include "behaviortree_cpp/xml_parsing.h"
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -29,48 +29,16 @@ template<class ActionT>
 class BtActionNode : public BT::CoroActionNode
 {
 public:
-  explicit BtActionNode(const std::string & action_name)
-  : BT::CoroActionNode(action_name), action_name_(action_name)
-  {
-  }
-
-  BtActionNode(const std::string & action_name, const BT::NodeParameters & params)
+  BtActionNode(const std::string & action_name, const BT::NodeConfiguration & params)
   : BT::CoroActionNode(action_name, params), action_name_(action_name)
   {
+    init();
   }
 
   BtActionNode() = delete;
 
   virtual ~BtActionNode()
   {
-  }
-
-  // This is a callback from the BT library invoked after the node is created and after the
-  // blackboard has been set for the node by the library. It is the first opportunity for
-  // the node to access the blackboard. Derived classes do not override this method,
-  // but override on_init instead.
-  void onInit() final
-  {
-    node_ = blackboard()->template get<rclcpp::Node::SharedPtr>("node");
-
-    // Initialize the input and output messages
-    goal_ = typename ActionT::Goal();
-    result_ = typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult();
-
-    // Get the required items from the blackboard
-    node_loop_timeout_ =
-      blackboard()->template get<std::chrono::milliseconds>("node_loop_timeout");
-
-    // Now that we have the ROS node to use, create the action client for this BT action
-    action_client_ = rclcpp_action::create_client<ActionT>(node_, action_name_);
-
-    // Make sure the server is actually there before continuing
-    RCLCPP_INFO(node_->get_logger(), "Waiting for \"%s\" action server", action_name_.c_str());
-    action_client_->wait_for_action_server();
-
-    // Give the derive class a chance to do any initialization
-    on_init();
-    RCLCPP_INFO(node_->get_logger(), "\"%s\" BtActionNode initialized", action_name_.c_str());
   }
 
   // Derived classes can override any of the following methods to hook into the
@@ -180,6 +148,30 @@ new_goal_received:
   }
 
 protected:
+  void init()
+  {
+    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+
+    // Initialize the input and output messages
+    goal_ = typename ActionT::Goal();
+    result_ = typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult();
+
+    // Get the required items from the blackboard
+    node_loop_timeout_ =
+      config().blackboard->get<std::chrono::milliseconds>("node_loop_timeout");
+
+    // Now that we have the ROS node to use, create the action client for this BT action
+    action_client_ = rclcpp_action::create_client<ActionT>(node_, action_name_);
+
+    // Make sure the server is actually there before continuing
+    RCLCPP_INFO(node_->get_logger(), "Waiting for \"%s\" action server", action_name_.c_str());
+    action_client_->wait_for_action_server();
+
+    // Give the derive class a chance to do any initialization
+    on_init();
+    RCLCPP_INFO(node_->get_logger(), "\"%s\" BtActionNode initialized", action_name_.c_str());
+  }
+
   bool should_cancel_goal()
   {
     // Shut the node down if it is currently running

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -42,12 +42,7 @@ public:
   }
 
   // Derived classes can override any of the following methods to hook into the
-  // processing for the action: on_init, on_tick, on_loop_timeout, and on_success
-
-  // Perform any local initialization such as getting values from the blackboard
-  virtual void on_init()
-  {
-  }
+  // processing for the action: on_tick, on_loop_timeout, and on_success
 
   // Could do dynamic checks, such as getting updates to values on the blackboard
   virtual void on_tick()
@@ -168,7 +163,6 @@ protected:
     action_client_->wait_for_action_server();
 
     // Give the derive class a chance to do any initialization
-    on_init();
     RCLCPP_INFO(node_->get_logger(), "\"%s\" BtActionNode initialized", action_name_.c_str());
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_conversions.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_conversions.hpp
@@ -27,7 +27,7 @@ namespace BT
 // data type.
 
 template<>
-inline geometry_msgs::msg::Point convertFromString(const StringView & key)
+inline geometry_msgs::msg::Point convertFromString(const StringView key)
 {
   // three real numbers separated by semicolons
   auto parts = BT::splitString(key, ';');
@@ -43,7 +43,7 @@ inline geometry_msgs::msg::Point convertFromString(const StringView & key)
 }
 
 template<>
-inline geometry_msgs::msg::Quaternion convertFromString(const StringView & key)
+inline geometry_msgs::msg::Quaternion convertFromString(const StringView key)
 {
   // three real numbers separated by semicolons
   auto parts = BT::splitString(key, ';');

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -31,9 +31,10 @@ class BtServiceNode : public BT::CoroActionNode
 public:
   BtServiceNode(
     const std::string & service_node_name,
-    const BT::NodeParameters & params)
+    const BT::NodeConfiguration & params)
   : BT::CoroActionNode(service_node_name, params), service_node_name_(service_node_name)
   {
+    init();
   }
 
   BtServiceNode() = delete;
@@ -43,11 +44,11 @@ public:
   }
 
   // Any BT node that accepts parameters must provide a requiredNodeParameters method
-  static const BT::NodeParameters & requiredNodeParameters()
+  static BT::PortsList providedPorts()
   {
-    static BT::NodeParameters params = {{"service_name",
-      "please_set_service_name_in_BT_Node"}};
-    return params;
+    return {
+      BT::InputPort<std::string>("service_name", "please_set_service_name_in_BT_Node")
+    };
   }
 
   // This is a callback from the BT library invoked after the node
@@ -55,13 +56,13 @@ public:
   // by the library. It is the first opportunity for the node to
   // access the blackboard. Derived classes do not override this method,
   // but override on_init instead.
-  void onInit() final
+  void init()
   {
-    node_ = blackboard()->template get<rclcpp::Node::SharedPtr>("node");
+    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
 
     // Get the required items from the blackboard
     node_loop_timeout_ =
-      blackboard()->template get<std::chrono::milliseconds>("node_loop_timeout");
+      config().blackboard->get<std::chrono::milliseconds>("node_loop_timeout");
 
     // Now that we have node_ to use, create the service client for this BT service
     service_client_ = node_->create_client<ServiceT>(service_name_);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -34,6 +34,7 @@ public:
     const BT::NodeConfiguration & params)
   : BT::CoroActionNode(service_node_name, params), service_node_name_(service_node_name)
   {
+    getInput("service_name", service_name_);
     init();
   }
 
@@ -54,8 +55,7 @@ public:
   // This is a callback from the BT library invoked after the node
   // is created and after the blackboard has been set for the node
   // by the library. It is the first opportunity for the node to
-  // access the blackboard. Derived classes do not override this method,
-  // but override on_init instead.
+  // access the blackboard.
   void init()
   {
     node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
@@ -75,8 +75,6 @@ public:
     RCLCPP_INFO(node_->get_logger(), "\"%s\" BtServiceNode initialized",
       service_node_name_.c_str());
 
-    // Give user a chance for initialization and get the service name
-    on_init();
   }
 
   // The main override required by a BT service
@@ -99,11 +97,6 @@ public:
   virtual void on_tick()
   {
     request_ = std::make_shared<typename ServiceT::Request>();
-  }
-
-  // Perform local initialization such as getting values from the blackboard
-  virtual void on_init()
-  {
   }
 
 protected:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/clear_costmap_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/clear_costmap_service.hpp
@@ -28,13 +28,12 @@ namespace nav2_behavior_tree
 class ClearEntireCostmapService : public BtServiceNode<nav2_msgs::srv::ClearEntireCostmap>
 {
 public:
-  explicit ClearEntireCostmapService(
+  ClearEntireCostmapService(
     const std::string & service_node_name,
-    const BT::NodeConfiguration & params)
-  : BtServiceNode<nav2_msgs::srv::ClearEntireCostmap>(service_node_name, params)
+    const BT::NodeConfiguration & conf)
+  : BtServiceNode<nav2_msgs::srv::ClearEntireCostmap>(service_node_name, conf)
   {
   }
-
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/clear_costmap_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/clear_costmap_service.hpp
@@ -33,12 +33,8 @@ public:
     const BT::NodeConfiguration & params)
   : BtServiceNode<nav2_msgs::srv::ClearEntireCostmap>(service_node_name, params)
   {
-    getInput<std::string>("service_name", service_name_);
   }
 
-  void on_init() override
-  {
-  }
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/clear_costmap_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/clear_costmap_service.hpp
@@ -30,10 +30,10 @@ class ClearEntireCostmapService : public BtServiceNode<nav2_msgs::srv::ClearEnti
 public:
   explicit ClearEntireCostmapService(
     const std::string & service_node_name,
-    const BT::NodeParameters & params)
+    const BT::NodeConfiguration & params)
   : BtServiceNode<nav2_msgs::srv::ClearEntireCostmap>(service_node_name, params)
   {
-    getParam<std::string>("service_name", service_name_);
+    getInput<std::string>("service_name", service_name_);
   }
 
   void on_init() override

--- a/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
@@ -37,12 +37,12 @@ public:
 
   void on_tick() override
   {
-    goal_.pose = *(config().blackboard->get<geometry_msgs::msg::PoseStamped::SharedPtr>("goal"));
+    getInput("goal", goal_.pose);
   }
 
   void on_success() override
   {
-    *(config().blackboard->get<nav_msgs::msg::Path::SharedPtr>("path")) = result_.result->path;
+    setOutput("path", result_.result->path );
 
     if (first_time_) {
       first_time_ = false;
@@ -53,7 +53,10 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return {};
+    return {
+      BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputePathToPose node"),
+      BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination to plan to")
+    };
   }
 
 private:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
@@ -30,8 +30,8 @@ class ComputePathToPoseAction : public BtActionNode<nav2_msgs::action::ComputePa
 public:
   ComputePathToPoseAction(
     const std::string & action_name,
-    const BT::NodeConfiguration & params)
-  : BtActionNode<nav2_msgs::action::ComputePathToPose>(action_name, params)
+    const BT::NodeConfiguration & conf)
+  : BtActionNode<nav2_msgs::action::ComputePathToPose>(action_name, conf)
   {
   }
 
@@ -42,7 +42,7 @@ public:
 
   void on_success() override
   {
-    setOutput("path", result_.result->path );
+    setOutput("path", result_.result->path);
 
     if (first_time_) {
       first_time_ = false;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
@@ -47,7 +47,7 @@ public:
     if (first_time_) {
       first_time_ = false;
     } else {
-      config().blackboard->set<bool>("path_updated", true);  // NOLINT
+      config().blackboard->set("path_updated", true);
     }
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
@@ -28,25 +28,32 @@ namespace nav2_behavior_tree
 class ComputePathToPoseAction : public BtActionNode<nav2_msgs::action::ComputePathToPose>
 {
 public:
-  explicit ComputePathToPoseAction(const std::string & action_name)
-  : BtActionNode<nav2_msgs::action::ComputePathToPose>(action_name)
+  ComputePathToPoseAction(
+    const std::string & action_name,
+    const BT::NodeConfiguration & params)
+  : BtActionNode<nav2_msgs::action::ComputePathToPose>(action_name, params)
   {
   }
 
   void on_tick() override
   {
-    goal_.pose = *(blackboard()->get<geometry_msgs::msg::PoseStamped::SharedPtr>("goal"));
+    goal_.pose = *(config().blackboard->get<geometry_msgs::msg::PoseStamped::SharedPtr>("goal"));
   }
 
   void on_success() override
   {
-    *(blackboard()->get<nav_msgs::msg::Path::SharedPtr>("path")) = result_.result->path;
+    *(config().blackboard->get<nav_msgs::msg::Path::SharedPtr>("path")) = result_.result->path;
 
     if (first_time_) {
       first_time_ = false;
     } else {
-      blackboard()->set<bool>("path_updated", true);  // NOLINT
+      config().blackboard->set<bool>("path_updated", true);  // NOLINT
     }
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {};
   }
 
 private:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
@@ -32,16 +32,12 @@ public:
     const BT::NodeConfiguration & params)
   : BtActionNode<nav2_msgs::action::FollowPath>(action_name, params)
   {
-  }
-
-  void on_init() override
-  {
     config().blackboard->set<bool>("path_updated", false);
   }
 
   void on_tick() override
   {
-    goal_.path = *(config().blackboard->get<nav_msgs::msg::Path::SharedPtr>("path"));
+    getInput("path", goal_.path);
   }
 
   void on_loop_timeout() override
@@ -53,14 +49,16 @@ public:
 
       // Grab the new goal and set the flag so that we send the new goal to
       // the action server on the next loop iteration
-      goal_.path = *(config().blackboard->get<nav_msgs::msg::Path::SharedPtr>("path"));
+      getInput("path", goal_.path);
       goal_updated_ = true;
     }
   }
 
   static BT::PortsList providedPorts()
   {
-    return {};
+    return {
+      BT::InputPort<nav_msgs::msg::Path>("path", "Path to follow"),
+    };
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
@@ -29,8 +29,8 @@ class FollowPathAction : public BtActionNode<nav2_msgs::action::FollowPath>
 public:
   FollowPathAction(
     const std::string & action_name,
-    const BT::NodeConfiguration & params)
-  : BtActionNode<nav2_msgs::action::FollowPath>(action_name, params)
+    const BT::NodeConfiguration & conf)
+  : BtActionNode<nav2_msgs::action::FollowPath>(action_name, conf)
   {
     config().blackboard->set<bool>("path_updated", false);
   }

--- a/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
@@ -32,7 +32,7 @@ public:
     const BT::NodeConfiguration & conf)
   : BtActionNode<nav2_msgs::action::FollowPath>(action_name, conf)
   {
-    config().blackboard->set<bool>("path_updated", false);
+    config().blackboard->set("path_updated", false);
   }
 
   void on_tick() override
@@ -45,7 +45,7 @@ public:
     // Check if the goal has been updated
     if (config().blackboard->get<bool>("path_updated")) {
       // Reset the flag in the blackboard
-      config().blackboard->set<bool>("path_updated", false);  // NOLINT
+      config().blackboard->set("path_updated", false);
 
       // Grab the new goal and set the flag so that we send the new goal to
       // the action server on the next loop iteration

--- a/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
@@ -27,33 +27,40 @@ namespace nav2_behavior_tree
 class FollowPathAction : public BtActionNode<nav2_msgs::action::FollowPath>
 {
 public:
-  explicit FollowPathAction(const std::string & action_name)
-  : BtActionNode<nav2_msgs::action::FollowPath>(action_name)
+  FollowPathAction(
+    const std::string & action_name,
+    const BT::NodeConfiguration & params)
+  : BtActionNode<nav2_msgs::action::FollowPath>(action_name, params)
   {
   }
 
   void on_init() override
   {
-    blackboard()->set<bool>("path_updated", false);
+    config().blackboard->set<bool>("path_updated", false);
   }
 
   void on_tick() override
   {
-    goal_.path = *(blackboard()->get<nav_msgs::msg::Path::SharedPtr>("path"));
+    goal_.path = *(config().blackboard->get<nav_msgs::msg::Path::SharedPtr>("path"));
   }
 
   void on_loop_timeout() override
   {
     // Check if the goal has been updated
-    if (blackboard()->get<bool>("path_updated")) {
+    if (config().blackboard->get<bool>("path_updated")) {
       // Reset the flag in the blackboard
-      blackboard()->set<bool>("path_updated", false);  // NOLINT
+      config().blackboard->set<bool>("path_updated", false);  // NOLINT
 
       // Grab the new goal and set the flag so that we send the new goal to
       // the action server on the next loop iteration
-      goal_.path = *(blackboard()->get<nav_msgs::msg::Path::SharedPtr>("path"));
+      goal_.path = *(config().blackboard->get<nav_msgs::msg::Path::SharedPtr>("path"));
       goal_updated_ = true;
     }
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {};
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/goal_reached_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/goal_reached_condition.hpp
@@ -30,10 +30,10 @@ namespace nav2_behavior_tree
 class GoalReachedCondition : public BT::ConditionNode
 {
 public:
-  explicit GoalReachedCondition(
+  GoalReachedCondition(
     const std::string & condition_name,
-    const BT::NodeConfiguration & config)
-  : BT::ConditionNode(condition_name, config), initialized_(false)
+    const BT::NodeConfiguration & conf)
+  : BT::ConditionNode(condition_name, conf), initialized_(false)
   {
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/goal_reached_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/goal_reached_condition.hpp
@@ -30,8 +30,10 @@ namespace nav2_behavior_tree
 class GoalReachedCondition : public BT::ConditionNode
 {
 public:
-  explicit GoalReachedCondition(const std::string & condition_name)
-  : BT::ConditionNode(condition_name), initialized_(false)
+  explicit GoalReachedCondition(
+    const std::string & condition_name,
+    const BT::NodeConfiguration & config)
+  : BT::ConditionNode(condition_name, config), initialized_(false)
   {
   }
 
@@ -56,9 +58,9 @@ public:
 
   void initialize()
   {
-    node_ = blackboard()->template get<rclcpp::Node::SharedPtr>("node");
+    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
     node_->get_parameter_or<double>("goal_reached_tol", goal_reached_tol_, 0.25);
-    tf_ = blackboard()->template get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
+    tf_ = config().blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
 
     initialized_ = true;
   }
@@ -73,7 +75,7 @@ public:
       return false;
     }
     // TODO(mhpanah): replace this with a function
-    blackboard()->get<geometry_msgs::msg::PoseStamped::SharedPtr>("goal", goal_);
+    config().blackboard->get<geometry_msgs::msg::PoseStamped::SharedPtr>("goal", goal_);
     double dx = goal_->pose.position.x - current_pose.pose.position.x;
     double dy = goal_->pose.position.y - current_pose.pose.position.y;
 
@@ -83,6 +85,8 @@ public:
       return false;
     }
   }
+
+  static BT::PortsList providedPorts() {return {};}
 
 protected:
   void cleanup()

--- a/nav2_behavior_tree/include/nav2_behavior_tree/goal_reached_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/goal_reached_condition.hpp
@@ -74,10 +74,11 @@ public:
       RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
       return false;
     }
-    // TODO(mhpanah): replace this with a function
-    config().blackboard->get<geometry_msgs::msg::PoseStamped::SharedPtr>("goal", goal_);
-    double dx = goal_->pose.position.x - current_pose.pose.position.x;
-    double dy = goal_->pose.position.y - current_pose.pose.position.y;
+
+    geometry_msgs::msg::PoseStamped goal;
+    getInput("goal", goal);
+    double dx = goal.pose.position.x - current_pose.pose.position.x;
+    double dy = goal.pose.position.y - current_pose.pose.position.y;
 
     if ( (dx * dx + dy * dy) <= (goal_reached_tol_ * goal_reached_tol_) ) {
       return true;
@@ -86,7 +87,12 @@ public:
     }
   }
 
-  static BT::PortsList providedPorts() {return {};}
+  static BT::PortsList providedPorts()
+  {
+    return {
+      BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination")
+    };
+  }
 
 protected:
   void cleanup()
@@ -96,7 +102,6 @@ protected:
 private:
   rclcpp::Node::SharedPtr node_;
   std::shared_ptr<tf2_ros::Buffer> tf_;
-  geometry_msgs::msg::PoseStamped::SharedPtr goal_;
 
   bool initialized_;
   double goal_reached_tol_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/is_stuck_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/is_stuck_condition.hpp
@@ -34,13 +34,16 @@ namespace nav2_behavior_tree
 class IsStuckCondition : public BT::ConditionNode
 {
 public:
-  explicit IsStuckCondition(const std::string & condition_name)
-  : BT::ConditionNode(condition_name),
+  explicit IsStuckCondition(
+    const std::string & condition_name,
+    const BT::NodeConfiguration & config)
+  : BT::ConditionNode(condition_name, config),
     is_stuck_(false),
     odom_history_size_(10),
     current_accel_(0.0),
     brake_accel_limit_(-10.0)
   {
+    init();
   }
 
   IsStuckCondition() = delete;
@@ -50,9 +53,9 @@ public:
     RCLCPP_DEBUG(node_->get_logger(), "Shutting down IsStuckCondition BT node");
   }
 
-  void onInit() override
+  void init()
   {
-    node_ = blackboard()->template get<rclcpp::Node::SharedPtr>("node");
+    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
 
     odom_sub_ = node_->create_subscription<nav_msgs::msg::Odometry>("odom",
         rclcpp::SystemDefaultsQoS(),
@@ -145,9 +148,7 @@ public:
     return false;
   }
 
-  void halt() override
-  {
-  }
+  static BT::PortsList providedPorts() {return {};}
 
 private:
   // The node that will be used for any ROS operations

--- a/nav2_behavior_tree/include/nav2_behavior_tree/is_stuck_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/is_stuck_condition.hpp
@@ -34,26 +34,14 @@ namespace nav2_behavior_tree
 class IsStuckCondition : public BT::ConditionNode
 {
 public:
-  explicit IsStuckCondition(
+  IsStuckCondition(
     const std::string & condition_name,
-    const BT::NodeConfiguration & config)
-  : BT::ConditionNode(condition_name, config),
+    const BT::NodeConfiguration & conf)
+  : BT::ConditionNode(condition_name, conf),
     is_stuck_(false),
     odom_history_size_(10),
     current_accel_(0.0),
     brake_accel_limit_(-10.0)
-  {
-    init();
-  }
-
-  IsStuckCondition() = delete;
-
-  ~IsStuckCondition()
-  {
-    RCLCPP_DEBUG(node_->get_logger(), "Shutting down IsStuckCondition BT node");
-  }
-
-  void init()
   {
     node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
 
@@ -64,6 +52,13 @@ public:
     RCLCPP_DEBUG(node_->get_logger(), "Initialized an IsStuckCondition BT node");
 
     RCLCPP_INFO_ONCE(node_->get_logger(), "Waiting on odometry");
+  }
+
+  IsStuckCondition() = delete;
+
+  ~IsStuckCondition()
+  {
+    RCLCPP_DEBUG(node_->get_logger(), "Shutting down IsStuckCondition BT node");
   }
 
   void onOdomReceived(const typename nav_msgs::msg::Odometry::SharedPtr msg)

--- a/nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp
@@ -41,8 +41,8 @@ public:
     geometry_msgs::msg::Point position;
     geometry_msgs::msg::Quaternion orientation;
 
-    bool have_position = getInput<geometry_msgs::msg::Point>("position", position);
-    bool have_orientation = getInput<geometry_msgs::msg::Quaternion>("orientation", orientation);
+    bool have_position = getInput("position", position);
+    bool have_orientation = getInput("orientation", orientation);
 
     if (!have_position || !have_orientation) {
       RCLCPP_ERROR(node_->get_logger(),

--- a/nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp
@@ -30,7 +30,7 @@ namespace nav2_behavior_tree
 class NavigateToPoseAction : public BtActionNode<nav2_msgs::action::NavigateToPose>
 {
 public:
-  NavigateToPoseAction(const std::string & action_name, const BT::NodeParameters & params)
+  NavigateToPoseAction(const std::string & action_name, const BT::NodeConfiguration & params)
   : BtActionNode<nav2_msgs::action::NavigateToPose>(action_name, params)
   {
   }
@@ -41,8 +41,8 @@ public:
     geometry_msgs::msg::Point position;
     geometry_msgs::msg::Quaternion orientation;
 
-    bool have_position = getParam<geometry_msgs::msg::Point>("position", position);
-    bool have_orientation = getParam<geometry_msgs::msg::Quaternion>("orientation", orientation);
+    bool have_position = getInput<geometry_msgs::msg::Point>("position", position);
+    bool have_orientation = getInput<geometry_msgs::msg::Quaternion>("orientation", orientation);
 
     if (!have_position || !have_orientation) {
       RCLCPP_ERROR(node_->get_logger(),
@@ -54,10 +54,12 @@ public:
   }
 
   // Any BT node that accepts parameters must provide a requiredNodeParameters method
-  static const BT::NodeParameters & requiredNodeParameters()
+  static BT::PortsList providedPorts()
   {
-    static BT::NodeParameters params = {{"position", "0;0;0"}, {"orientation", "0;0;0;0"}};
-    return params;
+    return {
+      BT::InputPort<geometry_msgs::msg::Point>("position", "0;0;0", "Position"),
+      BT::InputPort<geometry_msgs::msg::Quaternion>("orientation", "0;0;0;0", "Orientation")
+    };
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp
@@ -30,8 +30,10 @@ namespace nav2_behavior_tree
 class NavigateToPoseAction : public BtActionNode<nav2_msgs::action::NavigateToPose>
 {
 public:
-  NavigateToPoseAction(const std::string & action_name, const BT::NodeConfiguration & params)
-  : BtActionNode<nav2_msgs::action::NavigateToPose>(action_name, params)
+  NavigateToPoseAction(
+    const std::string & action_name,
+    const BT::NodeConfiguration & conf)
+  : BtActionNode<nav2_msgs::action::NavigateToPose>(action_name, conf)
   {
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/rate_controller_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/rate_controller_node.hpp
@@ -26,8 +26,10 @@ namespace nav2_behavior_tree
 class RateController : public BT::DecoratorNode
 {
 public:
-  RateController(const std::string & name, const BT::NodeConfiguration & params)
-  : BT::DecoratorNode(name, params)
+  RateController(
+    const std::string & name,
+    const BT::NodeConfiguration & conf)
+  : BT::DecoratorNode(name, conf)
   {
     double hz = 1.0;
     getInput("hz", hz);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/rate_controller_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/rate_controller_node.hpp
@@ -30,7 +30,7 @@ public:
   : BT::DecoratorNode(name, params)
   {
     double hz = 1.0;
-    getInput<double>("hz", hz);
+    getInput("hz", hz);
     period_ = 1.0 / hz;
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/rate_controller_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/rate_controller_node.hpp
@@ -26,19 +26,20 @@ namespace nav2_behavior_tree
 class RateController : public BT::DecoratorNode
 {
 public:
-  RateController(const std::string & name, const BT::NodeParameters & params)
+  RateController(const std::string & name, const BT::NodeConfiguration & params)
   : BT::DecoratorNode(name, params)
   {
     double hz = 1.0;
-    getParam<double>("hz", hz);
+    getInput<double>("hz", hz);
     period_ = 1.0 / hz;
   }
 
   // Any BT node that accepts parameters must provide a requiredNodeParameters method
-  static const BT::NodeParameters & requiredNodeParameters()
+  static BT::PortsList providedPorts()
   {
-    static BT::NodeParameters params = {{"hz", "10"}};
-    return params;
+    return {
+      BT::InputPort<double>("hz", 10.0, "Rate")
+    };
   }
 
 private:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/recovery_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/recovery_node.hpp
@@ -35,15 +35,16 @@ namespace nav2_behavior_tree
 class RecoveryNode : public BT::ControlNode
 {
 public:
-  RecoveryNode(const std::string & name, const BT::NodeParameters & params);
+  RecoveryNode(const std::string & name, const BT::NodeConfiguration & params);
 
   ~RecoveryNode() override = default;
 
   // Any BT node that accepts parameters must provide a requiredNodeParameters method
-  static const BT::NodeParameters & requiredNodeParameters()
+  static BT::PortsList providedPorts()
   {
-    static BT::NodeParameters params = {{"number_of_retries", "1"}};
-    return params;
+    return {
+      BT::InputPort<int>("number_of_retries", 1, "Number of retries")
+    };
   }
 
 private:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/recovery_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/recovery_node.hpp
@@ -35,7 +35,7 @@ namespace nav2_behavior_tree
 class RecoveryNode : public BT::ControlNode
 {
 public:
-  RecoveryNode(const std::string & name, const BT::NodeConfiguration & params);
+  RecoveryNode(const std::string & name, const BT::NodeConfiguration & conf);
 
   ~RecoveryNode() override = default;
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/reinitialize_global_localization_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/reinitialize_global_localization_service.hpp
@@ -30,11 +30,11 @@ class ReinitializeGlobalLocalizationService : public BtServiceNode<std_srvs::srv
 public:
   explicit ReinitializeGlobalLocalizationService(
     const std::string & service_node_name,
-    const BT::NodeParameters & params)
+    const BT::NodeConfiguration & params)
   : BtServiceNode<std_srvs::srv::Empty>(service_node_name, params)
   {
     // default should be reinitialize_global_localization
-    getParam<std::string>("service_name", service_name_);
+    getInput<std::string>("service_name", service_name_);
   }
 
   void on_init() override

--- a/nav2_behavior_tree/include/nav2_behavior_tree/reinitialize_global_localization_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/reinitialize_global_localization_service.hpp
@@ -33,12 +33,6 @@ public:
     const BT::NodeConfiguration & params)
   : BtServiceNode<std_srvs::srv::Empty>(service_node_name, params)
   {
-    // default should be reinitialize_global_localization
-    getInput<std::string>("service_name", service_name_);
-  }
-
-  void on_init() override
-  {
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/reinitialize_global_localization_service.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/reinitialize_global_localization_service.hpp
@@ -28,10 +28,10 @@ namespace nav2_behavior_tree
 class ReinitializeGlobalLocalizationService : public BtServiceNode<std_srvs::srv::Empty>
 {
 public:
-  explicit ReinitializeGlobalLocalizationService(
+  ReinitializeGlobalLocalizationService(
     const std::string & service_node_name,
-    const BT::NodeConfiguration & params)
-  : BtServiceNode<std_srvs::srv::Empty>(service_node_name, params)
+    const BT::NodeConfiguration & conf)
+  : BtServiceNode<std_srvs::srv::Empty>(service_node_name, conf)
   {
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
@@ -31,10 +31,10 @@ namespace nav2_behavior_tree
 class SpinAction : public BtActionNode<nav2_msgs::action::Spin>
 {
 public:
-  explicit SpinAction(
+  SpinAction(
     const std::string & action_name,
-    const BT::NodeConfiguration & params)
-  : BtActionNode<nav2_msgs::action::Spin>(action_name, params)
+    const BT::NodeConfiguration & conf)
+  : BtActionNode<nav2_msgs::action::Spin>(action_name, conf)
   {
     double dist;
     getInput("spin_dist", dist);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
@@ -33,7 +33,7 @@ class SpinAction : public BtActionNode<nav2_msgs::action::Spin>
 public:
   explicit SpinAction(
     const std::string & action_name,
-    const BT::NodeParameters & params)
+    const BT::NodeConfiguration & params)
   : BtActionNode<nav2_msgs::action::Spin>(action_name, params)
   {
   }
@@ -41,14 +41,15 @@ public:
   void on_init() override
   {
     double dist;
-    getParam<double>("spin_dist", dist);
+    getInput<double>("spin_dist", dist);
     goal_.target_yaw = dist;
   }
 
-  static const BT::NodeParameters & requiredNodeParameters()
+  static BT::PortsList providedPorts()
   {
-    static BT::NodeParameters params = {{"spin_dist", "1.57"}};
-    return params;
+    return {
+      BT::InputPort<double>("spin_dist", 1.57, "Spin distance")
+    };
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
@@ -36,12 +36,8 @@ public:
     const BT::NodeConfiguration & params)
   : BtActionNode<nav2_msgs::action::Spin>(action_name, params)
   {
-  }
-
-  void on_init() override
-  {
     double dist;
-    getInput<double>("spin_dist", dist);
+    getInput("spin_dist", dist);
     goal_.target_yaw = dist;
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
@@ -31,12 +31,8 @@ public:
   explicit WaitAction(const std::string & action_name, const BT::NodeConfiguration & params)
   : BtActionNode<nav2_msgs::action::Wait>(action_name, params)
   {
-  }
-
-  void on_init() override
-  {
     int duration;
-    getInput<int>("wait_duration", duration);
+    getInput("wait_duration", duration);
     if (duration <= 0) {
       RCLCPP_WARN(node_->get_logger(), "Wait duration is negative or zero "
         "(%i). Setting to positive.", duration);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
@@ -28,8 +28,10 @@ namespace nav2_behavior_tree
 class WaitAction : public BtActionNode<nav2_msgs::action::Wait>
 {
 public:
-  explicit WaitAction(const std::string & action_name, const BT::NodeConfiguration & params)
-  : BtActionNode<nav2_msgs::action::Wait>(action_name, params)
+  WaitAction(
+    const std::string & action_name,
+    const BT::NodeConfiguration & conf)
+  : BtActionNode<nav2_msgs::action::Wait>(action_name, conf)
   {
     int duration;
     getInput("wait_duration", duration);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
@@ -28,7 +28,7 @@ namespace nav2_behavior_tree
 class WaitAction : public BtActionNode<nav2_msgs::action::Wait>
 {
 public:
-  explicit WaitAction(const std::string & action_name, const BT::NodeParameters & params)
+  explicit WaitAction(const std::string & action_name, const BT::NodeConfiguration & params)
   : BtActionNode<nav2_msgs::action::Wait>(action_name, params)
   {
   }
@@ -36,7 +36,7 @@ public:
   void on_init() override
   {
     int duration;
-    getParam<int>("wait_duration", duration);
+    getInput<int>("wait_duration", duration);
     if (duration <= 0) {
       RCLCPP_WARN(node_->get_logger(), "Wait duration is negative or zero "
         "(%i). Setting to positive.", duration);
@@ -47,10 +47,11 @@ public:
   }
 
   // Any BT node that accepts parameters must provide a requiredNodeParameters method
-  static const BT::NodeParameters & requiredNodeParameters()
+  static BT::PortsList providedPorts()
   {
-    static BT::NodeParameters params = {{"wait_duration", "1"}};
-    return params;
+    return {
+      BT::InputPort<int>("wait_duration", 1, "Wait time")
+    };
   }
 };
 

--- a/nav2_behavior_tree/package.xml
+++ b/nav2_behavior_tree/package.xml
@@ -18,7 +18,7 @@
   <build_depend>rclcpp_action</build_depend>
   <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>behaviortree_cpp</build_depend>
+  <build_depend>behaviortree_cpp_v3</build_depend>
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>nav2_msgs</build_depend>
@@ -36,7 +36,7 @@
   <exec_depend>rclcpp_action</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>behaviortree_cpp</exec_depend>
+  <exec_depend>behaviortree_cpp_v3</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -72,7 +72,9 @@ BehaviorTreeEngine::run(
   std::chrono::milliseconds loopTimeout)
 {
   // Parse the input XML and create the corresponding Behavior Tree
-  BT::Tree tree = BT::buildTreeFromText(factory_, behavior_tree_xml, blackboard);
+  BT::XMLParser p(factory_);
+  p.loadFromText(behavior_tree_xml);
+  BT::Tree tree = p.instantiateTree(blackboard);
 
   rclcpp::WallRate loopRate(loopTimeout);
   BT::NodeStatus result = BT::NodeStatus::RUNNING;
@@ -124,13 +126,15 @@ BehaviorTreeEngine::run(
 BT::Tree
 BehaviorTreeEngine::buildTreeFromText(std::string & xml_string, BT::Blackboard::Ptr blackboard)
 {
-  return BT::buildTreeFromText(factory_, xml_string, blackboard);
+  BT::XMLParser p(factory_);
+  p.loadFromText(xml_string);
+  return p.instantiateTree(blackboard);
 }
 
 BT::NodeStatus
 BehaviorTreeEngine::initialPoseReceived(BT::TreeNode & tree_node)
 {
-  auto initPoseReceived = tree_node.blackboard()->template get<bool>("initial_pose_received");
+  auto initPoseReceived = tree_node.config().blackboard->get<bool>("initial_pose_received");
   return initPoseReceived ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
 }
 

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -72,9 +72,7 @@ BehaviorTreeEngine::run(
   std::chrono::milliseconds loopTimeout)
 {
   // Parse the input XML and create the corresponding Behavior Tree
-  BT::XMLParser p(factory_);
-  p.loadFromText(behavior_tree_xml);
-  BT::Tree tree = p.instantiateTree(blackboard);
+  BT::Tree tree = buildTreeFromText(behavior_tree_xml, blackboard);
 
   rclcpp::WallRate loopRate(loopTimeout);
   BT::NodeStatus result = BT::NodeStatus::RUNNING;
@@ -124,7 +122,9 @@ BehaviorTreeEngine::run(
 }
 
 BT::Tree
-BehaviorTreeEngine::buildTreeFromText(std::string & xml_string, BT::Blackboard::Ptr blackboard)
+BehaviorTreeEngine::buildTreeFromText(
+  const std::string & xml_string,
+  BT::Blackboard::Ptr blackboard)
 {
   BT::XMLParser p(factory_);
   p.loadFromText(xml_string);

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -17,7 +17,6 @@
 #include <memory>
 #include <string>
 
-#include "behaviortree_cpp/blackboard/blackboard_local.h"
 #include "nav2_behavior_tree/back_up_action.hpp"
 #include "nav2_behavior_tree/bt_conversions.hpp"
 #include "nav2_behavior_tree/compute_path_to_pose_action.hpp"

--- a/nav2_behavior_tree/src/recovery_node.cpp
+++ b/nav2_behavior_tree/src/recovery_node.cpp
@@ -20,7 +20,7 @@ namespace nav2_behavior_tree
 RecoveryNode::RecoveryNode(const std::string & name, const BT::NodeConfiguration & params)
 : BT::ControlNode::ControlNode(name, params), current_child_idx_(0), retry_count_(0)
 {
-  getInput<unsigned int>("number_of_retries", number_of_retries_);
+  getInput("number_of_retries", number_of_retries_);
 }
 
 void RecoveryNode::halt()

--- a/nav2_behavior_tree/src/recovery_node.cpp
+++ b/nav2_behavior_tree/src/recovery_node.cpp
@@ -17,10 +17,10 @@
 
 namespace nav2_behavior_tree
 {
-RecoveryNode::RecoveryNode(const std::string & name, const BT::NodeParameters & params)
+RecoveryNode::RecoveryNode(const std::string & name, const BT::NodeConfiguration & params)
 : BT::ControlNode::ControlNode(name, params), current_child_idx_(0), retry_count_(0)
 {
-  getParam<unsigned int>("number_of_retries", number_of_retries_);
+  getInput<unsigned int>("number_of_retries", number_of_retries_);
 }
 
 void RecoveryNode::halt()

--- a/nav2_behavior_tree/src/recovery_node.cpp
+++ b/nav2_behavior_tree/src/recovery_node.cpp
@@ -17,8 +17,10 @@
 
 namespace nav2_behavior_tree
 {
-RecoveryNode::RecoveryNode(const std::string & name, const BT::NodeConfiguration & params)
-: BT::ControlNode::ControlNode(name, params), current_child_idx_(0), retry_count_(0)
+RecoveryNode::RecoveryNode(
+  const std::string & name,
+  const BT::NodeConfiguration & conf)
+: BT::ControlNode::ControlNode(name, conf), current_child_idx_(0), retry_count_(0)
 {
   getInput("number_of_retries", number_of_retries_);
 }

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav2_behavior_tree REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
-find_package(behaviortree_cpp REQUIRED)
+find_package(behaviortree_cpp_v3 REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -43,7 +43,7 @@ set(dependencies
   nav2_behavior_tree
   nav_msgs
   nav2_msgs
-  behaviortree_cpp
+  behaviortree_cpp_v3
   std_srvs
   nav2_util
   tf2_ros

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning.xml
@@ -8,10 +8,10 @@
       <RateController hz="1.0">
         <Fallback>
           <GoalReached/>
-          <ComputePathToPose goal="${goal}"/>
+          <ComputePathToPose goal="{goal}"/>
         </Fallback>
       </RateController>
-      <FollowPath path="${path}"/>
+      <FollowPath path="{path}"/>
     </Sequence>
   </BehaviorTree>
 </root>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
@@ -10,13 +10,13 @@
           <Fallback name="GoalReached">
             <GoalReached/>
             <RecoveryNode number_of_retries="1" name="ComputePath">
-              <ComputePathToPose goal="${goal}" path="${path}"/>
+              <ComputePathToPose goal="{goal}" path="{path}"/>
               <ClearEntireCostmap service_name="global_costmap/clear_entirely_global_costmap"/>
             </RecoveryNode>
           </Fallback>
         </RateController>
         <RecoveryNode number_of_retries="1" name="FollowPath">
-          <FollowPath path="${path}"/>
+          <FollowPath path="{path}"/>
           <ClearEntireCostmap service_name="local_costmap/clear_entirely_local_costmap"/>
         </RecoveryNode>
       </Sequence>

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -18,7 +18,6 @@
 #include <memory>
 #include <string>
 
-#include "behaviortree_cpp/blackboard/blackboard_local.h"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_behavior_tree/behavior_tree_engine.hpp"
 #include "nav2_util/lifecycle_node.hpp"

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -64,12 +64,6 @@ protected:
   // The blackboard shared by all of the nodes in the tree
   BT::Blackboard::Ptr blackboard_;
 
-  // The goal (on the blackboard) to be passed to ComputePath
-  std::shared_ptr<geometry_msgs::msg::PoseStamped> goal_;
-
-  // The path (on the blackboard) to be returned from ComputePath and sent to the FollowPath task
-  std::shared_ptr<nav_msgs::msg::Path> path_;
-
   // The XML string that defines the Behavior Tree to create
   std::string xml_string_;
 

--- a/nav2_bt_navigator/package.xml
+++ b/nav2_bt_navigator/package.xml
@@ -17,13 +17,13 @@
   <build_depend>nav2_behavior_tree</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>nav2_msgs</build_depend>
-  <build_depend>behaviortree_cpp</build_depend>
+  <build_depend>behaviortree_cpp_v3</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>nav2_util</build_depend>
 
-  <exec_depend>behaviortree_cpp</exec_depend>
+  <exec_depend>behaviortree_cpp_v3</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_action</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -77,16 +77,10 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   // Create the class that registers our custom nodes and executes the BT
   bt_ = std::make_unique<nav2_behavior_tree::BehaviorTreeEngine>();
 
-  // Create the path that will be returned from ComputePath and sent to FollowPath
-  goal_ = std::make_shared<geometry_msgs::msg::PoseStamped>();
-  path_ = std::make_shared<nav_msgs::msg::Path>();
-
   // Create the blackboard that will be shared by all of the nodes in the tree
   blackboard_ = BT::Blackboard::create();
 
   // Put items on the blackboard
-  blackboard_->set<geometry_msgs::msg::PoseStamped::SharedPtr>("goal", goal_);  // NOLINT
-  blackboard_->set<nav_msgs::msg::Path::SharedPtr>("path", path_);  // NOLINT
   blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
   blackboard_->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", tf_);  // NOLINT
   blackboard_->set<std::chrono::milliseconds>("node_loop_timeout", std::chrono::milliseconds(10));  // NOLINT
@@ -155,7 +149,6 @@ BtNavigator::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   tf_.reset();
   tf_listener_.reset();
   action_server_.reset();
-  path_.reset();
   xml_string_.clear();
   tree_.reset();
   blackboard_.reset();
@@ -240,7 +233,7 @@ BtNavigator::initializeGoalPose()
     goal->pose.pose.position.x, goal->pose.pose.position.y);
 
   // Update the goal pose on the blackboard
-  *(blackboard_->get<geometry_msgs::msg::PoseStamped::SharedPtr>("goal")) = goal->pose;
+  blackboard_->set<geometry_msgs::msg::PoseStamped>("goal", goal->pose);
 }
 
 void

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -233,7 +233,7 @@ BtNavigator::initializeGoalPose()
     goal->pose.pose.position.x, goal->pose.pose.position.y);
 
   // Update the goal pose on the blackboard
-  blackboard_->set<geometry_msgs::msg::PoseStamped>("goal", goal->pose);
+  blackboard_->set("goal", goal->pose);
 }
 
 void

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -82,7 +82,7 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   path_ = std::make_shared<nav_msgs::msg::Path>();
 
   // Create the blackboard that will be shared by all of the nodes in the tree
-  blackboard_ = BT::Blackboard::create<BT::BlackboardLocal>();
+  blackboard_ = BT::Blackboard::create();
 
   // Put items on the blackboard
   blackboard_->set<geometry_msgs::msg::PoseStamped::SharedPtr>("goal", goal_);  // NOLINT

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   BehaviorTree.CPP:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: 2.5.2
+    version: 3.0.9
   angles:
     type: git
     url: https://github.com/ros/angles.git


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #958 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  System Test |

---

## Description of contribution in a few bullet points

* Switched to version 3 of the behavior tree library.
* Major changes include:
  * Parameters in the XML are now ports. The classes now use the new port interface for that data.
  * Tree nodes are provided a configuration that includes the ports instead of being passed parameters.
  * TreeNodes no longer have an onInit method. Initialization happens in the constructor instead.
  * The blackboard is accessed through the config method instead of the blackboard method