### PR TITLE
Fixing minor issues on eloquent-devel branch.

### DIFF
--- a/full_ros_build.Dockerfile
+++ b/full_ros_build.Dockerfile
@@ -63,6 +63,8 @@ RUN wget https://raw.githubusercontent.com/ros2/ros2/$ROS2_BRANCH/ros2.repos \
 # get skip keys
 COPY ./tools/skip_keys.txt ./
 
+RUN rosdep update
+
 # copy underlay manifests
 COPY --from=cache /tmp/underlay_ws src/underlay
 RUN cd src/underlay && colcon list --names-only | \

--- a/nav2_system_tests/package.xml
+++ b/nav2_system_tests/package.xml
@@ -53,6 +53,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>

--- a/nav2_util/include/nav2_util/parameter_events_subscriber.hpp
+++ b/nav2_util/include/nav2_util/parameter_events_subscriber.hpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <unordered_map>
 #include <vector>
+#include <list>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/parameter_events_filter.hpp"

--- a/release_branch.Dockerfile
+++ b/release_branch.Dockerfile
@@ -11,6 +11,8 @@
 ARG FROM_IMAGE=dashing
 FROM ros:$FROM_IMAGE
 
+RUN rosdep update
+
 # copy ros package repo
 ENV NAV2_WS /opt/nav2_ws
 RUN mkdir -p $NAV2_WS/src


### PR DESCRIPTION

## Basic Info

## Description of contribution in a few bullet points

* Testing the eloquent-devel branch shows a few minor issues:
  - rosdeps in the base docker images are out of date. They don't reflect the new behavior tree release. I added a rosdep update call in the dockerfiles to address this.
  - There's a missing dependency in the nav2_system_tests package.xml
  - There is a linter failure in nav2_util.

These fixes need to be forward ported to master as well.