### PR TITLE
Collision fix for 'flickering' laser scan.

### DIFF
--- a/nav2_bringup/bringup/worlds/waffle.model
+++ b/nav2_bringup/bringup/worlds/waffle.model
@@ -413,7 +413,7 @@
           <mass>0.035</mass>
         </inertial>
         <collision name="collision">
-          <pose>0 0.047 0 0 0 0</pose>
+          <pose>0 0.047 -0.004 0 0 0</pose>
           <geometry>
             <box>
               <size>0.008 0.130 0.022</size>
@@ -441,7 +441,7 @@
         </sensor>
 
         <collision name="collision">
-          <pose>0 0.047 0 0 0 0</pose>
+          <pose>0 0.047 -0.004 0 0 0</pose>
           <geometry>
             <box>
               <size>0.008 0.130 0.022</size>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1521  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | TB3 waffle simulation |

---

## Description of contribution in a few bullet points
* Shifted collision of RGBD model to prevent collisions with the laser scan.
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->


