### PR TITLE
Add ament_export_libraries to map_server

### DIFF
--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -92,5 +92,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-
+ament_export_libraries(
+  ${library_name}
+)
 ament_package()


### PR DESCRIPTION
This Pr would allow one to derive from map_server lib in another package to add custom functionality.