### PR TITLE
Disable boost includes in packages that use pluginlib

### DIFF
--- a/nav2_controller/CMakeLists.txt
+++ b/nav2_controller/CMakeLists.txt
@@ -50,6 +50,9 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
+# prevent pluginlib from using boost
+target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 ament_target_dependencies(${executable_name}
   ${dependencies}
 )

--- a/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
@@ -29,10 +29,16 @@ include_directories(
 
 add_library(simple_goal_checker SHARED src/simple_goal_checker.cpp)
 ament_target_dependencies(simple_goal_checker ${dependencies})
+# prevent pluginlib from using boost
+target_compile_definitions(simple_goal_checker PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 
 add_library(stopped_goal_checker SHARED src/stopped_goal_checker.cpp)
 target_link_libraries(stopped_goal_checker simple_goal_checker)
 ament_target_dependencies(stopped_goal_checker ${dependencies})
+# prevent pluginlib from using boost
+target_compile_definitions(stopped_goal_checker PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 
 add_library(standard_traj_generator SHARED
             src/standard_traj_generator.cpp
@@ -40,6 +46,9 @@ add_library(standard_traj_generator SHARED
             src/kinematic_parameters.cpp
             src/xy_theta_iterator.cpp)
 ament_target_dependencies(standard_traj_generator ${dependencies})
+# prevent pluginlib from using boost
+target_compile_definitions(standard_traj_generator PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/nav2_navfn_planner/CMakeLists.txt
+++ b/nav2_navfn_planner/CMakeLists.txt
@@ -52,6 +52,9 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
+# prevent pluginlib from using boost
+target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 pluginlib_export_plugin_description_file(nav2_core global_planner_plugin.xml)
 
 install(TARGETS ${library_name}

--- a/nav2_planner/CMakeLists.txt
+++ b/nav2_planner/CMakeLists.txt
@@ -64,6 +64,9 @@ ament_target_dependencies(${executable_name}
   ${dependencies}
 )
 
+# prevent pluginlib from using boost
+target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 install(TARGETS ${executable_name} ${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/nav2_recoveries/CMakeLists.txt
+++ b/nav2_recoveries/CMakeLists.txt
@@ -53,6 +53,9 @@ ament_target_dependencies(nav2_spin_recovery
   ${dependencies}
 )
 
+# prevent pluginlib from using boost
+target_compile_definitions(nav2_spin_recovery PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 add_library(nav2_backup_recovery SHARED
   plugins/back_up.cpp
 )
@@ -61,6 +64,9 @@ ament_target_dependencies(nav2_backup_recovery
   ${dependencies}
 )
 
+# prevent pluginlib from using boost
+target_compile_definitions(nav2_backup_recovery PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
 add_library(nav2_wait_recovery SHARED
   plugins/wait.cpp
 )
@@ -68,6 +74,9 @@ add_library(nav2_wait_recovery SHARED
 ament_target_dependencies(nav2_wait_recovery
   ${dependencies}
 )
+
+# prevent pluginlib from using boost
+target_compile_definitions(nav2_wait_recovery PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 pluginlib_export_plugin_description_file(nav2_core recovery_plugin.xml)
 
@@ -79,6 +88,9 @@ add_library(${library_name}
 ament_target_dependencies(${library_name}
   ${dependencies}
 )
+
+# prevent pluginlib from using boost
+target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 # Executable
 add_executable(${executable_name}


### PR DESCRIPTION
They aren't needed in ROS2 and cause the official build to break.

See http://build.ros2.org/job/Ebin_uB64__nav2_recoveries__ubuntu_bionic_amd64__binary/1/console for an example of the failure.