### PR TITLE
Fix segfault in test_planner_random_node/test_planner_costmaps_node

### DIFF
--- a/nav2_system_tests/src/planning/planner_tester.hpp
+++ b/nav2_system_tests/src/planning/planner_tester.hpp
@@ -83,6 +83,12 @@ public:
     }
     try {
       path = planners_["GridBased"]->createPlan(start, goal);
+      // The situation when createPlan() did not throw any exception
+      // does not guarantee that plan was created correctly.
+      // So it should be checked additionally that path is correct.
+      if (!path.poses.size()) {
+        return false;
+      }
     } catch (...) {
       return false;
     }


### PR DESCRIPTION
Fix for the `test_planner_random_node` and `test_planner_costmaps_node` flaky tests.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1585 |
| Primary OS tested on | Ubuntu 18.04 with ROS2 eloquent onboard |
| Platform tested on | colcon test |
---