### PR TITLE
Provide behavior tree logging output on the console and a topic

### DIFF
--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -111,9 +111,9 @@ BehaviorTreeEngine::run(
       return BtStatus::CANCELED;
     }
 
-    onLoop();
-
     result = tree->root_node->executeTick();
+
+    onLoop();
 
     loopRate.sleep();
   }

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -33,6 +33,7 @@ set(library_name ${executable_name}_core)
 add_library(${library_name} SHARED
   src/bt_navigator.cpp
   src/ros_console_logger.cpp
+  src/ros_topic_logger.cpp
 )
 
 set(dependencies

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -32,6 +32,7 @@ set(library_name ${executable_name}_core)
 
 add_library(${library_name} SHARED
   src/bt_navigator.cpp
+  src/ros_console_logger.cpp
 )
 
 set(dependencies

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning.xml
@@ -4,7 +4,7 @@
 
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
-    <Sequence name="root">
+    <Sequence name="NavigateSequence">
       <RateController hz="1.0">
         <Fallback>
           <GoalReached/>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_and_recovery.xml
@@ -7,22 +7,22 @@
     <RecoveryNode number_of_retries="6" name="NavigateRecovery">
       <Sequence name="NavigateWithReplanning">
         <RateController hz="1.0">
-          <Fallback name="GoalReached">
+          <Fallback name="GoalReachedFallback">
             <GoalReached/>
-            <RecoveryNode number_of_retries="1" name="ComputePath">
+            <RecoveryNode number_of_retries="1" name="ComputePathRecovery">
               <ComputePathToPose goal="{goal}" path="{path}"/>
-              <ClearEntireCostmap service_name="global_costmap/clear_entirely_global_costmap"/>
+              <ClearEntireCostmap  name="ClearLocalCostmap-CP" service_name="global_costmap/clear_entirely_global_costmap"/>
             </RecoveryNode>
           </Fallback>
         </RateController>
-        <RecoveryNode number_of_retries="1" name="FollowPath">
+        <RecoveryNode number_of_retries="1" name="FollowPathRecovery">
           <FollowPath path="{path}"/>
-          <ClearEntireCostmap service_name="local_costmap/clear_entirely_local_costmap"/>
+          <ClearEntireCostmap name="ClearLocalCostmap-FP" service_name="local_costmap/clear_entirely_local_costmap"/>
         </RecoveryNode>
       </Sequence>
       <SequenceStar name="RecoveryActions">
-        <ClearEntireCostmap service_name="local_costmap/clear_entirely_local_costmap"/>
-        <ClearEntireCostmap service_name="global_costmap/clear_entirely_global_costmap"/>
+        <ClearEntireCostmap name="ClearLocalCostmap-Top" service_name="local_costmap/clear_entirely_local_costmap"/>
+        <ClearEntireCostmap name="ClearGlobalCostmap-Top" service_name="global_costmap/clear_entirely_global_costmap"/>
         <Spin spin_dist="1.57"/>
         <Wait wait_duration="5"/>
       </SequenceStar>

--- a/nav2_bt_navigator/include/nav2_bt_navigator/ros_console_logger.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/ros_console_logger.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_BT_NAVIGATOR__ROS_CONSOLE_LOGGER_HPP_
+#define NAV2_BT_NAVIGATOR__ROS_CONSOLE_LOGGER_HPP_
+
+#include "behaviortree_cpp/loggers/abstract_logger.h"
+#include "rclcpp/rclcpp.hpp"
+
+namespace nav2_bt_navigator
+{
+
+class RosConsoleLogger : public BT::StatusChangeLogger
+{
+public:
+  RosConsoleLogger(const rclcpp::Logger & logger, const BT::Tree & tree);
+
+  void callback(
+    BT::Duration timestamp,
+    const BT::TreeNode & node,
+    BT::NodeStatus prev_status,
+    BT::NodeStatus status) override;
+
+  void flush() override {}
+
+protected:
+  const rclcpp::Logger & logger_;
+};
+
+}   // namespace nav2_bt_navigator
+
+#endif   // NAV2_BT_NAVIGATOR__ROS_CONSOLE_LOGGER_HPP_

--- a/nav2_bt_navigator/include/nav2_bt_navigator/ros_topic_logger.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/ros_topic_logger.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_BT_NAVIGATOR__ROS_TOPIC_LOGGER_HPP_
+#define NAV2_BT_NAVIGATOR__ROS_TOPIC_LOGGER_HPP_
+
+#include <vector>
+#include "behaviortree_cpp/loggers/abstract_logger.h"
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_msgs/msg/behavior_tree_log.hpp"
+#include "nav2_msgs/msg/behavior_tree_status_change.h"
+
+namespace nav2_bt_navigator
+{
+
+class RosTopicLogger : public BT::StatusChangeLogger
+{
+public:
+  RosTopicLogger(const rclcpp::Node::SharedPtr & ros_node, const BT::Tree & tree);
+
+  void callback(
+    BT::Duration timestamp,
+    const BT::TreeNode & node,
+    BT::NodeStatus prev_status,
+    BT::NodeStatus status) override;
+
+  void flush() override;
+
+protected:
+  rclcpp::Node::SharedPtr ros_node_;
+  rclcpp::Publisher<nav2_msgs::msg::BehaviorTreeLog>::SharedPtr log_pub_;
+  std::vector<nav2_msgs::msg::BehaviorTreeStatusChange> event_log_;
+};
+
+}   // namespace nav2_bt_navigator
+
+#endif   // NAV2_BT_NAVIGATOR__ROS_TOPIC_LOGGER_HPP_

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include "nav2_behavior_tree/bt_conversions.hpp"
+#include "nav2_bt_navigator/ros_console_logger.hpp"
 
 namespace nav2_bt_navigator
 {
@@ -196,6 +197,8 @@ BtNavigator::navigateToPose()
         initializeGoalPose();
       }
     };
+
+  RosConsoleLogger console_logger(client_node_->get_logger(), *tree_);
 
   // Execute the BT that was previously created in the configure step
   nav2_behavior_tree::BtStatus rc = bt_->run(tree_, on_loop, is_canceling);

--- a/nav2_bt_navigator/src/ros_console_logger.cpp
+++ b/nav2_bt_navigator/src/ros_console_logger.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_bt_navigator/ros_console_logger.hpp"
+
+namespace nav2_bt_navigator
+{
+
+RosConsoleLogger::RosConsoleLogger(const rclcpp::Logger & logger, const BT::Tree & tree)
+: StatusChangeLogger(tree.root_node), logger_(logger)
+{
+}
+
+void RosConsoleLogger::callback(
+  BT::Duration timestamp,
+  const BT::TreeNode & node,
+  BT::NodeStatus prev_status,
+  BT::NodeStatus status)
+{
+  RCLCPP_DEBUG(logger_, "[%.3f]: %25s %s -> %s",
+    std::chrono::duration<double>(timestamp).count(),
+    node.name().c_str(),
+    toStr(prev_status, true).c_str(),
+    toStr(status, true).c_str() );
+}
+
+}   // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/src/ros_topic_logger.cpp
+++ b/nav2_bt_navigator/src/ros_topic_logger.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <utility>
+#include "nav2_bt_navigator/ros_topic_logger.hpp"
+#include "tf2_ros/buffer_interface.h"
+
+namespace nav2_bt_navigator
+{
+
+RosTopicLogger::RosTopicLogger(
+  const rclcpp::Node::SharedPtr & ros_node, const BT::Tree & tree)
+: StatusChangeLogger(tree.root_node), ros_node_(ros_node)
+{
+  log_pub_ = ros_node_->create_publisher<nav2_msgs::msg::BehaviorTreeLog>(
+    "behavior_tree_log",
+    rclcpp::QoS(10));
+}
+
+void RosTopicLogger::callback(
+  BT::Duration timestamp,
+  const BT::TreeNode & node,
+  BT::NodeStatus prev_status,
+  BT::NodeStatus status)
+{
+  nav2_msgs::msg::BehaviorTreeStatusChange event;
+
+  // BT timestamps are a duration since the epoch. Need to convert to a time_point
+  // before converting to a msg.
+  event.timestamp =
+    tf2_ros::toMsg(std::chrono::time_point<std::chrono::high_resolution_clock>(timestamp));
+  event.node_name = node.name();
+  event.previous_status = toStr(prev_status, false);
+  event.current_status = toStr(status, false);
+  event_log_.push_back(std::move(event));
+}
+
+void RosTopicLogger::flush()
+{
+  if (event_log_.size() > 0) {
+    nav2_msgs::msg::BehaviorTreeLog log_msg;
+    log_msg.timestamp = ros_node_->now();
+    log_msg.event_log = event_log_;
+    log_pub_->publish(log_msg);
+    event_log_.clear();
+  }
+}
+
+}   // namespace nav2_bt_navigator

--- a/nav2_msgs/CMakeLists.txt
+++ b/nav2_msgs/CMakeLists.txt
@@ -16,6 +16,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Costmap.msg"
   "msg/CostmapMetaData.msg"
   "msg/VoxelGrid.msg"
+  "msg/BehaviorTreeStatusChange.msg"
+  "msg/BehaviorTreeLog.msg"
   "srv/GetCostmap.srv"
   "srv/ClearCostmapExceptRegion.srv"
   "srv/ClearCostmapAroundRobot.srv"

--- a/nav2_msgs/msg/BehaviorTreeLog.msg
+++ b/nav2_msgs/msg/BehaviorTreeLog.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time timestamp    # ROS time that this log message was sent.
+BehaviorTreeStatusChange[] event_log

--- a/nav2_msgs/msg/BehaviorTreeStatusChange.msg
+++ b/nav2_msgs/msg/BehaviorTreeStatusChange.msg
@@ -1,0 +1,4 @@
+builtin_interfaces/Time timestamp  # internal behavior tree event timestamp. Typically this is wall clock time
+string node_name
+string previous_status              # IDLE, RUNNING, SUCCESS or FAILURE
+string current_status               # IDLE, RUNNING, SUCCESS or FAILURE


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #589 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  TB3 in Gazebo |

---

## Description of contribution in a few bullet points

* The BT library provides a mechanism to log all node status changes. They provide an example to outputs to stdout. This PR creates two custom loggers and enables them in the behavior tree node. One logger outputs to the ROS console as RCLCPP_DEBUG messages and the other outputs the same data on the `behavior_tree_log` topic.
