### PR TITLE
Don't pass rosdistro when using empty index

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,7 @@ references:
                 (echo vcs_export && cat) >> checksum.txt
               sha256sum $PWD/checksum.txt >> checksum.txt
               apt-get update
-              rosdep update \
-                --rosdistro=$ROS_DISTRO
+              rosdep update
               dependencies=$(
                 rosdep install -q -y \
                   --from-paths src \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ FROM $FROM_IMAGE AS builder
 RUN apt-get update && apt-get install -q -y \
       ccache \
       lcov \
-    && rosdep update --rosdistro=$ROS_DISTRO \
+    && rosdep update \
     && rm -rf /var/lib/apt/lists/*
 
 # install underlay dependencies


### PR DESCRIPTION
Context: https://github.com/osrf/docker_images/pull/399