### PR TITLE
RotateToGoal param name fixes

### DIFF
--- a/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
@@ -104,6 +104,9 @@ controller_server:
     FollowPath.linear_granularity: 0.05
     FollowPath.angular_granularity: 0.025
     FollowPath.transform_tolerance: 0.2
+    FollowPath.trans_stopped_velocity: 0.25
+    FollowPath.short_circuit_trajectory_evaluation: True
+    FollowPath.stateful: True
     FollowPath.critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
     FollowPath.BaseObstacle.scale: 0.02
     FollowPath.PathAlign.scale: 0.0
@@ -111,11 +114,8 @@ controller_server:
     FollowPath.PathDist.scale: 32.0
     FollowPath.GoalDist.scale: 24.0
     FollowPath.RotateToGoal.scale: 32.0
-    FollowPath.short_circuit_trajectory_evaluation: True
-    FollowPath.trans_stopped_velocity: 0.25
-    FollowPath.slowing_factor: 5.0
-    FollowPath.lookahead_time: -1.0
-    FollowPath.stateful: True
+    FollowPath.RotateToGoal.slowing_factor: 5.0
+    FollowPath.RotateToGoal.lookahead_time: -1.0
 
 controller_server_rclcpp_node:
   ros__parameters:

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
@@ -104,6 +104,9 @@ controller_server:
     FollowPath.linear_granularity: 0.05
     FollowPath.angular_granularity: 0.025
     FollowPath.transform_tolerance: 0.2
+    FollowPath.trans_stopped_velocity: 0.25
+    FollowPath.short_circuit_trajectory_evaluation: True
+    FollowPath.stateful: True
     FollowPath.critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
     FollowPath.BaseObstacle.scale: 0.02
     FollowPath.PathAlign.scale: 0.0
@@ -111,11 +114,8 @@ controller_server:
     FollowPath.PathDist.scale: 32.0
     FollowPath.GoalDist.scale: 24.0
     FollowPath.RotateToGoal.scale: 32.0
-    FollowPath.short_circuit_trajectory_evaluation: True
-    FollowPath.trans_stopped_velocity: 0.25
-    FollowPath.slowing_factor: 5.0
-    FollowPath.lookahead_time: -1.0
-    FollowPath.stateful: True
+    FollowPath.RotateToGoal.slowing_factor: 5.0
+    FollowPath.RotateToGoal.lookahead_time: -1.0
 
 controller_server_rclcpp_node:
   ros__parameters:

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -106,6 +106,9 @@ controller_server:
     FollowPath.angular_granularity: 0.025
     FollowPath.transform_tolerance: 0.2
     FollowPath.xy_goal_tolerance: 0.25
+    FollowPath.trans_stopped_velocity: 0.25
+    FollowPath.short_circuit_trajectory_evaluation: True
+    FollowPath.stateful: True
     FollowPath.critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
     FollowPath.BaseObstacle.scale: 0.02
     FollowPath.PathAlign.scale: 0.0
@@ -113,11 +116,8 @@ controller_server:
     FollowPath.PathDist.scale: 32.0
     FollowPath.GoalDist.scale: 24.0
     FollowPath.RotateToGoal.scale: 32.0
-    FollowPath.short_circuit_trajectory_evaluation: True
-    FollowPath.trans_stopped_velocity: 0.25
-    FollowPath.slowing_factor: 5.0
-    FollowPath.lookahead_time: -1.0
-    FollowPath.stateful: True
+    FollowPath.RotateToGoal.slowing_factor: 5.0
+    FollowPath.RotateToGoal.lookahead_time: -1.0
 
 controller_server_rclcpp_node:
   ros__parameters:

--- a/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
+++ b/nav2_dwb_controller/dwb_critics/src/rotate_to_goal.cpp
@@ -55,11 +55,11 @@ void RotateToGoalCritic::onInit()
 {
   xy_goal_tolerance_ = nav_2d_utils::searchAndGetParam(
     nh_,
-    dwb_plugin_name_ + "." + name_ + ".xy_goal_tolerance", 0.25);
+    dwb_plugin_name_ + ".xy_goal_tolerance", 0.25);
   xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
   double stopped_xy_velocity = nav_2d_utils::searchAndGetParam(
     nh_,
-    dwb_plugin_name_ + "." + name_ + ".trans_stopped_velocity", 0.25);
+    dwb_plugin_name_ + ".trans_stopped_velocity", 0.25);
   stopped_xy_velocity_sq_ = stopped_xy_velocity * stopped_xy_velocity;
   slowing_factor_ = nav_2d_utils::searchAndGetParam(
     nh_,


### PR DESCRIPTION
this fixes issue: https://github.com/ros-planning/navigation2/issues/1567

I changed these two params because they are shared with other parts of the system

`xy_goal_tolerance` is used by the `rotate_to_goal` critic and the `simple_goal_checker`

`trans_stopped_velocity` is used by the `rotate_to_goal` critic and the  `stopped_goal_checker` (I do not use this and did now know what it was before this PR). 


The other two params, `slowing_factor` and `lookahead_time`, are exclusive to the `rotate_to_goal` critic, so I kept their names in that critics namespace (I don't use them and don't know what they do).  I updated the default param file in this repo to the correct names for these params.

I reordered some params in the yaml file so that only critic params are declared after the critics are listed. It's easier for me to read this way. 


