### PR TITLE
fix map loading

### DIFF
--- a/nav2_bringup/bringup/launch/nav2_bringup_launch.py
+++ b/nav2_bringup/bringup/launch/nav2_bringup_launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
 
     declare_namespace_cmd = DeclareLaunchArgument(
         'namespace',
-        default_value='navigation',
+        default_value='',
         description='Top-level namespace')
 
     declare_use_namespace_cmd = DeclareLaunchArgument(


### PR DESCRIPTION
Fixes #1470 

### Description of contribution in a few bullet points

Simply set the default value to an empty string as discussed in #1470.
Tested on simulation. Map loads and the robot is able to navigate.
