### PR TITLE
Cause build output to be sent to screen to prevent Travis timeouts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN find ./ -name "package.xml" | \
 # multi-stage for building
 FROM $FROM_IMAGE AS build
 
-# install CI dependencies	
-RUN apt-get update && apt-get install -q -y \	
+# install CI dependencies
+RUN apt-get update && apt-get install -q -y \
       ccache \
       lcov \
     && rm -rf /var/lib/apt/lists/*
@@ -63,6 +63,7 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
       --symlink-install \
       --mixin \
         $UNDERLAY_MIXINS \
+      --event-handlers console_direct+ \
     || touch build_failed && \
     if [ -f build_failed ] && [ -n "$FAIL_ON_BUILD_FAILURE" ]; then \
       exit 1; \


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1281 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* Testing to see if passing console output through prevents travis timeout failure