### PR TITLE
Fix trans_stopped_velocity comparison with x & y velocity

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
@@ -39,6 +39,7 @@
 #include "pluginlib/class_list_macros.hpp"
 #include "nav2_util/node_utils.hpp"
 
+using std::hypot;
 using std::fabs;
 
 namespace dwb_plugins
@@ -74,9 +75,9 @@ bool StoppedGoalChecker::isGoalReached(
   if (!ret) {
     return ret;
   }
+
   return fabs(velocity.angular.z) <= rot_stopped_velocity_ &&
-         fabs(velocity.linear.x) <= trans_stopped_velocity_ &&
-         fabs(velocity.linear.y) <= trans_stopped_velocity_;
+         hypot(velocity.linear.x, velocity.linear.y) <= trans_stopped_velocity_;
 }
 
 }  // namespace dwb_plugins


### PR DESCRIPTION
Signed-off-by: Shrijit Singh <shrijitsingh99@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1645) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation of turtlebot) |

---

## Description of contribution in a few bullet points
Updated trans_stopped_velocity threshold to compare with hypot() of x & y velocity.
