### PR TITLE
Fix twice backtracking of path by navfn planner.

### DIFF
--- a/nav2_navfn_planner/src/navfn.cpp
+++ b/nav2_navfn_planner/src/navfn.cpp
@@ -295,18 +295,7 @@ NavFn::calcNavFnDijkstra(bool atStart)
   setupNavFn(true);
 
   // calculate the nav fn and path
-  propNavFnDijkstra(std::max(nx * ny / 20, nx + ny), atStart);
-
-  // path
-  int len = calcPath(nx * ny / 2);
-
-  if (len > 0) {  // found plan
-    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "[NavFn] Path found, %d steps\n", len);
-    return true;
-  } else {
-    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "[NavFn] No path found\n");
-    return false;
-  }
+  return propNavFnDijkstra(std::max(nx * ny / 20, nx + ny), atStart);
 }
 
 
@@ -320,18 +309,7 @@ NavFn::calcNavFnAstar()
   setupNavFn(true);
 
   // calculate the nav fn and path
-  propNavFnAstar(std::max(nx * ny / 20, nx + ny));
-
-  // path
-  int len = calcPath(nx * 4);
-
-  if (len > 0) {  // found plan
-    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "[NavFn] Path found, %d steps\n", len);
-    return true;
-  } else {
-    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "[NavFn] No path found\n");
-    return false;
-  }
+  return propNavFnAstar(std::max(nx * ny / 20, nx + ny));
 }
 
 //

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -321,7 +321,13 @@ NavfnPlanner::getPlanFromPotential(
 
   planner_->setStart(map_goal);
 
-  planner_->calcPath(costmap_->getSizeInCellsX() * 4);
+  int path_len = planner_->calcPath(costmap_->getSizeInCellsX() * 4);
+  if (path_len == 0) {
+    RCLCPP_DEBUG(node_->get_logger(), "No path found\n");
+    return false;
+  }
+
+  RCLCPP_DEBUG(node_->get_logger(), "Path found, %d steps\n", path_len);
 
   // extract the plan
   float * x = planner_->getPathX();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #573 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* Fixed the bug where navfn planner was backtracking the path twice.
* Before the fix the whole operation was like
     1. set `goal` and `start` pose.
     2. call `calcNavFnAstar()`/`calcNavFnDijkstra`
         a. call `propNavFnAstar`/`propNavFnDijkstra`
         b. call `calcPath()`
     3. Find new `goal` point around the old `goal` which has low potential and is not far from old `goal` point.
     4. call `calcPath()` with new `goal` point.
* After the fix, its like
     1. set `goal` and `start` pose.
     2. call `calcNavFnAstar()`/`calcNavFnDijkstra`
         a. call `propNavFnAstar`/`propNavFnDijkstra`
     3. Find new `goal` point around the old `goal` which has low potential and is not far from old `goal` point.
     4. call `calcPath()` with new `goal` point.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

* Let me know if there is any other way to do it.
