### PR TITLE
Default subscribe to costmap topic (OccupancyGrid) in CostmapSubscriber

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(nav2_costmap_2d_core SHARED
   src/layer.cpp
   src/layered_costmap.cpp
   src/costmap_2d_ros.cpp
+  src/costmap_2d_utils.cpp
   src/costmap_2d_publisher.cpp
   src/costmap_math.cpp
   src/footprint.cpp

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_publisher.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_publisher.hpp
@@ -45,6 +45,7 @@
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/costmap_2d_utils.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "map_msgs/msg/occupancy_grid_update.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
@@ -153,8 +154,6 @@ private:
 
   nav_msgs::msg::OccupancyGrid grid_;
   nav2_msgs::msg::Costmap costmap_raw_;
-  // Translate from 0-255 values in costmap to -1 to 100 values in message.
-  static char * cost_translation_table_;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_utils.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_utils.hpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_COSTMAP_2D__COSTMAP_2D_UTILS_HPP_
+#define NAV2_COSTMAP_2D__COSTMAP_2D_UTILS_HPP_
+
+
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_msgs/msg/costmap.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "map_msgs/msg/occupancy_grid_update.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace nav2_costmap_2d
+{
+struct CostTranslationTable
+{
+  CostTranslationTable();
+  char * costs;
+};
+
+nav2_msgs::msg::Costmap
+toCostmapMsg(
+  const Costmap2D * costmap,
+  const std::string & global_frame,
+  const rclcpp::Time & timestamp = rclcpp::Time());
+
+nav_msgs::msg::OccupancyGrid
+toOccupancyGridMsg(
+  const Costmap2D * costmap,
+  const std::string & global_frame,
+  const rclcpp::Time & timestamp = rclcpp::Time());
+
+map_msgs::msg::OccupancyGridUpdate
+toOccupancyGridUpdateMsg(
+  const Costmap2D * costmap,
+  const std::string & global_frame,
+  unsigned int x0, unsigned int xn, unsigned int y0, unsigned int yn,
+  const rclcpp::Time & timestamp = rclcpp::Time());
+
+}  // namespace nav2_costmap_2d
+
+#endif  // NAV2_COSTMAP_2D__COSTMAP_2D_UTILS_HPP_

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
@@ -21,6 +21,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_msgs/msg/costmap.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "map_msgs/msg/occupancy_grid_update.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 
 namespace nav2_costmap_2d
@@ -31,17 +33,21 @@ class CostmapSubscriber
 public:
   CostmapSubscriber(
     nav2_util::LifecycleNode::SharedPtr node,
-    const std::string & topic_name);
+    const std::string & topic_name,
+    bool use_raw = false);
 
   CostmapSubscriber(
     rclcpp::Node::SharedPtr node,
-    const std::string & topic_name);
+    const std::string & topic_name,
+    bool use_raw = false);
 
   CostmapSubscriber(
     const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
     const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
     const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-    const std::string & topic_name);
+    const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    const std::string & topic_name,
+    bool use_raw = false);
 
   ~CostmapSubscriber() {}
 
@@ -52,15 +58,29 @@ protected:
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_;
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_;
 
   void toCostmap2D();
-  void costmapCallback(const nav2_msgs::msg::Costmap::SharedPtr msg);
+  void costmapRawCallback(const nav2_msgs::msg::Costmap::SharedPtr msg);
+  void costmapCallback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg);
+  void costmapUpdateCallback(const map_msgs::msg::OccupancyGridUpdate::SharedPtr msg);
+  unsigned char interpretValue(unsigned char value);
 
   std::shared_ptr<Costmap2D> costmap_;
-  nav2_msgs::msg::Costmap::SharedPtr costmap_msg_;
+  nav2_msgs::msg::Costmap::SharedPtr costmap_raw_msg_;
+  nav_msgs::msg::OccupancyGrid::SharedPtr costmap_msg_;
+  map_msgs::msg::OccupancyGridUpdate::SharedPtr costmap_update_msg_;
   std::string topic_name_;
   bool costmap_received_{false};
-  rclcpp::Subscription<nav2_msgs::msg::Costmap>::SharedPtr costmap_sub_;
+  bool use_raw_;
+  bool has_update_{false};
+  bool track_unknown_space_{false};
+  unsigned char lethal_threshold_{100};
+  unsigned char unknown_cost_value_{static_cast<unsigned char>(0xff)};
+  bool trinary_costmap_{true};
+  rclcpp::Subscription<nav2_msgs::msg::Costmap>::SharedPtr costmap_raw_sub_;
+  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr costmap_sub_;
+  rclcpp::Subscription<map_msgs::msg::OccupancyGridUpdate>::SharedPtr costmap_update_sub_;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/src/costmap_2d_utils.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_utils.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_costmap_2d/costmap_2d_utils.hpp"
+
+namespace nav2_costmap_2d
+{
+
+CostTranslationTable::CostTranslationTable()
+{
+  costs = new char[256];
+
+  // special values:
+  costs[0] = 0;  // NO obstacle
+  costs[253] = 99;  // INSCRIBED obstacle
+  costs[254] = 100;  // LETHAL obstacle
+  costs[255] = -1;  // UNKNOWN
+
+  // regular cost values scale the range 1 to 252 (inclusive) to fit
+  // into 1 to 98 (inclusive).
+  for (int i = 1; i < 253; i++) {
+    costs[i] = static_cast<char>(1 + (97 * (i - 1)) / 251);
+  }
+}
+
+CostTranslationTable cost_translation_table;
+
+nav2_msgs::msg::Costmap
+toCostmapMsg(
+  const Costmap2D * costmap,
+  const std::string & global_frame,
+  const rclcpp::Time & timestamp)
+{
+  double resolution = costmap->getResolution();
+
+  double wx, wy;
+  costmap->mapToWorld(0, 0, wx, wy);
+
+  unsigned char * data = costmap->getCharMap();
+
+  nav2_msgs::msg::Costmap costmap_msg;
+  costmap_msg.header.frame_id = global_frame;
+  costmap_msg.header.stamp = timestamp;
+  costmap_msg.metadata.layer = "master";
+  costmap_msg.metadata.resolution = resolution;
+  costmap_msg.metadata.size_x = costmap->getSizeInCellsX();
+  costmap_msg.metadata.size_y = costmap->getSizeInCellsY();
+  costmap_msg.metadata.origin.position.x = wx - resolution / 2;
+  costmap_msg.metadata.origin.position.y = wy - resolution / 2;
+  costmap_msg.metadata.origin.position.z = 0.0;
+  costmap_msg.metadata.origin.orientation.w = 1.0;
+  costmap_msg.data.resize(costmap_msg.metadata.size_x * costmap_msg.metadata.size_y);
+
+  for (unsigned int i = 0; i < costmap_msg.data.size(); i++) {
+    costmap_msg.data[i] = data[i];
+  }
+
+  return costmap_msg;
+}
+
+nav_msgs::msg::OccupancyGrid
+toOccupancyGridMsg(
+  const Costmap2D * costmap,
+  const std::string & global_frame,
+  const rclcpp::Time & timestamp)
+{
+  double resolution = costmap->getResolution();
+
+  double wx, wy;
+  costmap->mapToWorld(0, 0, wx, wy);
+
+  unsigned char * data = costmap->getCharMap();
+
+  nav_msgs::msg::OccupancyGrid grid_msg;
+  grid_msg.header.frame_id = global_frame;
+  grid_msg.header.stamp = timestamp;
+  grid_msg.info.resolution = resolution;
+  grid_msg.info.width = costmap->getSizeInCellsX();
+  grid_msg.info.height = costmap->getSizeInCellsY();
+  grid_msg.info.origin.position.x = wx - resolution / 2;
+  grid_msg.info.origin.position.y = wy - resolution / 2;
+  grid_msg.info.origin.position.z = 0.0;
+  grid_msg.info.origin.orientation.w = 1.0;
+  grid_msg.data.resize(grid_msg.info.width * grid_msg.info.height);
+
+  for (unsigned int i = 0; i < grid_msg.data.size(); i++) {
+    grid_msg.data[i] = cost_translation_table.costs[data[i]];
+  }
+
+  return grid_msg;
+}
+
+map_msgs::msg::OccupancyGridUpdate
+toOccupancyGridUpdateMsg(
+  const Costmap2D * costmap,
+  const std::string & global_frame,
+  unsigned int x0, unsigned int xn, unsigned int y0, unsigned int yn,
+  const rclcpp::Time & timestamp)
+{
+  map_msgs::msg::OccupancyGridUpdate grid_update;
+  grid_update.header.stamp = timestamp;
+  grid_update.header.frame_id = global_frame;
+  grid_update.x = x0;
+  grid_update.y = y0;
+  grid_update.width = xn - x0;
+  grid_update.height = yn - y0;
+  grid_update.data.resize(grid_update.width * grid_update.height);
+  unsigned int i = 0;
+  for (unsigned int y = y0; y < yn; y++) {
+    for (unsigned int x = x0; x < xn; x++) {
+      unsigned char cost = costmap->getCost(x, y);
+      grid_update.data[i++] = cost_translation_table.costs[cost];
+    }
+  }
+
+  return grid_update;
+}
+
+}  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/src/costmap_subscriber.cpp
+++ b/nav2_costmap_2d/src/costmap_subscriber.cpp
@@ -99,7 +99,6 @@ std::shared_ptr<Costmap2D> CostmapSubscriber::getCostmap()
   if (!costmap_received_) {
     throw std::runtime_error("Costmap is not available");
   }
-  toCostmap2D();
   return costmap_;
 }
 
@@ -143,6 +142,7 @@ void CostmapSubscriber::toCostmap2D()
           master_array[index] = interpretValue(costmap_update_msg_->data[di++]);
         }
       }
+      has_update_ = false;
     } else {
       if (costmap_ == nullptr) {
         costmap_ = std::make_shared<Costmap2D>(
@@ -199,6 +199,7 @@ void CostmapSubscriber::costmapRawCallback(const nav2_msgs::msg::Costmap::Shared
   if (!costmap_received_) {
     costmap_received_ = true;
   }
+  toCostmap2D();
 }
 
 void CostmapSubscriber::costmapCallback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg)
@@ -207,6 +208,7 @@ void CostmapSubscriber::costmapCallback(const nav_msgs::msg::OccupancyGrid::Shar
   if (!costmap_received_) {
     costmap_received_ = true;
   }
+  toCostmap2D();
 }
 
 void CostmapSubscriber::costmapUpdateCallback(
@@ -217,6 +219,7 @@ void CostmapSubscriber::costmapUpdateCallback(
     costmap_received_ = true;
   }
   has_update_ = true;
+  toCostmap2D();
 }
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/src/costmap_subscriber.cpp
+++ b/nav2_costmap_2d/src/costmap_subscriber.cpp
@@ -16,41 +16,82 @@
 #include <memory>
 
 #include "nav2_costmap_2d/costmap_subscriber.hpp"
+#include "nav2_costmap_2d/cost_values.hpp"
+
+using nav2_costmap_2d::NO_INFORMATION;
+using nav2_costmap_2d::LETHAL_OBSTACLE;
+using nav2_costmap_2d::FREE_SPACE;
 
 namespace nav2_costmap_2d
 {
 
 CostmapSubscriber::CostmapSubscriber(
   nav2_util::LifecycleNode::SharedPtr node,
-  const std::string & topic_name)
+  const std::string & topic_name,
+  bool use_raw)
 : CostmapSubscriber(node->get_node_base_interface(),
     node->get_node_topics_interface(),
     node->get_node_logging_interface(),
-    topic_name)
+    node->get_node_parameters_interface(),
+    topic_name,
+    use_raw)
 {}
 
 CostmapSubscriber::CostmapSubscriber(
   rclcpp::Node::SharedPtr node,
-  const std::string & topic_name)
+  const std::string & topic_name,
+  bool use_raw)
 : CostmapSubscriber(node->get_node_base_interface(),
     node->get_node_topics_interface(),
     node->get_node_logging_interface(),
-    topic_name)
+    node->get_node_parameters_interface(),
+    topic_name,
+    use_raw)
 {}
 
 CostmapSubscriber::CostmapSubscriber(
   const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
   const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
   const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-  const std::string & topic_name)
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+  const std::string & topic_name,
+  bool use_raw)
 : node_base_(node_base),
   node_topics_(node_topics),
   node_logging_(node_logging),
-  topic_name_(topic_name)
+  node_parameters_(node_parameters),
+  topic_name_(topic_name),
+  use_raw_(use_raw)
 {
-  costmap_sub_ = rclcpp::create_subscription<nav2_msgs::msg::Costmap>(node_topics_, topic_name_,
+  if (use_raw_) {
+    costmap_raw_sub_ = rclcpp::create_subscription<nav2_msgs::msg::Costmap>(node_topics_,
+        topic_name_,
+        rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable(),
+        std::bind(&CostmapSubscriber::costmapRawCallback, this, std::placeholders::_1));
+  } else {
+    costmap_sub_ = rclcpp::create_subscription<nav_msgs::msg::OccupancyGrid>(node_topics_,
+        topic_name_,
+        rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable(),
+        std::bind(&CostmapSubscriber::costmapCallback, this, std::placeholders::_1));
+    costmap_update_sub_ = rclcpp::create_subscription<map_msgs::msg::OccupancyGridUpdate>(
+      node_topics_,
+      topic_name_,
       rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable(),
-      std::bind(&CostmapSubscriber::costmapCallback, this, std::placeholders::_1));
+      std::bind(&CostmapSubscriber::costmapUpdateCallback, this, std::placeholders::_1));
+    rclcpp::Parameter p;
+    if (node_parameters_->get_parameter("track_unknown_space", p)) {
+      track_unknown_space_ = p.get_value<bool>();
+    }
+    if (node_parameters_->get_parameter("lethal_cost_threshold", p)) {
+      lethal_threshold_ = p.get_value<unsigned char>();
+    }
+    if (node_parameters_->get_parameter("unknown_cost_value", p)) {
+      unknown_cost_value_ = p.get_value<unsigned char>();
+    }
+    if (node_parameters_->get_parameter("trinary_costmap", p)) {
+      trinary_costmap_ = p.get_value<bool>();
+    }
+  }
 }
 
 std::shared_ptr<Costmap2D> CostmapSubscriber::getCostmap()
@@ -64,40 +105,118 @@ std::shared_ptr<Costmap2D> CostmapSubscriber::getCostmap()
 
 void CostmapSubscriber::toCostmap2D()
 {
-  if (costmap_ == nullptr) {
-    costmap_ = std::make_shared<Costmap2D>(
-      costmap_msg_->metadata.size_x, costmap_msg_->metadata.size_y,
-      costmap_msg_->metadata.resolution, costmap_msg_->metadata.origin.position.x,
-      costmap_msg_->metadata.origin.position.y);
-  } else if (costmap_->getSizeInCellsX() != costmap_msg_->metadata.size_x ||  // NOLINT
-    costmap_->getSizeInCellsY() != costmap_msg_->metadata.size_y ||
-    costmap_->getResolution() != costmap_msg_->metadata.resolution ||
-    costmap_->getOriginX() != costmap_msg_->metadata.origin.position.x ||
-    costmap_->getOriginY() != costmap_msg_->metadata.origin.position.y)
-  {
-    // Update the size of the costmap
-    costmap_->resizeMap(costmap_msg_->metadata.size_x, costmap_msg_->metadata.size_y,
-      costmap_msg_->metadata.resolution,
-      costmap_msg_->metadata.origin.position.x,
-      costmap_msg_->metadata.origin.position.y);
-  }
+  if (use_raw_) {
+    if (costmap_ == nullptr) {
+      costmap_ = std::make_shared<Costmap2D>(
+        costmap_raw_msg_->metadata.size_x, costmap_raw_msg_->metadata.size_y,
+        costmap_raw_msg_->metadata.resolution, costmap_raw_msg_->metadata.origin.position.x,
+        costmap_raw_msg_->metadata.origin.position.y);
+    } else if (costmap_->getSizeInCellsX() != costmap_raw_msg_->metadata.size_x ||  // NOLINT
+      costmap_->getSizeInCellsY() != costmap_raw_msg_->metadata.size_y ||
+      costmap_->getResolution() != costmap_raw_msg_->metadata.resolution ||
+      costmap_->getOriginX() != costmap_raw_msg_->metadata.origin.position.x ||
+      costmap_->getOriginY() != costmap_raw_msg_->metadata.origin.position.y)
+    {
+      // Update the size of the costmap
+      costmap_->resizeMap(costmap_raw_msg_->metadata.size_x, costmap_raw_msg_->metadata.size_y,
+        costmap_raw_msg_->metadata.resolution,
+        costmap_raw_msg_->metadata.origin.position.x,
+        costmap_raw_msg_->metadata.origin.position.y);
+    }
 
-  unsigned char * master_array = costmap_->getCharMap();
-  unsigned int index = 0;
-  for (unsigned int i = 0; i < costmap_msg_->metadata.size_x; ++i) {
-    for (unsigned int j = 0; j < costmap_msg_->metadata.size_y; ++j) {
-      master_array[index] = costmap_msg_->data[index];
-      ++index;
+    unsigned char * master_array = costmap_->getCharMap();
+    unsigned int index = 0;
+    for (unsigned int i = 0; i < costmap_raw_msg_->metadata.size_x; ++i) {
+      for (unsigned int j = 0; j < costmap_raw_msg_->metadata.size_y; ++j) {
+        master_array[index] = costmap_raw_msg_->data[index];
+        ++index;
+      }
+    }
+  } else {
+    if (has_update_) {
+      unsigned char * master_array = costmap_->getCharMap();
+      unsigned int di = 0;
+      for (unsigned int y = 0; y < costmap_update_msg_->height; y++) {
+        unsigned int index_base = (costmap_update_msg_->y + y) * costmap_msg_->info.width;
+        for (unsigned int x = 0; x < costmap_update_msg_->width; x++) {
+          unsigned int index = index_base + x + costmap_update_msg_->x;
+          master_array[index] = interpretValue(costmap_update_msg_->data[di++]);
+        }
+      }
+    } else {
+      if (costmap_ == nullptr) {
+        costmap_ = std::make_shared<Costmap2D>(
+          costmap_msg_->info.width, costmap_msg_->info.height,
+          costmap_msg_->info.resolution, costmap_msg_->info.origin.position.x,
+          costmap_msg_->info.origin.position.y);
+      } else if (costmap_->getSizeInCellsX() != costmap_msg_->info.width ||  // NOLINT
+        costmap_->getSizeInCellsY() != costmap_msg_->info.height ||
+        costmap_->getResolution() != costmap_msg_->info.resolution ||
+        costmap_->getOriginX() != costmap_msg_->info.origin.position.x ||
+        costmap_->getOriginY() != costmap_msg_->info.origin.position.y)
+      {
+        // Update the size of the costmap
+        costmap_->resizeMap(costmap_msg_->info.width, costmap_msg_->info.height,
+          costmap_msg_->info.resolution,
+          costmap_msg_->info.origin.position.x,
+          costmap_msg_->info.origin.position.y);
+      }
+
+      unsigned char * master_array = costmap_->getCharMap();
+      unsigned int index = 0;
+      for (unsigned int i = 0; i < costmap_msg_->info.width; ++i) {
+        for (unsigned int j = 0; j < costmap_msg_->info.height; ++j) {
+          unsigned char value = costmap_msg_->data[index];
+          master_array[index] = interpretValue(value);
+          ++index;
+        }
+      }
     }
   }
 }
 
-void CostmapSubscriber::costmapCallback(const nav2_msgs::msg::Costmap::SharedPtr msg)
+unsigned char
+CostmapSubscriber::interpretValue(unsigned char value)
+{
+  // check if the static value is above the unknown or lethal thresholds
+  if (track_unknown_space_ && value == unknown_cost_value_) {
+    return NO_INFORMATION;
+  } else if (!track_unknown_space_ && value == unknown_cost_value_) {
+    return FREE_SPACE;
+  } else if (value >= lethal_threshold_) {
+    return LETHAL_OBSTACLE;
+  } else if (trinary_costmap_) {
+    return FREE_SPACE;
+  }
+
+  double scale = static_cast<double>(value) / lethal_threshold_;
+  return scale * LETHAL_OBSTACLE;
+}
+
+void CostmapSubscriber::costmapRawCallback(const nav2_msgs::msg::Costmap::SharedPtr msg)
+{
+  costmap_raw_msg_ = msg;
+  if (!costmap_received_) {
+    costmap_received_ = true;
+  }
+}
+
+void CostmapSubscriber::costmapCallback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg)
 {
   costmap_msg_ = msg;
   if (!costmap_received_) {
     costmap_received_ = true;
   }
+}
+
+void CostmapSubscriber::costmapUpdateCallback(
+  const map_msgs::msg::OccupancyGridUpdate::SharedPtr msg)
+{
+  costmap_update_msg_ = msg;
+  if (!costmap_received_) {
+    costmap_received_ = true;
+  }
+  has_update_ = true;
 }
 
 }  // namespace nav2_costmap_2d

--- a/nav2_recoveries/src/recovery_server.cpp
+++ b/nav2_recoveries/src/recovery_server.cpp
@@ -26,7 +26,7 @@ RecoveryServer::RecoveryServer()
   plugin_loader_("nav2_core", "nav2_core::Recovery")
 {
   declare_parameter("costmap_topic",
-    rclcpp::ParameterValue(std::string("local_costmap/costmap_raw")));
+    rclcpp::ParameterValue(std::string("local_costmap/costmap")));
   declare_parameter("footprint_topic",
     rclcpp::ParameterValue(std::string("local_costmap/published_footprint")));
   declare_parameter("cycle_frequency", rclcpp::ParameterValue(10.0));


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  #1028 |
| Primary OS tested on | Ubuntu |

---

## Description of contribution in a few bullet points
- added flag and conversion support to allow `CostmapSubscriber` to subscribe to the nav2_msgs/Costmap topic ("/costmap") or use the nav_msgs/OccupancyGrid topic ("/costmap_raw")
- modifed `test_collision_checker` to test for either using the raw costmap topic or the occupancy grid
- changed recoveries to use the occupancy grid topic

