### PR TITLE
[website sprint] remove the "how it works" tab from documentation

### DIFF
--- a/sphinx_doc/how_it_works/index.rst
+++ b/sphinx_doc/how_it_works/index.rst
@@ -1,7 +1,0 @@
-.. _how_it_works:
-
-How It Works
-############
-
-This website is under construction. Please visit the `project repo`_ in the
-meantime.

--- a/sphinx_doc/index.rst
+++ b/sphinx_doc/index.rst
@@ -39,7 +39,6 @@ Sections
    :maxdepth: 1
 
    getting_started/index.rst
-   how_it_works/index.rst
    howtos/index.rst
    release_notes.rst
    contribute/index.rst


### PR DESCRIPTION
its empty and not likely to be filled in anytime in the medium term future