### PR TITLE
Order of activate/deactivate nodes in lifecycle manager

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -129,7 +129,7 @@ protected:
   /**
    * @brief For each node in the map, transition to the new target state
    */
-  bool changeStateForAllNodes(std::uint8_t transition, bool reverse_order = false);
+  bool changeStateForAllNodes(std::uint8_t transition);
 
   // Convenience function to highlight the output on the console
   /**

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -153,9 +153,11 @@ LifecycleManager::changeStateForNode(const std::string & node_name, std::uint8_t
 }
 
 bool
-LifecycleManager::changeStateForAllNodes(std::uint8_t transition, bool reverse_order)
+LifecycleManager::changeStateForAllNodes(std::uint8_t transition)
 {
-  if (!reverse_order) {
+  if (transition == Transition::TRANSITION_CONFIGURE ||
+    transition == Transition::TRANSITION_ACTIVATE)
+  {
     for (auto & node_name : node_names_) {
       if (!changeStateForNode(node_name, transition)) {
         return false;
@@ -169,7 +171,6 @@ LifecycleManager::changeStateForAllNodes(std::uint8_t transition, bool reverse_o
       }
     }
   }
-
   return true;
 }
 
@@ -177,9 +178,9 @@ void
 LifecycleManager::shutdownAllNodes()
 {
   message("Deactivate, cleanup, and shutdown nodes");
-  changeStateForAllNodes(Transition::TRANSITION_DEACTIVATE, true);
-  changeStateForAllNodes(Transition::TRANSITION_CLEANUP, true);
-  changeStateForAllNodes(Transition::TRANSITION_UNCONFIGURED_SHUTDOWN, true);
+  changeStateForAllNodes(Transition::TRANSITION_DEACTIVATE);
+  changeStateForAllNodes(Transition::TRANSITION_CLEANUP);
+  changeStateForAllNodes(Transition::TRANSITION_UNCONFIGURED_SHUTDOWN);
 }
 
 bool
@@ -213,8 +214,8 @@ LifecycleManager::reset()
 {
   message("Resetting managed nodes...");
   // Should transition in reverse order
-  if (!changeStateForAllNodes(Transition::TRANSITION_DEACTIVATE, true) ||
-    !changeStateForAllNodes(Transition::TRANSITION_CLEANUP, true))
+  if (!changeStateForAllNodes(Transition::TRANSITION_DEACTIVATE) ||
+    !changeStateForAllNodes(Transition::TRANSITION_CLEANUP))
   {
     RCLCPP_ERROR(get_logger(), "Failed to reset nodes: aborting reset");
     return false;


### PR DESCRIPTION
Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1345 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of Tally |

---

## Description of contribution in a few bullet points

* I removed the need to pass a flag for performing the transition of nodes in reverse or normal order. As @orduno said in #1345, this was prone to errors.
* My PR removes the flag. The transition itself defines the order.
* I tested on gazebo with tb3. Nodes are activated in order and deactivated in reverse order when pausing.

---

## Future work that may be required in bullet points

