### PR TITLE
Remove dead code from behavior tree engine

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
@@ -34,13 +34,6 @@ public:
   virtual ~BehaviorTreeEngine() {}
 
   BtStatus run(
-    BT::Blackboard::Ptr & blackboard,
-    const std::string & behavior_tree_xml,
-    std::function<void()> onLoop,
-    std::function<bool()> cancelRequested,
-    std::chrono::milliseconds loopTimeout = std::chrono::milliseconds(10));
-
-  BtStatus run(
     std::unique_ptr<BT::Tree> & tree,
     std::function<void()> onLoop,
     std::function<bool()> cancelRequested,

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -65,37 +65,6 @@ BehaviorTreeEngine::BehaviorTreeEngine()
 
 BtStatus
 BehaviorTreeEngine::run(
-  BT::Blackboard::Ptr & blackboard,
-  const std::string & behavior_tree_xml,
-  std::function<void()> onLoop,
-  std::function<bool()> cancelRequested,
-  std::chrono::milliseconds loopTimeout)
-{
-  // Parse the input XML and create the corresponding Behavior Tree
-  BT::Tree tree = buildTreeFromText(behavior_tree_xml, blackboard);
-
-  rclcpp::WallRate loopRate(loopTimeout);
-  BT::NodeStatus result = BT::NodeStatus::RUNNING;
-
-  // Loop until something happens with ROS or the node completes
-  while (rclcpp::ok() && result == BT::NodeStatus::RUNNING) {
-    if (cancelRequested()) {
-      tree.root_node->halt();
-      return BtStatus::CANCELED;
-    }
-
-    onLoop();
-
-    result = tree.root_node->executeTick();
-
-    loopRate.sleep();
-  }
-
-  return (result == BT::NodeStatus::SUCCESS) ? BtStatus::SUCCEEDED : BtStatus::FAILED;
-}
-
-BtStatus
-BehaviorTreeEngine::run(
   std::unique_ptr<BT::Tree> & tree,
   std::function<void()> onLoop,
   std::function<bool()> cancelRequested,


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu 18 |
| Robotic platform tested on | TB3 in simulation |

---

## Description of contribution in a few bullet points

* removing an unused variant of the `run` method from the behavior tree engine class