### PR TITLE
Run rosdep update in builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,8 @@ references:
                 (echo vcs_export && cat) >> checksum.txt
               sha256sum $PWD/checksum.txt >> checksum.txt
               apt-get update
+              rosdep update \
+                --rosdistro=$ROS_DISTRO
               dependencies=$(
                 rosdep install -q -y \
                   --from-paths src \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ FROM $FROM_IMAGE AS builder
 RUN apt-get update && apt-get install -q -y \
       ccache \
       lcov \
+    && rosdep update --rosdistro=$ROS_DISTRO \
     && rm -rf /var/lib/apt/lists/*
 
 # TODO: clean up once libgazebo11-dev released into ros2 repo


### PR DESCRIPTION
So we don't have to wait for the nightly parent image to update rosdep.
Related: https://github.com/ros-planning/navigation2/pull/1750#issuecomment-630482940