### PR TITLE
Allow reaction to cancellation and preemption on wait recovery plugin

### DIFF
--- a/nav2_recoveries/plugins/wait.cpp
+++ b/nav2_recoveries/plugins/wait.cpp
@@ -32,20 +32,20 @@ Wait::~Wait()
 
 Status Wait::onRun(const std::shared_ptr<const WaitAction::Goal> command)
 {
-  run_end_ = std::chrono::steady_clock::now() + rclcpp::Duration(command->time).to_chrono<std::chrono::nanoseconds>();
+  wait_end_ = std::chrono::steady_clock::now() +
+    rclcpp::Duration(command->time).to_chrono<std::chrono::nanoseconds>();
   return Status::SUCCEEDED;
 }
 
 Status Wait::onCycleUpdate()
 {
   auto current_point = std::chrono::steady_clock::now();
-  auto time_left = std::chrono::duration_cast<std::chrono::nanoseconds>(run_end_ - current_point).count();
+  auto time_left =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(wait_end_ - current_point).count();
 
   if (time_left > 0) {
     return Status::RUNNING;
-  }
-  else {
-    rclcpp::sleep_for(std::chrono::milliseconds(100));
+  } else {
     return Status::SUCCEEDED;
   }
 }

--- a/nav2_recoveries/plugins/wait.hpp
+++ b/nav2_recoveries/plugins/wait.hpp
@@ -37,7 +37,7 @@ public:
   Status onCycleUpdate() override;
 
 protected:
-  builtin_interfaces::msg::Duration duration_;
+  std::chrono::time_point<std::chrono::steady_clock> run_end_;
 };
 
 }  // namespace nav2_recoveries

--- a/nav2_recoveries/plugins/wait.hpp
+++ b/nav2_recoveries/plugins/wait.hpp
@@ -37,7 +37,7 @@ public:
   Status onCycleUpdate() override;
 
 protected:
-  std::chrono::time_point<std::chrono::steady_clock> run_end_;
+  std::chrono::time_point<std::chrono::steady_clock> wait_end_;
 };
 
 }  // namespace nav2_recoveries


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1622 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | gazebo simulation of turtlebot3 |

---

## Description of contribution in a few bullet points
* Updated onCycleUpdate to check if wait time has passed instead of using a sleep function. This allows stopping the wait action if needed.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points
* Currently only the cancellation is working due to issues with the preemption handling.
This will most likely require bigger changes and will be taken care of in a different pull request.
<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
