### PR TITLE
make nav2_bringup part of navigation2 metapackage

### DIFF
--- a/doc/tutorials/navigation2_on_real_turtlebot3.md
+++ b/doc/tutorials/navigation2_on_real_turtlebot3.md
@@ -29,7 +29,7 @@ This tutorial may take about 1-2 hours to complete. It depends on your experienc
 
 - Install Navigation2
 
-    - ```sudo apt install ros-<ros2-distro>-navigation2 ros-<ros2-distro>-nav2-bringup```
+    - ```sudo apt install ros-<ros2-distro>-navigation2```
 
 - Install Turtlebot 3 
 

--- a/doc/tutorials/navigation2_with_turtlebot3_in_gazebo.md
+++ b/doc/tutorials/navigation2_with_turtlebot3_in_gazebo.md
@@ -27,7 +27,7 @@ This tutorial may take about 1-2 hours to complete. It depends on your experienc
 
 - Install Navigation2
 
-    - ```sudo apt install ros-<ros2-distro>-navigation2 ros-<ros2-distro>-nav2-bringup```
+    - ```sudo apt install ros-<ros2-distro>-navigation2```
 
 - Install Turtlebot 3 
 

--- a/nav2_bringup/bringup/CMakeLists.txt
+++ b/nav2_bringup/bringup/CMakeLists.txt
@@ -3,7 +3,6 @@ project(nav2_bringup)
 
 find_package(ament_cmake REQUIRED)
 find_package(nav2_common REQUIRED)
-find_package(navigation2 REQUIRED)
 
 nav2_package()
 

--- a/nav2_bringup/bringup/package.xml
+++ b/nav2_bringup/bringup/package.xml
@@ -12,12 +12,17 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>nav2_common</build_depend>
 
-  <build_depend>navigation2</build_depend>
-  <build_depend>launch_ros</build_depend>
-
   <exec_depend>launch_ros</exec_depend>
-  <exec_depend>navigation2</exec_depend>
+  <exec_depend>nav2_amcl</exec_depend>
+  <exec_depend>nav2_bt_navigator</exec_depend>
   <exec_depend>nav2_common</exec_depend>
+  <exec_depend>nav2_controller</exec_depend>
+  <exec_depend>nav2_lifecycle_manager</exec_depend>
+  <exec_depend>nav2_map_server</exec_depend>
+  <exec_depend>nav2_planner</exec_depend>
+  <exec_depend>nav2_recoveries</exec_depend>
+  <exec_depend>nav2_rviz_plugins</exec_depend>
+
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_system_tests/CMakeLists.txt
+++ b/nav2_system_tests/CMakeLists.txt
@@ -2,46 +2,46 @@ cmake_minimum_required(VERSION 3.5)
 project(nav2_system_tests)
 
 find_package(ament_cmake REQUIRED)
-find_package(nav2_common REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(nav2_util REQUIRED)
-find_package(nav2_bringup REQUIRED)
-find_package(nav2_msgs REQUIRED)
-find_package(nav_msgs REQUIRED)
-find_package(visualization_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
-find_package(gazebo_ros_pkgs REQUIRED)
-find_package(nav2_amcl REQUIRED)
-find_package(nav2_lifecycle_manager REQUIRED)
-find_package(rclpy REQUIRED)
-find_package(nav2_navfn_planner REQUIRED)
-find_package(nav2_planner REQUIRED)
-find_package(navigation2)
-
-nav2_package()
-
-set(dependencies
-  rclcpp
-  nav2_util
-  nav2_bringup
-  nav2_msgs
-  nav_msgs
-  visualization_msgs
-  nav2_amcl
-  nav2_lifecycle_manager
-  gazebo_ros_pkgs
-  geometry_msgs
-  std_msgs
-  tf2_geometry_msgs
-  rclpy
-  nav2_planner
-  nav2_navfn_planner
-)
 
 if(BUILD_TESTING)
+  find_package(nav2_common REQUIRED)
+  find_package(rclcpp REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(nav2_util REQUIRED)
+  find_package(nav2_bringup REQUIRED)
+  find_package(nav2_msgs REQUIRED)
+  find_package(nav_msgs REQUIRED)
+  find_package(visualization_msgs REQUIRED)
+  find_package(geometry_msgs REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(tf2_geometry_msgs REQUIRED)
+  find_package(gazebo_ros_pkgs REQUIRED)
+  find_package(nav2_amcl REQUIRED)
+  find_package(nav2_lifecycle_manager REQUIRED)
+  find_package(rclpy REQUIRED)
+  find_package(nav2_navfn_planner REQUIRED)
+  find_package(nav2_planner REQUIRED)
+
+  nav2_package()
+
+  set(dependencies
+    rclcpp
+    nav2_util
+    nav2_bringup
+    nav2_msgs
+    nav_msgs
+    visualization_msgs
+    nav2_amcl
+    nav2_lifecycle_manager
+    gazebo_ros_pkgs
+    geometry_msgs
+    std_msgs
+    tf2_geometry_msgs
+    rclpy
+    nav2_planner
+    nav2_navfn_planner
+  )
+
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 

--- a/nav2_system_tests/package.xml
+++ b/nav2_system_tests/package.xml
@@ -8,56 +8,31 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclpy</build_depend>
-  <build_depend>nav2_util</build_depend>
-  <build_depend>nav2_msgs</build_depend>
-  <build_depend>nav2_lifecycle_manager</build_depend>
-  <build_depend>nav2_navfn_planner</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <build_depend>nav2_amcl</build_depend>
-  <build_depend>launch_ros</build_depend>
-  <build_depend>launch_testing</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
-  <build_depend>gazebo_ros_pkgs</build_depend>
-  <build_depend>launch_ros</build_depend>
-  <build_depend>launch_testing</build_depend>
-  <build_depend>nav2_planner</build_depend>
-
-  <exec_depend>launch_ros</exec_depend>
-  <exec_depend>launch_testing</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclpy</exec_depend>
-  <exec_depend>nav2_bringup</exec_depend>
-  <exec_depend>nav2_util</exec_depend>
-  <exec_depend>nav2_msgs</exec_depend>
-  <exec_depend>nav2_lifecycle_manager</exec_depend>
-  <exec_depend>nav2_navfn_planner</exec_depend>
-  <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>visualization_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>nav2_amcl</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>tf2_geometry_msgs</exec_depend>
-  <exec_depend>gazebo_ros_pkgs</exec_depend>
-  <exec_depend>launch_ros</exec_depend>
-  <exec_depend>launch_testing</exec_depend>
-  <exec_depend>navigation2</exec_depend>
-  <exec_depend>lcov</exec_depend>
-  <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>nav2_planner</exec_depend>
-
-  <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>gazebo_ros_pkgs</test_depend>
+  <test_depend>geometry_msgs</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
+  <test_depend>lcov</test_depend>
+  <test_depend>nav2_amcl</test_depend>
+  <test_depend>nav2_bringup</test_depend>
+  <test_depend>nav2_common</test_depend>
+  <test_depend>nav2_lifecycle_manager</test_depend>
+  <test_depend>nav2_msgs</test_depend>
+  <test_depend>nav2_navfn_planner</test_depend>
+  <test_depend>nav2_planner</test_depend>
+  <test_depend>nav2_util</test_depend>
+  <test_depend>nav_msgs</test_depend>
+  <test_depend>rclcpp</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>robot_state_publisher</test_depend>
+  <test_depend>std_msgs</test_depend>
+  <test_depend>tf2_geometry_msgs</test_depend>
+  <test_depend>visualization_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/navigation2/CMakeLists.txt
+++ b/navigation2/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(navigation2)
+project(navigation2 NONE)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/navigation2/package.xml
+++ b/navigation2/package.xml
@@ -12,8 +12,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <!-- nav2_bringup doesn't belong for recursive dependencies -->
   <exec_depend>nav2_amcl</exec_depend>
+  <exec_depend>nav2_bringup</exec_depend>
   <exec_depend>nav2_bt_navigator</exec_depend>
   <exec_depend>nav2_costmap_2d</exec_depend>
   <exec_depend>nav2_core</exec_depend>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points

Disclaimer: Not being involved in navigation2 development this may be changing a design decision instead of fixing what seems to be a fluke.
Feel free to decline this PR if not relevant.

It happened to me a couple time than installing navigation2 (either `navigation2` from debs or `navigation2` and its dependencies via `rosinstall_generator`) I fail to launch my nodes because I didn't pull in `nav2_bringup`.

This PR changes the dependency orders for `nav2_bringup` to be grouped under `navigation2` and not the opposite.
It also changes the `nav2_system_tests` to not `find_package` a lot of things when being built with `-DBUILD_TESTING=OFF`


<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
