### PR TITLE
Minor improvement on best practice for pluginlib export

### DIFF
--- a/sphinx_doc/tutorials/docs/writing_new_costmap2d_plugin.rst
+++ b/sphinx_doc/tutorials/docs/writing_new_costmap2d_plugin.rst
@@ -139,7 +139,7 @@ In our example the ``nav2_gradient_costmap_plugin::GradientLayer`` plugin's clas
   #include "pluginlib/class_list_macros.hpp"
   PLUGINLIB_EXPORT_CLASS(nav2_gradient_costmap_plugin::GradientLayer, nav2_costmap_2d::Layer)
 
-This part is usually placed at the end of cpp-file where the plugin class was written (in our example ``gradient_layer.cpp``). 
+This part is usually placed at the end of cpp-file where the plugin class was written (in our example ``gradient_layer.cpp``). It is good practice to place these lines at the end of the file but technically, you can also place at the top.
 
 2. Plugin's inormation should be stored to plugin description file. This is done by using separate XML (in our example ``gradient_plugins.xml``) in the plugin's package. This file contains information about:
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on |  |
| Robotic platform tested on |  |

---

## Description of contribution in a few bullet points
* Add best practice line for pluginlib export macro's location in costmap plugin docs
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
