### PR TITLE
Check if future is valid in action server deactivate

### DIFF
--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -190,6 +190,10 @@ public:
       stop_execution_ = true;
     }
 
+    if (!execution_future_.valid()) {
+      return;
+    }
+
     if (is_running()) {
       warn_msg("Requested to deactivate server but goal is still executing."
         " Should check if action server is running before deactivating.");


### PR DESCRIPTION
If the action server is deactivated before it has accepted its first action goal request, then the future does not have a state associated with it since it was never initialized with the async thread. In this PR, I'm checking that the future is valid in the `deactivate` call with the assumption that there has yet to be a goal request accepted. 

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1429  |
| Primary OS tested on | Ubuntu 18.04 |



