### PR TITLE
Add server_name parameter to BtActionNode

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -41,6 +41,10 @@ public:
     goal_ = typename ActionT::Goal();
     result_ = typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult();
 
+    std::string remapped_action_name;
+    if (getInput("server_name", remapped_action_name)) {
+      action_name_ = remapped_action_name;
+    }
     createActionClient(action_name_);
 
     // Give the derive class a chance to do any initialization
@@ -69,6 +73,7 @@ public:
   static BT::PortsList providedBasicPorts(BT::PortsList addition)
   {
     BT::PortsList basic = {
+      BT::InputPort<std::string>("server_name", "Action server name"),
       BT::InputPort<std::chrono::milliseconds>("server_timeout")
     };
     basic.insert(addition.begin(), addition.end());
@@ -233,7 +238,7 @@ protected:
     }
   }
 
-  const std::string action_name_;
+  std::string action_name_;
   typename std::shared_ptr<rclcpp_action::Client<ActionT>> action_client_;
 
   // All ROS2 actions have a goal and a result

--- a/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
@@ -34,11 +34,6 @@ public:
     const BT::NodeConfiguration & conf)
   : BtActionNode<nav2_msgs::action::ComputePathToPose>(xml_tag_name, action_name, conf)
   {
-    std::string remapped_action_name;
-    if (getInput("server_name", remapped_action_name)) {
-      action_client_.reset();
-      createActionClient(remapped_action_name);
-    }
   }
 
   void on_tick() override
@@ -66,7 +61,6 @@ public:
         BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputePathToPose node"),
         BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination to plan to"),
         BT::InputPort<std::string>("planner_id", ""),
-        BT::InputPort<std::string>("server_name", "")
       });
   }
 

--- a/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/follow_path_action.cpp
@@ -33,11 +33,6 @@ public:
     const BT::NodeConfiguration & conf)
   : BtActionNode<nav2_msgs::action::FollowPath>(xml_tag_name, action_name, conf)
   {
-    std::string remapped_action_name;
-    if (getInput("server_name", remapped_action_name)) {
-      action_client_.reset();
-      createActionClient(remapped_action_name);
-    }
     config().blackboard->set("path_updated", false);
   }
 
@@ -67,7 +62,6 @@ public:
       {
         BT::InputPort<nav_msgs::msg::Path>("path", "Path to follow"),
         BT::InputPort<std::string>("controller_id", ""),
-        BT::InputPort<std::string>("server_name", "")
       });
   }
 };


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1613  |
| Primary OS tested on | Ubuntu |
---

## Description of contribution in a few bullet points
- A `BT::InputPort` `server_name` is introduced in case the user wants to change the default action_name
of `BtActionNode`.
- A similar implementation (which was dysfunctional) was removed from `ComputePathToPose` and `FollowPath` BT actions
