### PR TITLE
a bugfix of clear costmap service action

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -45,6 +45,9 @@ public:
     getInput("service_name", service_name_);
     service_client_ = node_->create_client<ServiceT>(service_name_);
 
+    // Make a request for the service without parameter
+    request_ = std::make_shared<typename ServiceT::Request>();
+
     // Make sure the server is actually there before continuing
     RCLCPP_INFO(
       node_->get_logger(), "Waiting for \"%s\" service",
@@ -91,7 +94,6 @@ public:
   // Fill in service request with information if necessary
   virtual void on_tick()
   {
-    request_ = std::make_shared<typename ServiceT::Request>();
   }
 
   // Check the future and decide the status of Behaviortree


### PR DESCRIPTION
The following is an example of the error.

[ERROR] [1590171638.335693813] [bt_navigator]: Action server failed while executing action callback: "failed to send request: ros_request argument is null, at /opt/ros/src/ros2/rcl/rcl/src/rcl/client.c:278"a bugfix of clear costmap service action

`BtServiceNode` creates `request_` in `on_tick` but it was overrided without it.  
https://github.com/ros-planning/navigation2/blob/master/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp#L94

Signed-off-by: Daisuke Sato <daisukes@cmu.edu>
