### PR TITLE
declare parameters inside searchAndGetParam

### DIFF
--- a/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
@@ -172,9 +172,9 @@ DWBLocalPlanner::loadCritics()
     std::string plugin_name = critic_names[i];
     std::string plugin_class;
 
-    declare_parameter_if_not_declared(node_, plugin_name + "/class",
+    declare_parameter_if_not_declared(node_, plugin_name + ".class",
       rclcpp::ParameterValue(plugin_name));
-    node_->get_parameter(plugin_name + "/class", plugin_class);
+    node_->get_parameter(plugin_name + ".class", plugin_class);
 
     plugin_class = resolveCriticClassName(plugin_class);
 

--- a/nav2_dwb_controller/dwb_critics/src/goal_align.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/goal_align.cpp
@@ -46,7 +46,8 @@ void GoalAlignCritic::onInit()
 {
   GoalDistCritic::onInit();
   stop_on_failure_ = false;
-  forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_, "forward_point_distance", 0.325);
+  forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_,
+      name_ + ".forward_point_distance", 0.325);
 }
 
 bool GoalAlignCritic::prepare(

--- a/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
@@ -91,11 +91,13 @@ bool OscillationCritic::CommandTrend::hasSignFlipped()
 
 void OscillationCritic::onInit()
 {
-  oscillation_reset_dist_ = nav_2d_utils::searchAndGetParam(nh_, "oscillation_reset_dist", 0.05);
+  oscillation_reset_dist_ = nav_2d_utils::searchAndGetParam(nh_,
+      name_ + ".oscillation_reset_dist", 0.05);
   oscillation_reset_dist_sq_ = oscillation_reset_dist_ * oscillation_reset_dist_;
-  oscillation_reset_angle_ = nav_2d_utils::searchAndGetParam(nh_, "oscillation_reset_angle", 0.2);
+  oscillation_reset_angle_ = nav_2d_utils::searchAndGetParam(nh_,
+      name_ + ".oscillation_reset_angle", 0.2);
   oscillation_reset_time_ = rclcpp::Duration::from_seconds(
-    nav_2d_utils::searchAndGetParam(nh_, "oscillation_reset_time", -1.0));
+    nav_2d_utils::searchAndGetParam(nh_, name_ + ".oscillation_reset_time", -1.0));
 
   nav2_util::declare_parameter_if_not_declared(nh_,
     name_ + ".x_only_threshold", rclcpp::ParameterValue(0.05));

--- a/nav2_dwb_controller/dwb_critics/src/path_align.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/path_align.cpp
@@ -46,7 +46,8 @@ void PathAlignCritic::onInit()
 {
   PathDistCritic::onInit();
   stop_on_failure_ = false;
-  forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_, "forward_point_distance", 0.325);
+  forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_,
+      name_ + ".forward_point_distance", 0.325);
 }
 
 bool PathAlignCritic::prepare(

--- a/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
@@ -47,7 +47,7 @@ namespace dwb_critics
 
 void RotateToGoalCritic::onInit()
 {
-  xy_goal_tolerance_ = nav_2d_utils::searchAndGetParam(nh_, "xy_goal_tolerance", 0.25);
+  xy_goal_tolerance_ = nav_2d_utils::searchAndGetParam(nh_, name_ + ".xy_goal_tolerance", 0.25);
   xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
 }
 

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
@@ -40,6 +40,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/node_utils.hpp"
 
 // TODO(crdelsey): Remove when code is re-enabled
 #pragma GCC diagnostic push
@@ -71,8 +72,10 @@ param_t searchAndGetParam(
   //   nh->param(resolved_name, value, default_value);
   //   return value;
   // }
-  param_t value = 0;
-  nh->get_parameter_or(param_name, value, default_value);
+  param_t value;
+  nav2_util::declare_parameter_if_not_declared(nh, param_name,
+    rclcpp::ParameterValue(default_value));
+  nh->get_parameter(param_name, value);
   return value;
 }
 


### PR DESCRIPTION
Fixes issue with some dwb critic parameters not being declared.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1154 |

---

## Description of contribution in a few bullet points
- updates `searchAndGetParam` utility function to declare parameters if not declared
- adds parameter namespace where relevant for critics

## Future work that may be required in bullet points
- the `searchAndGetParam` has largely lost its original meaning, so we should consider to remove function entirely or rename 
