### PR TITLE
Revert libgazebo11 workaround for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,10 +74,6 @@ references:
                 rosdep install -q -y \
                   --from-paths src \
                   --ignore-src \
-                  --skip-keys " \
-                    gazebo11 \
-                    libgazebo11-dev \
-                  " \
                   --verbose | \
                 awk '$1 ~ /^resolution\:/' | \
                 awk -F'[][]' '{print $2}' | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,19 +42,6 @@ RUN apt-get update && apt-get install -q -y \
       lcov \
     && rm -rf /var/lib/apt/lists/*
 
-# TODO: clean up once libgazebo11-dev released into ros2 repo
-# https://github.com/ros-infrastructure/reprepro-updater/pull/75
-# https://github.com/ros/rosdistro/pull/24646
-# setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
-# setup sources.list
-RUN . /etc/os-release \
-    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
-# install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
-      libgazebo11-dev \
-    && rm -rf /var/lib/apt/lists/*
-
 # install underlay dependencies
 ARG UNDERLAY_WS
 WORKDIR $UNDERLAY_WS
@@ -63,10 +50,6 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
     apt-get update && rosdep install -q -y \
       --from-paths src \
       --ignore-src \
-      --skip-keys " \
-        gazebo11 \
-        libgazebo11-dev \
-      " \
     && rm -rf /var/lib/apt/lists/*
 
 # build underlay source
@@ -92,10 +75,6 @@ RUN . $UNDERLAY_WS/install/setup.sh && \
       --from-paths src \
         $UNDERLAY_WS/src \
       --ignore-src \
-      --skip-keys " \
-        gazebo11 \
-        libgazebo11-dev \
-      " \
     && rm -rf /var/lib/apt/lists/*
 
 # build overlay source

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -10,10 +10,7 @@ repositories:
   ros-simulation/gazebo_ros_pkgs:
     type: git
     url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-    # TODO: Revert after support for Gazebo v11 is merged
-    # https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1093
-    # version: ros2
-    version: gazebo11_foxy
+    version: ros2
   ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git


### PR DESCRIPTION
Fixes: https://github.com/ros-planning/navigation2/issues/1687 