### PR TITLE
[dwb_core] Never shortcut trajectory scoring

### DIFF
--- a/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
@@ -111,7 +111,6 @@ controller_server:
     FollowPath.PathDist.scale: 32.0
     FollowPath.GoalDist.scale: 24.0
     FollowPath.RotateToGoal.scale: 32.0
-    FollowPath.short_circuit_trajectory_evaluation: True
     FollowPath.trans_stopped_velocity: 0.25
     FollowPath.slowing_factor: 5.0
     FollowPath.lookahead_time: -1.0

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
@@ -111,7 +111,6 @@ controller_server:
     FollowPath.PathDist.scale: 32.0
     FollowPath.GoalDist.scale: 24.0
     FollowPath.RotateToGoal.scale: 32.0
-    FollowPath.short_circuit_trajectory_evaluation: True
     FollowPath.trans_stopped_velocity: 0.25
     FollowPath.slowing_factor: 5.0
     FollowPath.lookahead_time: -1.0

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -113,7 +113,6 @@ controller_server:
     FollowPath.PathDist.scale: 32.0
     FollowPath.GoalDist.scale: 24.0
     FollowPath.RotateToGoal.scale: 32.0
-    FollowPath.short_circuit_trajectory_evaluation: True
     FollowPath.trans_stopped_velocity: 0.25
     FollowPath.slowing_factor: 5.0
     FollowPath.lookahead_time: -1.0

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/dwb_local_planner.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/dwb_local_planner.hpp
@@ -116,17 +116,11 @@ public:
   /**
    * @brief Score a given command. Can be used for testing.
    *
-   * Given a trajectory, calculate the score where lower scores are better.
-   * If the given (positive) score exceeds the best_score, calculation may be cut short, as the
-   * score can only go up from there.
-   *
    * @param traj Trajectory to check
-   * @param best_score If positive, the threshold for early termination
    * @return The full scoring of the input trajectory
    */
   virtual dwb_msgs::msg::TrajectoryScore scoreTrajectory(
-    const dwb_msgs::msg::Trajectory2D & traj,
-    double best_score = -1);
+    const dwb_msgs::msg::Trajectory2D & traj);
 
   /**
    * @brief Compute the best command given the current pose and velocity, with possible debug information
@@ -217,8 +211,6 @@ protected:
   std::vector<TrajectoryCritic::Ptr> critics_;
 
   std::string dwb_plugin_name_;
-
-  bool short_circuit_trajectory_evaluation_;
 };
 
 }  // namespace dwb_core

--- a/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
@@ -428,10 +428,6 @@ DWBLocalPlanner::coreScoringAlgorithm(
       if (results) {
         results->twists.push_back(score);
       }
-
-      //RCLCPP_INFO(rclcpp::get_logger("DWBLocalPlanner"), "score: %lf x %lf y %lf theta %lf",
-      //    score.total, twist.x, twist.y, twist.theta);
-
       if (best.total < 0 || score.total < best.total) {
         best = score;
         if (results) {

--- a/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
@@ -92,9 +92,6 @@ void DWBLocalPlanner::configure(
   declare_parameter_if_not_declared(
     node_, dwb_plugin_name_ + ".transform_tolerance",
     rclcpp::ParameterValue(0.1));
-  declare_parameter_if_not_declared(
-    node_, dwb_plugin_name_ + ".short_circuit_trajectory_evaluation",
-    rclcpp::ParameterValue(true));
 
   std::string traj_generator_name;
   std::string goal_checker_name;

--- a/sphinx_doc/configuration/configuring-the-controller.rst
+++ b/sphinx_doc/configuration/configuring-the-controller.rst
@@ -317,17 +317,6 @@ Debug Parameters
   |                | **transformed_global_plan** topic and can be visualized in RViz            |
   +----------------+----------------------------------------------------------------------------+
 
-:short_circuit_trajectory_evaluation:
-  +----------------+----------------------------------------------------------------------------+
-  |**type**        | bool                                                                       |
-  +----------------+----------------------------------------------------------------------------+
-  |**default**     | true                                                                       |
-  +----------------+----------------------------------------------------------------------------+
-  |**description** | This parameter allows process to move forward if trajectories score by     |
-  |                | critics is just equal to the best score. As after this point it would be   |
-  |                | pointless to increse the score as it will always be more than best score.  | 
-  +----------------+----------------------------------------------------------------------------+
-
 :trans_stopped_velocity:
   +----------------+----------------------------------------------------------------------------+
   |**type**        | double                                                                     |

--- a/sphinx_doc/configuration/params/tunable-params.rst
+++ b/sphinx_doc/configuration/params/tunable-params.rst
@@ -142,7 +142,6 @@ Hosts the `DWB` controller.
         vy_samples: 5
         xy_goal_tolerance: 0.25
         yaw_goal_tolerance: 0.25
-        short_circuit_trajectory_evaluation: True
         trans_stopped_velocity: 0.25
         slowing_factor: 5.0
         lookahead_time: -1.0


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of turtlebot waffle |

---

## Description of contribution in a few bullet points

* Removed short cut of trajectory scoring from `dwb_core` because it often leads to worse overall trajectories being chosen

## Description of documentation updates required from your changes

* Removed documentation of parameter that optionally disabled short cut taking

---

## Future work that may be required in bullet points

* an ABI compatible patch to Eloquent could be done by always passing `-1` for `best_score` to `scoreTrajectory()`



## Long description
When evaluating trajectories, dwb will stop running critics as soon as
the trajectory's score is better than the best trajectory seen so far.
It looks like this often leads to worse trajectories being chosen as the
overall best.

Consider 3 trajectories and 2 critics:

1. t1 is scored by both critics and gets scores [0.5, 0.0] for a total
score of 0.5
1. t2 is scored by the first critic and gets a score of 0.6. Since
it's better than the best so far, the scoring gets cut short. If it
hadn't been cut short, t2's scores would have been [0.6, 0.5] for a
total of 1.1
2. t3 is scored by both critics for scores [0.4, 0.4] for a total of
0.8. t3 is chosen as the best trajectory even though it's total score of
0.8 is smaller than what t2's would have been if all critics had been
run on it.