### PR TITLE
making documentation distro agnostic

### DIFF
--- a/sphinx_doc/build_instructions/index.rst
+++ b/sphinx_doc/build_instructions/index.rst
@@ -37,12 +37,12 @@ We're going to create a new workspace, ``navigation2_ws``, clone our Navigation2
 
   mkdir -p ~/navigation2_ws/src
   cd ~/navigation2_ws/src
-  git clone https://github.com/ros-planning/navigation2.git --branch eloquent-devel
+  git clone https://github.com/ros-planning/navigation2.git --branch <ros2-distro>-devel
   cd ~/navigation2_ws
-  rosdep install -y -r -q --from-paths src --ignore-src --rosdistro eloquent
+  rosdep install -y -r -q --from-paths src --ignore-src --rosdistro <ros2-distro>
   colcon build --symlink-install
 
-Note: You need to change ``--rosdistro`` to the selected ROS 2 distribution name (e.g ``eloquent``).
+Note: You need to change ``--rosdistro`` to the selected ROS 2 distribution name (e.g ``eloquent``, ``foxy``).
 
 
 
@@ -54,7 +54,7 @@ Quickstart Build Master
 Steps
 -----
 
-Install all ROS 2 dependencies from the `ROS2 Installation page <https://index.ros.org/doc/ros2/Installation/Dashing/Linux-Development-Setup>`_.
+Install all ROS 2 dependencies from the `ROS2 Installation page <https://index.ros.org/doc/ros2/Installation/>`_.
 Ensure there are no ROS environment variables set in your terminal or `.bashrc` file before taking the steps below.*
 
 

--- a/sphinx_doc/getting_started/index.rst
+++ b/sphinx_doc/getting_started/index.rst
@@ -4,8 +4,7 @@ Getting Started
 ###############
 
 This document will take you through the process of installing the |PN| binaries
-and navigating a simulated Turtlebot 3 in the Gazebo simulator. We'll use the
-|Distro| version of ROS 2 and Ubuntu 18 for the standard installation options.
+and navigating a simulated Turtlebot 3 in the Gazebo simulator.
 
 .. note::
 
@@ -26,14 +25,14 @@ Installation
 
    .. code-block:: bash
 
-      sudo apt install ros-dashing-navigation2
-      sudo apt install ros-dashing-nav2-bringup
+      sudo apt install ros-<ros2-distro>-navigation2
+      sudo apt install ros-<ros2-distro>-nav2-bringup
 
 3. Install the Turtlebot 3 packages:
 
    .. code-block:: bash
 
-      sudo apt install ros-dashing-turtlebot3*
+      sudo apt install ros-<ros2-distro>-turtlebot3*
 
 Running the Example
 *******************
@@ -43,9 +42,9 @@ Running the Example
 
    .. code-block:: bash
 
-      source /opt/ros/dashing/setup.bash
+      source /opt/ros/<ros2-distro>/setup.bash
       export TURTLEBOT3_MODEL=waffle
-      export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/dashing/share/turtlebot3_gazebo/models
+      export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/<ros2-distro>/share/turtlebot3_gazebo/models
 
 3. In the same terminal, run
 

--- a/sphinx_doc/substitutions.txt
+++ b/sphinx_doc/substitutions.txt
@@ -19,11 +19,7 @@
 
 .. |PP| replace:: https://github.com/ros-planning/navigation2/blob/master
 
-.. |Distro| replace:: Dashing
-
-.. |distro| replace:: dashing
-
-.. _`ROS 2 binary packages`: https://index.ros.org/doc/ros2/Installation/Dashing/#binary-packages
+.. _`ROS 2 binary packages`: https://index.ros.org/doc/ros2/Installation/
 
 .. _`official Turtlebot 3 manual`: http://emanual.robotis.com/docs/en/platform/turtlebot3/ros2/#ros2
 

--- a/sphinx_doc/tutorials/docs/navigation2_on_real_turtlebot3.rst
+++ b/sphinx_doc/tutorials/docs/navigation2_on_real_turtlebot3.rst
@@ -21,9 +21,6 @@ Overview
 This tutorial shows how to control and navigate Turtlebot 3 using the ROS2 Navigation2 on a physical Turtlebot 3 robot.
 Before completing this tutorials, completing :ref:`getting_started` is highly recommended especially if you are new to ROS and Navigation2.
 
-``ROS2 Dashing`` and ``Navigation2 Dashing 0.2.4`` are used to create this tutorial.
-You should be able to do this tutorial using other Navigation2 versions as well.
-
 This tutorial may take about 1 hour to complete. 
 It depends on your experience with ROS, robots, and what computer system you have.
 

--- a/sphinx_doc/tutorials/docs/navigation2_with_slam.rst
+++ b/sphinx_doc/tutorials/docs/navigation2_with_slam.rst
@@ -27,11 +27,11 @@ If you don't have them installed, please follow :ref:`getting_started`.
 
 SLAM Toolbox can be installed via:
 
-  ``sudo apt install ros-dashing-slam-toolbox``
+  ``sudo apt install ros-<ros2-distro>-slam-toolbox``
 
 or from built from source in your workspace with:
 
-  ``git clone -b dashing-devel git@github.com:stevemacenski/slam_toolbox.git``
+  ``git clone -b <ros2-distro>-devel git@github.com:stevemacenski/slam_toolbox.git``
 
 
 Tutorial Steps

--- a/sphinx_doc/tutorials/docs/navigation2_with_stvl.rst
+++ b/sphinx_doc/tutorials/docs/navigation2_with_stvl.rst
@@ -52,7 +52,7 @@ Follow the same process as in :ref:`getting_started` for installing and setting 
 1- Install STVL
 ---------------
 
-STVL can be installed in ROS2 Dashing and Eloquent via the ROS Build Farm:
+STVL can be installed in ROS2 via the ROS Build Farm:
 
 - ``sudo apt install ros-<ros2-distro>-spatio-temporal-voxel-layer``
 


### PR DESCRIPTION
Updating docs to reference only the abstract `<ros2-distro>` in install and setup guides to reduce burden on maintainers to keep updating. At this point, we don't expect any major changes to happen in the future to require too much additional versioning