### PR TITLE
Update index.rst

### DIFF
--- a/sphinx_doc/getting_started/index.rst
+++ b/sphinx_doc/getting_started/index.rst
@@ -36,7 +36,7 @@ Installation
 
    .. code-block:: bash
 
-      sudo apt install ros2-dashing-turtlebot3*
+      sudo apt install ros-dashing-turtlebot3*
 
 Running the Example
 *******************

--- a/sphinx_doc/getting_started/index.rst
+++ b/sphinx_doc/getting_started/index.rst
@@ -29,8 +29,8 @@ Installation
 
    .. code-block:: bash
 
-      sudo apt install ros2-dashing-navigation2
-      sudo apt install ros2-dashing-nav2-bringup
+      sudo apt install ros-dashing-navigation2
+      sudo apt install ros-dashing-nav2-bringup
 
 3. Install the Turtlebot 3 packages. Again, for Ubuntu 18, it looks like this:
 


### PR DESCRIPTION
I was following this guide.
To install ros2-navigation, need to edit `ros2-dashing-navigation2` to `ros-dashing-navigation2`.

When I tried original command from this guide, I got error below.

```bash
$ sudo apt install ros2-dashing-navigation2
Reading package lists... Done
Building dependency tree... 50%
Building dependency tree       
Reading state information... Done
E: Unable to locate package ros2-dashing-navigation2
$ sudo apt install ros2-dashing-nav2-bringup
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package ros2-dashing-nav2-bringup
```

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
