### PR TITLE
add clear area method for plugins

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
@@ -60,6 +60,8 @@ public:
 
   virtual void matchSize();
 
+  virtual void clearArea(int start_x, int start_y, int end_x, int end_y);
+
   /**
    * If an external source changes values in the costmap,
    * it should call this method with the area that it changed

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -60,6 +60,23 @@ void CostmapLayer::matchSize()
     master->getOriginX(), master->getOriginY());
 }
 
+void CostmapLayer::clearArea(int start_x, int start_y, int end_x, int end_y)
+{
+  unsigned char * grid = getCharMap();
+  for(int x = 0; x < static_cast<int>(getSizeInCellsX()); x++) {
+    bool xrange = x > start_x && x < end_x;
+
+    for(int y = 0; y < static_cast<int>(getSizeInCellsY()); y++) {
+      if(xrange && y > start_y && y < end_y)
+        continue;
+      int index = getIndex(x,y);
+      if(grid[index] != NO_INFORMATION){
+        grid[index] = NO_INFORMATION;
+      }
+    }
+  }
+}
+
 void CostmapLayer::addExtraBounds(double mx0, double my0, double mx1, double my1)
 {
   extra_min_x_ = std::min(mx0, extra_min_x_);

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -63,14 +63,15 @@ void CostmapLayer::matchSize()
 void CostmapLayer::clearArea(int start_x, int start_y, int end_x, int end_y)
 {
   unsigned char * grid = getCharMap();
-  for(int x = 0; x < static_cast<int>(getSizeInCellsX()); x++) {
+  for (int x = 0; x < static_cast<int>(getSizeInCellsX()); x++) {
     bool xrange = x > start_x && x < end_x;
 
-    for(int y = 0; y < static_cast<int>(getSizeInCellsY()); y++) {
-      if(xrange && y > start_y && y < end_y)
+    for (int y = 0; y < static_cast<int>(getSizeInCellsY()); y++) {
+      if (xrange && y > start_y && y < end_y) {
         continue;
-      int index = getIndex(x,y);
-      if(grid[index] != NO_INFORMATION){
+      }
+      int index = getIndex(x, y);
+      if (grid[index] != NO_INFORMATION) {
         grid[index] = NO_INFORMATION;
       }
     }


### PR DESCRIPTION
#1290 

This PR gives control to costmap_2d plugins to clear sections of its own area. This also helps by letting a plugin override this method if it also needs to clear out sections of its own internal data structure separate of the costmap_2d projected costmap.

Nothing uses this right now but it is necessary as more things are ported to ROS2