### PR TITLE
removing last time updated from readthedocs

### DIFF
--- a/sphinx_doc/conf.py
+++ b/sphinx_doc/conf.py
@@ -172,8 +172,8 @@ html_show_sourcelink = False
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page
 # bottom,
-# using the given strftime format.
-html_last_updated_fmt = '%b %d, %Y'
+# using the given strftime format (ei %b %d, %Y).
+html_last_updated_fmt = ''
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1421  |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

* Its a little involved to update the timestamp, and its not that important. I'm removing it so that we don't burn maintainers time on a superficial accessory. 

---
@crdelsey can you give your thoughts on this one? I won't just charge it in since I know its something that people may disagree with. Its definitely the "easy way out" but hour-for-hour with limited bandwidth, it seems silly to spend any time on this.