### PR TITLE
Fix segfault in test_planner_random_node

### DIFF
--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -86,6 +86,7 @@ void PlannerTester::deactivate()
   spin_thread_.reset();
 
   auto state = rclcpp_lifecycle::State();
+  planner_tester_->onDeactivate(state);
   planner_tester_->onCleanup(state);
 
   map_timer_.reset();

--- a/nav2_system_tests/src/planning/planner_tester.hpp
+++ b/nav2_system_tests/src/planning/planner_tester.hpp
@@ -105,6 +105,11 @@ public:
     on_activate(state);
   }
 
+  void onDeactivate(const rclcpp_lifecycle::State & state)
+  {
+    on_deactivate(state);
+  }
+
   void onConfigure(const rclcpp_lifecycle::State & state)
   {
     on_configure(state);


### PR DESCRIPTION
deactivate needs to be called before cleanup to stop the mapUpdateLoop()

Signed-off-by: Siddarth Gore <siddarth.gore@gmail.com>

---
## Basic Info
| ------ | ----------- |
| Ticket(s) this addresses   | #1585  |
| Primary OS tested on | Ubuntu 18.04 (WSL2) |
| Robotic platform tested on | colcon test |

---