### PR TITLE
Fix BT xml paths on tests

### DIFF
--- a/nav2_system_tests/src/system/test_multi_robot_launch.py
+++ b/nav2_system_tests/src/system/test_multi_robot_launch.py
@@ -17,7 +17,7 @@
 import os
 import sys
 
-from ament_index_python.packages import get_package_prefix, get_package_share_directory
+from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription, LaunchService
 from launch.actions import (ExecuteProcess, GroupAction,
@@ -35,7 +35,7 @@ def generate_launch_description():
     urdf = os.getenv('TEST_URDF')
     sdf = os.getenv('TEST_SDF')
 
-    bt_xml_file = os.path.join(get_package_prefix('nav2_bt_navigator'),
+    bt_xml_file = os.path.join(get_package_share_directory('nav2_bt_navigator'),
                                'behavior_trees',
                                os.getenv('BT_NAVIGATOR_XML'))
 

--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -17,7 +17,7 @@
 import os
 import sys
 
-from ament_index_python.packages import get_package_prefix, get_package_share_directory
+from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch import LaunchService
@@ -33,7 +33,7 @@ def generate_launch_description():
     map_yaml_file = os.getenv('TEST_MAP')
     world = os.getenv('TEST_WORLD')
 
-    bt_navigator_xml = os.path.join(get_package_prefix('nav2_bt_navigator'),
+    bt_navigator_xml = os.path.join(get_package_share_directory('nav2_bt_navigator'),
                                     'behavior_trees',
                                     os.getenv('BT_NAVIGATOR_XML'))
 


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1283 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo simulation of TB3 |

---

## Description of contribution in a few bullet points

Path to the BT xml description file was not provided correctly to the tests. Fixes #1283.