### PR TITLE
Track Behavior Tree 3.0.9 release tag instead of ros2-dev branch.

### DIFF
--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   BehaviorTree.CPP:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: ros2-dev
+    version: 3.0.9
   angles:
     type: git
     url: https://github.com/ros/angles.git


### PR DESCRIPTION
There is no "stable" branch the behavior tree repo. We just need to track the latest tag instead.

The branch we were tracking was deleted, so this fix is needed to get CI working again.

We need to update to 3.1.0 before making our Eloquent release, however, 3.1.0 doesn't build successfully yet, so I'm tracking 3.0.9 instead.
