### PR TITLE
[WIP] Following an object a certain distance

### DIFF
--- a/nav2_behavior_tree/CMakeLists.txt
+++ b/nav2_behavior_tree/CMakeLists.txt
@@ -53,6 +53,9 @@ ament_target_dependencies(${library_name}
 add_library(nav2_compute_path_to_pose_action_bt_node SHARED plugins/action/compute_path_to_pose_action.cpp)
 list(APPEND plugin_libs nav2_compute_path_to_pose_action_bt_node)
 
+add_library(nav2_update_goal_pose_action_bt_node SHARED plugins/action/update_goal_pose_action.cpp)
+list(APPEND plugin_libs nav2_update_goal_pose_action_bt_node)
+
 add_library(nav2_follow_path_action_bt_node SHARED plugins/action/follow_path_action.cpp)
 list(APPEND plugin_libs nav2_follow_path_action_bt_node)
 

--- a/nav2_behavior_tree/README.md
+++ b/nav2_behavior_tree/README.md
@@ -66,8 +66,9 @@ The nav2_behavior_tree package provides several navigation-specific nodes that a
 | BT Node   |      Type      |  Description |
 |----------|:-------------|------|
 | Backup |  Action | Invokes the BackUp ROS2 action server, which causes the robot to back up to a specific pose. This is used in nav2 Behavior Trees as a recovery behavior. The nav2_recoveries module implements the BackUp action server. |
-| ComputePathToPose |    Action   | Invokes the ComputePathToPose ROS2 action server, which is implemented by the nav2_planner module. The server address can be remapped using the `server_name` input port. |
 | FollowPath | Action |Invokes the FollowPath ROS2 action server, which is implemented by the controller plugin modules loaded. The server address can be remapped using the `server_name` input port. |
+| ComputePathToPose |    Action   | Invokes the ComputePathToPose ROS2 action server, which is implemented by the nav2_planner module. The server address can be remapped using the `server_name` input port. |
+| UpdateGoalPose | Action |Overwrite goal pose by one received in a topic. |
 | GoalReached | Condition | Checks the distance to the goal, if the distance to goal is less than the pre-defined threshold, the tree returns SUCCESS, otherwise it returns FAILURE. |
 | IsStuck | Condition | Determines if the robot is not progressing towards the goal. If the robot is stuck and not progressing, the condition returns SUCCESS, otherwise it returns FAILURE. |
 | TransformAvailable | Condition | Checks if a TF transform is available. Returns failure if it cannot be found. Once found, it will always return success. Useful for initial condition checks. |

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -42,6 +42,10 @@
       <input_port name="wait_duration">Wait time</input_port>
     </Action>
 
+    <Action ID="UpdateGoalPose">
+      <input_port name="goal">Destination to plan to</input_port>
+    </Action>
+
     <!-- ############################### CONDITION NODES ############################## -->
     <Condition ID="GoalReached">
         <input_port name="goal">Destination</input_port>

--- a/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/follow_path_action.cpp
@@ -40,6 +40,8 @@ public:
   {
     getInput("path", goal_.path);
     getInput("controller_id", goal_.controller_id);
+    getInput("distance_to_goal", goal_.distance_to_goal);
+    getInput("keep_running", goal_.keep_running);
   }
 
   void on_wait_for_result() override
@@ -62,6 +64,8 @@ public:
       {
         BT::InputPort<nav_msgs::msg::Path>("path", "Path to follow"),
         BT::InputPort<std::string>("controller_id", ""),
+        BT::InputPort<double>("distance_to_goal", "Distance to goal to stop translation"),
+        BT::InputPort<bool>("keep_running", "The action never finish"),
       });
   }
 };

--- a/nav2_behavior_tree/plugins/action/update_goal_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/update_goal_pose_action.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_BEHAVIOR_TREE__UPDATE_GOAL_POSE_ACTION_HPP_
+#define NAV2_BEHAVIOR_TREE__UPDATE_GOAL_POSE_ACTION_HPP_
+
+#include <string>
+#include <memory>
+#include <cmath>
+
+#include "behaviortree_cpp_v3/control_node.h"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav2_behavior_tree/bt_action_node.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace nav2_behavior_tree
+{
+
+class UpdateGoalPoseAction : public BT::ControlNode
+{
+public:
+  UpdateGoalPoseAction(
+    const std::string & xml_tag_name,
+    const BT::NodeConfiguration & conf)
+  : ControlNode(xml_tag_name, conf),
+    initialized_(false)
+  {
+  }
+
+  UpdateGoalPoseAction() = delete;
+
+  BT::NodeStatus tick() override
+  { 
+    if (!initialized_) {
+      initialize();
+    }
+
+    auto current_goal = config().blackboard->get<geometry_msgs::msg::PoseStamped>("goal");
+    if (rclcpp::Time(goal_.header.stamp) < rclcpp::Time(current_goal.header.stamp)) {
+      goal_ = current_goal;
+    }
+
+    config().blackboard->set<geometry_msgs::msg::PoseStamped>("goal", goal_);
+
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  void initialize()
+  {
+    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+
+    updated_goal_sub_ = node_->create_subscription<geometry_msgs::msg::PoseStamped>("goal_update",
+      10, std::bind(&UpdateGoalPoseAction::updatedGoalCallback, this, std::placeholders::_1));
+
+    initialized_ = true;
+  }
+
+  void updatedGoalCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg)
+  {
+    goal_ = *msg;
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    BT::PortsList ports = {
+      BT::BidirectionalPort<geometry_msgs::msg::PoseStamped>("goal", "Destination to plan to"),
+    };
+
+    return ports;
+  }
+private:
+  rclcpp::Node::SharedPtr node_;
+  
+  geometry_msgs::msg::PoseStamped goal_;
+  bool initialized_;
+
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr updated_goal_sub_;
+};
+
+}  // namespace nav2_behavior_tree
+
+#include "behaviortree_cpp_v3/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<nav2_behavior_tree::UpdateGoalPoseAction>("UpdateGoalPose");
+}
+
+#endif  // NAV2_BEHAVIOR_TREE__UPDATE_GOAL_POSE_ACTION_HPP_

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -52,6 +52,7 @@ bt_navigator:
     bt_xml_filename: "navigate_w_replanning_and_recovery.xml"
     plugin_lib_names:
     - nav2_compute_path_to_pose_action_bt_node
+    - nav2_update_goal_pose_action_bt_node
     - nav2_follow_path_action_bt_node
     - nav2_back_up_action_bt_node
     - nav2_spin_action_bt_node

--- a/nav2_bt_navigator/behavior_trees/navigate_carrot.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_carrot.xml
@@ -1,0 +1,17 @@
+<!--
+  This Behavior Tree replans the global path periodically at 1 Hz.
+-->
+
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <PipelineSequence name="NavigateWithReplanning">
+      <RateController hz="1.0">
+        <PipelineSequence name="GeneratePath">
+          <UpdateGoalPose goal="{goal}"/>
+          <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"/>
+        </PipelineSequence> 
+      </RateController>
+      <FollowPath path="{path}"  controller_id="FollowPath" distance_to_goal="1.0" keep_running="True"/>
+    </PipelineSequence>
+  </BehaviorTree>
+</root>

--- a/nav2_msgs/action/FollowPath.action
+++ b/nav2_msgs/action/FollowPath.action
@@ -1,6 +1,8 @@
 #goal definition
 nav_msgs/Path path
 string controller_id
+float64 distance_to_goal 0.0
+bool keep_running false
 ---
 #result definition
 std_msgs/Empty result


### PR DESCRIPTION
Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1660  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of Tally |

---
This is a **work in progress**. I don't pretend to be accepted as is. I want only to discuss this approach.

The goal of this work is following a dynamic pose to a certain distance:
* The goal pose can change during the execution of `navigate_to_pose` action.
* The robot stops when the goal is nearer than a configured distance, and then it faces the goal.

One use case could be following a person to ~1 meter in a house. We want to use it in RoboCup@Home.

I don't want to implement this as a new plugin for controller or planner. This work is independent of the algorithms used to create the plan and following it. To implement it I have:

* developed a new control node in nav2_behavior_tree that overwrites the goal received in the `navigate_to_pose` action for the one received in the `goal_update` topic.
* added two input ports to `FollowPath` for indicating that never returns from the action, and the distance to the object. The other option was to create another action node in BT, action, action client, action server...

![BT_carrot](https://user-images.githubusercontent.com/3810011/82154598-4551c500-986f-11ea-84ca-f977509d6380.png)

This is the result (click for video):

[![](https://img.youtube.com/vi/t7helr1IY_8/0.jpg)](https://www.youtube.com/watch?v=t7helr1IY_8&feature=youtu.be "Click to play on You Tube")

---

I don't know if this is the right place to discuss this, but the complete real use case I want to address is:
1. Make the robot navigate to the desired pose on the map.
2. Once there, make the robot follow a person (the dynamic goal pose, provided from outside Nav2)

The behavior trees used in the two steps in this application are (could be) different, but the BT to use is defined statically in the yaml param files. One option to solve this could be to select the BT to use in `NavigateToPose` action. Maybe `NavigateToPose` action could also include some options decided from behaviors, instead to be fixed in params.

Francisco


