### PR TITLE
Improvements to (Simple) Action Server

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -226,10 +226,12 @@ BtNavigator::navigateToPose()
 
     case nav2_behavior_tree::BtStatus::FAILED:
       RCLCPP_ERROR(get_logger(), "Navigation failed");
+      action_server_->terminate_current();
       break;
 
     case nav2_behavior_tree::BtStatus::CANCELED:
       RCLCPP_INFO(get_logger(), "Navigation canceled");
+      action_server_->terminate_current();
       // Reset the BT so that it can be run again in the future
       bt_->resetTree(tree_->root_node);
       break;

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -226,12 +226,10 @@ BtNavigator::navigateToPose()
 
     case nav2_behavior_tree::BtStatus::FAILED:
       RCLCPP_ERROR(get_logger(), "Navigation failed");
-      action_server_->terminate_goals();
       break;
 
     case nav2_behavior_tree::BtStatus::CANCELED:
       RCLCPP_INFO(get_logger(), "Navigation canceled");
-      action_server_->terminate_goals();
       // Reset the BT so that it can be run again in the future
       bt_->resetTree(tree_->root_node);
       break;

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -231,7 +231,7 @@ BtNavigator::navigateToPose()
 
     case nav2_behavior_tree::BtStatus::CANCELED:
       RCLCPP_INFO(get_logger(), "Navigation canceled");
-      action_server_->terminate_all();
+      action_server_->terminate_current();
       // Reset the BT so that it can be run again in the future
       bt_->resetTree(tree_->root_node);
       break;

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -231,7 +231,7 @@ BtNavigator::navigateToPose()
 
     case nav2_behavior_tree::BtStatus::CANCELED:
       RCLCPP_INFO(get_logger(), "Navigation canceled");
-      action_server_->terminate_current();
+      action_server_->terminate_all();
       // Reset the BT so that it can be run again in the future
       bt_->resetTree(tree_->root_node);
       break;

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -169,7 +169,6 @@ void ControllerServer::followPath()
 
       if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(get_logger(), "Goal was canceled. Stopping the robot.");
-        action_server_->terminate_goals();
         publishZeroVelocity();
         return;
       }
@@ -191,7 +190,6 @@ void ControllerServer::followPath()
   } catch (nav2_core::PlannerException & e) {
     RCLCPP_ERROR(this->get_logger(), e.what());
     publishZeroVelocity();
-    action_server_->terminate_goals();
     return;
   }
 

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -169,7 +169,7 @@ void ControllerServer::followPath()
 
       if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(get_logger(), "Goal was canceled. Stopping the robot.");
-        action_server_->terminate_current();
+        action_server_->terminate_all();
         publishZeroVelocity();
         return;
       }

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -169,6 +169,7 @@ void ControllerServer::followPath()
 
       if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(get_logger(), "Goal was canceled. Stopping the robot.");
+        action_server_->terminate_current();
         publishZeroVelocity();
         return;
       }
@@ -190,6 +191,7 @@ void ControllerServer::followPath()
   } catch (nav2_core::PlannerException & e) {
     RCLCPP_ERROR(this->get_logger(), e.what());
     publishZeroVelocity();
+    action_server_->terminate_current();
     return;
   }
 

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -169,7 +169,7 @@ void ControllerServer::followPath()
 
       if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(get_logger(), "Goal was canceled. Stopping the robot.");
-        action_server_->terminate_all();
+        action_server_->terminate_current();
         publishZeroVelocity();
         return;
       }

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -206,7 +206,6 @@ PlannerServer::computePlan()
 
     if (action_server_->is_cancel_requested()) {
       RCLCPP_INFO(get_logger(), "Goal was canceled. Canceling planning action.");
-      action_server_->terminate_goals();
       return;
     }
 
@@ -246,8 +245,6 @@ PlannerServer::computePlan()
       RCLCPP_WARN(get_logger(), "Planning algorithm %s failed to generate a valid"
         " path to (%.2f, %.2f)", goal->planner_property.c_str(),
         goal->pose.pose.position.x, goal->pose.pose.position.y);
-      // TODO(orduno): define behavior if a preemption is available
-      action_server_->terminate_goals();
       return;
     }
 
@@ -266,19 +263,11 @@ PlannerServer::computePlan()
     RCLCPP_WARN(get_logger(), "%s plugin failed to plan calculation to (%.2f, %.2f): \"%s\"",
       goal->planner_property.c_str(), goal->pose.pose.position.x,
       goal->pose.pose.position.y, ex.what());
-
-    // TODO(orduno): provide information about fail error to parent task,
-    //               for example: couldn't get costmap update
-    action_server_->terminate_goals();
     return;
   } catch (...) {
     RCLCPP_WARN(get_logger(), "Plan calculation failed, "
       "An unexpected error has occurred. The planner server"
       " may not be able to continue operating correctly.");
-
-    // TODO(orduno): provide information about the failure to the parent task,
-    //               for example: couldn't get costmap update
-    action_server_->terminate_goals();
     return;
   }
 }

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -206,7 +206,7 @@ PlannerServer::computePlan()
 
     if (action_server_->is_cancel_requested()) {
       RCLCPP_INFO(get_logger(), "Goal was canceled. Canceling planning action.");
-      action_server_->terminate_all();
+      action_server_->terminate_current();
       return;
     }
 

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -206,7 +206,7 @@ PlannerServer::computePlan()
 
     if (action_server_->is_cancel_requested()) {
       RCLCPP_INFO(get_logger(), "Goal was canceled. Canceling planning action.");
-      action_server_->terminate_current();
+      action_server_->terminate_all();
       return;
     }
 

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -206,6 +206,7 @@ PlannerServer::computePlan()
 
     if (action_server_->is_cancel_requested()) {
       RCLCPP_INFO(get_logger(), "Goal was canceled. Canceling planning action.");
+      action_server_->terminate_current();
       return;
     }
 
@@ -245,6 +246,7 @@ PlannerServer::computePlan()
       RCLCPP_WARN(get_logger(), "Planning algorithm %s failed to generate a valid"
         " path to (%.2f, %.2f)", goal->planner_property.c_str(),
         goal->pose.pose.position.x, goal->pose.pose.position.y);
+      action_server_->terminate_current();
       return;
     }
 
@@ -263,11 +265,17 @@ PlannerServer::computePlan()
     RCLCPP_WARN(get_logger(), "%s plugin failed to plan calculation to (%.2f, %.2f): \"%s\"",
       goal->planner_property.c_str(), goal->pose.pose.position.x,
       goal->pose.pose.position.y, ex.what());
+    // TODO(orduno): provide information about fail error to parent task,
+    //               for example: couldn't get costmap update
+    action_server_->terminate_current();
     return;
   } catch (...) {
     RCLCPP_WARN(get_logger(), "Plan calculation failed, "
       "An unexpected error has occurred. The planner server"
       " may not be able to continue operating correctly.");
+    // TODO(orduno): provide information about fail error to parent task,
+    //               for example: couldn't get costmap update
+    action_server_->terminate_current();
     return;
   }
 }

--- a/nav2_recoveries/include/nav2_recoveries/recovery.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery.hpp
@@ -165,7 +165,6 @@ protected:
 
     if (onRun(action_server_->get_current_goal()) != Status::SUCCEEDED) {
       RCLCPP_INFO(node_->get_logger(), "Initial checks failed for %s", recovery_name_.c_str());
-      action_server_->terminate_goals();
       return;
     }
 
@@ -179,7 +178,6 @@ protected:
       if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(node_->get_logger(), "Canceling %s", recovery_name_.c_str());
         stopRobot();
-        action_server_->terminate_goals();
         return;
       }
 
@@ -189,7 +187,6 @@ protected:
           " however feature is currently not implemented. Aborting and stopping.",
           recovery_name_.c_str());
         stopRobot();
-        action_server_->terminate_goals();
         return;
       }
 
@@ -201,7 +198,6 @@ protected:
 
         case Status::FAILED:
           RCLCPP_WARN(node_->get_logger(), "%s failed", recovery_name_.c_str());
-          action_server_->terminate_goals();
           return;
 
         case Status::RUNNING:

--- a/nav2_recoveries/include/nav2_recoveries/recovery.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery.hpp
@@ -179,7 +179,7 @@ protected:
       if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(node_->get_logger(), "Canceling %s", recovery_name_.c_str());
         stopRobot();
-        action_server_->terminate_current();
+        action_server_->terminate_all();
         return;
       }
 

--- a/nav2_recoveries/include/nav2_recoveries/recovery.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery.hpp
@@ -165,6 +165,7 @@ protected:
 
     if (onRun(action_server_->get_current_goal()) != Status::SUCCEEDED) {
       RCLCPP_INFO(node_->get_logger(), "Initial checks failed for %s", recovery_name_.c_str());
+      action_server_->terminate_current();
       return;
     }
 
@@ -178,6 +179,7 @@ protected:
       if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(node_->get_logger(), "Canceling %s", recovery_name_.c_str());
         stopRobot();
+        action_server_->terminate_current();
         return;
       }
 
@@ -187,6 +189,7 @@ protected:
           " however feature is currently not implemented. Aborting and stopping.",
           recovery_name_.c_str());
         stopRobot();
+        action_server_->terminate_current();
         return;
       }
 
@@ -198,6 +201,7 @@ protected:
 
         case Status::FAILED:
           RCLCPP_WARN(node_->get_logger(), "%s failed", recovery_name_.c_str());
+          action_server_->terminate_current();
           return;
 
         case Status::RUNNING:

--- a/nav2_recoveries/include/nav2_recoveries/recovery.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery.hpp
@@ -179,7 +179,7 @@ protected:
       if (action_server_->is_cancel_requested()) {
         RCLCPP_INFO(node_->get_logger(), "Canceling %s", recovery_name_.c_str());
         stopRobot();
-        action_server_->terminate_all();
+        action_server_->terminate_current();
         return;
       }
 

--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -123,6 +123,9 @@ public:
                 } catch (std::exception & ex) {
                   RCLCPP_ERROR(node_logging_interface_->get_logger(),
                     "Action server failed while executing action callback: \"%s\"", ex.what());
+                  terminate(current_handle_);
+                  terminate(pending_handle_);
+                  preempt_requested_ = false;
                   return;
                 }
 
@@ -199,8 +202,7 @@ public:
       end_time += server_timeout_;
     }
 
-    while (execution_future_.wait_for(milliseconds(100)) != std::future_status::ready)
-    {
+    while (execution_future_.wait_for(milliseconds(100)) != std::future_status::ready) {
       info_msg("Waiting for async process to finish.");
       if (steady_clock::now() >= end_time) {
         warn_msg("Async process is past stop deadline. Continuing deactivation");


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #861 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo simulation of TB3 |

---

## Description of contribution in a few bullet points

Addressing #861 and partially #1344.

Improvements:
- Simplify usage by removing the need to terminate goals if the action was not successfully completed.
- Handle action server deactivation while the action is still running.
- Handle race condition between completing an action and receiving a preemption.

Improvements were mainly implemented by wrapping the action execution callback around a method that will terminate the goals if needed and re-run the callback if there are any pending handles. This addresses #861, i.e. if there is a pending preemption in DWB after returning from the callback, the server will re-run the callback with the preemption.
   
Adding unit tests for:
  - Activate-Deactivate cycling including in the middle of execution.
  - Preemption during goal execution
  - Preemption race condition after the goal has been completed