### PR TITLE
setStatus(BT::NodeStatus::IDLE) removed

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -149,15 +149,12 @@ new_goal_received:
     switch (result_.code) {
       case rclcpp_action::ResultCode::SUCCEEDED:
         on_success();
-        setStatus(BT::NodeStatus::IDLE);
         return BT::NodeStatus::SUCCESS;
 
       case rclcpp_action::ResultCode::ABORTED:
-        setStatus(BT::NodeStatus::IDLE);
         return BT::NodeStatus::FAILURE;
 
       case rclcpp_action::ResultCode::CANCELED:
-        setStatus(BT::NodeStatus::IDLE);
         return BT::NodeStatus::SUCCESS;
 
       default:


### PR DESCRIPTION
The removed code has no effect at all: the status of a node will be its returned value!

In general, you never set your status to IDLE, unless halted.
