### PR TITLE
Changing dockerhub from status to pull counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 | Builder                | Status                    |
 |----------------------|-------------------------|
 | CircleCI             | [![Build Status](https://circleci.com/gh/ros-planning/navigation2/tree/master.svg?style=svg)](https://circleci.com/gh/ros-planning/navigation2/tree/master)   |
-| DockerHub       | [![Build Status](https://img.shields.io/docker/cloud/build/rosplanning/navigation2.svg?label=build)](https://hub.docker.com/r/rosplanning/navigation2)       |
+| DockerHub       | [![Build Status](https://img.shields.io/docker/pulls/rosplanning/navigation2.svg?maxAge=2592000)](https://hub.docker.com/r/rosplanning/navigation2)       |
 | ROS2 Build Farm   | [![Build Status](http://build.ros2.org/job/Cdev__navigation2__ubuntu_bionic_amd64/badge/icon)](http://build.ros2.org/job/Cdev__navigation2__ubuntu_bionic_amd64/)      |
 | Code Coverage   | [![codecov](https://codecov.io/gh/ros-planning/navigation2/branch/master/graph/badge.svg)](https://codecov.io/gh/ros-planning/navigation2)    |
 


### PR DESCRIPTION
Per https://github.com/ros-planning/navigation2/issues/1499, DockerHub is incorrectly reporting a failing status when it is building fine.

I've seen this problem in 5 projects and there's tickets filed with DockerHub that are being ignored widely. As a result, I'm going to replace the badge with something that's actually accurate, the pull pointer