### PR TITLE
a patch for #1773 BT navigator nodes with use_sim_time

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -31,7 +31,7 @@ namespace nav2_bt_navigator
 {
 
 BtNavigator::BtNavigator()
-: nav2_util::LifecycleNode("bt_navigator", "", true),
+: nav2_util::LifecycleNode("bt_navigator", "", false),
   start_time_(0)
 {
   RCLCPP_INFO(get_logger(), "Creating");
@@ -76,9 +76,10 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Configuring");
 
+  // use suffix '_rclcpp_node' to keep parameter file consistency #1773
   auto options = rclcpp::NodeOptions().arguments(
     {"--ros-args",
-      "-r", std::string("__node:=") + get_name() + "_client_node",
+      "-r", std::string("__node:=") + get_name() + "_rclcpp_node",
       "--"});
   // Support for handling the topic-based goal pose from rviz
   client_node_ = std::make_shared<rclcpp::Node>("_", options);

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -26,7 +26,7 @@ namespace nav2_waypoint_follower
 {
 
 WaypointFollower::WaypointFollower()
-: nav2_util::LifecycleNode("WaypointFollower", "", true)
+: nav2_util::LifecycleNode("WaypointFollower", "", false)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
@@ -47,8 +47,9 @@ WaypointFollower::on_configure(const rclcpp_lifecycle::State & /*state*/)
   stop_on_failure_ = get_parameter("stop_on_failure").as_bool();
   loop_rate_ = get_parameter("loop_rate").as_int();
 
+  // use suffix '_rclcpp_node' to keep parameter file consistency #1773
   client_node_ = std::make_shared<rclcpp::Node>(
-    std::string(get_name()) + std::string("_client_node"));
+    std::string(get_name()) + std::string("_rclcpp_node"));
 
   nav_to_pose_client_ = rclcpp_action::create_client<ClientT>(
     client_node_, "navigate_to_pose");


### PR DESCRIPTION
Signed-off-by: Daisuke Sato <daisukes@cmu.edu>

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1773  |
| Primary OS tested on | Ubuntu |

---

## Description of contribution in a few bullet points

To deal with #1773 issue
- set `use_rclcpp_node` option to true to prevent from creating a node not used
- change the name of the node `client_node_` as `xxx_rclcpp_node` to keep configuration file consistency 

## Description of documentation updates required from your changes

N/A