### PR TITLE
Adding destroy call to rclpy action client in system tests 

### DIFF
--- a/nav2_system_tests/src/system/tester_node.py
+++ b/nav2_system_tests/src/system/tester_node.py
@@ -179,8 +179,10 @@ class NavTester(Node):
         req.command = ManageLifecycleNodes.Request().SHUTDOWN
         future = mgr_client.call_async(req)
         try:
+            self.info_msg('Shutting down navigation lifecycle manager...')
             rclpy.spin_until_future_complete(self, future)
             future.result()
+            self.info_msg('Shutting down navigation lifecycle manager complete.')
         except Exception as e:
             self.error_msg('Service call failed %r' % (e,))
         transition_service = 'lifecycle_manager_localization/manage_nodes'
@@ -192,8 +194,10 @@ class NavTester(Node):
         req.command = ManageLifecycleNodes.Request().SHUTDOWN
         future = mgr_client.call_async(req)
         try:
+            self.info_msg('Shutting down localization lifecycle manager...')
             rclpy.spin_until_future_complete(self, future)
             future.result()
+            self.info_msg('Shutting down localization lifecycle manager complete')
         except Exception as e:
             self.error_msg('Service call failed %r' % (e,))
 
@@ -323,8 +327,14 @@ def main(argv=sys.argv[1:]):
         # stop and shutdown the nav stack to exit cleanly
         tester.shutdown()
 
+    testers[0].info_msg('Done Shutting Down.')
+
     if not passed:
+        testers[0].info_msg('Exiting failed')
         exit(1)
+    else:
+        testers[0].info_msg('Exiting passed')
+        exit(0)
 
 
 if __name__ == '__main__':

--- a/nav2_system_tests/src/system/tester_node.py
+++ b/nav2_system_tests/src/system/tester_node.py
@@ -170,6 +170,8 @@ class NavTester(Node):
 
     def shutdown(self):
         self.info_msg('Shutting down')
+        self.action_client.destroy()
+
         transition_service = 'lifecycle_manager_navigation/manage_nodes'
         mgr_client = self.create_client(ManageLifecycleNodes, transition_service)
         while not mgr_client.wait_for_service(timeout_sec=1.0):

--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -181,10 +181,13 @@ def main(argv=sys.argv[1:]):
 
     result = test.run()
     test.shutdown()
+    test.info_msg('Done Shutting Down.')
 
     if not result:
+        test.info_msg('Exiting failed')
         exit(1)
     else:
+        test.info_msg('Exiting passed')
         exit(0)
 
 


### PR DESCRIPTION
I suspect this is causing the issues:

```
[453.043s] 10: [tester_node-13] [ERROR] [1583454435.358193353] [nav2_tester]: [1;37;41mService call failed RuntimeError('Failed to take status with an action client: error not set',)[0m
[344.359s] 13: [tester_node-13] [ERROR] [1583454326.674545839] [nav2_waypoint_tester]: [1;37;41mService call failed RuntimeError('Failed to take feedback with an action client: error not set',)[0m
```
which may be leaving a server up causing the lack of exiting. This is not seen in Fast-RTPS, which is the only RMW which regularly passes the nightly builds. 

