### PR TITLE
declaring default_critic_namespaces param in dwb_local_planner

### DIFF
--- a/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
@@ -74,6 +74,7 @@ void DWBLocalPlanner::configure(
   tf_ = tf;
   dwb_plugin_name_ = name;
   declare_parameter_if_not_declared(node_, dwb_plugin_name_ + ".critics");
+  declare_parameter_if_not_declared(node_, dwb_plugin_name_ + ".default_critic_namespaces");
   declare_parameter_if_not_declared(
     node_, dwb_plugin_name_ + ".prune_plan",
     rclcpp::ParameterValue(true));


### PR DESCRIPTION
Declared `<dwb plugin>.default_critic_namespaces` parameter as discussed in #1783