### PR TITLE
Fix uninitialized variable warnings and change default value

### DIFF
--- a/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
@@ -187,7 +187,7 @@ planner_server:
     planner_plugin_types: ["nav2_navfn_planner/NavfnPlanner"]
     planner_plugin_ids: ["GridBased"]
     use_sim_time: True
-    GridBased.tolerance: 2.0
+    GridBased.tolerance: 0.5
     GridBased.use_astar: false
     GridBased.allow_unknown: true
 

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
@@ -187,7 +187,7 @@ planner_server:
     planner_plugin_types: ["nav2_navfn_planner/NavfnPlanner"]
     planner_plugin_ids: ["GridBased"]
     use_sim_time: True
-    GridBased.tolerance: 2.0
+    GridBased.tolerance: 0.5
     GridBased.use_astar: false
     GridBased.allow_unknown: true
 

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -232,7 +232,7 @@ planner_server:
     planner_plugin_types: ["nav2_navfn_planner/NavfnPlanner"]
     planner_plugin_ids: ["GridBased"]
     use_sim_time: True
-    GridBased.tolerance: 2.0
+    GridBased.tolerance: 0.5
     GridBased.use_astar: false
     GridBased.allow_unknown: true
 

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -117,7 +117,7 @@ void
 StaticLayer::getParameters()
 {
   int temp_lethal_threshold = 0;
-  double temp_tf_tol;
+  double temp_tf_tol = 0.0;
 
   declareParameter("enabled", rclcpp::ParameterValue(true));
   declareParameter("subscribe_to_updates", rclcpp::ParameterValue(false));

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -72,7 +72,7 @@ NavfnPlanner::configure(
 
   // Initialize parameters
   // Declare this plugin's parameters
-  declare_parameter_if_not_declared(node_, name + ".tolerance", rclcpp::ParameterValue(2.0));
+  declare_parameter_if_not_declared(node_, name + ".tolerance", rclcpp::ParameterValue(0.5));
   node_->get_parameter(name + ".tolerance", tolerance_);
   declare_parameter_if_not_declared(node_, name + ".use_astar", rclcpp::ParameterValue(false));
   node_->get_parameter(name + ".use_astar", use_astar_);


### PR DESCRIPTION
1. Fix minor build error for uninitialized temp_tf_tol in static_layer.cpp.
2. Follow [this ticket](https://github.com/ros-planning/navigation2/issues/1683). Change default GridBased.tolerance from 2.0 to 0.5 meters. People (like me) are used to 0 meter tolerance without knowing there is a new parameter set to 2.0 meters. If we keep using default 2.0 meters, users may wonder why navigation is always successful even the robot is stuck inside a 2x2 meter square area.