### PR TITLE
initialized member variable root_key with default value

### DIFF
--- a/nav2_common/nav2_common/launch/rewritten_yaml.py
+++ b/nav2_common/nav2_common/launch/rewritten_yaml.py
@@ -59,6 +59,7 @@ class RewrittenYaml(launch.Substitution):
     self.__param_rewrites = {}
     self.__key_rewrites = {}
     self.__convert_types = convert_types
+    self.__root_key = None
     for key in param_rewrites:
         self.__param_rewrites[key] = normalize_to_list_of_substitutions(param_rewrites[key])
     if key_rewrites is not None:


### PR DESCRIPTION
A default value of None is not given to __root_key in the RewrittenYaml class and will cause it to throw an exception if root_key is None. This PR initializes __root_key with None to avoid this exception.
