### PR TITLE
Service timeout

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
@@ -53,9 +53,9 @@ public:
   static BT::PortsList providedPorts()
   {
     return providedBasicPorts({
-      BT::InputPort<double>("backup_dist", -0.15, "Distance to backup"),
-      BT::InputPort<double>("backup_speed", 0.025, "Speed at which to backup")
-    });
+        BT::InputPort<double>("backup_dist", -0.15, "Distance to backup"),
+        BT::InputPort<double>("backup_speed", 0.025, "Speed at which to backup")
+      });
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/back_up_action.hpp
@@ -52,10 +52,10 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return {
+    return providedBasicPorts({
       BT::InputPort<double>("backup_dist", -0.15, "Distance to backup"),
       BT::InputPort<double>("backup_speed", 0.025, "Speed at which to backup")
-    };
+    });
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -62,12 +62,21 @@ public:
   {
   }
 
-  // Any BT node that accepts parameters must provide a requiredNodeParameters method
-  static BT::PortsList providedPorts()
+  // Any subclass of BtActionNode that accepts parameters must provide a providedPorts method
+  // and call providedBasicPorts in it.
+  static BT::PortsList providedBasicPorts(BT::PortsList addition)
   {
-    return {
+    BT::PortsList basic = {
       BT::InputPort<std::chrono::milliseconds>("server_timeout")
     };
+    basic.insert(addition.begin(), addition.end());
+
+    return basic;
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return providedBasicPorts({});
   }
 
   // Derived classes can override any of the following methods to hook into the

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_conversions.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_conversions.hpp
@@ -59,6 +59,12 @@ inline geometry_msgs::msg::Quaternion convertFromString(const StringView key)
   }
 }
 
+template <>
+inline std::chrono::milliseconds convertFromString<std::chrono::milliseconds>(StringView str)
+{
+  return std::chrono::milliseconds(std::stoul(str.data()));
+}
+
 }  // namespace BT
 
 #endif  // NAV2_BEHAVIOR_TREE__BT_CONVERSIONS_HPP_

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_conversions.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_conversions.hpp
@@ -59,10 +59,10 @@ inline geometry_msgs::msg::Quaternion convertFromString(const StringView key)
   }
 }
 
-template <>
-inline std::chrono::milliseconds convertFromString<std::chrono::milliseconds>(StringView str)
+template<>
+inline std::chrono::milliseconds convertFromString<std::chrono::milliseconds>(const StringView key)
 {
-  return std::chrono::milliseconds(std::stoul(str.data()));
+  return std::chrono::milliseconds(std::stoul(key.data()));
 }
 
 }  // namespace BT

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -80,9 +80,9 @@ public:
         future_result, server_timeout_);
     if (rc == rclcpp::executor::FutureReturnCode::SUCCESS) {
       return BT::NodeStatus::SUCCESS;
-    } else if(rc == rclcpp::executor::FutureReturnCode::TIMEOUT) {
+    } else if (rc == rclcpp::executor::FutureReturnCode::TIMEOUT) {
       RCLCPP_WARN(node_->get_logger(),
-                  "Node timed out while executing service call to %s.", service_name_.c_str());
+        "Node timed out while executing service call to %s.", service_name_.c_str());
       on_server_timeout();
     }
     return BT::NodeStatus::FAILURE;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -60,13 +60,22 @@ public:
   {
   }
 
-  // Any BT node that accepts parameters must provide a requiredNodeParameters method
-  static BT::PortsList providedPorts()
+  // Any subclass of BtServiceNode that accepts parameters must provide a providedPorts method
+  // and call providedBasicPorts in it.
+  static BT::PortsList providedBasicPorts(BT::PortsList addition)
   {
-    return {
+    BT::PortsList basic = {
       BT::InputPort<std::string>("service_name", "please_set_service_name_in_BT_Node"),
       BT::InputPort<std::chrono::milliseconds>("server_timeout")
     };
+    basic.insert(addition.begin(), addition.end());
+
+    return basic;
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return providedBasicPorts({});
   }
 
   // The main override required by a BT service

--- a/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
@@ -53,10 +53,10 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return {
+    return providedBasicPorts({
       BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputePathToPose node"),
       BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination to plan to")
-    };
+    });
   }
 
 private:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/compute_path_to_pose_action.hpp
@@ -54,9 +54,9 @@ public:
   static BT::PortsList providedPorts()
   {
     return providedBasicPorts({
-      BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputePathToPose node"),
-      BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination to plan to")
-    });
+        BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputePathToPose node"),
+        BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination to plan to")
+      });
   }
 
 private:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
@@ -40,7 +40,7 @@ public:
     getInput("path", goal_.path);
   }
 
-  void on_loop_timeout() override
+  void on_server_timeout() override
   {
     // Check if the goal has been updated
     if (config().blackboard->get<bool>("path_updated")) {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
@@ -56,9 +56,9 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return {
+    return providedBasicPorts({
       BT::InputPort<nav_msgs::msg::Path>("path", "Path to follow"),
-    };
+    });
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/follow_path_action.hpp
@@ -57,8 +57,8 @@ public:
   static BT::PortsList providedPorts()
   {
     return providedBasicPorts({
-      BT::InputPort<nav_msgs::msg::Path>("path", "Path to follow"),
-    });
+        BT::InputPort<nav_msgs::msg::Path>("path", "Path to follow"),
+      });
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp
@@ -58,10 +58,10 @@ public:
   // Any BT node that accepts parameters must provide a requiredNodeParameters method
   static BT::PortsList providedPorts()
   {
-    return {
+    return providedBasicPorts({
       BT::InputPort<geometry_msgs::msg::Point>("position", "0;0;0", "Position"),
       BT::InputPort<geometry_msgs::msg::Quaternion>("orientation", "0;0;0;0", "Orientation")
-    };
+    });
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/navigate_to_pose_action.hpp
@@ -59,9 +59,9 @@ public:
   static BT::PortsList providedPorts()
   {
     return providedBasicPorts({
-      BT::InputPort<geometry_msgs::msg::Point>("position", "0;0;0", "Position"),
-      BT::InputPort<geometry_msgs::msg::Quaternion>("orientation", "0;0;0;0", "Orientation")
-    });
+        BT::InputPort<geometry_msgs::msg::Point>("position", "0;0;0", "Position"),
+        BT::InputPort<geometry_msgs::msg::Quaternion>("orientation", "0;0;0;0", "Orientation")
+      });
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
@@ -43,9 +43,9 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return {
+    return providedBasicPorts({
       BT::InputPort<double>("spin_dist", 1.57, "Spin distance")
-    };
+    });
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/spin_action.hpp
@@ -44,8 +44,8 @@ public:
   static BT::PortsList providedPorts()
   {
     return providedBasicPorts({
-      BT::InputPort<double>("spin_dist", 1.57, "Spin distance")
-    });
+        BT::InputPort<double>("spin_dist", 1.57, "Spin distance")
+      });
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
@@ -48,8 +48,8 @@ public:
   static BT::PortsList providedPorts()
   {
     return providedBasicPorts({
-      BT::InputPort<int>("wait_duration", 1, "Wait time")
-    });
+        BT::InputPort<int>("wait_duration", 1, "Wait time")
+      });
   }
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/wait_action.hpp
@@ -47,9 +47,9 @@ public:
   // Any BT node that accepts parameters must provide a requiredNodeParameters method
   static BT::PortsList providedPorts()
   {
-    return {
+    return providedBasicPorts({
       BT::InputPort<int>("wait_duration", 1, "Wait time")
-    };
+    });
   }
 };
 

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -82,7 +82,7 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   // Put items on the blackboard
   blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
   blackboard_->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", tf_);  // NOLINT
-  blackboard_->set<std::chrono::milliseconds>("node_loop_timeout", std::chrono::milliseconds(10));  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>("server_timeout", std::chrono::milliseconds(10));  // NOLINT
   blackboard_->set<bool>("path_updated", false);  // NOLINT
   blackboard_->set<bool>("initial_pose_received", false);  // NOLINT
 


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#1248 ) |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (Yunji Robot) |

---

## Description of contribution in a few bullet points

* Add a parameter to control the timeout of every specific action/service
``` <ClearEntireCostmap service_name="/local_costmap/clear_entirely_local_costmap" server_timeout="200"/> ```
* Add  a warning  stating that the service timed out 

---

## Future work that may be required in bullet points
* There might be another elegant way to fix this problem, cz' clear a 10000x10000pix costmap  may take a while.
<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
