### PR TITLE
Added tool to request transition to ErrorState

### DIFF
--- a/nav2_util/include/nav2_util/lifecycle_utils.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_utils.hpp
@@ -77,6 +77,33 @@ void reset_lifecycle_nodes(
   reset_lifecycle_nodes(split(nodes, ':'), service_call_timeout, retries);
 }
 
+/// Transition the given lifecycle nodes to the ErrorProcessing state in order
+/** At this time, service calls frequently hang for unknown reasons. The only
+ *  way to combat that is to timeout the service call and retry it. To use this
+ *  function, estimate how long your nodes should take to at each transition and
+ *  set your timeout accordingly.
+ * \param[in] node_names A vector of the fully qualified node names to reset.
+ * \param[in] service_call_timeout The maximum amount of time to wait for a
+ *            service call.
+ * \param[in] retries The number of times to try a state transition service call
+ */
+void process_error_lifecycle_nodes(
+  const std::vector<std::string> & node_names,
+  const std::chrono::seconds service_call_timeout = std::chrono::seconds::max(),
+  const int retries = 3);
+
+/// Transition the given lifecycle nodes to the ErrorProcessing state in order.
+/**
+ * \param[in] nodes A ':' seperated list of node names. eg. "/node1:/node2"
+ */
+void process_error_lifecycle_nodes(
+  const std::string & nodes,
+  const std::chrono::seconds service_call_timeout = std::chrono::seconds::max(),
+  const int retries = 3)
+{
+  process_error_lifecycle_nodes(split(nodes, ':'), service_call_timeout, retries);
+}
+
 }  // namespace nav2_util
 
 #endif  // NAV2_UTIL__LIFECYCLE_UTILS_HPP_

--- a/nav2_util/src/lifecycle_utils.cpp
+++ b/nav2_util/src/lifecycle_utils.cpp
@@ -99,6 +99,9 @@ void reset_lifecycle_nodes(
   }
 }
 
+// TODO(gimait): This should be updated with the missing transitions to error after
+// PRs ros2/rcl_interfaces#97, ros2/rcl#618 and ros2/rclcpp#1064 are merged.
+// This tool should not be used for until then.
 static void processErrorLifecycleNode(
   const std::string & node_name,
   const std::chrono::seconds service_call_timeout,
@@ -110,16 +113,6 @@ static void processErrorLifecycleNode(
   // to the ErrorProcessing state. Some states do not support transitions
   // to ErrorProcessing.
   switch (sc.get_state(service_call_timeout)) {
-    case State::PRIMARY_STATE_UNKNOWN:
-      return;
-    case State::PRIMARY_STATE_UNCONFIGURED:
-      return;
-    case State::PRIMARY_STATE_INACTIVE:
-      return;
-    case State::PRIMARY_STATE_ACTIVE:
-      return;
-    case State::PRIMARY_STATE_FINALIZED:
-      return;
     case State::TRANSITION_STATE_CONFIGURING:
       transition = Transition::TRANSITION_ON_CONFIGURE_ERROR;
       break;
@@ -139,7 +132,7 @@ static void processErrorLifecycleNode(
       transition = Transition::TRANSITION_ON_ERROR_ERROR;
       break;
     default:
-      return;
+      throw std::runtime_error("Invalid state.");
   }
 
   // Despite waiting for the service to be available and using reliable transport


### PR DESCRIPTION
Signed-off-by: Aitor Miguel Blanco <aitormibl@gmail.com>

Included tool in lifecycle utils to call a transition to the error state in lifecycle nodes.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | - |

---

## Description of contribution in a few bullet points

This is a preliminary version of the tool, and I would like to ask for some feedback.

At the moment, this tool can only transition from Transition States to ErrorProcessing. This is because the Primary States do not include (yet) the transitions to the ErrorProcessing state. 

The pull requests [ros2/rcl_interfaces#97](https://github.com/ros2/rcl_interfaces/pull/97), [ros2/rcl#618](https://github.com/ros2/rcl/pull/618) and [ros2/rclcpp#1064](https://github.com/ros2/rclcpp/pull/1064) address this issue by including the extra transitions for Primary States plus a `raise_error` function that triggers the transition from the active and inactive states.

Because of this limitation, it won't be that easy to test the `on_error` callback from lifecycle nodes until the mentioned PRs are merged.

I would also appreciate any ideas about how to test the tool itself. I can only think on creating a mock class that waits on specific states for the error to be triggered.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
