### PR TITLE
Re-enable nightly debug builds for codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,10 +390,10 @@ workflows:
             - release_build
   nightly:
     jobs:
-      # - debug_build
-      # - debug_test:
-      #     requires:
-      #       - debug_build
+      - debug_build
+      - debug_test:
+          requires:
+            - debug_build
       - release_build
       # - test_rmw_connext_cpp:
       #     requires:


### PR DESCRIPTION
Looks like codecov analytics from merged PRs alone do not update codecov status for the master branch. Re-enabling nightly debug builds to keep codecov status on master up-to-date.

![image](https://user-images.githubusercontent.com/2293573/82602782-792a3480-9b66-11ea-83ad-37f6e5b162c5.png)

https://codecov.io/gh/ros-planning/navigation2