### PR TITLE
Add SLAM Toolbox and map_saver_server into launch-files

### DIFF
--- a/nav2_bringup/bringup/launch/slam_launch.py
+++ b/nav2_bringup/bringup/launch/slam_launch.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2012 Samsung Research Russia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from nav2_common.launch import RewrittenYaml
+
+
+def generate_launch_description():
+    # Input parameters declaration
+    namespace = LaunchConfiguration('namespace')
+    params_file = LaunchConfiguration('params_file')
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    autostart = LaunchConfiguration('autostart')
+
+    # Variables
+    lifecycle_nodes = ['map_saver']
+
+    # Getting directories and launch-files
+    bringup_dir = get_package_share_directory('nav2_bringup')
+    slam_toolbox_dir = get_package_share_directory('slam_toolbox')
+    slam_launch_file = os.path.join(slam_toolbox_dir, 'launch', 'online_sync_launch.py')
+    temp_dir = tempfile.gettempdir()
+    temp_map = os.path.join(temp_dir, 'output_map')
+
+    # Create our own temporary YAML files that include substitutions
+    param_substitutions = {
+        'use_sim_time': use_sim_time}
+
+    configured_params = RewrittenYaml(
+        source_file=params_file,
+        root_key=namespace,
+        param_rewrites=param_substitutions,
+        convert_types=True)
+
+    # Declare the launch arguments
+    declare_namespace_cmd = DeclareLaunchArgument(
+        'namespace',
+        default_value='',
+        description='Top-level namespace')
+
+    declare_params_file_cmd = DeclareLaunchArgument(
+        'params_file',
+        default_value=os.path.join(bringup_dir, 'params', 'nav2_params.yaml'),
+        description='Full path to the ROS2 parameters file to use for all launched nodes')
+
+    declare_use_sim_time_cmd = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='true',
+        description='Use simulation (Gazebo) clock if true')
+
+    declare_autostart_cmd = DeclareLaunchArgument(
+        'autostart', default_value='true',
+        description='Automatically startup the nav2 stack')
+
+    # Nodes launching commands
+    start_slam_toolbox_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(slam_launch_file),
+        launch_arguments={'use_sim_time': use_sim_time}.items())
+
+    start_map_saver_server_cmd = Node(
+            package='nav2_map_server',
+            node_executable='map_saver_server',
+            output='screen',
+            parameters=[configured_params])
+
+    start_lifecycle_manager_cmd = Node(
+            package='nav2_lifecycle_manager',
+            node_executable='lifecycle_manager',
+            node_name='lifecycle_manager_map_saver',
+            output='screen',
+            parameters=[{'use_sim_time': use_sim_time},
+                        {'autostart': autostart},
+                        {'node_names': lifecycle_nodes}])
+
+    service_name = '/map_saver/save_map'
+    service_type = 'nav2_msgs/srv/SaveMap'
+    map_topic = 'map'
+    image_format = 'pgm'
+    map_mode = 'trinary'
+    free_thresh = '0.25'
+    occupied_thresh = '0.65'
+    service_line = '{map_topic: ' + map_topic + \
+                   ', map_url: ' + temp_map + \
+                   ', image_format: ' + image_format + \
+                   ', map_mode: ' + map_mode + \
+                   ', free_thresh: ' + free_thresh + \
+                   ', occupied_thresh: ' + occupied_thresh + '}'
+    map_saver_server_service_call_cmd = ExecuteProcess(
+        cmd=['ros2', 'service', 'call', service_name, service_type, service_line],
+        cwd=[bringup_dir], output='screen')
+
+    ld = LaunchDescription()
+
+    # Declare the launch options
+    ld.add_action(declare_namespace_cmd)
+    ld.add_action(declare_params_file_cmd)
+    ld.add_action(declare_use_sim_time_cmd)
+    ld.add_action(declare_autostart_cmd)
+
+    # Running SLAM Toolbox
+    ld.add_action(start_slam_toolbox_cmd)
+
+    # Running Map Saver Server
+    ld.add_action(start_map_saver_server_cmd)
+    ld.add_action(start_lifecycle_manager_cmd)
+    ld.add_action(map_saver_server_service_call_cmd)
+
+    return ld

--- a/nav2_bringup/bringup/launch/tb3_simulation_launch.py
+++ b/nav2_bringup/bringup/launch/tb3_simulation_launch.py
@@ -32,6 +32,7 @@ def generate_launch_description():
     launch_dir = os.path.join(bringup_dir, 'launch')
 
     # Create the launch configuration variables
+    slam = LaunchConfiguration('slam')
     namespace = LaunchConfiguration('namespace')
     use_namespace = LaunchConfiguration('use_namespace')
     map_yaml_file = LaunchConfiguration('map')
@@ -67,6 +68,11 @@ def generate_launch_description():
         'use_namespace',
         default_value='false',
         description='Whether to apply a namespace to the navigation stack')
+
+    declare_slam_cmd = DeclareLaunchArgument(
+        'slam',
+        default_value='False',
+        description='Whether run a SLAM')
 
     declare_map_yaml_cmd = DeclareLaunchArgument(
         'map',
@@ -163,6 +169,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(os.path.join(launch_dir, 'bringup_launch.py')),
         launch_arguments={'namespace': namespace,
                           'use_namespace': use_namespace,
+                          'slam': slam,
                           'map': map_yaml_file,
                           'use_sim_time': use_sim_time,
                           'params_file': params_file,
@@ -175,6 +182,7 @@ def generate_launch_description():
     # Declare the launch options
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_use_namespace_cmd)
+    ld.add_action(declare_slam_cmd)
     ld.add_action(declare_map_yaml_cmd)
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_params_file_cmd)

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -232,6 +232,13 @@ map_server:
     use_sim_time: True
     yaml_filename: "turtlebot3_world.yaml"
 
+map_saver:
+  ros__parameters:
+    use_sim_time: True
+    save_map_timeout: 2000
+    free_thresh_default: 0.25
+    occupied_thresh_default: 0.65
+
 planner_server:
   ros__parameters:
     planner_plugin_types: ["nav2_navfn_planner/NavfnPlanner"]

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -235,7 +235,7 @@ map_server:
 map_saver:
   ros__parameters:
     use_sim_time: True
-    save_map_timeout: 2000
+    save_map_timeout: 5000
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65
 

--- a/nav2_bringup/bringup/worlds/waffle.model
+++ b/nav2_bringup/bringup/worlds/waffle.model
@@ -413,7 +413,7 @@
           <mass>0.035</mass>
         </inertial>
         <collision name="collision">
-          <pose>0 0.047 -0.004 0 0 0</pose>
+          <pose>0 0.047 -0.005 0 0 0</pose>
           <geometry>
             <box>
               <size>0.008 0.130 0.022</size>
@@ -441,7 +441,7 @@
         </sensor>
 
         <collision name="collision">
-          <pose>0 0.047 -0.004 0 0 0</pose>
+          <pose>0 0.047 -0.005 0 0 0</pose>
           <geometry>
             <box>
               <size>0.008 0.130 0.022</size>


### PR DESCRIPTION
Adding new `nav2_bringup/bringup/launch/slam_launch.py` file running SLAM Toolbox, map_saver_server and requesting once a map through `/map_saver/save_map'` service call. This can be enabled via `slam` parameter, as follows:
```
ros2 launch nav2_bringup tb3_simulation_launch.py slam:=True
```
Default behavior when `slam` parameter is not specified did not changed.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1630 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Gazebo simulation of TB3 waffle |
