### PR TITLE
adding lifecycle shared from this to lifecycle utils

### DIFF
--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
@@ -62,7 +62,7 @@ public:
    * @param default_topic Name of the topic that will be loaded of the odom_topic param is not set.
    */
   explicit OdomSubscriber(
-    nav2_util::LifecycleNode::SharedPtr & nh,
+    nav2_util::LifecycleNode::SharedPtr nh,
     std::string default_topic = "odom")
   {
     std::string odom_topic;

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -115,6 +115,12 @@ public:
     declare_parameter(descriptor.name, default_value, descriptor);
   }
 
+  std::shared_ptr<nav2_util::LifecycleNode> shared_from_this()
+  {
+      return std::static_pointer_cast<nav2_util::LifecycleNode>(
+        rclcpp_lifecycle::LifecycleNode::shared_from_this());
+  }
+
 protected:
   void print_lifecycle_node_notification();
 

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -117,8 +117,8 @@ public:
 
   std::shared_ptr<nav2_util::LifecycleNode> shared_from_this()
   {
-      return std::static_pointer_cast<nav2_util::LifecycleNode>(
-        rclcpp_lifecycle::LifecycleNode::shared_from_this());
+    return std::static_pointer_cast<nav2_util::LifecycleNode>(
+      rclcpp_lifecycle::LifecycleNode::shared_from_this());
   }
 
 protected:


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1409 |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

* Adding proposed lifecycle shared from this implementation.

---

## Future work that may be required in bullet points

* Perhaps rethink the use of a lifecycle node wrapper **once** we are able to remove effectively the client nodes. For now its required, and as @bpwilcox brings up, it may be beneficial for some users. 
