### PR TITLE
fixing BT node action processors

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -116,8 +116,7 @@ new_goal_received:
     auto send_goal_options = typename rclcpp_action::Client<ActionT>::SendGoalOptions();
     send_goal_options.result_callback =
       [this](const typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult & result) {
-        if (result.code != rclcpp_action::ResultCode::ABORTED)
-        {
+        if (result.code != rclcpp_action::ResultCode::ABORTED) {
           goal_result_available_ = true;
           result_ = result;
         }

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -41,11 +41,6 @@ public:
     goal_ = typename ActionT::Goal();
     result_ = typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult();
 
-    // Get the required items from the blackboard
-    server_timeout_ =
-      config().blackboard->get<std::chrono::milliseconds>("server_timeout");
-    getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
-
     createActionClient(action_name_);
 
     // Give the derive class a chance to do any initialization
@@ -222,10 +217,6 @@ protected:
 
   // The node that will be used for any ROS operations
   rclcpp::Node::SharedPtr node_;
-
-  // The timeout value while to use in the tick loop while waiting for
-  // a result from the server
-  std::chrono::milliseconds server_timeout_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -96,7 +96,7 @@ public:
       RCLCPP_WARN(
         node_->get_logger(),
         "Node timed out while executing service call to %s.", service_name_.c_str());
-      on_server_timeout();
+      on_wait_for_result();
     }
     return BT::NodeStatus::FAILURE;
   }
@@ -109,7 +109,7 @@ public:
 
   // An opportunity to do something after
   // a timeout waiting for a result that hasn't been received yet
-  virtual void on_server_timeout()
+  virtual void on_wait_for_result()
   {
   }
 

--- a/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/follow_path_action.cpp
@@ -47,7 +47,7 @@ public:
     getInput("controller_id", goal_.controller_id);
   }
 
-  void on_server_timeout() override
+  void on_wait_for_result() override
   {
     // Check if the goal has been updated
     if (config().blackboard->get<bool>("path_updated")) {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1289 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of TB3 |

---

## Description of contribution in a few bullet points
* Clears up unnecessary networking traffic in constantly timing out a request
* Handle the preemption of the controller server abort rather than throwing away results

@crdelsey I'd appreciate a review on this one since its a big behavioral change. I found the issue in the last time I tried to do this.

Turns out the controller server will return a preempt (which translates to failure in the BT action node) which the `goto` actually completely throws out and is missed. My synchronous callback method didn't throw it out because it triggers on a result. So I added a check if it was preempted, if so I ignore the result and continue spinning, since a preemption means a new goal was accepted and is processing. Then the next loop will grab that new goal and replace the handle. 