### PR TITLE
Fixing linter failure in nav2_util on eloquent branch

### DIFF
--- a/nav2_util/include/nav2_util/parameter_events_subscriber.hpp
+++ b/nav2_util/include/nav2_util/parameter_events_subscriber.hpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <unordered_map>
 #include <vector>
+#include <list>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/parameter_events_filter.hpp"


### PR DESCRIPTION
## Basic Info

## Description of contribution in a few bullet points

* Linter failure was introduced on the eloquent branch. This PR fixes it.