### PR TITLE
wrap spins for waypoint follower in try / except

### DIFF
--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -128,8 +128,8 @@ class WaypointFollowerTest(Node):
         req = ManageLifecycleNodes.Request()
         req.command = ManageLifecycleNodes.Request().SHUTDOWN
         future = mgr_client.call_async(req)
-        rclpy.spin_until_future_complete(self, future)
         try:
+            rclpy.spin_until_future_complete(self, future)
             future.result()
         except Exception as e:
             self.error_msg('Service call failed %r' % (e,))
@@ -142,8 +142,8 @@ class WaypointFollowerTest(Node):
         req = ManageLifecycleNodes.Request()
         req.command = ManageLifecycleNodes.Request().SHUTDOWN
         future = mgr_client.call_async(req)
-        rclpy.spin_until_future_complete(self, future)
         try:
+            rclpy.spin_until_future_complete(self, future)
             future.result()
         except Exception as e:
             self.error_msg('Service call failed %r' % (e,))


### PR DESCRIPTION
On the path to fixing nightly woes

This stops the crashing for all nightly builds, but doesn't yet solve the issue of them not exiting after destruction, which is interesting. 

See here (https://8834-135363400-gh.circle-artifacts.com/0/opt/overlay_ws/log/test/nav2_system_tests/stdout.log) and search for `***Timeout` . You'll see they all pass and appear to shutdown cleanly, yet fail to actually return to exit the test