### PR TITLE
[dashing-backport] store shared files in share/{PROJECT_NAME} rather …

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -132,7 +132,7 @@ install(TARGETS nav2_costmap_2d_core nav2_costmap_2d layers nav2_costmap_2d_clie
 )
 
 install(FILES costmap_plugins.xml
-  DESTINATION share
+  DESTINATION share/${PROJECT_NAME}
 )
 
 install(DIRECTORY include/

--- a/nav2_dwb_controller/dwb_critics/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_critics/CMakeLists.txt
@@ -66,7 +66,7 @@ install(DIRECTORY include/
         DESTINATION include/
 )
 install(FILES default_critics.xml
-        DESTINATION share
+        DESTINATION share/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)

--- a/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
@@ -60,7 +60,7 @@ install(DIRECTORY include/
         DESTINATION include/
 )
 install(FILES plugins.xml
-        DESTINATION share
+        DESTINATION share/${PROJECT_NAME}
 )
 
 ament_export_include_directories(include)


### PR DESCRIPTION
backports https://github.com/ros-planning/navigation2/pull/1481 to dashing 

The other two CMakeLists didn't install anything into share/* in dashing. 

I did another basic grep and didn't see any additional offenders.