### PR TITLE
Switch to nightly tag for release image

### DIFF
--- a/.dockerhub/release/hooks/build
+++ b/.dockerhub/release/hooks/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-export FROM_IMAGE=osrf/ros2:nightly-rmw-nonfree
+export FROM_IMAGE=osrf/ros2:nightly
 export FAIL_ON_BUILD_FAILURE=""
 export UNDERLAY_MIXINS="release ccache"
 export OVERLAY_MIXINS="release ccache"


### PR DESCRIPTION
Not sure why connext related cmake from the upstream nightly archive is blocking our builds.
This switches away from the `nightly-rmw-nofree` tag, given connext rmw tests where disabled.
Related:
* https://github.com/ros-planning/navigation2/pull/1742#issuecomment-629703245
* https://github.com/osrf/docker_images/issues/403

I manually pushed a local build to Dockerhub to check, and the release CI seems fine with this:
Example: https://circleci.com/workflow-run/11963602-4cc1-44c3-a3f2-e66b176e4547