### PR TITLE
Explicitly set junit_family parameter for nav2_gazebo_spawner tests

### DIFF
--- a/nav2_bringup/nav2_gazebo_spawner/setup.cfg
+++ b/nav2_bringup/nav2_gazebo_spawner/setup.cfg
@@ -2,3 +2,5 @@
 script-dir=$base/lib/nav2_gazebo_spawner
 [install]
 install-scripts=$base/lib/nav2_gazebo_spawner
+[tool:pytest]
+junit_family=xunit2


### PR DESCRIPTION
Explicitly set `junit_family` parameter which fixes pytest warning message appearing in stderr.

---

| Info |  |
| ------ | ----------- |
| Ticket(s) this addresses   | #1749  |
| Primary OS tested on | Ubuntu 20.04 Focal |
| ROS tested on | Foxy |