### PR TITLE
Dwb dynamic param callbacks

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -351,12 +351,14 @@ AmclNode::on_shutdown(const rclcpp_lifecycle::State & /*state*/)
 }
 
 void
-AmclNode::parameterEventCallback(const rcl_interfaces::msg::ParameterEvent::SharedPtr & /*event*/)
+AmclNode::parameterEventCallback(const rcl_interfaces::msg::ParameterEvent::SharedPtr & event)
 {
-  initParameters();
-  initMessageFilters();
-  initOdometry();
-  initParticleFilter();
+  if (event->node == get_node_base_interface()->get_fully_qualified_name()) {
+    initParameters();
+    initMessageFilters();
+    initOdometry();
+    initParticleFilter();
+  }
 }
 
 void

--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -178,6 +178,10 @@ protected:
 
   // Whether we've published the single controller warning yet
   bool single_controller_warning_given_{false};
+
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_subscriber_;
+  std::vector<nav2_util::ParameterEventsCallbackHandle::SharedPtr> callback_handles_;
+  std::recursive_mutex mutex_;
 };
 
 }  // namespace nav2_controller

--- a/nav2_core/include/nav2_core/goal_checker.hpp
+++ b/nav2_core/include/nav2_core/goal_checker.hpp
@@ -41,6 +41,7 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/twist.hpp"
+#include "nav2_util/parameter_events_subscriber.hpp"
 
 namespace nav2_core
 {
@@ -65,7 +66,7 @@ public:
    * @brief Initialize any parameters from the NodeHandle
    * @param nh NodeHandle for grabbing parameters
    */
-  virtual void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh) = 0;
+  virtual void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) = 0;
 
   /**
    * @brief Check whether the goal should be considered reached

--- a/nav2_core/include/nav2_core/goal_checker.hpp
+++ b/nav2_core/include/nav2_core/goal_checker.hpp
@@ -66,7 +66,10 @@ public:
    * @brief Initialize any parameters from the NodeHandle
    * @param nh NodeHandle for grabbing parameters
    */
-  virtual void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) = 0;
+  virtual void initialize(
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr)
+  = 0;
 
   /**
    * @brief Check whether the goal should be considered reached

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/dwb_local_planner.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/dwb_local_planner.hpp
@@ -50,6 +50,7 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "pluginlib/class_loader.hpp"
 #include "pluginlib/class_list_macros.hpp"
+#include "nav2_util/parameter_events_subscriber.hpp"
 
 namespace dwb_core
 {
@@ -214,6 +215,8 @@ protected:
 
   pluginlib::ClassLoader<TrajectoryCritic> critic_loader_;
   std::vector<TrajectoryCritic::Ptr> critics_;
+
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_subscriber_;
 };
 
 }  // namespace dwb_core

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
@@ -106,11 +106,13 @@ public:
       nh_->declare_parameter(name_ + ".scale", rclcpp::ParameterValue(1.0));
     }
     nh_->get_parameter(name_ + ".scale", scale_);
-    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".scale",
-      [&](const rclcpp::Parameter & p) {
-        std::lock_guard<std::recursive_mutex> lock(mutex_);
-        scale_ = p.get_value<double>();
-      }));
+    if (param_sub) {
+      callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".scale",
+        [&](const rclcpp::Parameter & p) {
+          std::lock_guard<std::recursive_mutex> lock(mutex_);
+          scale_ = p.get_value<double>();
+        }));
+    }
     onInit();
   }
   virtual void onInit() {}

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_critic.hpp
@@ -47,6 +47,7 @@
 #include "dwb_msgs/msg/trajectory2_d.hpp"
 #include "sensor_msgs/msg/point_cloud.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/parameter_events_subscriber.hpp"
 
 namespace dwb_core
 {
@@ -94,11 +95,13 @@ public:
   void initialize(
     const nav2_util::LifecycleNode::SharedPtr & nh,
     std::string & name,
-    std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros)
+    std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr)
   {
     name_ = name;
     costmap_ros_ = costmap_ros;
     nh_ = nh;
+    param_subcriber_ = param_sub;
     if (!nh_->has_parameter(name_ + ".scale")) {
       nh_->declare_parameter(name_ + ".scale", rclcpp::ParameterValue(1.0));
     }
@@ -177,6 +180,7 @@ protected:
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   double scale_;
   nav2_util::LifecycleNode::SharedPtr nh_;
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_subcriber_;
 };
 
 }  // namespace dwb_core

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_generator.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_generator.hpp
@@ -72,7 +72,10 @@ public:
    * @brief Initialize parameters as needed
    * @param nh NodeHandle to read parameters from
    */
-  virtual void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) = 0;
+  virtual void initialize(
+    const nav2_util::LifecycleNode::SharedPtr & nh,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr)
+  = 0;
 
   /**
    * @brief Start a new iteration based on the current velocity

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_generator.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_generator.hpp
@@ -41,6 +41,7 @@
 #include "nav_2d_msgs/msg/twist2_d.hpp"
 #include "dwb_msgs/msg/trajectory2_d.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/parameter_events_subscriber.hpp"
 
 namespace dwb_core
 {
@@ -71,7 +72,7 @@ public:
    * @brief Initialize parameters as needed
    * @param nh NodeHandle to read parameters from
    */
-  virtual void initialize(const nav2_util::LifecycleNode::SharedPtr & nh) = 0;
+  virtual void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) = 0;
 
   /**
    * @brief Start a new iteration based on the current velocity

--- a/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
@@ -106,8 +106,8 @@ void DWBLocalPlanner::configure(
   traj_generator_ = traj_gen_loader_.createUniqueInstance(traj_generator_name);
   goal_checker_ = goal_checker_loader_.createUniqueInstance(goal_checker_name);
 
-  traj_generator_->initialize(node_);
-  goal_checker_->initialize(node_);
+  traj_generator_->initialize(node_, param_subscriber_);
+  goal_checker_->initialize(node_, param_subscriber_);
 
   try {
     loadCritics();
@@ -185,7 +185,7 @@ DWBLocalPlanner::loadCritics()
       "Using critic \"%s\" (%s)", plugin_name.c_str(), plugin_class.c_str());
     critics_.push_back(plugin);
     try {
-      plugin->initialize(node_, plugin_name, costmap_ros_);
+      plugin->initialize(node_, plugin_name, costmap_ros_, param_subscriber_);
     } catch (const std::exception & e) {
       RCLCPP_ERROR(node_->get_logger(), "Couldn't initialize critic plugin!");
       throw;

--- a/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
@@ -72,6 +72,8 @@ void DWBLocalPlanner::configure(
   node_ = node;
   costmap_ros_ = costmap_ros;
   tf_ = tf;
+
+  param_subscriber_ = std::make_shared<nav2_util::ParameterEventsSubscriber>(node_);
   declare_parameter_if_not_declared(node_, "critics");
   declare_parameter_if_not_declared(node_, "prune_plan", rclcpp::ParameterValue(true));
   declare_parameter_if_not_declared(node_, "prune_distance", rclcpp::ParameterValue(1.0));

--- a/nav2_dwb_controller/dwb_critics/include/dwb_critics/map_grid.hpp
+++ b/nav2_dwb_controller/dwb_critics/include/dwb_critics/map_grid.hpp
@@ -35,6 +35,7 @@
 #ifndef DWB_CRITICS__MAP_GRID_HPP_
 #define DWB_CRITICS__MAP_GRID_HPP_
 
+#include <string>
 #include <vector>
 #include <memory>
 #include "dwb_core/trajectory_critic.hpp"

--- a/nav2_dwb_controller/dwb_critics/include/dwb_critics/map_grid.hpp
+++ b/nav2_dwb_controller/dwb_critics/include/dwb_critics/map_grid.hpp
@@ -100,6 +100,8 @@ protected:
   // cppcheck-suppress syntaxError
   enum class ScoreAggregationType {Last, Sum, Product};
 
+  void getAggregationType(std::string & aggro_str);
+
   /**
    * @class MapGridQueue
    * @brief Subclass of CostmapQueue that avoids Obstacles and Unknown Values

--- a/nav2_dwb_controller/dwb_critics/src/base_obstacle.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/base_obstacle.cpp
@@ -50,11 +50,13 @@ void BaseObstacleCritic::onInit()
   nav2_util::declare_parameter_if_not_declared(nh_,
     name_ + ".sum_scores", rclcpp::ParameterValue(false));
   nh_->get_parameter(name_ + ".sum_scores", sum_scores_);
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".sum_scores",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      sum_scores_ = p.get_value<bool>();
-    }));
+  if (param_subscriber_) {
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".sum_scores",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        sum_scores_ = p.get_value<bool>();
+      }));
+  }
 }
 
 double BaseObstacleCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & traj)

--- a/nav2_dwb_controller/dwb_critics/src/base_obstacle.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/base_obstacle.cpp
@@ -50,6 +50,11 @@ void BaseObstacleCritic::onInit()
   nav2_util::declare_parameter_if_not_declared(nh_,
     name_ + ".sum_scores", rclcpp::ParameterValue(false));
   nh_->get_parameter(name_ + ".sum_scores", sum_scores_);
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".sum_scores",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      sum_scores_ = p.get_value<bool>();
+    }));
 }
 
 double BaseObstacleCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & traj)

--- a/nav2_dwb_controller/dwb_critics/src/goal_align.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/goal_align.cpp
@@ -48,7 +48,8 @@ void GoalAlignCritic::onInit()
   stop_on_failure_ = false;
   forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_,
       name_ + ".forward_point_distance", 0.325);
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".forward_point_distance",
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+    ".forward_point_distance",
     [&](const rclcpp::Parameter & p) {
       std::lock_guard<std::recursive_mutex> lock(mutex_);
       forward_point_distance_ = p.get_value<double>();

--- a/nav2_dwb_controller/dwb_critics/src/goal_align.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/goal_align.cpp
@@ -48,6 +48,11 @@ void GoalAlignCritic::onInit()
   stop_on_failure_ = false;
   forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_,
       name_ + ".forward_point_distance", 0.325);
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".forward_point_distance",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      forward_point_distance_ = p.get_value<double>();
+    }));
 }
 
 bool GoalAlignCritic::prepare(

--- a/nav2_dwb_controller/dwb_critics/src/goal_align.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/goal_align.cpp
@@ -48,12 +48,14 @@ void GoalAlignCritic::onInit()
   stop_on_failure_ = false;
   forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_,
       name_ + ".forward_point_distance", 0.325);
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
-    ".forward_point_distance",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      forward_point_distance_ = p.get_value<double>();
-    }));
+  if (param_subscriber_) {
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+      ".forward_point_distance",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        forward_point_distance_ = p.get_value<double>();
+      }));
+  }
 }
 
 bool GoalAlignCritic::prepare(

--- a/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
@@ -67,11 +67,14 @@ void MapGridCritic::onInit()
   std::string aggro_str;
   nh_->get_parameter(name_ + ".aggregation_type", aggro_str);
   getAggregationType(aggro_str);
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".aggregation_type",
-    [&](const rclcpp::Parameter & p) {
-      auto aggro_str = p.get_value<std::string>();
-      getAggregationType(aggro_str);
-    }));
+  if (param_subscriber_) {
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+      ".aggregation_type",
+      [&](const rclcpp::Parameter & p) {
+        auto aggro_str = p.get_value<std::string>();
+        getAggregationType(aggro_str);
+      }));
+  }
 }
 
 void MapGridCritic::getAggregationType(std::string & aggro_str)

--- a/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
@@ -66,6 +66,17 @@ void MapGridCritic::onInit()
 
   std::string aggro_str;
   nh_->get_parameter(name_ + ".aggregation_type", aggro_str);
+  getAggregationType(aggro_str);
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".aggregation_type",
+    [&](const rclcpp::Parameter & p) {
+      auto aggro_str = p.get_value<std::string>();
+      getAggregationType(aggro_str);
+    }));
+}
+
+void MapGridCritic::getAggregationType(std::string & aggro_str)
+{
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::transform(aggro_str.begin(), aggro_str.end(), aggro_str.begin(), ::tolower);
   if (aggro_str == "last") {
     aggregationType_ = ScoreAggregationType::Last;
@@ -78,7 +89,7 @@ void MapGridCritic::onInit()
         "MapGridCritic"), "aggregation_type parameter \"%s\" invalid. Using Last.",
       aggro_str.c_str());
     aggregationType_ = ScoreAggregationType::Last;
-  }
+  }  
 }
 
 void MapGridCritic::setAsObstacle(unsigned int index)

--- a/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/map_grid.cpp
@@ -89,7 +89,7 @@ void MapGridCritic::getAggregationType(std::string & aggro_str)
         "MapGridCritic"), "aggregation_type parameter \"%s\" invalid. Using Last.",
       aggro_str.c_str());
     aggregationType_ = ScoreAggregationType::Last;
-  }  
+  }
 }
 
 void MapGridCritic::setAsObstacle(unsigned int index)

--- a/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
@@ -132,30 +132,33 @@ void OscillationCritic::onInit()
   //   x_only_threshold_ = 0.05;
   // }
 
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
-    ".oscillation_reset_dist",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      oscillation_reset_dist_ = p.get_value<double>();
-      oscillation_reset_dist_sq_ = oscillation_reset_dist_ * oscillation_reset_dist_;
-    }));
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
-    ".oscillation_reset_angle",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      oscillation_reset_angle_ = p.get_value<double>();
-    }));
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
-    ".oscillation_reset_time",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      oscillation_reset_time_ = rclcpp::Duration::from_seconds(p.get_value<double>());
-    }));
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".x_only_threshold",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      x_only_threshold_ = p.get_value<double>();
-    }));
+  if (param_subscriber_) {
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+      ".oscillation_reset_dist",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        oscillation_reset_dist_ = p.get_value<double>();
+        oscillation_reset_dist_sq_ = oscillation_reset_dist_ * oscillation_reset_dist_;
+      }));
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+      ".oscillation_reset_angle",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        oscillation_reset_angle_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+      ".oscillation_reset_time",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        oscillation_reset_time_ = rclcpp::Duration::from_seconds(p.get_value<double>());
+      }));
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+      ".x_only_threshold",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        x_only_threshold_ = p.get_value<double>();
+      }));
+  }
 
   reset();
 }

--- a/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
@@ -132,18 +132,21 @@ void OscillationCritic::onInit()
   //   x_only_threshold_ = 0.05;
   // }
 
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".oscillation_reset_dist",
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+    ".oscillation_reset_dist",
     [&](const rclcpp::Parameter & p) {
       std::lock_guard<std::recursive_mutex> lock(mutex_);
       oscillation_reset_dist_ = p.get_value<double>();
       oscillation_reset_dist_sq_ = oscillation_reset_dist_ * oscillation_reset_dist_;
     }));
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".oscillation_reset_angle",
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+    ".oscillation_reset_angle",
     [&](const rclcpp::Parameter & p) {
       std::lock_guard<std::recursive_mutex> lock(mutex_);
       oscillation_reset_angle_ = p.get_value<double>();
     }));
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".oscillation_reset_time",
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+    ".oscillation_reset_time",
     [&](const rclcpp::Parameter & p) {
       std::lock_guard<std::recursive_mutex> lock(mutex_);
       oscillation_reset_time_ = rclcpp::Duration::from_seconds(p.get_value<double>());

--- a/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/oscillation.cpp
@@ -132,6 +132,28 @@ void OscillationCritic::onInit()
   //   x_only_threshold_ = 0.05;
   // }
 
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".oscillation_reset_dist",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      oscillation_reset_dist_ = p.get_value<double>();
+      oscillation_reset_dist_sq_ = oscillation_reset_dist_ * oscillation_reset_dist_;
+    }));
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".oscillation_reset_angle",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      oscillation_reset_angle_ = p.get_value<double>();
+    }));
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".oscillation_reset_time",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      oscillation_reset_time_ = rclcpp::Duration::from_seconds(p.get_value<double>());
+    }));
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".x_only_threshold",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      x_only_threshold_ = p.get_value<double>();
+    }));
+
   reset();
 }
 

--- a/nav2_dwb_controller/dwb_critics/src/path_align.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/path_align.cpp
@@ -48,12 +48,14 @@ void PathAlignCritic::onInit()
   stop_on_failure_ = false;
   forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_,
       name_ + ".forward_point_distance", 0.325);
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
-    ".forward_point_distance",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      forward_point_distance_ = p.get_value<double>();
-    }));
+  if (param_subscriber_) {
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+      ".forward_point_distance",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        forward_point_distance_ = p.get_value<double>();
+      }));
+  }
 }
 
 bool PathAlignCritic::prepare(

--- a/nav2_dwb_controller/dwb_critics/src/path_align.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/path_align.cpp
@@ -48,6 +48,11 @@ void PathAlignCritic::onInit()
   stop_on_failure_ = false;
   forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_,
       name_ + ".forward_point_distance", 0.325);
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".forward_point_distance",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      forward_point_distance_ = p.get_value<double>();
+    }));
 }
 
 bool PathAlignCritic::prepare(

--- a/nav2_dwb_controller/dwb_critics/src/path_align.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/path_align.cpp
@@ -48,7 +48,8 @@ void PathAlignCritic::onInit()
   stop_on_failure_ = false;
   forward_point_distance_ = nav_2d_utils::searchAndGetParam(nh_,
       name_ + ".forward_point_distance", 0.325);
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".forward_point_distance",
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+    ".forward_point_distance",
     [&](const rclcpp::Parameter & p) {
       std::lock_guard<std::recursive_mutex> lock(mutex_);
       forward_point_distance_ = p.get_value<double>();

--- a/nav2_dwb_controller/dwb_critics/src/prefer_forward.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/prefer_forward.cpp
@@ -55,6 +55,27 @@ void PreferForwardCritic::onInit()
   nh_->get_parameter(name_ + ".strafe_x", strafe_x_);
   nh_->get_parameter(name_ + ".strafe_theta", strafe_theta_);
   nh_->get_parameter(name_ + ".theta_scale", theta_scale_);
+
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".penalty",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      penalty_ = p.get_value<double>();
+    }));
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".strafe_x",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      strafe_x_ = p.get_value<double>();
+    }));
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".strafe_theta",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      strafe_theta_ = p.get_value<double>();
+    }));
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".theta_scale",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      theta_scale_ = p.get_value<double>();
+    }));
 }
 
 double PreferForwardCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & traj)

--- a/nav2_dwb_controller/dwb_critics/src/prefer_forward.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/prefer_forward.cpp
@@ -56,26 +56,28 @@ void PreferForwardCritic::onInit()
   nh_->get_parameter(name_ + ".strafe_theta", strafe_theta_);
   nh_->get_parameter(name_ + ".theta_scale", theta_scale_);
 
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".penalty",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      penalty_ = p.get_value<double>();
-    }));
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".strafe_x",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      strafe_x_ = p.get_value<double>();
-    }));
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".strafe_theta",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      strafe_theta_ = p.get_value<double>();
-    }));
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".theta_scale",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      theta_scale_ = p.get_value<double>();
-    }));
+  if (param_subscriber_) {
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".penalty",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        penalty_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".strafe_x",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        strafe_x_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".strafe_theta",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        strafe_theta_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".theta_scale",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        theta_scale_ = p.get_value<double>();
+      }));
+  }
 }
 
 double PreferForwardCritic::scoreTrajectory(const dwb_msgs::msg::Trajectory2D & traj)

--- a/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
@@ -49,6 +49,12 @@ void RotateToGoalCritic::onInit()
 {
   xy_goal_tolerance_ = nav_2d_utils::searchAndGetParam(nh_, name_ + ".xy_goal_tolerance", 0.25);
   xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".xy_goal_tolerance",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      xy_goal_tolerance_ = p.get_value<double>();
+      xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
+    }));  
 }
 
 bool RotateToGoalCritic::prepare(

--- a/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
@@ -49,13 +49,15 @@ void RotateToGoalCritic::onInit()
 {
   xy_goal_tolerance_ = nav_2d_utils::searchAndGetParam(nh_, name_ + ".xy_goal_tolerance", 0.25);
   xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
-    ".xy_goal_tolerance",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      xy_goal_tolerance_ = p.get_value<double>();
-      xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
-    }));
+  if (param_subscriber_) {
+    callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+      ".xy_goal_tolerance",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        xy_goal_tolerance_ = p.get_value<double>();
+        xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
+      }));
+  }
 }
 
 bool RotateToGoalCritic::prepare(

--- a/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
@@ -49,12 +49,13 @@ void RotateToGoalCritic::onInit()
 {
   xy_goal_tolerance_ = nav_2d_utils::searchAndGetParam(nh_, name_ + ".xy_goal_tolerance", 0.25);
   xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
-  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ + ".xy_goal_tolerance",
+  callback_handles_.push_back(param_subscriber_->add_parameter_callback(name_ +
+    ".xy_goal_tolerance",
     [&](const rclcpp::Parameter & p) {
       std::lock_guard<std::recursive_mutex> lock(mutex_);
       xy_goal_tolerance_ = p.get_value<double>();
       xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
-    }));  
+    }));
 }
 
 bool RotateToGoalCritic::prepare(

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -113,7 +113,10 @@ protected:
   double min_speed_xy_sq_{0};
   double max_speed_xy_sq_{0};
 
-  void reconfigureCB();
+  std::vector<nav2_util::ParameterEventsCallbackHandle::SharedPtr> callback_handles_;
+
+  void setParamCallbacks(std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub);
+  std::recursive_mutex mutex_;
 };
 
 }  // namespace dwb_plugins

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -39,6 +39,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/parameter_events_subscriber.hpp"
 
 namespace dwb_plugins
 {
@@ -51,7 +52,7 @@ class KinematicParameters
 {
 public:
   KinematicParameters();
-  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh);
+  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr);
 
   inline double getMinX() {return min_vel_x_;}
   inline double getMaxX() {return max_vel_x_;}

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -113,9 +113,8 @@ protected:
   double min_speed_xy_sq_{0};
   double max_speed_xy_sq_{0};
 
-  std::vector<nav2_util::ParameterEventsCallbackHandle::SharedPtr> callback_handles_;
-
   void setParamCallbacks(std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub);
+  std::vector<nav2_util::ParameterEventsCallbackHandle::SharedPtr> callback_handles_;
   std::recursive_mutex mutex_;
 };
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -36,6 +36,7 @@
 #define DWB_PLUGINS__KINEMATIC_PARAMETERS_HPP_
 
 #include <memory>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_util/lifecycle_node.hpp"

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -52,7 +52,9 @@ class KinematicParameters
 {
 public:
   KinematicParameters();
-  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr);
+  void initialize(
+    const nav2_util::LifecycleNode::SharedPtr & nh,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr);
 
   inline double getMinX() {return min_vel_x_;}
   inline double getMaxX() {return max_vel_x_;}

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/limited_accel_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/limited_accel_generator.hpp
@@ -49,7 +49,10 @@ namespace dwb_plugins
 class LimitedAccelGenerator : public StandardTrajectoryGenerator
 {
 public:
-  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) override;
+  void initialize(
+    const nav2_util::LifecycleNode::SharedPtr & nh,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr)
+  override;
   void checkUseDwaParam(const nav2_util::LifecycleNode::SharedPtr & nh) override;
   void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity) override;
   dwb_msgs::msg::Trajectory2D generateTrajectory(

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/limited_accel_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/limited_accel_generator.hpp
@@ -54,6 +54,7 @@ public:
     std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr)
   override;
   void checkUseDwaParam(const nav2_util::LifecycleNode::SharedPtr & nh) override;
+  void computeAccelerationTime(double controller_frequency);
   void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity) override;
   dwb_msgs::msg::Trajectory2D generateTrajectory(
     const geometry_msgs::msg::Pose2D & start_pose,

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/limited_accel_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/limited_accel_generator.hpp
@@ -49,7 +49,7 @@ namespace dwb_plugins
 class LimitedAccelGenerator : public StandardTrajectoryGenerator
 {
 public:
-  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh) override;
+  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) override;
   void checkUseDwaParam(const nav2_util::LifecycleNode::SharedPtr & nh) override;
   void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity) override;
   dwb_msgs::msg::Trajectory2D generateTrajectory(

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
@@ -53,7 +53,7 @@ class SimpleGoalChecker : public nav2_core::GoalChecker
 public:
   SimpleGoalChecker();
   // Standard GoalChecker Interface
-  void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh) override;
+  void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) override;
   bool isGoalReached(
     const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
     const geometry_msgs::msg::Twist & velocity) override;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
@@ -53,7 +53,10 @@ class SimpleGoalChecker : public nav2_core::GoalChecker
 public:
   SimpleGoalChecker();
   // Standard GoalChecker Interface
-  void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) override;
+  void initialize(
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr)
+  override;
   bool isGoalReached(
     const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
     const geometry_msgs::msg::Twist & velocity) override;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
@@ -36,6 +36,7 @@
 #define DWB_PLUGINS__SIMPLE_GOAL_CHECKER_HPP_
 
 #include <memory>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
@@ -63,6 +63,9 @@ protected:
 
   // Cached squared xy_goal_tolerance_
   double xy_goal_tolerance_sq_;
+
+  std::vector<nav2_util::ParameterEventsCallbackHandle::SharedPtr> callback_handles_;
+  std::recursive_mutex mutex_;
 };
 
 }  // namespace dwb_plugins

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -55,7 +55,10 @@ class StandardTrajectoryGenerator : public dwb_core::TrajectoryGenerator
 {
 public:
   // Standard TrajectoryGenerator interface
-  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) override;
+  void initialize(
+    const nav2_util::LifecycleNode::SharedPtr & nh,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr)
+  override;
   void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity) override;
   bool hasMoreTwists() override;
   nav_2d_msgs::msg::Twist2D nextTwist() override;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -135,6 +135,9 @@ protected:
 
   /// @brief If not discretizing by time, the amount of angular space between points
   double angular_granularity_;
+
+  std::vector<nav2_util::ParameterEventsCallbackHandle::SharedPtr> callback_handles_;
+  std::recursive_mutex mutex_;
 };
 
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -55,7 +55,7 @@ class StandardTrajectoryGenerator : public dwb_core::TrajectoryGenerator
 {
 public:
   // Standard TrajectoryGenerator interface
-  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh) override;
+  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) override;
   void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity) override;
   bool hasMoreTwists() override;
   nav_2d_msgs::msg::Twist2D nextTwist() override;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -72,7 +72,9 @@ protected:
   /**
    * @brief Initialize the VelocityIterator pointer. Put in its own function for easy overriding
    */
-  virtual void initializeIterator(const nav2_util::LifecycleNode::SharedPtr & nh);
+  virtual void initializeIterator(
+    const nav2_util::LifecycleNode::SharedPtr & nh,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr);
 
   /**
    * @brief Check if the deprecated use_dwa parameter is set to the functionality that matches this class

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
@@ -60,6 +60,9 @@ public:
 
 protected:
   double rot_stopped_velocity_, trans_stopped_velocity_;
+
+  std::vector<nav2_util::ParameterEventsCallbackHandle::SharedPtr> callback_handles_;
+  std::recursive_mutex mutex_;
 };
 
 }  // namespace dwb_plugins

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
@@ -63,9 +63,6 @@ public:
 
 protected:
   double rot_stopped_velocity_, trans_stopped_velocity_;
-
-  std::vector<nav2_util::ParameterEventsCallbackHandle::SharedPtr> callback_handles_;
-  std::recursive_mutex mutex_;
 };
 
 }  // namespace dwb_plugins

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
@@ -53,7 +53,10 @@ class StoppedGoalChecker : public SimpleGoalChecker
 public:
   StoppedGoalChecker();
   // Standard GoalChecker Interface
-  void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) override;
+  void initialize(
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr)
+  override;
   bool isGoalReached(
     const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
     const geometry_msgs::msg::Twist & velocity) override;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
@@ -53,7 +53,7 @@ class StoppedGoalChecker : public SimpleGoalChecker
 public:
   StoppedGoalChecker();
   // Standard GoalChecker Interface
-  void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh) override;
+  void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) override;
   bool isGoalReached(
     const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
     const geometry_msgs::msg::Twist & velocity) override;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/velocity_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/velocity_iterator.hpp
@@ -41,6 +41,7 @@
 #include "nav_2d_msgs/msg/twist2_d.hpp"
 #include "dwb_plugins/kinematic_parameters.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/parameter_events_subscriber.hpp"
 
 namespace dwb_plugins
 {
@@ -50,7 +51,8 @@ public:
   virtual ~VelocityIterator() {}
   virtual void initialize(
     const nav2_util::LifecycleNode::SharedPtr & nh,
-    KinematicParameters::Ptr kinematics) = 0;
+    KinematicParameters::Ptr kinematics,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) = 0;
   virtual void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity, double dt) = 0;
   virtual bool hasMoreTwists() = 0;
   virtual nav_2d_msgs::msg::Twist2D nextTwist() = 0;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
@@ -63,6 +63,9 @@ protected:
   KinematicParameters::Ptr kinematics_;
 
   std::shared_ptr<OneDVelocityIterator> x_it_, y_it_, th_it_;
+
+  std::vector<nav2_util::ParameterEventsCallbackHandle::SharedPtr> callback_handles_;
+  std::recursive_mutex mutex_;
 };
 }  // namespace dwb_plugins
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
@@ -50,7 +50,8 @@ public:
   : kinematics_(nullptr), x_it_(nullptr), y_it_(nullptr), th_it_(nullptr) {}
   void initialize(
     const nav2_util::LifecycleNode::SharedPtr & nh,
-    KinematicParameters::Ptr kinematics) override;
+    KinematicParameters::Ptr kinematics,
+    std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub = nullptr) override;
   void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity, double dt) override;
   bool hasMoreTwists() override;
   nav_2d_msgs::msg::Twist2D nextTwist() override;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
@@ -36,6 +36,7 @@
 #define DWB_PLUGINS__XY_THETA_ITERATOR_HPP_
 
 #include <memory>
+#include <vector>
 
 #include "dwb_plugins/velocity_iterator.hpp"
 #include "dwb_plugins/one_d_velocity_iterator.hpp"

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -52,7 +52,7 @@ KinematicParameters::KinematicParameters()
 {
 }
 
-void KinematicParameters::initialize(const nav2_util::LifecycleNode::SharedPtr & nh)
+void KinematicParameters::initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> /*param_sub*/)
 {
   // Special handling for renamed parameters
   moveDeprecatedParameter<double>(nh, "max_vel_theta", "max_rot_vel");

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -52,7 +52,7 @@ KinematicParameters::KinematicParameters()
 {
 }
 
-void KinematicParameters::initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> /*param_sub*/)
+void KinematicParameters::initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
 {
   // Special handling for renamed parameters
   moveDeprecatedParameter<double>(nh, "max_vel_theta", "max_rot_vel");
@@ -92,6 +92,86 @@ void KinematicParameters::initialize(const nav2_util::LifecycleNode::SharedPtr &
 
   min_speed_xy_sq_ = min_speed_xy_ * min_speed_xy_;
   max_speed_xy_sq_ = max_speed_xy_ * max_speed_xy_;
+
+  setParamCallbacks(param_sub);
+}
+
+void KinematicParameters::setParamCallbacks(std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_subscriber)
+{
+  if (param_subscriber) {
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("min_vel_x",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        min_vel_x_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("min_vel_y",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        min_vel_y_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("max_vel_x",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        max_vel_x_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("max_vel_y",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        max_vel_y_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("max_vel_theta",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        max_vel_theta_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("min_speed_xy",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        min_speed_xy_ = p.get_value<double>();
+        min_speed_xy_sq_ = min_speed_xy_ * min_speed_xy_;
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("max_speed_xy",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        max_speed_xy_ = p.get_value<double>();
+        max_speed_xy_sq_ = max_speed_xy_ * max_speed_xy_;
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("min_speed_theta",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        min_speed_theta_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("acc_lim_x",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        acc_lim_x_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("acc_lim_y",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        acc_lim_y_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("acc_lim_theta",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        acc_lim_theta_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("decel_lim_x",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        decel_lim_x_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("decel_lim_y",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        decel_lim_y_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_subscriber->add_parameter_callback("decel_lim_theta",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        decel_lim_theta_ = p.get_value<double>();
+      }));
+  }
 }
 
 bool KinematicParameters::isValidSpeed(double x, double y, double theta)

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -52,7 +52,9 @@ KinematicParameters::KinematicParameters()
 {
 }
 
-void KinematicParameters::initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
+void KinematicParameters::initialize(
+  const nav2_util::LifecycleNode::SharedPtr & nh,
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
 {
   // Special handling for renamed parameters
   moveDeprecatedParameter<double>(nh, "max_vel_theta", "max_rot_vel");
@@ -96,7 +98,8 @@ void KinematicParameters::initialize(const nav2_util::LifecycleNode::SharedPtr &
   setParamCallbacks(param_sub);
 }
 
-void KinematicParameters::setParamCallbacks(std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_subscriber)
+void KinematicParameters::setParamCallbacks(
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_subscriber)
 {
   if (param_subscriber) {
     callback_handles_.push_back(param_subscriber->add_parameter_callback("min_vel_x",

--- a/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -43,7 +43,7 @@
 namespace dwb_plugins
 {
 
-void LimitedAccelGenerator::initialize(const nav2_util::LifecycleNode::SharedPtr & nh)
+void LimitedAccelGenerator::initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> /*param_sub*/)
 {
   StandardTrajectoryGenerator::initialize(nh);
 

--- a/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -43,7 +43,9 @@
 namespace dwb_plugins
 {
 
-void LimitedAccelGenerator::initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> /*param_sub*/)
+void LimitedAccelGenerator::initialize(
+  const nav2_util::LifecycleNode::SharedPtr & nh,
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber>/*param_sub*/)
 {
   StandardTrajectoryGenerator::initialize(nh);
 

--- a/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -45,9 +45,9 @@ namespace dwb_plugins
 
 void LimitedAccelGenerator::initialize(
   const nav2_util::LifecycleNode::SharedPtr & nh,
-  std::shared_ptr<nav2_util::ParameterEventsSubscriber>/*param_sub*/)
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
 {
-  StandardTrajectoryGenerator::initialize(nh);
+  StandardTrajectoryGenerator::initialize(nh, param_sub);
 
   nav2_util::declare_parameter_if_not_declared(nh, "sim_period");
 

--- a/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
@@ -50,7 +50,7 @@ SimpleGoalChecker::SimpleGoalChecker()
 {
 }
 
-void SimpleGoalChecker::initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh)
+void SimpleGoalChecker::initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> /*param_sub*/)
 {
   nav2_util::declare_parameter_if_not_declared(nh,
     "xy_goal_tolerance", rclcpp::ParameterValue(0.25));

--- a/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
@@ -64,17 +64,19 @@ void SimpleGoalChecker::initialize(
 
   xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
 
-  callback_handles_.push_back(param_sub->add_parameter_callback("xy_goal_tolerance",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      xy_goal_tolerance_ = p.get_value<double>();
-      xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
-    }));
-  callback_handles_.push_back(param_sub->add_parameter_callback("yaw_goal_tolerance",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      yaw_goal_tolerance_ = p.get_value<double>();
-    }));
+  if (param_sub) {
+    callback_handles_.push_back(param_sub->add_parameter_callback("xy_goal_tolerance",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        xy_goal_tolerance_ = p.get_value<double>();
+        xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
+      }));
+    callback_handles_.push_back(param_sub->add_parameter_callback("yaw_goal_tolerance",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        yaw_goal_tolerance_ = p.get_value<double>();
+      }));
+  }
 }
 
 bool SimpleGoalChecker::isGoalReached(

--- a/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
@@ -50,7 +50,9 @@ SimpleGoalChecker::SimpleGoalChecker()
 {
 }
 
-void SimpleGoalChecker::initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
+void SimpleGoalChecker::initialize(
+  const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
 {
   nav2_util::declare_parameter_if_not_declared(nh,
     "xy_goal_tolerance", rclcpp::ParameterValue(0.25));

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -48,7 +48,7 @@ using nav_2d_utils::loadParameterWithDeprecation;
 namespace dwb_plugins
 {
 
-void StandardTrajectoryGenerator::initialize(const nav2_util::LifecycleNode::SharedPtr & nh)
+void StandardTrajectoryGenerator::initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> /*param_sub*/)
 {
   kinematics_ = std::make_shared<KinematicParameters>();
   kinematics_->initialize(nh);

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -48,7 +48,9 @@ using nav_2d_utils::loadParameterWithDeprecation;
 namespace dwb_plugins
 {
 
-void StandardTrajectoryGenerator::initialize(const nav2_util::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
+void StandardTrajectoryGenerator::initialize(
+  const nav2_util::LifecycleNode::SharedPtr & nh,
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
 {
   kinematics_ = std::make_shared<KinematicParameters>();
   kinematics_->initialize(nh);

--- a/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
@@ -52,7 +52,7 @@ void StoppedGoalChecker::initialize(
   const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
   std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
 {
-  SimpleGoalChecker::initialize(nh);
+  SimpleGoalChecker::initialize(nh, param_sub);
 
   nav2_util::declare_parameter_if_not_declared(nh,
     "rot_stopped_velocity", rclcpp::ParameterValue(0.25));
@@ -62,16 +62,18 @@ void StoppedGoalChecker::initialize(
   nh->get_parameter("rot_stopped_velocity", rot_stopped_velocity_);
   nh->get_parameter("trans_stopped_velocity", trans_stopped_velocity_);
 
-  callback_handles_.push_back(param_sub->add_parameter_callback("rot_stopped_velocity",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      rot_stopped_velocity_ = p.get_value<double>();
-    }));
-  callback_handles_.push_back(param_sub->add_parameter_callback("trans_stopped_velocity",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      trans_stopped_velocity_ = p.get_value<double>();
-    }));
+  if (param_sub) {
+    callback_handles_.push_back(param_sub->add_parameter_callback("rot_stopped_velocity",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        rot_stopped_velocity_ = p.get_value<double>();
+      }));
+    callback_handles_.push_back(param_sub->add_parameter_callback("trans_stopped_velocity",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        trans_stopped_velocity_ = p.get_value<double>();
+      }));
+  }
 }
 
 bool StoppedGoalChecker::isGoalReached(

--- a/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
@@ -48,7 +48,7 @@ StoppedGoalChecker::StoppedGoalChecker()
 {
 }
 
-void StoppedGoalChecker::initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh)
+void StoppedGoalChecker::initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> /*param_sub*/)
 {
   SimpleGoalChecker::initialize(nh);
 

--- a/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
@@ -48,7 +48,9 @@ StoppedGoalChecker::StoppedGoalChecker()
 {
 }
 
-void StoppedGoalChecker::initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
+void StoppedGoalChecker::initialize(
+  const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
 {
   SimpleGoalChecker::initialize(nh);
 

--- a/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
@@ -48,7 +48,7 @@ StoppedGoalChecker::StoppedGoalChecker()
 {
 }
 
-void StoppedGoalChecker::initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> /*param_sub*/)
+void StoppedGoalChecker::initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
 {
   SimpleGoalChecker::initialize(nh);
 
@@ -59,6 +59,17 @@ void StoppedGoalChecker::initialize(const rclcpp_lifecycle::LifecycleNode::Share
 
   nh->get_parameter("rot_stopped_velocity", rot_stopped_velocity_);
   nh->get_parameter("trans_stopped_velocity", trans_stopped_velocity_);
+
+  callback_handles_.push_back(param_sub->add_parameter_callback("rot_stopped_velocity",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      rot_stopped_velocity_ = p.get_value<double>();
+    }));
+  callback_handles_.push_back(param_sub->add_parameter_callback("trans_stopped_velocity",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      trans_stopped_velocity_ = p.get_value<double>();
+    }));
 }
 
 bool StoppedGoalChecker::isGoalReached(

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -41,7 +41,8 @@ namespace dwb_plugins
 {
 void XYThetaIterator::initialize(
   const nav2_util::LifecycleNode::SharedPtr & nh,
-  KinematicParameters::Ptr kinematics)
+  KinematicParameters::Ptr kinematics,
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> /*param_sub*/)
 {
   kinematics_ = kinematics;
 

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -55,33 +55,35 @@ void XYThetaIterator::initialize(
   vtheta_samples_ = nav_2d_utils::loadParameterWithDeprecation(nh, "vtheta_samples", "vth_samples",
       20);
 
-  callback_handles_.push_back(param_sub->add_parameter_callback("vx_samples",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      if (p.get_value<int>() < 0) {
-        vx_samples_ = 1;
-      } else {
-        vx_samples_ = p.get_value<int>();
-      }
-    }));
-  callback_handles_.push_back(param_sub->add_parameter_callback("vy_samples",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      if (p.get_value<int>() < 0) {
-        vy_samples_ = 1;
-      } else {
-        vy_samples_ = p.get_value<int>();
-      }
-    }));
-  callback_handles_.push_back(param_sub->add_parameter_callback("vtheta_samples",
-    [&](const rclcpp::Parameter & p) {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      if (p.get_value<int>() < 0) {
-        vtheta_samples_ = 1;
-      } else {
-        vtheta_samples_ = p.get_value<int>();
-      }
-    }));
+  if (param_sub) {
+    callback_handles_.push_back(param_sub->add_parameter_callback("vx_samples",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        if (p.get_value<int>() < 0) {
+          vx_samples_ = 1;
+        } else {
+          vx_samples_ = p.get_value<int>();
+        }
+      }));
+    callback_handles_.push_back(param_sub->add_parameter_callback("vy_samples",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        if (p.get_value<int>() < 0) {
+          vy_samples_ = 1;
+        } else {
+          vy_samples_ = p.get_value<int>();
+        }
+      }));
+    callback_handles_.push_back(param_sub->add_parameter_callback("vtheta_samples",
+      [&](const rclcpp::Parameter & p) {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        if (p.get_value<int>() < 0) {
+          vtheta_samples_ = 1;
+        } else {
+          vtheta_samples_ = p.get_value<int>();
+        }
+      }));
+  }
 }
 
 void XYThetaIterator::startNewIteration(

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -42,7 +42,7 @@ namespace dwb_plugins
 void XYThetaIterator::initialize(
   const nav2_util::LifecycleNode::SharedPtr & nh,
   KinematicParameters::Ptr kinematics,
-  std::shared_ptr<nav2_util::ParameterEventsSubscriber> /*param_sub*/)
+  std::shared_ptr<nav2_util::ParameterEventsSubscriber> param_sub)
 {
   kinematics_ = kinematics;
 
@@ -54,6 +54,34 @@ void XYThetaIterator::initialize(
 
   vtheta_samples_ = nav_2d_utils::loadParameterWithDeprecation(nh, "vtheta_samples", "vth_samples",
       20);
+
+  callback_handles_.push_back(param_sub->add_parameter_callback("vx_samples",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      if (p.get_value<int>() < 0) {
+        vx_samples_ = 1;
+      } else {
+        vx_samples_ = p.get_value<int>();
+      }
+    }));
+  callback_handles_.push_back(param_sub->add_parameter_callback("vy_samples",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      if (p.get_value<int>() < 0) {
+        vy_samples_ = 1;
+      } else {
+        vy_samples_ = p.get_value<int>();
+      }
+    }));
+  callback_handles_.push_back(param_sub->add_parameter_callback("vtheta_samples",
+    [&](const rclcpp::Parameter & p) {
+      std::lock_guard<std::recursive_mutex> lock(mutex_);
+      if (p.get_value<int>() < 0) {
+        vtheta_samples_ = 1;
+      } else {
+        vtheta_samples_ = p.get_value<int>();
+      }
+    }));
 }
 
 void XYThetaIterator::startNewIteration(

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
@@ -96,16 +96,12 @@ param_t loadParameterWithDeprecation(
   nav2_util::declare_parameter_if_not_declared(nh, old_name);
   param_t value = 0;
 
-  auto param = nh->get_parameter(current_name);
-  if (param.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) {
-    value = param.get_value<param_t>();
+  if (nh->get_parameter(current_name, value)) {
     nh->undeclare_parameter(old_name);
     return value;
   }
 
-  param = nh->get_parameter(old_name);
-  if (param.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) {
-    value = param.get_value<param_t>();
+  if (nh->get_parameter(old_name, value)) {
     nh->undeclare_parameter(current_name);
     RCLCPP_WARN(nh->get_logger(),
       "Parameter %s is deprecated. Please use the name %s instead.",

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
@@ -72,7 +72,7 @@ param_t searchAndGetParam(
   //   nh->param(resolved_name, value, default_value);
   //   return value;
   // }
-  param_t value;
+  param_t value = 0;
   nav2_util::declare_parameter_if_not_declared(nh, param_name,
     rclcpp::ParameterValue(default_value));
   nh->get_parameter(param_name, value);

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
@@ -92,10 +92,14 @@ param_t loadParameterWithDeprecation(
   const nav2_util::LifecycleNode::SharedPtr & nh, const std::string current_name,
   const std::string old_name, const param_t & default_value)
 {
+  nav2_util::declare_parameter_if_not_declared(nh, current_name,
+    rclcpp::ParameterValue(default_value));
   param_t value = 0;
   if (nh->get_parameter(current_name, value)) {
     return value;
   }
+  nav2_util::declare_parameter_if_not_declared(nh, old_name,
+    rclcpp::ParameterValue(default_value));
   if (nh->get_parameter(old_name, value)) {
     RCLCPP_WARN(nh->get_logger(),
       "Parameter %s is deprecated. Please use the name %s instead.",


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses  | #956 |

---

## Description of contribution in a few bullet points
- Adds `ParmeterEventsSubscribers` to dwb plugins and critics to create parameter callbacks during `initialize`
- fixes `loadParametersWithDeprecation` so that parameters are declared first
- filters event for the its own node name in amcl and costmap event callback

## Future work that may be required in bullet points
- Refactor such that callbacks can be added from node (either from nav2_util::LifecycleNode wrapper or from upstream changes)

