### PR TITLE
Added thread synchronization to KinematicParameters (#1459)

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -45,11 +45,13 @@ namespace dwb_plugins
 {
 
 /**
- * @class KinematicParameters
- * @brief A class containing one representation of the robot's kinematics
+ * @struct KinematicParameters
+ * @brief A struct containing one representation of the robot's kinematics
  */
 struct KinematicParameters
 {
+  friend class KinematicsHandler;
+
   inline double getMinX() {return min_vel_x_;}
   inline double getMaxX() {return max_vel_x_;}
   inline double getAccX() {return acc_lim_x_;}
@@ -106,8 +108,6 @@ protected:
   // Cached square values of min_speed_xy and max_speed_xy
   double min_speed_xy_sq_{0};
   double max_speed_xy_sq_{0};
-
-  friend class KinematicsHandler;
 };
 
 /**

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -48,12 +48,8 @@ namespace dwb_plugins
  * @class KinematicParameters
  * @brief A class containing one representation of the robot's kinematics
  */
-class KinematicParameters
+struct KinematicParameters
 {
-public:
-  KinematicParameters();
-  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, const std::string & plugin_name);
-
   inline double getMinX() {return min_vel_x_;}
   inline double getMaxX() {return max_vel_x_;}
   inline double getAccX() {return acc_lim_x_;}
@@ -90,8 +86,6 @@ public:
    */
   bool isValidSpeed(double x, double y, double theta);
 
-  using Ptr = std::shared_ptr<KinematicParameters>;
-
 protected:
   // For parameter descriptions, see cfg/KinematicParams.cfg
   double min_vel_x_{0};
@@ -113,13 +107,34 @@ protected:
   double min_speed_xy_sq_{0};
   double max_speed_xy_sq_{0};
 
-  void reconfigureCB();
+  friend class KinematicsHandler;
+};
+
+/**
+ * @class KinematicsHandler
+ * @brief A class managing the representation of the robot's kinematics
+ */
+class KinematicsHandler
+{
+public:
+  KinematicsHandler();
+  ~KinematicsHandler();
+  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, const std::string & plugin_name);
+
+  inline KinematicParameters getKinematics() {return *kinematics_.load();}
+
+  bool isValidSpeed(double x, double y, double theta);
+
+  using Ptr = std::shared_ptr<KinematicsHandler>;
+
+protected:
+  std::atomic<KinematicParameters *> kinematics_;
 
   // Subscription for parameter change
   rclcpp::AsyncParametersClient::SharedPtr parameters_client_;
   rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr parameter_event_sub_;
   void on_parameter_event_callback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
-
+  void update_kinematics(KinematicParameters kinematics);
   std::string plugin_name_;
 };
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -113,7 +113,7 @@ protected:
    */
   virtual std::vector<double> getTimeSteps(const nav_2d_msgs::msg::Twist2D & cmd_vel);
 
-  KinematicParameters::Ptr kinematics_;
+  KinematicsHandler::Ptr kinematics_handler_;
   std::shared_ptr<VelocityIterator> velocity_iterator_;
 
   double sim_time_;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/velocity_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/velocity_iterator.hpp
@@ -51,7 +51,7 @@ public:
   virtual ~VelocityIterator() {}
   virtual void initialize(
     const nav2_util::LifecycleNode::SharedPtr & nh,
-    KinematicParameters::Ptr kinematics,
+    KinematicsHandler::Ptr kinematics,
     const std::string & plugin_name) = 0;
   virtual void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity, double dt) = 0;
   virtual bool hasMoreTwists() = 0;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
@@ -48,10 +48,10 @@ class XYThetaIterator : public VelocityIterator
 {
 public:
   XYThetaIterator()
-  : kinematics_(nullptr), x_it_(nullptr), y_it_(nullptr), th_it_(nullptr) {}
+  : kinematics_handler_(nullptr), x_it_(nullptr), y_it_(nullptr), th_it_(nullptr) {}
   void initialize(
     const nav2_util::LifecycleNode::SharedPtr & nh,
-    KinematicParameters::Ptr kinematics,
+    KinematicsHandler::Ptr kinematics,
     const std::string & plugin_name) override;
   void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity, double dt) override;
   bool hasMoreTwists() override;
@@ -61,7 +61,7 @@ protected:
   virtual bool isValidVelocity();
   void iterateToValidVelocity();
   int vx_samples_, vy_samples_, vtheta_samples_;
-  KinematicParameters::Ptr kinematics_;
+  KinematicsHandler::Ptr kinematics_handler_;
 
   std::shared_ptr<OneDVelocityIterator> x_it_, y_it_, th_it_;
 };

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -53,8 +53,8 @@ void StandardTrajectoryGenerator::initialize(
   const std::string & plugin_name)
 {
   plugin_name_ = plugin_name;
-  kinematics_ = std::make_shared<KinematicParameters>();
-  kinematics_->initialize(nh, plugin_name_);
+  kinematics_handler_ = std::make_shared<KinematicsHandler>();
+  kinematics_handler_->initialize(nh, plugin_name_);
   initializeIterator(nh);
 
   nav2_util::declare_parameter_if_not_declared(
@@ -97,7 +97,7 @@ void StandardTrajectoryGenerator::initializeIterator(
   const nav2_util::LifecycleNode::SharedPtr & nh)
 {
   velocity_iterator_ = std::make_shared<XYThetaIterator>();
-  velocity_iterator_->initialize(nh, kinematics_, plugin_name_);
+  velocity_iterator_->initialize(nh, kinematics_handler_, plugin_name_);
 }
 
 void StandardTrajectoryGenerator::startNewIteration(
@@ -185,16 +185,17 @@ nav_2d_msgs::msg::Twist2D StandardTrajectoryGenerator::computeNewVelocity(
   const nav_2d_msgs::msg::Twist2D & cmd_vel,
   const nav_2d_msgs::msg::Twist2D & start_vel, const double dt)
 {
+  KinematicParameters kinematics = kinematics_handler_->getKinematics();
   nav_2d_msgs::msg::Twist2D new_vel;
   new_vel.x = projectVelocity(
-    start_vel.x, kinematics_->getAccX(),
-    kinematics_->getDecelX(), dt, cmd_vel.x);
+    start_vel.x, kinematics.getAccX(),
+    kinematics.getDecelX(), dt, cmd_vel.x);
   new_vel.y = projectVelocity(
-    start_vel.y, kinematics_->getAccY(),
-    kinematics_->getDecelY(), dt, cmd_vel.y);
+    start_vel.y, kinematics.getAccY(),
+    kinematics.getDecelY(), dt, cmd_vel.y);
   new_vel.theta = projectVelocity(
     start_vel.theta,
-    kinematics_->getAccTheta(), kinematics_->getDecelTheta(),
+    kinematics.getAccTheta(), kinematics.getDecelTheta(),
     dt, cmd_vel.theta);
   return new_vel;
 }

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -42,10 +42,10 @@ namespace dwb_plugins
 {
 void XYThetaIterator::initialize(
   const nav2_util::LifecycleNode::SharedPtr & nh,
-  KinematicParameters::Ptr kinematics,
+  KinematicsHandler::Ptr kinematics,
   const std::string & plugin_name)
 {
-  kinematics_ = kinematics;
+  kinematics_handler_ = kinematics;
 
   nav2_util::declare_parameter_if_not_declared(
     nh,
@@ -66,18 +66,19 @@ void XYThetaIterator::startNewIteration(
   const nav_2d_msgs::msg::Twist2D & current_velocity,
   double dt)
 {
+  KinematicParameters kinematics = kinematics_handler_->getKinematics();
   x_it_ = std::make_shared<OneDVelocityIterator>(
     current_velocity.x,
-    kinematics_->getMinX(), kinematics_->getMaxX(),
-    kinematics_->getAccX(), kinematics_->getDecelX(), dt, vx_samples_);
+    kinematics.getMinX(), kinematics.getMaxX(),
+    kinematics.getAccX(), kinematics.getDecelX(), dt, vx_samples_);
   y_it_ = std::make_shared<OneDVelocityIterator>(
     current_velocity.y,
-    kinematics_->getMinY(), kinematics_->getMaxY(),
-    kinematics_->getAccY(), kinematics_->getDecelY(), dt, vy_samples_);
+    kinematics.getMinY(), kinematics.getMaxY(),
+    kinematics.getAccY(), kinematics.getDecelY(), dt, vy_samples_);
   th_it_ = std::make_shared<OneDVelocityIterator>(
     current_velocity.theta,
-    kinematics_->getMinTheta(), kinematics_->getMaxTheta(),
-    kinematics_->getAccTheta(), kinematics_->getDecelTheta(),
+    kinematics.getMinTheta(), kinematics.getMaxTheta(),
+    kinematics.getAccTheta(), kinematics.getDecelTheta(),
     dt, vtheta_samples_);
   if (!isValidVelocity()) {
     iterateToValidVelocity();
@@ -86,7 +87,7 @@ void XYThetaIterator::startNewIteration(
 
 bool XYThetaIterator::isValidVelocity()
 {
-  return kinematics_->isValidSpeed(
+  return kinematics_handler_->isValidSpeed(
     x_it_->getVelocity(), y_it_->getVelocity(),
     th_it_->getVelocity());
 }


### PR DESCRIPTION
Signed-off-by: Aitor Miguel Blanco <aitormibl@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1459  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | gazebo simulation of Turtlebot3) |

---

## Description of contribution in a few bullet points

* Refactored KinematicParameters class.
* Added KinematicsHandler class managing the kinematic parameters (initialization, parameter update).
* Parameters are now managed dinamically with an atomic pointer, making their access thread safe.
* Deleted unused function declaration ```reconfigureCB```.
* Fixed bug: values of ```min_speed_xy_sq_``` and ```max_speed_xy_sq_``` are now updated when updating the parameters ```min_speed_xy_``` and ```max_speed_xy_``` (before they were only set on initialization).
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
