### PR TITLE
FootprintSubscriber use from_seconds() to avoid integer truncation

### DIFF
--- a/nav2_costmap_2d/src/footprint_subscriber.cpp
+++ b/nav2_costmap_2d/src/footprint_subscriber.cpp
@@ -55,7 +55,7 @@ FootprintSubscriber::FootprintSubscriber(
   node_logging_(node_logging),
   node_clock_(node_clock),
   topic_name_(topic_name),
-  footprint_timeout_(rclcpp::Duration(footprint_timeout, 0.))
+  footprint_timeout_(rclcpp::Duration::from_seconds(footprint_timeout))
 {
   footprint_sub_ = rclcpp::create_subscription<geometry_msgs::msg::PolygonStamped>(
     node_topics_,


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | () |
| Primary OS tested on | (Ubuntu Bionic) |
| Robotic platform tested on | (gazebo simulation of turtlebot waffle) |

---

## Description of contribution in a few bullet points

* uses `Duration::from_seconds()` to avoid the footprint timeout (given as a `double`) being truncated to an integer
---

## Future work that may be required in bullet points

* This change could be safely backported to `eloquent`
