### PR TITLE
move odom sub thresholds to the controller server for no change in be…

### DIFF
--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -167,6 +167,31 @@ protected:
    */
   bool getRobotPose(geometry_msgs::msg::PoseStamped & pose);
 
+  /**
+   * @brief get the thresholded velocity
+   * @param velocity The current velocity from odometry
+   * @param threshold The minimum velocity to return non-zero
+   * @return double velocity value
+   */
+  double getThresholdedVelocity(double velocity, double threshold)
+  {
+    return (std::abs(velocity) > threshold) ? velocity : 0.0;
+  }
+
+  /**
+   * @brief get the thresholded Twist
+   * @param Twist The current Twist from odometry
+   * @return Twist Twist after thresholds applied
+   */
+  nav_2d_msgs::msg::Twist2D getThresholdedTwist(const nav_2d_msgs::msg::Twist2D & twist)
+  {
+    nav_2d_msgs::msg::Twist2D twist_thresh;
+    twist_thresh.x = getThresholdedVelocity(twist.x, min_x_velocity_threshold_);
+    twist_thresh.y = getThresholdedVelocity(twist.y, min_y_velocity_threshold_);
+    twist_thresh.theta = getThresholdedVelocity(twist.theta, min_theta_velocity_threshold_);
+    return twist_thresh;
+  }
+
   // The controller needs a costmap node
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   std::unique_ptr<nav2_util::NodeThread> costmap_thread_;
@@ -184,6 +209,9 @@ protected:
   std::unique_ptr<ProgressChecker> progress_checker_;
 
   double controller_frequency_;
+  double min_x_velocity_threshold_;
+  double min_y_velocity_threshold_;
+  double min_theta_velocity_threshold_;
 
   // Whether we've published the single controller warning yet
   bool single_controller_warning_given_{false};

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
@@ -72,20 +72,6 @@ public:
       odom_topic,
       rclcpp::SystemDefaultsQoS(),
       std::bind(&OdomSubscriber::odomCallback, this, std::placeholders::_1));
-
-    nav2_util::declare_parameter_if_not_declared(
-      nh,
-      "min_x_velocity_threshold", rclcpp::ParameterValue(0.0001));
-    nav2_util::declare_parameter_if_not_declared(
-      nh,
-      "min_y_velocity_threshold", rclcpp::ParameterValue(0.0001));
-    nav2_util::declare_parameter_if_not_declared(
-      nh,
-      "min_theta_velocity_threshold", rclcpp::ParameterValue(0.0001));
-
-    nh->get_parameter("min_x_velocity_threshold", min_x_velocity_threshold_);
-    nh->get_parameter("min_y_velocity_threshold", min_y_velocity_threshold_);
-    nh->get_parameter("min_theta_velocity_threshold", min_theta_velocity_threshold_);
   }
 
   inline nav_2d_msgs::msg::Twist2D getTwist() {return odom_vel_.velocity;}
@@ -97,26 +83,14 @@ protected:
     // ROS_INFO_ONCE("odom received!");
     std::lock_guard<std::mutex> lock(odom_mutex_);
     odom_vel_.header = msg->header;
-    odom_vel_.velocity.x =
-      thresholded_velocity(msg->twist.twist.linear.x, min_x_velocity_threshold_);
-    odom_vel_.velocity.y =
-      thresholded_velocity(msg->twist.twist.linear.y, min_y_velocity_threshold_);
-    odom_vel_.velocity.theta =
-      thresholded_velocity(msg->twist.twist.angular.z, min_theta_velocity_threshold_);
-  }
-
-  double thresholded_velocity(double velocity, double threshold)
-  {
-    return (std::abs(velocity) > threshold) ? velocity : 0.0;
+    odom_vel_.velocity.x = msg->twist.twist.linear.x;
+    odom_vel_.velocity.y = msg->twist.twist.linear.y;
+    odom_vel_.velocity.theta = msg->twist.twist.angular.z;
   }
 
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
   nav_2d_msgs::msg::Twist2DStamped odom_vel_;
   std::mutex odom_mutex_;
-
-  double min_x_velocity_threshold_;
-  double min_y_velocity_threshold_;
-  double min_theta_velocity_threshold_;
 };
 
 }  // namespace nav_2d_utils


### PR DESCRIPTION
…havior but prior change in authority

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |#710 |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

* Move the thresholding where appropriate
* To not change behavior for other plugins, its been moved to the controller server, which is very high profile as a place to look, so I think it'll be clear this is happening. This threshold is minimal and probably good for everyone anyhow

---
