### PR TITLE
[eloquent] use remapping tag in urdf/sdf

### DIFF
--- a/nav2_bringup/bringup/worlds/waffle.model
+++ b/nav2_bringup/bringup/worlds/waffle.model
@@ -139,9 +139,7 @@
           <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
             <ros>
               <!-- <namespace>/tb3</namespace> -->
-              <argument>--ros-args</argument>
-              <argument>-r</argument>
-              <argument>~/out:=imu</argument>
+              <remapping>~/out:=imu</remapping>
             </ros>
           </plugin>
         </sensor>
@@ -209,9 +207,7 @@
           <plugin name="turtlebot3_laserscan" filename="libgazebo_ros_ray_sensor.so">
             <ros>
                 <!-- <namespace>/tb3</namespace> -->
-                <argument>--ros-args</argument>
-                <argument>-r </argument>
-                <argument>~/out:=scan</argument>
+                <remapping>~/out:=scan</remapping>
             </ros>
             <output_type>sensor_msgs/LaserScan</output_type>
             <frame_name>base_scan</frame_name>
@@ -552,9 +548,7 @@
       <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
         <ros>
           <!-- <namespace>/tb3</namespace> -->
-            <argument>--ros-args</argument>
-            <argument>-r </argument>
-            <argument>~/out:=joint_states</argument>
+            <remapping>~/out:=joint_states</remapping>
         </ros>
         <update_rate>30</update_rate>
         <joint_name>wheel_left_joint</joint_name>

--- a/nav2_system_tests/models/turtlebot3_waffle/model-1_4.sdf
+++ b/nav2_system_tests/models/turtlebot3_waffle/model-1_4.sdf
@@ -89,7 +89,7 @@
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=imu</argument>
+            <remapping>~/out:=imu</remapping>
           </ros>
         </plugin>
       </sensor>
@@ -157,7 +157,7 @@
         <plugin name="turtlebot3_laserscan" filename="libgazebo_ros_ray_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=scan</argument>
+            <remapping>~/out:=scan</remapping>
           </ros>
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>base_scan</frame_name>
@@ -401,8 +401,8 @@
           <plugin name="camera_driver" filename="libgazebo_ros_camera.so">
             <ros>
               <!-- <namespace>test_cam</namespace> -->
-              <!-- <argument>image_raw:=image_demo</argument> -->
-              <!-- <argument>camera_info:=camera_info_demo</argument> -->
+              <!-- <remapping>image_raw:=image_demo</remapping> -->
+              <!-- <remapping>camera_info:=camera_info_demo</remapping> -->
             </ros>
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frameName-->
@@ -508,7 +508,7 @@
     <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
       <ros>
         <!-- <namespace>/tb3</namespace> -->
-        <argument>~/out:=joint_states</argument>
+        <remapping>~/out:=joint_states</remapping>
       </ros>
       <update_rate>30</update_rate>
       <joint_name>wheel_left_joint</joint_name>

--- a/nav2_system_tests/models/turtlebot3_waffle/model.sdf
+++ b/nav2_system_tests/models/turtlebot3_waffle/model.sdf
@@ -89,7 +89,7 @@
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=imu</argument>
+            <remapping>~/out:=imu</remapping>
           </ros>
         </plugin>
       </sensor>
@@ -157,7 +157,7 @@
         <plugin name="turtlebot3_laserscan" filename="libgazebo_ros_ray_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=scan</argument>
+            <remapping>~/out:=scan</remapping>
           </ros>
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>base_scan</frame_name>
@@ -401,8 +401,8 @@
           <plugin name="camera_driver" filename="libgazebo_ros_camera.so">
             <ros>
               <!-- <namespace>test_cam</namespace> -->
-              <!-- <argument>image_raw:=image_demo</argument> -->
-              <!-- <argument>camera_info:=camera_info_demo</argument> -->
+              <!-- <remapping>image_raw:=image_demo</remapping> -->
+              <!-- <remapping>camera_info:=camera_info_demo</remapping> -->
             </ros>
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frameName-->
@@ -508,7 +508,7 @@
     <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
       <ros>
         <!-- <namespace>/tb3</namespace> -->
-        <argument>~/out:=joint_states</argument>
+        <remapping>~/out:=joint_states</remapping>
       </ros>
       <update_rate>30</update_rate>
       <joint_name>wheel_left_joint</joint_name>

--- a/nav2_system_tests/models/turtlebot3_waffle_depth_camera/model.sdf
+++ b/nav2_system_tests/models/turtlebot3_waffle_depth_camera/model.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.5">
-  <model name="TurtleBot3_Waffle_DepthCamera">  
+  <model name="TurtleBot3_Waffle_DepthCamera">
   <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
 
     <link name="base_footprint"/>
@@ -79,13 +79,13 @@
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=imu</argument>
+            <remapping>~/out:=imu</remapping>
           </ros>
         </plugin>
       </sensor>
     </link>
 
-    <link name="base_scan">    
+    <link name="base_scan">
       <inertial>
         <pose>-0.052 0 0.111 0 0 0</pose>
         <inertia>
@@ -137,7 +137,7 @@
         <plugin name="turtlebot3_laserscan" filename="libgazebo_ros_ray_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=scan</argument>
+            <remapping>~/out:=scan</remapping>
           </ros>
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>base_scan</frame_name>
@@ -207,7 +207,7 @@
         </inertia>
         <mass>0.1</mass>
       </inertial>
-    
+
       <collision name="wheel_right_collision">
         <pose>0.0 -0.144 0.023 -1.57 0 0</pose>
         <geometry>
@@ -341,12 +341,12 @@
         </camera>
 	      <plugin name="intel_realsense_r200_depth_driver" filename="libgazebo_ros_camera.so">
           <ros>
-        <!-- 
-              <argument>custom_camera/image_raw:=custom_camera/custom_image</argument>
-              <argument>custom_camera/image_depth:=custom_camera/custom_image_depth</argument>
-              <argument>custom_camera/camera_info:=custom_camera/custom_info_raw</argument>
-              <argument>custom_camera/camera_info_depth:=custom_camera/custom_info_depth</argument>
-              <argument>custom_camera/points:=custom_camera/custom_points</argument> 
+        <!--
+              <remapping>custom_camera/image_raw:=custom_camera/custom_image</remapping>
+              <remapping>custom_camera/image_depth:=custom_camera/custom_image_depth</remapping>
+              <remapping>custom_camera/camera_info:=custom_camera/custom_info_raw</remapping>
+              <remapping>custom_camera/camera_info_depth:=custom_camera/custom_info_depth</remapping>
+              <remapping>custom_camera/points:=custom_camera/custom_points</remapping>
         -->
           </ros>
           <camera_name>intel_realsense_r200_depth</camera_name>
@@ -355,7 +355,7 @@
           <min_depth>0.001</min_depth>
         </plugin>
       </sensor>
-    </link>  
+    </link>
 
     <joint name="base_joint" type="fixed">
       <parent>base_footprint</parent>
@@ -441,12 +441,12 @@
     <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
       <ros>
         <!-- <namespace>/tb3</namespace> -->
-        <argument>~/out:=joint_states</argument>
+        <remapping>~/out:=joint_states</remapping>
       </ros>
       <update_rate>30</update_rate>
       <joint_name>wheel_left_joint</joint_name>
       <joint_name>wheel_right_joint</joint_name>
-    </plugin>    
+    </plugin>
 
   </model>
 </sdf>

--- a/nav2_system_tests/worlds/turtlebot3_ros2_demo.world
+++ b/nav2_system_tests/worlds/turtlebot3_ros2_demo.world
@@ -139,9 +139,7 @@
           <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
             <ros>
               <!-- <namespace>/tb3</namespace> -->
-              <argument>--ros-args</argument>
-              <argument>-r</argument>
-              <argument>~/out:=imu</argument>
+              <remapping>~/out:=imu</remapping>
             </ros>
           </plugin>
         </sensor>
@@ -209,9 +207,7 @@
             <plugin name="laserscan" filename="libgazebo_ros_ray_sensor.so">
               <ros>
                 <!-- <namespace>/tb3</namespace> -->
-                <argument>--ros-args</argument>
-                <argument>-r </argument>
-                <argument>~/out:=scan</argument>
+                <remapping>~/out:=scan</remapping>
               </ros>
               <output_type>sensor_msgs/LaserScan</output_type>
             </plugin>
@@ -485,9 +481,7 @@
         <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>--ros-args</argument>
-            <argument>-r </argument>
-            <argument>~/out:=joint_states</argument>
+            <remapping>~/out:=joint_states</remapping>
           </ros>
           <update_rate>250</update_rate>
           <joint_name>wheel_left_joint</joint_name>

--- a/nav2_system_tests/worlds/turtlebot3_ros2_demo_obstacle.world
+++ b/nav2_system_tests/worlds/turtlebot3_ros2_demo_obstacle.world
@@ -139,9 +139,7 @@
           <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
             <ros>
               <!-- <namespace>/tb3</namespace> -->
-              <argument>--ros-args</argument>
-              <argument>-r</argument>
-              <argument>~/out:=imu</argument>
+              <remapping>~/out:=imu</remapping>
             </ros>
           </plugin>
         </sensor>
@@ -209,9 +207,7 @@
             <plugin name="laserscan" filename="libgazebo_ros_ray_sensor.so">
               <ros>
                 <!-- <namespace>/tb3</namespace> -->
-                <argument>--ros-args</argument>
-                <argument>-r </argument>
-                <argument>~/out:=scan</argument>
+                <remapping>~/out:=scan</remapping>
               </ros>
               <output_type>sensor_msgs/LaserScan</output_type>
             </plugin>
@@ -485,9 +481,7 @@
         <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>--ros-args</argument>
-            <argument>-r </argument>
-            <argument>~/out:=joint_states</argument>
+            <remapping>~/out:=joint_states</remapping>
           </ros>
           <update_rate>250</update_rate>
           <joint_name>wheel_left_joint</joint_name>


### PR DESCRIPTION
Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None? |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | None, used simulated tb3 to test the implementation of the tag itself https://github.com/ros-simulation/gazebo_ros_pkgs/issues/991#issuecomment-544895833 |

---

## Description of contribution in a few bullet points

- This change is not valid for dashing and older.
- This is the result of a simple search/replace for all argument tags with the new `remapping` tag in SDF.
- Apologies for unrelated whitespace changes

I sanity checked the diff but haven't use this on actual hardware, assuming that the CI here will run all the tests on this change. 
Ran tests locally but had failures, they didn't seem related to this change.

## Alternative or follow-up solution

Pull the turtlebot3 SDF files from upstream once https://github.com/ROBOTIS-GIT/turtlebot3_simulations/pull/101 has been validated / merged