### PR TITLE
Ignore codecov paths in tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,5 @@
 fixes:
   - "src/navigation2/::"
+
+ignore:
+  - "*/**/test/*"  # ignore package test directories

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,5 @@ fixes:
   - "src/navigation2/::"
 
 ignore:
-  - "*/**/test/*"  # ignore package test directories
+  - "*/**/test/*"  # ignore package test directories, e.g. nav2_dwb_controller/costmap_queue/tests
+  - "**/test/*" # ignore package  test directories, e.g. nav2_costmap_2d/tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ fixes:
 
 ignore:
   - "*/**/test/*"  # ignore package test directories, e.g. nav2_dwb_controller/costmap_queue/tests
-  - "**/*/test/*" # ignore package  test directories, e.g. nav2_costmap_2d/tests
+  - "*/test/**/*" # ignore package  test directories, e.g. nav2_costmap_2d/tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ fixes:
 
 ignore:
   - "*/**/test/*"  # ignore package test directories, e.g. nav2_dwb_controller/costmap_queue/tests
-  - "**/test/*" # ignore package  test directories, e.g. nav2_costmap_2d/tests
+  - "*/test/*" # ignore package  test directories, e.g. nav2_costmap_2d/tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ fixes:
 
 ignore:
   - "*/**/test/*"  # ignore package test directories, e.g. nav2_dwb_controller/costmap_queue/tests
-  - "*/test/*" # ignore package  test directories, e.g. nav2_costmap_2d/tests
+  - "**/*/test/*" # ignore package  test directories, e.g. nav2_costmap_2d/tests

--- a/nav2_util/test/test_string_utils.cpp
+++ b/nav2_util/test/test_string_utils.cpp
@@ -26,5 +26,5 @@ TEST(Split, SplitFunction)
   ASSERT_EQ(split("foo:bar:", ':'), Tokens({"foo", "bar", ""}));
   ASSERT_EQ(split(":", ':'), Tokens({"", ""}));
   ASSERT_EQ(split("foo::bar", ':'), Tokens({"foo", "", "bar"}));
-  ASSERT_TRUE(strip_leading_slash(std::string("/hi")) == std::string("hi"))
+  ASSERT_TRUE(nav2_util::strip_leading_slash(std::string("/hi")) == std::string("hi"));
 }

--- a/nav2_util/test/test_string_utils.cpp
+++ b/nav2_util/test/test_string_utils.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+
 #include "nav2_util/string_utils.hpp"
 #include "gtest/gtest.h"
 

--- a/nav2_util/test/test_string_utils.cpp
+++ b/nav2_util/test/test_string_utils.cpp
@@ -26,4 +26,5 @@ TEST(Split, SplitFunction)
   ASSERT_EQ(split("foo:bar:", ':'), Tokens({"foo", "bar", ""}));
   ASSERT_EQ(split(":", ':'), Tokens({"", ""}));
   ASSERT_EQ(split("foo::bar", ':'), Tokens({"foo", "", "bar"}));
+  ASSERT_TRUE(strip_leading_slash(std::string("/hi")) == std::string("hi"))
 }


### PR DESCRIPTION
Ignoring the codecov results for the test directories. We should be measuring code coverage of production code, not redundant coverage of the tests themselves. 