### PR TITLE
Using Goal Handle in action server 

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -104,25 +104,31 @@ new_goal_received:
     }
 
     auto future_result = goal_handle_->async_result();
-    rclcpp::executor::FutureReturnCode rc;
-    do {
-      rc = rclcpp::spin_until_future_complete(node_, future_result, node_loop_timeout_);
-      if (rc == rclcpp::executor::FutureReturnCode::TIMEOUT) {
-        on_loop_timeout();
+    rclcpp::executor::FutureReturnCode rc = rclcpp::executor::FutureReturnCode::UNKNOWN;
+    while (rc != rclcpp::executor::FutureReturnCode::SUCCESS) {
 
-        // We can handle a new goal if we're still executing
-        auto status = goal_handle_->get_status();
-        if (goal_updated_ && (status == action_msgs::msg::GoalStatus::STATUS_EXECUTING ||
-          status == action_msgs::msg::GoalStatus::STATUS_ACCEPTED ))
-        {
-          goal_updated_ = false;
-          goto new_goal_received;
+      // We can handle a new goal if we're still executing
+      auto status = goal_handle_->get_status();
+      if (goal_updated_ && (status == action_msgs::msg::GoalStatus::STATUS_EXECUTING ||
+        status == action_msgs::msg::GoalStatus::STATUS_ACCEPTED ))
+      {
+        goal_updated_ = false;
+        goto new_goal_received;
+      } else if (status == action_msgs::msg::GoalStatus::STATUS_SUCCEEDED ||
+        status == action_msgs::msg::GoalStatus::STATUS_CANCELLED ||
+        status == action_msgs::msg::GoalStatus::STATUS_ABORTED) {
+        // In a terminal condition, lets get our result
+        rc = rclcpp::spin_until_future_complete(node_, future_result, node_loop_timeout_);
+        if (rc == rclcpp::executor::FutureReturnCode::TIMEOUT ||
+          rc == rclcpp::executor::FutureReturnCode::INTERRUPTED) {
+          RCLCPP_ERROR(node_->get_logger(), "Timed out getting terminal action result!");
+          on_loop_timeout();
         }
-
-        // Yield to any other CoroActionNodes (coroutines)
-        setStatusRunningAndYield();
       }
-    } while (rc != rclcpp::executor::FutureReturnCode::SUCCESS);
+
+      // Yield to any other CoroActionNodes (coroutines)
+      setStatusRunningAndYield();
+    }
 
     result_ = future_result.get();
     switch (result_.code) {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1289  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 simulation |

---

## Description of contribution in a few bullet points

* Right now we check if done using an action server result request, which is not using the information we have right in front of us, it also doesnt handle most other terminal cases other than success
* This instead uses the goal handle we have available to check the state of the goal and only request a result in a terminal condition
* Also lets us meaningfully catch errors in networking

Need to test in simulation before merging that it handles preemptions correctly and we're all squared away.
