### PR TITLE
Dependency test related fixes needed for eloquent release.

### DIFF
--- a/full_ros_build.Dockerfile
+++ b/full_ros_build.Dockerfile
@@ -63,6 +63,8 @@ RUN wget https://raw.githubusercontent.com/ros2/ros2/$ROS2_BRANCH/ros2.repos \
 # get skip keys
 COPY ./tools/skip_keys.txt ./
 
+RUN rosdep update
+
 # copy underlay manifests
 COPY --from=cache /tmp/underlay_ws src/underlay
 RUN cd src/underlay && colcon list --names-only | \

--- a/nav2_system_tests/package.xml
+++ b/nav2_system_tests/package.xml
@@ -53,6 +53,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>

--- a/release_branch.Dockerfile
+++ b/release_branch.Dockerfile
@@ -11,6 +11,8 @@
 ARG FROM_IMAGE=dashing
 FROM ros:$FROM_IMAGE
 
+RUN rosdep update
+
 # copy ros package repo
 ENV NAV2_WS /opt/nav2_ws
 RUN mkdir -p $NAV2_WS/src


### PR DESCRIPTION
## Description of contribution in a few bullet points

* We need to update the docker builds that are used to test the release branch. They don't have up-to-date rosdep information in them, resulting in a failure to install the behavior tree package. I added a call to rosdep update into the build sequence, and that fixes the problem.

* The test found a missing dependency in the nav2_system_tests package. I've added that dependency as well.

This will need to be merged to eloquent in order to release.