### PR TITLE
Fix costmap on_cleanup issues [eloquent-devel] 

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -99,7 +99,6 @@ public:
 
   virtual void reset()
   {
-    undeclareAllParameters();
     onInitialize();
   }
 

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -655,7 +655,6 @@ ObstacleLayer::reset()
   resetMaps();
   current_ = true;
   activate();
-  undeclareAllParameters();
 }
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -125,7 +125,6 @@ StaticLayer::reset()
   map_sub_.reset();
   map_update_sub_.reset();
 
-  undeclareAllParameters();
   onInitialize();
 }
 

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -171,7 +171,6 @@ void VoxelLayer::reset()
   deactivate();
   resetMaps();
   activate();
-  undeclareAllParameters();
   voxel_pub_->on_activate();
 }
 

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -249,7 +249,7 @@ Costmap2DROS::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Cleaning up");
 
-  resetLayers();
+  param_subscriber_.reset();
   delete layered_costmap_;
   layered_costmap_ = nullptr;
 

--- a/nav2_costmap_2d/test/integration/obstacle_tests.cpp
+++ b/nav2_costmap_2d/test/integration/obstacle_tests.cpp
@@ -357,20 +357,10 @@ TEST_F(TestNode, testRepeatedResets) {
       return plugin->hasParameter(layer_param);
     }));
 
-  // Reset all layers. This will un-declare all params and might re-declare internal ones
+  // Reset all layers. Parameters should be declared if not declared, otherwise skipped.
   // Should run without throwing exceptions
   ASSERT_NO_THROW(
     for_each(begin(*plugins), end(*plugins), [](const auto & plugin) {
       plugin->reset();
-    }));
-
-  // Check for node-level param
-  ASSERT_TRUE(node_->has_parameter(node_dummy.first));
-
-  // Layer-level parameters shouldn't be found
-  ASSERT_TRUE(
-    none_of(begin(*plugins), end(*plugins), [&layer_dummy](const auto & plugin) {
-      string layer_param = layer_dummy.first + "_" + plugin->getName();
-      return plugin->hasParameter(layer_param);
     }));
 }


### PR DESCRIPTION


The `nav2_system_tests` were failing in large part due to the parameter callbacks being called erroneously during the `on_cleanup` of the `Costmap2DROS` object. It is a pattern that the `reset` of costmap plugins will reset/deactivate and also re-initialize. In this PR I'm maintaining that behavior since I believe that is intended for use when clearing the costmap during run-time, but here I'm  removing the `resetLayers` inside of `on_cleanup`, especially since deleting the `layered_costmap` will destroy the plugins anyway. Also, since the parameters are being `declare_if_not_declared`, there's no real need to undeclare the parameters when resetting. 
 
## Future work that may be required in bullet points
- cleanup plugin activate/deactivate/reset logic in alignment with lifecycle transitions
