### PR TITLE
Updating PR template to force people to reference necessary documentation changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,13 @@
 * Also fixed a typo in a parameter name in nav2_costmap_2d
 -->
 
+## Description of documentation updates required from your changes
+
+<!--
+* Added new parameter, so need to add that to default configs and documentation page
+* I added some capabilities, need to document them
+-->
+
 ---
 
 ## Future work that may be required in bullet points


### PR DESCRIPTION
I've spent a bunch of time (and will continue to) on improving the documentation and compiling resources.

I do not want this work to go in vein because documentation isn't kept up with changes. This acts as a reminder in case folks forget when they make changes to add them to documentation