### PR TITLE
Change stvl video link to embed type instead of watch.

### DIFF
--- a/sphinx_doc/howtos/tutorials/docs/navigation2_with_stvl.rst
+++ b/sphinx_doc/howtos/tutorials/docs/navigation2_with_stvl.rst
@@ -144,5 +144,5 @@ Video
 .. raw:: html
 
     <div style="position: relative; padding-bottom: 0%; overflow: hidden; max-width: 100%; height: auto;">
-      <iframe width="960" height="720" src="https://www.youtube.com/watch?v=TGxb1OzgmNQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      <iframe width="960" height="720" src="https://www.youtube.com/embed/TGxb1OzgmNQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>


### PR DESCRIPTION

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #1452  |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

* Fixes displaying the STVL video in the docs.
    *Change stvl video link to embed type instead of watch.
    *You can get the youtube embed html by clicking the `share` button under the video and choosing the embed option.
