### PR TITLE
only let a new goal in after the currently running goal's thread has …

### DIFF
--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -109,7 +109,7 @@ public:
     std::lock_guard<std::recursive_mutex> lock(update_mutex_);
     debug_msg("Receiving a new goal");
 
-    if (is_active(current_handle_)) {
+    if (is_active(current_handle_) || is_running()) {
       debug_msg("An older goal is active, moving the new goal to a pending slot.");
 
       if (is_active(pending_handle_)) {
@@ -217,7 +217,9 @@ public:
 
   bool is_running()
   {
-    return execution_future_.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready;
+    return execution_future_.valid() &&
+           (execution_future_.wait_for(std::chrono::milliseconds(0)) ==
+           std::future_status::timeout);
   }
 
   bool is_server_active()


### PR DESCRIPTION
this seems to fix https://github.com/ros-planning/navigation2/issues/1519

All I’m doing here is waiting to execute a new goal until after the thread executing the current goal returns, so we don’t start a new goal before we’ve cleaned up everything related to the old goal. 


I think its a little awkward that `execute_callback_()` has to handle setting the status of the goal, because there's no atomic way to set the current goal status and do cleanup on the simple action server. But I don't have any change suggestions right now
