### PR TITLE
Add warning to lifecycle node constructor, so people know they've launched a lifecyle node

### DIFF
--- a/nav2_map_server/src/map_server.cpp
+++ b/nav2_map_server/src/map_server.cpp
@@ -35,6 +35,8 @@ MapServer::MapServer()
 
   // Declare the node parameters
   declare_parameter("yaml_filename");
+
+  RCLCPP_WARN(get_logger(), "map_server lifecycle node launched. Awaiting lifecycle transitions");
 }
 
 MapServer::~MapServer()

--- a/nav2_map_server/src/map_server.cpp
+++ b/nav2_map_server/src/map_server.cpp
@@ -35,8 +35,6 @@ MapServer::MapServer()
 
   // Declare the node parameters
   declare_parameter("yaml_filename");
-
-  RCLCPP_WARN(get_logger(), "map_server lifecycle node launched. Awaiting lifecycle transitions");
 }
 
 MapServer::~MapServer()

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -26,8 +26,6 @@
 namespace nav2_util
 {
 
-void print_lifecycle_node_notification(const rclcpp_lifecycle::LifecycleNode * const node);
-
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 // The following is a temporary wrapper for rclcpp_lifecycle::LifecycleNode. This class
@@ -118,6 +116,8 @@ public:
   }
 
 protected:
+  void print_lifecycle_node_notification();
+
   // Whether or not to create a local rclcpp::Node which can be used for ROS2 classes that don't
   // yet support lifecycle nodes
   bool use_rclcpp_node_;

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -26,6 +26,8 @@
 namespace nav2_util
 {
 
+void print_lifecycle_node_notification(const rclcpp_lifecycle::LifecycleNode * const node);
+
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 // The following is a temporary wrapper for rclcpp_lifecycle::LifecycleNode. This class

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -73,7 +73,8 @@ LifecycleNode::~LifecycleNode()
 
 void LifecycleNode::print_lifecycle_node_notification()
 {
-  RCLCPP_INFO(get_logger(),
+  RCLCPP_INFO(
+    get_logger(),
     "\n\t%s lifecycle node launched. \n"
     "\tWaiting on external lifecycle transitions to activate\n"
     "\tSee https://design.ros2.org/articles/node_lifecycle.html for more information.", get_name());

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -57,6 +57,7 @@ LifecycleNode::LifecycleNode(
       "_", namespace_, rclcpp::NodeOptions(options).arguments(new_args));
     rclcpp_thread_ = std::make_unique<NodeThread>(rclcpp_node_);
   }
+  print_lifecycle_node_notification(this);
 }
 
 LifecycleNode::~LifecycleNode()
@@ -69,5 +70,15 @@ LifecycleNode::~LifecycleNode()
     on_cleanup(get_current_state());
   }
 }
+
+void print_lifecycle_node_notification(const rclcpp_lifecycle::LifecycleNode * const node)
+{
+  RCLCPP_INFO(node->get_logger(),
+    "\n\t%s lifecycle node launched. \n"
+    "\tWaiting on external lifecycle transitions to activate\n"
+    "\tSee https://design.ros2.org/articles/node_lifecycle.html for more information.", node->get_name());
+}
+
+
 
 }  // namespace nav2_util

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -57,7 +57,7 @@ LifecycleNode::LifecycleNode(
       "_", namespace_, rclcpp::NodeOptions(options).arguments(new_args));
     rclcpp_thread_ = std::make_unique<NodeThread>(rclcpp_node_);
   }
-  print_lifecycle_node_notification(this);
+  print_lifecycle_node_notification();
 }
 
 LifecycleNode::~LifecycleNode()
@@ -71,14 +71,12 @@ LifecycleNode::~LifecycleNode()
   }
 }
 
-void print_lifecycle_node_notification(const rclcpp_lifecycle::LifecycleNode * const node)
+void LifecycleNode::print_lifecycle_node_notification()
 {
-  RCLCPP_INFO(node->get_logger(),
+  RCLCPP_INFO(get_logger(),
     "\n\t%s lifecycle node launched. \n"
     "\tWaiting on external lifecycle transitions to activate\n"
-    "\tSee https://design.ros2.org/articles/node_lifecycle.html for more information.", node->get_name());
+    "\tSee https://design.ros2.org/articles/node_lifecycle.html for more information.", get_name());
 }
-
-
 
 }  // namespace nav2_util


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | fixes #1240 |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

* Adds a warning to end of each lifecycle node constructor informing the user that they've launched a lifecycle need and need to take addtional action
* This is mainly meant as a warning to users who directly run a node using `ros2 run` and aren't aware that additional steps are needed to get the node fully active.

Thoughts on this approach? If that seems reasonable, I'll go ahead and change the other nodes as well.