### PR TITLE
Replace deprecated ament_export_interfaces

### DIFF
--- a/nav2_rviz_plugins/CMakeLists.txt
+++ b/nav2_rviz_plugins/CMakeLists.txt
@@ -112,7 +112,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_interfaces(${library_name} HAS_LIBRARY_TARGET)
+ament_export_targets(${library_name} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   Qt5
   rviz_common


### PR DESCRIPTION
with ament_export_targets
See foxy notice here:
https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/