### PR TITLE
Fix launching multiple gzclient instances

### DIFF
--- a/nav2_bringup/bringup/launch/nav2_multi_tb3_simulation_launch.py
+++ b/nav2_bringup/bringup/launch/nav2_multi_tb3_simulation_launch.py
@@ -169,6 +169,7 @@ def generate_launch_description():
                                   'rviz_config_file': namespaced_rviz_config_file,
                                   'use_rviz': use_rviz,
                                   'use_simulator': 'False',
+                                  'headless': 'False',
                                   'use_robot_state_pub': use_robot_state_pub}.items()),
 
             LogInfo(

--- a/nav2_bringup/bringup/launch/nav2_tb3_simulation_launch.py
+++ b/nav2_bringup/bringup/launch/nav2_tb3_simulation_launch.py
@@ -21,11 +21,11 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (DeclareLaunchArgument, EmitEvent, ExecuteProcess,
                             IncludeLaunchDescription, RegisterEventHandler)
-from launch.conditions import IfCondition, UnlessCondition
+from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit
 from launch.events import Shutdown
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 
 from nav2_common.launch import Node
 
@@ -136,7 +136,7 @@ def generate_launch_description():
         cwd=[launch_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=(IfCondition(use_simulator) and UnlessCondition(headless)),
+        condition=IfCondition(PythonExpression([use_simulator, ' and not ', headless])),
         cmd=['gzclient'],
         cwd=[launch_dir], output='screen')
 


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1410 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo simulation of TB3 |

---

## Description of contribution in a few bullet points

Fixes #1410, the problem is here:

https://github.com/ros-planning/navigation2/blob/c2d93596084968376ccb3d6213621f1cf59fe7b5/nav2_bringup/bringup/launch/nav2_tb3_simulation_launch.py#L138-L141

Where the `and` operation over two conditions is not well defined.