### PR TITLE
Inflation test fix

### DIFF
--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -129,7 +129,7 @@ void TestNode::validatePointInflation(
     bin != m.end(); ++bin)
   {
     for (unsigned int i = 0; i < bin->second.size(); ++i) {
-      const CellData & cell = bin->second[i];
+      const CellData cell = bin->second[i];
       if (!seen[cell.index_]) {
         seen[cell.index_] = true;
         unsigned int dx = (cell.x_ > cell.src_x_) ? cell.x_ - cell.src_x_ : cell.src_x_ - cell.x_;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#1689 ) |
| Primary OS tested on | (Ubuntu) |
---

## Description of contribution in a few bullet points
* Fixed mentioned issue by replacing object reference with copy.
* Added distance calculation before enqueuing cell since map key should be distance of the cell being enqueued from it source.

