### PR TITLE
[test, ignore] testing planner test failure rate in cloud -- getting CI metrics on failure rates

### DIFF
--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -68,7 +68,7 @@ void PlannerTester::activate()
   planner_tester_->onConfigure(state);
   publishRobotTransform();
   map_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("map", 1);
-  rclcpp::Rate r(1);
+  rclcpp::Rate r(0.2);
   r.sleep();
   planner_tester_->onActivate(state);
 }

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -53,14 +53,17 @@ void PlannerTester::activate()
   }
   is_active_ = true;
 
+  // Provide the robot pose transform
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
+
+  startRobotTransform();
+
   // Launch a thread to process the messages for this node
   spin_thread_ = std::make_unique<nav2_util::NodeThread>(this);
 
   // We start with a 10x10 grid with no obstacles
   costmap_ = std::make_unique<Costmap>(this);
   loadSimpleCostmap(TestCostmap::open_space);
-
-  startRobotTransform();
 
   // The navfn wrapper
   auto state = rclcpp_lifecycle::State();
@@ -101,9 +104,6 @@ PlannerTester::~PlannerTester()
 
 void PlannerTester::startRobotTransform()
 {
-  // Provide the robot pose transform
-  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
-
   // Set an initial pose
   geometry_msgs::msg::Point robot_position;
   robot_position.x = 1.0;

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -68,7 +68,7 @@ void PlannerTester::activate()
   planner_tester_->onConfigure(state);
   publishRobotTransform();
   map_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("map", 1);
-  rclcpp::Rate r(0.2);
+  rclcpp::Rate r(0.1);
   r.sleep();
   planner_tester_->onActivate(state);
 }

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -68,7 +68,7 @@ void PlannerTester::activate()
   planner_tester_->onConfigure(state);
   publishRobotTransform();
   map_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("map", 1);
-  rclcpp::Rate r(0.1);
+  rclcpp::Rate r(0.2);
   r.sleep();
   planner_tester_->onActivate(state);
 }

--- a/nav2_system_tests/src/planning/test_planner_random_node.cpp
+++ b/nav2_system_tests/src/planning/test_planner_random_node.cpp
@@ -33,7 +33,6 @@ TEST(testWithHundredRandomEndPoints, testWithHundredRandomEndPoints)
   auto obj = std::make_shared<PlannerTester>();
   obj->activate();
   obj->loadDefaultMap();
-  obj->loadDefaultMap();
 
   bool success = false;
   int num_tries = 3;

--- a/nav2_system_tests/src/planning/test_planner_random_node.cpp
+++ b/nav2_system_tests/src/planning/test_planner_random_node.cpp
@@ -33,6 +33,7 @@ TEST(testWithHundredRandomEndPoints, testWithHundredRandomEndPoints)
   auto obj = std::make_shared<PlannerTester>();
   obj->activate();
   obj->loadDefaultMap();
+  obj->loadDefaultMap();
 
   bool success = false;
   int num_tries = 3;


### PR DESCRIPTION
Please ignore. Testing number of planner test failures across many CI runs 

Run 1: 3/4
Run 2: 2/4
Run 3: 3/4
Run 4: 1/4
Run 5: 3/4

so we have a 60% success rate on the planner tests. Fails waiting for map frame.

With a longer wait:
Run 1: 3/4
Run 2: 4/4
Run 3: 2/4
Run 4: 3/4
Run 5: 3/4

so we have 75% success rate when we add a 5s vs 1s sleep

With even longer wait:
Run 1: 4/4
Run 2: 3/4
Run 3: 3/4
Run 4: 2/4
Run 5: 3/4

10s also has 75% success rate, so that doesn't do anything helpful extended.

Changed some TF tolerances and reduced back to 5 seconds.
Run 1: 3/4

* I'm pretty sure at this point it is not actually related to TF but node spinning or executors. After this bit, Ill look into that.