### PR TITLE
Fix some parameters not being passed to getCurrentPose

### DIFF
--- a/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
@@ -82,7 +82,9 @@ public:
   {
     geometry_msgs::msg::PoseStamped current_pose;
 
-    if (!nav2_util::getCurrentPose(current_pose, *tf_, "map", "base_link", transform_tolerance_)) {
+    if (!nav2_util::getCurrentPose(
+        current_pose, *tf_, global_frame_, robot_base_frame_, transform_tolerance_))
+    {
       RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
       return false;
     }

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -140,6 +140,7 @@ protected:
   rclcpp::Time start_time_;
   std::string robot_frame_;
   std::string global_frame_;
+  double transform_tolerance_;
 };
 
 }  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -110,6 +110,7 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   plugin_lib_names_ = get_parameter("plugin_lib_names").as_string_array();
   global_frame_ = get_parameter("global_frame").as_string();
   robot_frame_ = get_parameter("robot_base_frame").as_string();
+  transform_tolerance_ = get_parameter("transform_tolerance").as_double();
 
   // Create the class that registers our custom nodes and executes the BT
   bt_ = std::make_unique<nav2_behavior_tree::BehaviorTreeEngine>(plugin_lib_names_);
@@ -242,7 +243,8 @@ BtNavigator::navigateToPose()
 
       // action server feedback (pose, duration of task,
       // number of recoveries, and distance remaining to goal)
-      nav2_util::getCurrentPose(feedback_msg->current_pose, *tf_);
+      nav2_util::getCurrentPose(
+        feedback_msg->current_pose, *tf_, global_frame_, robot_frame_, transform_tolerance_);
 
       geometry_msgs::msg::PoseStamped goal_pose;
       blackboard_->get("goal", goal_pose);


### PR DESCRIPTION

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None (related to #1742) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | [Stage](https://github.com/rtv/Stage) and [stage_ros2](https://github.com/ymd-stella/stage_ros2) |

---

## Description of contribution in a few bullet points
* Fix some parameters (global_frame, robot_frame, transform_tolerance) not being passed to getCurrentPose

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
<!--
## Description of documentation updates required from your changes
-->
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
<!--
## Future work that may be required in bullet points
-->
<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
