### PR TITLE
Clear controller and planner map on_cleanup

### DIFF
--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -38,9 +38,8 @@ ControllerServer::ControllerServer()
   std::vector<std::string> default_id, default_type;
   default_type.push_back("dwb_core::DWBLocalPlanner");
   default_id.push_back("FollowPath");
-  controller_ids_ = declare_parameter("controller_plugin_ids",
-      default_id);
-  controller_types_ = declare_parameter("controller_plugin_types", default_type);
+  declare_parameter("controller_plugin_ids", default_id);
+  declare_parameter("controller_plugin_types", default_type);
 
   // The costmap node is used in the implementation of the controller
   costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
@@ -59,6 +58,11 @@ nav2_util::CallbackReturn
 ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
 {
   RCLCPP_INFO(get_logger(), "Configuring controller interface");
+
+  get_parameter("controller_plugin_ids", controller_ids_);
+  get_parameter("controller_plugin_types", controller_types_);
+  get_parameter("controller_frequency", controller_frequency_);
+  RCLCPP_INFO(get_logger(), "Controller frequency set to %.4fHz", controller_frequency_);
 
   costmap_ros_->on_configure(state);
 
@@ -91,9 +95,6 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
   for (uint i = 0; i != controller_ids_.size(); i++) {
     controller_ids_concat_ += controller_ids_[i] + std::string(" ");
   }
-
-  get_parameter("controller_frequency", controller_frequency_);
-  RCLCPP_INFO(get_logger(), "Controller frequency set to %.4fHz", controller_frequency_);
 
   odom_sub_ = std::make_unique<nav_2d_utils::OdomSubscriber>(node);
   vel_publisher_ = create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
@@ -149,6 +150,7 @@ ControllerServer::on_cleanup(const rclcpp_lifecycle::State & state)
   for (it = controllers_.begin(); it != controllers_.end(); ++it) {
     it->second->cleanup();
   }
+  controllers_.clear();
   costmap_ros_->on_cleanup(state);
 
   // Release any allocated resources

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -165,10 +165,7 @@ PlannerServer::on_cleanup(const rclcpp_lifecycle::State & state)
   for (it = planners_.begin(); it != planners_.end(); ++it) {
     it->second->cleanup();
   }
-
-  for (it = planners_.begin(); it != planners_.end(); ++it) {
-    it->second.reset();
-  }
+  planners_.clear();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }


### PR DESCRIPTION
This PR fixes bugs in the `controller_server` and `planner_server` where upon a reset/startup of the stack, the plugins are not being reassigned into the map since the keys still exist on the map. I think it makes better sense to clear all the plugins in the map when cleaning up. After this PR and #1430, the stack should be able to successfully reset and startup. 


