### PR TITLE
[eloquent] Backport #1560 Use from_seconds() to avoid integer truncation

### DIFF
--- a/nav2_costmap_2d/src/footprint_subscriber.cpp
+++ b/nav2_costmap_2d/src/footprint_subscriber.cpp
@@ -55,7 +55,7 @@ FootprintSubscriber::FootprintSubscriber(
   node_logging_(node_logging),
   node_clock_(node_clock),
   topic_name_(topic_name),
-  footprint_timeout_(rclcpp::Duration(footprint_timeout, 0.))
+  footprint_timeout_(rclcpp::Duration::from_seconds(footprint_timeout))
 {
   footprint_sub_ = rclcpp::create_subscription<geometry_msgs::msg::PolygonStamped>(node_topics_,
       topic_name, rclcpp::SystemDefaultsQoS(),


### PR DESCRIPTION
Backports #1560 to the `eloquent-devel` branch. This PR is a cherry-pick of 547f7bc.