### PR TITLE
fix for publishing to /goal_pose topic

### DIFF
--- a/nav2_bringup/bringup/rviz/nav2_default_view.rviz
+++ b/nav2_bringup/bringup/rviz/nav2_default_view.rviz
@@ -356,6 +356,9 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /clicked_point
     - Class: nav2_rviz_plugins/GoalTool
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Value: /goal_pose
   Transformation:
     Current:
       Class: rviz_default_plugins/TF

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -257,9 +257,7 @@ BtNavigator::initializeGoalPose()
 void
 BtNavigator::onGoalPoseReceived(const geometry_msgs::msg::PoseStamped::SharedPtr pose)
 {
-  auto is_action_server_ready =
-    self_client_->wait_for_action_server(std::chrono::seconds(5));
-  if (!is_action_server_ready) {
+  if (!self_client_->wait_for_action_server(std::chrono::milliseconds(500))) {
     RCLCPP_ERROR(client_node_->get_logger(),
       "NavigateToPose action server is not available."
       " Is the initial pose set?");
@@ -269,11 +267,6 @@ BtNavigator::onGoalPoseReceived(const geometry_msgs::msg::PoseStamped::SharedPtr
   nav2_msgs::action::NavigateToPose::Goal navigation_goal_;
   navigation_goal_.pose = *pose;
 
-  // Enable result awareness by providing an empty lambda function
-  auto send_goal_options =
-    rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SendGoalOptions();
-  send_goal_options.result_callback = [](auto) {};
-
-  self_client_->async_send_goal(navigation_goal_, send_goal_options);
+  self_client_->async_send_goal(navigation_goal_);
 }
 }  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -55,9 +55,6 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   // Support for handling the topic-based goal pose from rviz
   client_node_ = std::make_shared<rclcpp::Node>("_", options);
 
-//  self_client_ = rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(
-//    client_node_, "navigate_to_pose");
-
   self_client_ =
     rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(client_node_,
       "NavigateToPose");


### PR DESCRIPTION
Publishing PoseStamped messages to /goal_pose topic was not working via CLI and RViz.

- rviz SetGoal tool default publishes to the /goal topic. 
    - changed it to /goal_pose in rviz file.

- Modified onGoalPoseReceived()
    - to be able to send a goal to NavigateToPose action server, I followed the same method [here](https://github.com/ros-planning/navigation2/blob/aa764eb9a24e8b1f4b979871c76721afdc81f442/nav2_rviz_plugins/src/nav2_panel.cpp#L458)