### PR TITLE
Fix docs_publish error if nothing to commit.

### DIFF
--- a/sphinx_doc/Makefile
+++ b/sphinx_doc/Makefile
@@ -52,7 +52,10 @@ publish:
 	rm -fr $(PUBLISHDIR)/*
 	cp -r $(BUILDDIR)/html/* $(PUBLISHDIR)
 	cp scripts/.nojekyll $(PUBLISHDIR)/.nojekyll
-	cd $(PUBLISHDIR) && git add -A && git commit -s -m "[skip ci] publish $(RELEASE)" && git push origin
+	cd $(PUBLISHDIR) && \
+	git add -A && \
+	git diff-index --quiet HEAD || \  #if no changes, don't commit.
+	(git commit -s -m "[skip ci] publish $(RELEASE)" && git push origin)
 
 
 # Catch-all target: route all unknown targets to Sphinx using the new


### PR DESCRIPTION
## Description of contribution in a few bullet points

* This fixes the doc_publish step in CI. It is currently failing if there are no updates to publish. The failure is harmless, but gives us another red X in CI.
* This PR makes the docs_publish step check whether there are actual changes before making the commit. if none, then it just returns.