### PR TITLE
Allow zero velocity to be valid

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -38,43 +38,41 @@
 #include <memory>
 #include <string>
 
-#include "rclcpp/rclcpp.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 
 /**
  * @struct KinematicParameters
  * @brief A struct containing one representation of the robot's kinematics
  */
-struct KinematicParameters
-{
+struct KinematicParameters {
   friend class KinematicsHandler;
 
-  inline double getMinX() {return min_vel_x_;}
-  inline double getMaxX() {return max_vel_x_;}
-  inline double getAccX() {return acc_lim_x_;}
-  inline double getDecelX() {return decel_lim_x_;}
+  inline double getMinX() { return min_vel_x_; }
+  inline double getMaxX() { return max_vel_x_; }
+  inline double getAccX() { return acc_lim_x_; }
+  inline double getDecelX() { return decel_lim_x_; }
 
-  inline double getMinY() {return min_vel_y_;}
-  inline double getMaxY() {return max_vel_y_;}
-  inline double getAccY() {return acc_lim_y_;}
-  inline double getDecelY() {return decel_lim_y_;}
+  inline double getMinY() { return min_vel_y_; }
+  inline double getMaxY() { return max_vel_y_; }
+  inline double getAccY() { return acc_lim_y_; }
+  inline double getDecelY() { return decel_lim_y_; }
 
-  inline double getMinSpeedXY() {return min_speed_xy_;}
-  inline double getMaxSpeedXY() {return max_speed_xy_;}
+  inline double getMinSpeedXY() { return min_speed_xy_; }
+  inline double getMaxSpeedXY() { return max_speed_xy_; }
 
-  inline double getMinTheta() {return -max_vel_theta_;}
-  inline double getMaxTheta() {return max_vel_theta_;}
-  inline double getAccTheta() {return acc_lim_theta_;}
-  inline double getDecelTheta() {return decel_lim_theta_;}
-  inline double getMinSpeedTheta() {return min_speed_theta_;}
+  inline double getMinTheta() { return -max_vel_theta_; }
+  inline double getMaxTheta() { return max_vel_theta_; }
+  inline double getAccTheta() { return acc_lim_theta_; }
+  inline double getDecelTheta() { return decel_lim_theta_; }
+  inline double getMinSpeedTheta() { return min_speed_theta_; }
 
-  inline double getMinSpeedXY_SQ() {return min_speed_xy_sq_;}
-  inline double getMaxSpeedXY_SQ() {return max_speed_xy_sq_;}
+  inline double getMinSpeedXY_SQ() { return min_speed_xy_sq_; }
+  inline double getMaxSpeedXY_SQ() { return max_speed_xy_sq_; }
 
-protected:
+ protected:
   // For parameter descriptions, see cfg/KinematicParams.cfg
   double min_vel_x_{0};
   double min_vel_y_{0};
@@ -100,24 +98,26 @@ protected:
  * @class KinematicsHandler
  * @brief A class managing the representation of the robot's kinematics
  */
-class KinematicsHandler
-{
-public:
+class KinematicsHandler {
+ public:
   KinematicsHandler();
   ~KinematicsHandler();
-  void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, const std::string & plugin_name);
+  void initialize(const nav2_util::LifecycleNode::SharedPtr &nh,
+                  const std::string &plugin_name);
 
-  inline KinematicParameters getKinematics() {return *kinematics_.load();}
+  inline KinematicParameters getKinematics() { return *kinematics_.load(); }
 
   using Ptr = std::shared_ptr<KinematicsHandler>;
 
-protected:
+ protected:
   std::atomic<KinematicParameters *> kinematics_;
 
   // Subscription for parameter change
   rclcpp::AsyncParametersClient::SharedPtr parameters_client_;
-  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr parameter_event_sub_;
-  void on_parameter_event_callback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
+  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr
+      parameter_event_sub_;
+  void on_parameter_event_callback(
+      const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
   void update_kinematics(KinematicParameters kinematics);
   std::string plugin_name_;
 };

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -41,38 +41,40 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 
 /**
  * @struct KinematicParameters
  * @brief A struct containing one representation of the robot's kinematics
  */
-struct KinematicParameters {
+struct KinematicParameters
+{
   friend class KinematicsHandler;
 
-  inline double getMinX() { return min_vel_x_; }
-  inline double getMaxX() { return max_vel_x_; }
-  inline double getAccX() { return acc_lim_x_; }
-  inline double getDecelX() { return decel_lim_x_; }
+  inline double getMinX() {return min_vel_x_;}
+  inline double getMaxX() {return max_vel_x_;}
+  inline double getAccX() {return acc_lim_x_;}
+  inline double getDecelX() {return decel_lim_x_;}
 
-  inline double getMinY() { return min_vel_y_; }
-  inline double getMaxY() { return max_vel_y_; }
-  inline double getAccY() { return acc_lim_y_; }
-  inline double getDecelY() { return decel_lim_y_; }
+  inline double getMinY() {return min_vel_y_;}
+  inline double getMaxY() {return max_vel_y_;}
+  inline double getAccY() {return acc_lim_y_;}
+  inline double getDecelY() {return decel_lim_y_;}
 
-  inline double getMinSpeedXY() { return min_speed_xy_; }
-  inline double getMaxSpeedXY() { return max_speed_xy_; }
+  inline double getMinSpeedXY() {return min_speed_xy_;}
+  inline double getMaxSpeedXY() {return max_speed_xy_;}
 
-  inline double getMinTheta() { return -max_vel_theta_; }
-  inline double getMaxTheta() { return max_vel_theta_; }
-  inline double getAccTheta() { return acc_lim_theta_; }
-  inline double getDecelTheta() { return decel_lim_theta_; }
-  inline double getMinSpeedTheta() { return min_speed_theta_; }
+  inline double getMinTheta() {return -max_vel_theta_;}
+  inline double getMaxTheta() {return max_vel_theta_;}
+  inline double getAccTheta() {return acc_lim_theta_;}
+  inline double getDecelTheta() {return decel_lim_theta_;}
+  inline double getMinSpeedTheta() {return min_speed_theta_;}
 
-  inline double getMinSpeedXY_SQ() { return min_speed_xy_sq_; }
-  inline double getMaxSpeedXY_SQ() { return max_speed_xy_sq_; }
+  inline double getMinSpeedXY_SQ() {return min_speed_xy_sq_;}
+  inline double getMaxSpeedXY_SQ() {return max_speed_xy_sq_;}
 
- protected:
+protected:
   // For parameter descriptions, see cfg/KinematicParams.cfg
   double min_vel_x_{0};
   double min_vel_y_{0};
@@ -98,26 +100,28 @@ struct KinematicParameters {
  * @class KinematicsHandler
  * @brief A class managing the representation of the robot's kinematics
  */
-class KinematicsHandler {
- public:
+class KinematicsHandler
+{
+public:
   KinematicsHandler();
   ~KinematicsHandler();
-  void initialize(const nav2_util::LifecycleNode::SharedPtr &nh,
-                  const std::string &plugin_name);
+  void initialize(
+    const nav2_util::LifecycleNode::SharedPtr & nh,
+    const std::string & plugin_name);
 
-  inline KinematicParameters getKinematics() { return *kinematics_.load(); }
+  inline KinematicParameters getKinematics() {return *kinematics_.load();}
 
   using Ptr = std::shared_ptr<KinematicsHandler>;
 
- protected:
+protected:
   std::atomic<KinematicParameters *> kinematics_;
 
   // Subscription for parameter change
   rclcpp::AsyncParametersClient::SharedPtr parameters_client_;
   rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr
-      parameter_event_sub_;
+    parameter_event_sub_;
   void on_parameter_event_callback(
-      const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
+    const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
   void update_kinematics(KinematicParameters kinematics);
   std::string plugin_name_;
 };

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -63,6 +63,7 @@ struct KinematicParameters
   inline double getDecelY() {return decel_lim_y_;}
 
   inline double getMinSpeedXY() {return min_speed_xy_;}
+  inline double getMaxSpeedXY() {return max_speed_xy_;}
 
   inline double getMinTheta() {return -max_vel_theta_;}
   inline double getMaxTheta() {return max_vel_theta_;}
@@ -70,23 +71,8 @@ struct KinematicParameters
   inline double getDecelTheta() {return decel_lim_theta_;}
   inline double getMinSpeedTheta() {return min_speed_theta_;}
 
-  /**
-   * @brief Check to see whether the combined x/y/theta velocities are valid
-   * @return True if the magnitude hypot(x,y) and theta are within the robot's absolute limits
-   *
-   * This is based on three parameters: min_speed_xy, max_speed_xy and min_speed_theta.
-   * The speed is valid if
-   *  1) The combined magnitude hypot(x,y) is less than max_speed_xy (or max_speed_xy is negative)
-   *  AND
-   *  2) min_speed_xy is negative or min_speed_theta is negative or
-   *     hypot(x,y) is greater than min_speed_xy or fabs(theta) is greater than min_speed_theta.
-   *
-   * In English, it makes sure the diagonal motion is not too fast,
-   * and that the velocity is moving in some meaningful direction.
-   *
-   * In Latin, quod si motus sit signum quaerit et movere ieiunium et significantissime comprehendite.
-   */
-  bool isValidSpeed(double x, double y, double theta);
+  inline double getMinSpeedXY_SQ() {return min_speed_xy_sq_;}
+  inline double getMaxSpeedXY_SQ() {return max_speed_xy_sq_;}
 
 protected:
   // For parameter descriptions, see cfg/KinematicParams.cfg
@@ -122,8 +108,6 @@ public:
   void initialize(const nav2_util::LifecycleNode::SharedPtr & nh, const std::string & plugin_name);
 
   inline KinematicParameters getKinematics() {return *kinematics_.load();}
-
-  bool isValidSpeed(double x, double y, double theta);
 
   using Ptr = std::shared_ptr<KinematicsHandler>;
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/limited_accel_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/limited_accel_generator.hpp
@@ -41,20 +41,23 @@
 #include "dwb_plugins/standard_traj_generator.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 /**
  * @class LimitedAccelGenerator
  * @brief Limits the acceleration in the generated trajectories to a fraction of
  * the simulated time.
  */
-class LimitedAccelGenerator : public StandardTrajectoryGenerator {
- public:
-  void initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
-                  const std::string& plugin_name) override;
+class LimitedAccelGenerator : public StandardTrajectoryGenerator
+{
+public:
+  void initialize(
+    const nav2_util::LifecycleNode::SharedPtr & nh,
+    const std::string & plugin_name) override;
   void startNewIteration(
-      const nav_2d_msgs::msg::Twist2D& current_velocity) override;
+    const nav_2d_msgs::msg::Twist2D & current_velocity) override;
 
- protected:
+protected:
   /**
    * @brief Calculate the velocity after a set period of time, given the desired
    * velocity and acceleration limits
@@ -68,8 +71,8 @@ class LimitedAccelGenerator : public StandardTrajectoryGenerator {
    * @return cmd_vel
    */
   nav_2d_msgs::msg::Twist2D computeNewVelocity(
-      const nav_2d_msgs::msg::Twist2D& cmd_vel,
-      const nav_2d_msgs::msg::Twist2D& start_vel, const double dt) override;
+    const nav_2d_msgs::msg::Twist2D & cmd_vel,
+    const nav_2d_msgs::msg::Twist2D & start_vel, const double dt) override;
   double acceleration_time_;
   std::string plugin_name_;
 };

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/limited_accel_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/limited_accel_generator.hpp
@@ -41,25 +41,26 @@
 #include "dwb_plugins/standard_traj_generator.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 /**
  * @class LimitedAccelGenerator
- * @brief Limits the acceleration in the generated trajectories to a fraction of the simulated time.
+ * @brief Limits the acceleration in the generated trajectories to a fraction of
+ * the simulated time.
  */
-class LimitedAccelGenerator : public StandardTrajectoryGenerator
-{
-public:
-  void initialize(
-    const nav2_util::LifecycleNode::SharedPtr & nh,
-    const std::string & plugin_name) override;
-  void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity) override;
+class LimitedAccelGenerator : public StandardTrajectoryGenerator {
+ public:
+  void initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
+                  const std::string& plugin_name) override;
+  void startNewIteration(
+      const nav_2d_msgs::msg::Twist2D& current_velocity) override;
 
-protected:
+ protected:
   /**
-   * @brief Calculate the velocity after a set period of time, given the desired velocity and acceleration limits
+   * @brief Calculate the velocity after a set period of time, given the desired
+   * velocity and acceleration limits
    *
-   * Unlike the StandardTrajectoryGenerator, the velocity remains constant in the LimitedAccelGenerator
+   * Unlike the StandardTrajectoryGenerator, the velocity remains constant in
+   * the LimitedAccelGenerator
    *
    * @param cmd_vel Desired velocity
    * @param start_vel starting velocity
@@ -67,9 +68,8 @@ protected:
    * @return cmd_vel
    */
   nav_2d_msgs::msg::Twist2D computeNewVelocity(
-    const nav_2d_msgs::msg::Twist2D & cmd_vel,
-    const nav_2d_msgs::msg::Twist2D & start_vel,
-    const double dt) override;
+      const nav_2d_msgs::msg::Twist2D& cmd_vel,
+      const nav_2d_msgs::msg::Twist2D& start_vel, const double dt) override;
   double acceleration_time_;
   std::string plugin_name_;
 };

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/one_d_velocity_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/one_d_velocity_iterator.hpp
@@ -38,7 +38,8 @@
 #include <algorithm>
 #include <cmath>
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 
 const double EPSILON = 1E-5;
 
@@ -52,8 +53,10 @@ const double EPSILON = 1E-5;
  * @param target target velocity
  * @return The velocity dt seconds after v0.
  */
-inline double projectVelocity(double v0, double accel, double decel, double dt,
-                              double target) {
+inline double projectVelocity(
+  double v0, double accel, double decel, double dt,
+  double target)
+{
   double v1;
   if (v0 < target) {
     v1 = v0 + accel * dt;
@@ -79,8 +82,9 @@ inline double projectVelocity(double v0, double accel, double decel, double dt,
  *
  *
  */
-class OneDVelocityIterator {
- public:
+class OneDVelocityIterator
+{
+public:
   /**
    * @brief Constructor for the velocity iterator
    *
@@ -91,8 +95,10 @@ class OneDVelocityIterator {
    * @param decel_limit Deceleration Limit
    * @param num_samples The number of samples to return
    */
-  OneDVelocityIterator(double current, double min, double max, double acc_limit,
-                       double decel_limit, double acc_time, int num_samples) {
+  OneDVelocityIterator(
+    double current, double min, double max, double acc_limit,
+    double decel_limit, double acc_time, int num_samples)
+  {
     if (current < min) {
       current = min;
     } else if (current > max) {
@@ -115,7 +121,8 @@ class OneDVelocityIterator {
   /**
    * @brief Get the next velocity available
    */
-  double getVelocity() const {
+  double getVelocity() const
+  {
     if (return_zero_now_) {
       return 0.0;
     }
@@ -125,9 +132,11 @@ class OneDVelocityIterator {
   /**
    * @brief Increment the iterator
    */
-  OneDVelocityIterator& operator++() {
+  OneDVelocityIterator & operator++()
+  {
     if (return_zero_ && current_ < 0.0 && current_ + increment_ > 0.0 &&
-        current_ + increment_ <= max_vel_ + EPSILON) {
+      current_ + increment_ <= max_vel_ + EPSILON)
+    {
       return_zero_now_ = true;
       return_zero_ = false;
     } else {
@@ -140,7 +149,8 @@ class OneDVelocityIterator {
   /**
    * @brief Reset back to the first velocity
    */
-  void reset() {
+  void reset()
+  {
     current_ = min_vel_;
     return_zero_ = true;
     return_zero_now_ = false;
@@ -149,9 +159,9 @@ class OneDVelocityIterator {
   /**
    * If we have returned all the velocities for this iteration
    */
-  bool isFinished() const { return current_ > max_vel_ + EPSILON; }
+  bool isFinished() const {return current_ > max_vel_ + EPSILON;}
 
- private:
+private:
   bool return_zero_, return_zero_now_;
   double min_vel_, max_vel_;
   double current_;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/one_d_velocity_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/one_d_velocity_iterator.hpp
@@ -38,8 +38,7 @@
 #include <algorithm>
 #include <cmath>
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 
 const double EPSILON = 1E-5;
 
@@ -53,8 +52,8 @@ const double EPSILON = 1E-5;
  * @param target target velocity
  * @return The velocity dt seconds after v0.
  */
-inline double projectVelocity(double v0, double accel, double decel, double dt, double target)
-{
+inline double projectVelocity(double v0, double accel, double decel, double dt,
+                              double target) {
   double v1;
   if (v0 < target) {
     v1 = v0 + accel * dt;
@@ -69,19 +68,19 @@ inline double projectVelocity(double v0, double accel, double decel, double dt, 
  * @class OneDVelocityIterator
  * @brief An iterator for generating a number of samples in a range
  *
- * In its simplest usage, this gives us N (num_samples) different velocities that are reachable
- * given our current velocity. However, there is some fancy logic around zero velocities and
- * the min/max velocities
+ * In its simplest usage, this gives us N (num_samples) different velocities
+ * that are reachable given our current velocity. However, there is some fancy
+ * logic around zero velocities and the min/max velocities
  *
- * If the current velocity is 2 m/s, and the acceleration limit is 1 m/ss and the acc_time is 1 s,
- * this class would provide velocities between 1 m/s and 3 m/s.
+ * If the current velocity is 2 m/s, and the acceleration limit is 1 m/ss and
+ * the acc_time is 1 s, this class would provide velocities between 1 m/s and 3
+ * m/s.
  *
  *
  *
  */
-class OneDVelocityIterator
-{
-public:
+class OneDVelocityIterator {
+ public:
   /**
    * @brief Constructor for the velocity iterator
    *
@@ -92,10 +91,8 @@ public:
    * @param decel_limit Deceleration Limit
    * @param num_samples The number of samples to return
    */
-  OneDVelocityIterator(
-    double current, double min, double max, double acc_limit, double decel_limit, double acc_time,
-    int num_samples)
-  {
+  OneDVelocityIterator(double current, double min, double max, double acc_limit,
+                       double decel_limit, double acc_time, int num_samples) {
     if (current < min) {
       current = min;
     } else if (current > max) {
@@ -118,20 +115,19 @@ public:
   /**
    * @brief Get the next velocity available
    */
-  double getVelocity() const
-  {
-    if (return_zero_now_) {return 0.0;}
+  double getVelocity() const {
+    if (return_zero_now_) {
+      return 0.0;
+    }
     return current_;
   }
 
   /**
    * @brief Increment the iterator
    */
-  OneDVelocityIterator & operator++()
-  {
+  OneDVelocityIterator& operator++() {
     if (return_zero_ && current_ < 0.0 && current_ + increment_ > 0.0 &&
-      current_ + increment_ <= max_vel_ + EPSILON)
-    {
+        current_ + increment_ <= max_vel_ + EPSILON) {
       return_zero_now_ = true;
       return_zero_ = false;
     } else {
@@ -144,8 +140,7 @@ public:
   /**
    * @brief Reset back to the first velocity
    */
-  void reset()
-  {
+  void reset() {
     current_ = min_vel_;
     return_zero_ = true;
     return_zero_now_ = false;
@@ -154,12 +149,9 @@ public:
   /**
    * If we have returned all the velocities for this iteration
    */
-  bool isFinished() const
-  {
-    return current_ > max_vel_ + EPSILON;
-  }
+  bool isFinished() const { return current_ > max_vel_ + EPSILON; }
 
-private:
+ private:
   bool return_zero_, return_zero_now_;
   double min_vel_, max_vel_;
   double current_;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
@@ -38,34 +38,32 @@
 #include <memory>
 #include <string>
 
+#include "nav2_core/goal_checker.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
-#include "nav2_core/goal_checker.hpp"
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 
 /**
  * @class SimpleGoalChecker
  * @brief Goal Checker plugin that only checks the position difference
  *
- * This class can be stateful if the stateful parameter is set to true (which it is by default).
- * This means that the goal checker will not check if the xy position matches again once it is found to be true.
+ * This class can be stateful if the stateful parameter is set to true (which it
+ * is by default). This means that the goal checker will not check if the xy
+ * position matches again once it is found to be true.
  */
-class SimpleGoalChecker : public nav2_core::GoalChecker
-{
-public:
+class SimpleGoalChecker : public nav2_core::GoalChecker {
+ public:
   SimpleGoalChecker();
   // Standard GoalChecker Interface
-  void initialize(
-    const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
-    const std::string & plugin_name) override;
+  void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr& nh,
+                  const std::string& plugin_name) override;
   void reset() override;
-  bool isGoalReached(
-    const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
-    const geometry_msgs::msg::Twist & velocity) override;
+  bool isGoalReached(const geometry_msgs::msg::Pose& query_pose,
+                     const geometry_msgs::msg::Pose& goal_pose,
+                     const geometry_msgs::msg::Twist& velocity) override;
 
-protected:
+ protected:
   double xy_goal_tolerance_, yaw_goal_tolerance_;
   bool stateful_, check_xy_;
   // Cached squared xy_goal_tolerance_

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/simple_goal_checker.hpp
@@ -42,7 +42,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 
 /**
  * @class SimpleGoalChecker
@@ -52,18 +53,21 @@ namespace dwb_plugins {
  * is by default). This means that the goal checker will not check if the xy
  * position matches again once it is found to be true.
  */
-class SimpleGoalChecker : public nav2_core::GoalChecker {
- public:
+class SimpleGoalChecker : public nav2_core::GoalChecker
+{
+public:
   SimpleGoalChecker();
   // Standard GoalChecker Interface
-  void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr& nh,
-                  const std::string& plugin_name) override;
+  void initialize(
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
+    const std::string & plugin_name) override;
   void reset() override;
-  bool isGoalReached(const geometry_msgs::msg::Pose& query_pose,
-                     const geometry_msgs::msg::Pose& goal_pose,
-                     const geometry_msgs::msg::Twist& velocity) override;
+  bool isGoalReached(
+    const geometry_msgs::msg::Pose & query_pose,
+    const geometry_msgs::msg::Pose & goal_pose,
+    const geometry_msgs::msg::Twist & velocity) override;
 
- protected:
+protected:
   double xy_goal_tolerance_, yaw_goal_tolerance_;
   bool stateful_, check_xy_;
   // Cached squared xy_goal_tolerance_

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -35,47 +35,48 @@
 #ifndef DWB_PLUGINS__STANDARD_TRAJ_GENERATOR_HPP_
 #define DWB_PLUGINS__STANDARD_TRAJ_GENERATOR_HPP_
 
-#include <vector>
 #include <memory>
 #include <string>
+#include <vector>
 
-#include "rclcpp/rclcpp.hpp"
 #include "dwb_core/trajectory_generator.hpp"
-#include "dwb_plugins/velocity_iterator.hpp"
 #include "dwb_plugins/kinematic_parameters.hpp"
+#include "dwb_plugins/velocity_iterator.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 
 /**
  * @class StandardTrajectoryGenerator
  * @brief Standard DWA-like trajectory generator.
  */
-class StandardTrajectoryGenerator : public dwb_core::TrajectoryGenerator
-{
-public:
+class StandardTrajectoryGenerator : public dwb_core::TrajectoryGenerator {
+ public:
   // Standard TrajectoryGenerator interface
-  void initialize(
-    const nav2_util::LifecycleNode::SharedPtr & nh,
-    const std::string & plugin_name) override;
-  void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity) override;
+  void initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
+                  const std::string& plugin_name) override;
+  void startNewIteration(
+      const nav_2d_msgs::msg::Twist2D& current_velocity) override;
   bool hasMoreTwists() override;
   nav_2d_msgs::msg::Twist2D nextTwist() override;
 
   dwb_msgs::msg::Trajectory2D generateTrajectory(
-    const geometry_msgs::msg::Pose2D & start_pose,
-    const nav_2d_msgs::msg::Twist2D & start_vel,
-    const nav_2d_msgs::msg::Twist2D & cmd_vel) override;
+      const geometry_msgs::msg::Pose2D& start_pose,
+      const nav_2d_msgs::msg::Twist2D& start_vel,
+      const nav_2d_msgs::msg::Twist2D& cmd_vel) override;
 
-protected:
+ protected:
   /**
-   * @brief Initialize the VelocityIterator pointer. Put in its own function for easy overriding
+   * @brief Initialize the VelocityIterator pointer. Put in its own function for
+   * easy overriding
    */
-  virtual void initializeIterator(const nav2_util::LifecycleNode::SharedPtr & nh);
+  virtual void initializeIterator(
+      const nav2_util::LifecycleNode::SharedPtr& nh);
 
   /**
-   * @brief Calculate the velocity after a set period of time, given the desired velocity and acceleration limits
+   * @brief Calculate the velocity after a set period of time, given the desired
+   * velocity and acceleration limits
    *
    * @param cmd_vel Desired velocity
    * @param start_vel starting velocity
@@ -83,11 +84,12 @@ protected:
    * @return new velocity after dt seconds
    */
   virtual nav_2d_msgs::msg::Twist2D computeNewVelocity(
-    const nav_2d_msgs::msg::Twist2D & cmd_vel, const nav_2d_msgs::msg::Twist2D & start_vel,
-    const double dt);
+      const nav_2d_msgs::msg::Twist2D& cmd_vel,
+      const nav_2d_msgs::msg::Twist2D& start_vel, const double dt);
 
   /**
-   * @brief Use the robot's kinematic model to predict new positions for the robot
+   * @brief Use the robot's kinematic model to predict new positions for the
+   * robot
    *
    * @param start_pose Starting pose
    * @param vel Actual robot velocity (assumed to be within acceleration limits)
@@ -95,23 +97,26 @@ protected:
    * @return New pose after dt seconds
    */
   virtual geometry_msgs::msg::Pose2D computeNewPosition(
-    const geometry_msgs::msg::Pose2D start_pose, const nav_2d_msgs::msg::Twist2D & vel,
-    const double dt);
-
+      const geometry_msgs::msg::Pose2D start_pose,
+      const nav_2d_msgs::msg::Twist2D& vel, const double dt);
 
   /**
-   * @brief Compute an array of time deltas between the points in the generated trajectory.
+   * @brief Compute an array of time deltas between the points in the generated
+   * trajectory.
    *
    * @param cmd_vel The desired command velocity
-   * @return vector of the difference between each time step in the generated trajectory
+   * @return vector of the difference between each time step in the generated
+   * trajectory
    *
-   * If we are discretizing by time, the returned vector will be the same constant time_granularity
-   * for all cmd_vels. Otherwise, you will get times based on the linear/angular granularity.
+   * If we are discretizing by time, the returned vector will be the same
+   * constant time_granularity for all cmd_vels. Otherwise, you will get times
+   * based on the linear/angular granularity.
    *
-   * Right now the vector contains a single value repeated many times, but this method could be overridden
-   * to allow for dynamic spacing
+   * Right now the vector contains a single value repeated many times, but this
+   * method could be overridden to allow for dynamic spacing
    */
-  virtual std::vector<double> getTimeSteps(const nav_2d_msgs::msg::Twist2D & cmd_vel);
+  virtual std::vector<double> getTimeSteps(
+      const nav_2d_msgs::msg::Twist2D& cmd_vel);
 
   KinematicsHandler::Ptr kinematics_handler_;
   std::shared_ptr<VelocityIterator> velocity_iterator_;
@@ -121,13 +126,16 @@ protected:
   // Sampling Parameters
   bool discretize_by_time_;
 
-  /// @brief If discretizing by time, the amount of time between each point in the traj
+  /// @brief If discretizing by time, the amount of time between each point in
+  /// the traj
   double time_granularity_;
 
-  /// @brief If not discretizing by time, the amount of linear space between points
+  /// @brief If not discretizing by time, the amount of linear space between
+  /// points
   double linear_granularity_;
 
-  /// @brief If not discretizing by time, the amount of angular space between points
+  /// @brief If not discretizing by time, the amount of angular space between
+  /// points
   double angular_granularity_;
 
   /// @brief the name of the overlying plugin ID
@@ -137,18 +145,19 @@ protected:
    *
    * dwa had an off-by-one error built into it.
    * It generated N trajectory points, where N = ceil(sim_time / time_delta).
-   * If for example, sim_time=3.0 and time_delta=1.5, it would generate trajectories with 2 points, which
-   * indeed were time_delta seconds apart. However, the points would be at t=0 and t=1.5, and thus the
-   * actual sim_time was much less than advertised.
+   * If for example, sim_time=3.0 and time_delta=1.5, it would generate
+   * trajectories with 2 points, which indeed were time_delta seconds apart.
+   * However, the points would be at t=0 and t=1.5, and thus the actual sim_time
+   * was much less than advertised.
    *
-   * This is remedied by adding one final point at t=sim_time, but only if include_last_point_ is true.
+   * This is remedied by adding one final point at t=sim_time, but only if
+   * include_last_point_ is true.
    *
-   * Nothing I could find actually used the time_delta variable or seemed to care that the trajectories
-   * were not projected out as far as they intended.
+   * Nothing I could find actually used the time_delta variable or seemed to
+   * care that the trajectories were not projected out as far as they intended.
    */
   bool include_last_point_;
 };
-
 
 }  // namespace dwb_plugins
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -45,34 +45,37 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 
 /**
  * @class StandardTrajectoryGenerator
  * @brief Standard DWA-like trajectory generator.
  */
-class StandardTrajectoryGenerator : public dwb_core::TrajectoryGenerator {
- public:
+class StandardTrajectoryGenerator : public dwb_core::TrajectoryGenerator
+{
+public:
   // Standard TrajectoryGenerator interface
-  void initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
-                  const std::string& plugin_name) override;
+  void initialize(
+    const nav2_util::LifecycleNode::SharedPtr & nh,
+    const std::string & plugin_name) override;
   void startNewIteration(
-      const nav_2d_msgs::msg::Twist2D& current_velocity) override;
+    const nav_2d_msgs::msg::Twist2D & current_velocity) override;
   bool hasMoreTwists() override;
   nav_2d_msgs::msg::Twist2D nextTwist() override;
 
   dwb_msgs::msg::Trajectory2D generateTrajectory(
-      const geometry_msgs::msg::Pose2D& start_pose,
-      const nav_2d_msgs::msg::Twist2D& start_vel,
-      const nav_2d_msgs::msg::Twist2D& cmd_vel) override;
+    const geometry_msgs::msg::Pose2D & start_pose,
+    const nav_2d_msgs::msg::Twist2D & start_vel,
+    const nav_2d_msgs::msg::Twist2D & cmd_vel) override;
 
- protected:
+protected:
   /**
    * @brief Initialize the VelocityIterator pointer. Put in its own function for
    * easy overriding
    */
   virtual void initializeIterator(
-      const nav2_util::LifecycleNode::SharedPtr& nh);
+    const nav2_util::LifecycleNode::SharedPtr & nh);
 
   /**
    * @brief Calculate the velocity after a set period of time, given the desired
@@ -84,8 +87,8 @@ class StandardTrajectoryGenerator : public dwb_core::TrajectoryGenerator {
    * @return new velocity after dt seconds
    */
   virtual nav_2d_msgs::msg::Twist2D computeNewVelocity(
-      const nav_2d_msgs::msg::Twist2D& cmd_vel,
-      const nav_2d_msgs::msg::Twist2D& start_vel, const double dt);
+    const nav_2d_msgs::msg::Twist2D & cmd_vel,
+    const nav_2d_msgs::msg::Twist2D & start_vel, const double dt);
 
   /**
    * @brief Use the robot's kinematic model to predict new positions for the
@@ -97,8 +100,8 @@ class StandardTrajectoryGenerator : public dwb_core::TrajectoryGenerator {
    * @return New pose after dt seconds
    */
   virtual geometry_msgs::msg::Pose2D computeNewPosition(
-      const geometry_msgs::msg::Pose2D start_pose,
-      const nav_2d_msgs::msg::Twist2D& vel, const double dt);
+    const geometry_msgs::msg::Pose2D start_pose,
+    const nav_2d_msgs::msg::Twist2D & vel, const double dt);
 
   /**
    * @brief Compute an array of time deltas between the points in the generated
@@ -116,7 +119,7 @@ class StandardTrajectoryGenerator : public dwb_core::TrajectoryGenerator {
    * method could be overridden to allow for dynamic spacing
    */
   virtual std::vector<double> getTimeSteps(
-      const nav_2d_msgs::msg::Twist2D& cmd_vel);
+    const nav_2d_msgs::msg::Twist2D & cmd_vel);
 
   KinematicsHandler::Ptr kinematics_handler_;
   std::shared_ptr<VelocityIterator> velocity_iterator_;

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
@@ -42,23 +42,27 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 
 /**
  * @class StoppedGoalChecker
  * @brief Goal Checker plugin that checks the position difference and velocity
  */
-class StoppedGoalChecker : public SimpleGoalChecker {
- public:
+class StoppedGoalChecker : public SimpleGoalChecker
+{
+public:
   StoppedGoalChecker();
   // Standard GoalChecker Interface
-  void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr& nh,
-                  const std::string& plugin_name) override;
-  bool isGoalReached(const geometry_msgs::msg::Pose& query_pose,
-                     const geometry_msgs::msg::Pose& goal_pose,
-                     const geometry_msgs::msg::Twist& velocity) override;
+  void initialize(
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
+    const std::string & plugin_name) override;
+  bool isGoalReached(
+    const geometry_msgs::msg::Pose & query_pose,
+    const geometry_msgs::msg::Pose & goal_pose,
+    const geometry_msgs::msg::Twist & velocity) override;
 
- protected:
+protected:
   double rot_stopped_velocity_, trans_stopped_velocity_;
 };
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/stopped_goal_checker.hpp
@@ -38,30 +38,27 @@
 #include <memory>
 #include <string>
 
+#include "dwb_plugins/simple_goal_checker.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
-#include "dwb_plugins/simple_goal_checker.hpp"
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 
 /**
  * @class StoppedGoalChecker
  * @brief Goal Checker plugin that checks the position difference and velocity
  */
-class StoppedGoalChecker : public SimpleGoalChecker
-{
-public:
+class StoppedGoalChecker : public SimpleGoalChecker {
+ public:
   StoppedGoalChecker();
   // Standard GoalChecker Interface
-  void initialize(
-    const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
-    const std::string & plugin_name) override;
-  bool isGoalReached(
-    const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
-    const geometry_msgs::msg::Twist & velocity) override;
+  void initialize(const rclcpp_lifecycle::LifecycleNode::SharedPtr& nh,
+                  const std::string& plugin_name) override;
+  bool isGoalReached(const geometry_msgs::msg::Pose& query_pose,
+                     const geometry_msgs::msg::Pose& goal_pose,
+                     const geometry_msgs::msg::Twist& velocity) override;
 
-protected:
+ protected:
   double rot_stopped_velocity_, trans_stopped_velocity_;
 };
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/velocity_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/velocity_iterator.hpp
@@ -43,15 +43,18 @@
 #include "nav_2d_msgs/msg/twist2_d.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-namespace dwb_plugins {
-class VelocityIterator {
- public:
+namespace dwb_plugins
+{
+class VelocityIterator
+{
+public:
   virtual ~VelocityIterator() {}
-  virtual void initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
-                          KinematicsHandler::Ptr kinematics,
-                          const std::string& plugin_name) = 0;
+  virtual void initialize(
+    const nav2_util::LifecycleNode::SharedPtr & nh,
+    KinematicsHandler::Ptr kinematics,
+    const std::string & plugin_name) = 0;
   virtual void startNewIteration(
-      const nav_2d_msgs::msg::Twist2D& current_velocity, double dt) = 0;
+    const nav_2d_msgs::msg::Twist2D & current_velocity, double dt) = 0;
   virtual bool hasMoreTwists() = 0;
   virtual nav_2d_msgs::msg::Twist2D nextTwist() = 0;
 };

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/velocity_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/velocity_iterator.hpp
@@ -38,22 +38,20 @@
 #include <memory>
 #include <string>
 
-#include "rclcpp/rclcpp.hpp"
-#include "nav_2d_msgs/msg/twist2_d.hpp"
 #include "dwb_plugins/kinematic_parameters.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav_2d_msgs/msg/twist2_d.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-namespace dwb_plugins
-{
-class VelocityIterator
-{
-public:
+namespace dwb_plugins {
+class VelocityIterator {
+ public:
   virtual ~VelocityIterator() {}
-  virtual void initialize(
-    const nav2_util::LifecycleNode::SharedPtr & nh,
-    KinematicsHandler::Ptr kinematics,
-    const std::string & plugin_name) = 0;
-  virtual void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity, double dt) = 0;
+  virtual void initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
+                          KinematicsHandler::Ptr kinematics,
+                          const std::string& plugin_name) = 0;
+  virtual void startNewIteration(
+      const nav_2d_msgs::msg::Twist2D& current_velocity, double dt) = 0;
   virtual bool hasMoreTwists() = 0;
   virtual nav_2d_msgs::msg::Twist2D nextTwist() = 0;
 };

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
@@ -38,41 +38,43 @@
 #include <memory>
 #include <string>
 
-#include "dwb_plugins/velocity_iterator.hpp"
 #include "dwb_plugins/one_d_velocity_iterator.hpp"
+#include "dwb_plugins/velocity_iterator.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 
-namespace dwb_plugins
-{
-class XYThetaIterator : public VelocityIterator
-{
-public:
+namespace dwb_plugins {
+class XYThetaIterator : public VelocityIterator {
+ public:
   XYThetaIterator()
-  : kinematics_handler_(nullptr), x_it_(nullptr), y_it_(nullptr), th_it_(nullptr) {}
-  void initialize(
-    const nav2_util::LifecycleNode::SharedPtr & nh,
-    KinematicsHandler::Ptr kinematics,
-    const std::string & plugin_name) override;
-  void startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity, double dt) override;
+      : kinematics_handler_(nullptr),
+        x_it_(nullptr),
+        y_it_(nullptr),
+        th_it_(nullptr) {}
+  void initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
+                  KinematicsHandler::Ptr kinematics,
+                  const std::string& plugin_name) override;
+  void startNewIteration(const nav_2d_msgs::msg::Twist2D& current_velocity,
+                         double dt) override;
   bool hasMoreTwists() override;
   nav_2d_msgs::msg::Twist2D nextTwist() override;
 
-protected:
+ protected:
   /**
    * @brief Check to see whether the combined x/y/theta velocities are valid
-   * @return True if the magnitude hypot(x,y) and theta are within the robot's absolute limits
+   * @return True if the magnitude hypot(x,y) and theta are within the robot's
+   * absolute limits
    *
-   * This is based on three parameters: min_speed_xy, max_speed_xy and min_speed_theta.
-   * The speed is valid if
-   *  1) The combined magnitude hypot(x,y) is less than max_speed_xy (or max_speed_xy is negative)
-   *  AND
-   *  2) min_speed_xy is negative or min_speed_theta is negative or
-   *     hypot(x,y) is greater than min_speed_xy or fabs(theta) is greater than min_speed_theta.
+   * This is based on three parameters: min_speed_xy, max_speed_xy and
+   * min_speed_theta. The speed is valid if 1) The combined magnitude hypot(x,y)
+   * is less than max_speed_xy (or max_speed_xy is negative) AND 2) min_speed_xy
+   * is negative or min_speed_theta is negative or hypot(x,y) is greater than
+   * min_speed_xy or fabs(theta) is greater than min_speed_theta.
    *
    * In English, it makes sure the diagonal motion is not too fast,
    * and that the velocity is moving in some meaningful direction.
    *
-   * In Latin, quod si motus sit signum quaerit et movere ieiunium et significantissime comprehendite.
+   * In Latin, quod si motus sit signum quaerit et movere ieiunium et
+   * significantissime comprehendite.
    */
   bool isValidSpeed(double x, double y, double theta);
   virtual bool isValidVelocity();

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
@@ -42,23 +42,27 @@
 #include "dwb_plugins/velocity_iterator.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 
-namespace dwb_plugins {
-class XYThetaIterator : public VelocityIterator {
- public:
+namespace dwb_plugins
+{
+class XYThetaIterator : public VelocityIterator
+{
+public:
   XYThetaIterator()
-      : kinematics_handler_(nullptr),
-        x_it_(nullptr),
-        y_it_(nullptr),
-        th_it_(nullptr) {}
-  void initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
-                  KinematicsHandler::Ptr kinematics,
-                  const std::string& plugin_name) override;
-  void startNewIteration(const nav_2d_msgs::msg::Twist2D& current_velocity,
-                         double dt) override;
+  : kinematics_handler_(nullptr),
+    x_it_(nullptr),
+    y_it_(nullptr),
+    th_it_(nullptr) {}
+  void initialize(
+    const nav2_util::LifecycleNode::SharedPtr & nh,
+    KinematicsHandler::Ptr kinematics,
+    const std::string & plugin_name) override;
+  void startNewIteration(
+    const nav_2d_msgs::msg::Twist2D & current_velocity,
+    double dt) override;
   bool hasMoreTwists() override;
   nav_2d_msgs::msg::Twist2D nextTwist() override;
 
- protected:
+protected:
   /**
    * @brief Check to see whether the combined x/y/theta velocities are valid
    * @return True if the magnitude hypot(x,y) and theta are within the robot's

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
@@ -58,6 +58,23 @@ public:
   nav_2d_msgs::msg::Twist2D nextTwist() override;
 
 protected:
+  /**
+   * @brief Check to see whether the combined x/y/theta velocities are valid
+   * @return True if the magnitude hypot(x,y) and theta are within the robot's absolute limits
+   *
+   * This is based on three parameters: min_speed_xy, max_speed_xy and min_speed_theta.
+   * The speed is valid if
+   *  1) The combined magnitude hypot(x,y) is less than max_speed_xy (or max_speed_xy is negative)
+   *  AND
+   *  2) min_speed_xy is negative or min_speed_theta is negative or
+   *     hypot(x,y) is greater than min_speed_xy or fabs(theta) is greater than min_speed_theta.
+   *
+   * In English, it makes sure the diagonal motion is not too fast,
+   * and that the velocity is moving in some meaningful direction.
+   *
+   * In Latin, quod si motus sit signum quaerit et movere ieiunium et significantissime comprehendite.
+   */
+  bool isValidSpeed(double x, double y, double theta);
   virtual bool isValidVelocity();
   void iterateToValidVelocity();
   int vx_samples_, vy_samples_, vtheta_samples_;

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -38,67 +38,67 @@
 #include <memory>
 #include <string>
 
-#include "nav_2d_utils/parameters.hpp"
 #include "nav2_util/node_utils.hpp"
+#include "nav_2d_utils/parameters.hpp"
 
 #define EPSILON 1E-5
 
-using std::fabs;
 using nav2_util::declare_parameter_if_not_declared;
 using nav_2d_utils::moveDeprecatedParameter;
 using rcl_interfaces::msg::ParameterType;
+using std::fabs;
 using std::placeholders::_1;
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 
-KinematicsHandler::KinematicsHandler()
-{
+KinematicsHandler::KinematicsHandler() {
   kinematics_.store(new KinematicParameters);
 }
 
-KinematicsHandler::~KinematicsHandler()
-{
-  delete kinematics_.load();
-}
+KinematicsHandler::~KinematicsHandler() { delete kinematics_.load(); }
 
 void KinematicsHandler::initialize(
-  const nav2_util::LifecycleNode::SharedPtr & nh,
-  const std::string & plugin_name)
-{
+    const nav2_util::LifecycleNode::SharedPtr& nh,
+    const std::string& plugin_name) {
   plugin_name_ = plugin_name;
   // Special handling for renamed parameters
-  moveDeprecatedParameter<double>(nh, plugin_name + ".max_vel_theta", "max_rot_vel");
-  moveDeprecatedParameter<double>(nh, plugin_name + ".min_speed_xy", "min_trans_vel");
-  moveDeprecatedParameter<double>(nh, plugin_name + ".max_speed_xy", "max_trans_vel");
-  moveDeprecatedParameter<double>(nh, plugin_name + ".min_speed_theta", "min_rot_vel");
+  moveDeprecatedParameter<double>(nh, plugin_name + ".max_vel_theta",
+                                  "max_rot_vel");
+  moveDeprecatedParameter<double>(nh, plugin_name + ".min_speed_xy",
+                                  "min_trans_vel");
+  moveDeprecatedParameter<double>(nh, plugin_name + ".max_speed_xy",
+                                  "max_trans_vel");
+  moveDeprecatedParameter<double>(nh, plugin_name + ".min_speed_theta",
+                                  "min_rot_vel");
 
-  declare_parameter_if_not_declared(nh, plugin_name + ".min_vel_x", rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".min_vel_y", rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".max_vel_x", rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".max_vel_y", rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(
-    nh, plugin_name + ".max_vel_theta",
-    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(
-    nh, plugin_name + ".min_speed_xy",
-    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(
-    nh, plugin_name + ".max_speed_xy",
-    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(
-    nh, plugin_name + ".min_speed_theta",
-    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".acc_lim_x", rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".acc_lim_y", rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(
-    nh, plugin_name + ".acc_lim_theta",
-    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".decel_lim_x", rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".decel_lim_y", rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(
-    nh, plugin_name + ".decel_lim_theta",
-    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".min_vel_x",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".min_vel_y",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".max_vel_x",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".max_vel_y",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".max_vel_theta",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".min_speed_xy",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".max_speed_xy",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".min_speed_theta",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".acc_lim_x",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".acc_lim_y",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".acc_lim_theta",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".decel_lim_x",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".decel_lim_y",
+                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(nh, plugin_name + ".decel_lim_theta",
+                                    rclcpp::ParameterValue(0.0));
 
   KinematicParameters kinematics;
 
@@ -109,41 +109,40 @@ void KinematicsHandler::initialize(
   nh->get_parameter(plugin_name + ".max_vel_theta", kinematics.max_vel_theta_);
   nh->get_parameter(plugin_name + ".min_speed_xy", kinematics.min_speed_xy_);
   nh->get_parameter(plugin_name + ".max_speed_xy", kinematics.max_speed_xy_);
-  nh->get_parameter(plugin_name + ".min_speed_theta", kinematics.min_speed_theta_);
+  nh->get_parameter(plugin_name + ".min_speed_theta",
+                    kinematics.min_speed_theta_);
   nh->get_parameter(plugin_name + ".acc_lim_x", kinematics.acc_lim_x_);
   nh->get_parameter(plugin_name + ".acc_lim_y", kinematics.acc_lim_y_);
   nh->get_parameter(plugin_name + ".acc_lim_theta", kinematics.acc_lim_theta_);
   nh->get_parameter(plugin_name + ".decel_lim_x", kinematics.decel_lim_x_);
   nh->get_parameter(plugin_name + ".decel_lim_y", kinematics.decel_lim_y_);
-  nh->get_parameter(plugin_name + ".decel_lim_theta", kinematics.decel_lim_theta_);
+  nh->get_parameter(plugin_name + ".decel_lim_theta",
+                    kinematics.decel_lim_theta_);
 
   // Setup callback for changes to parameters.
   parameters_client_ = std::make_shared<rclcpp::AsyncParametersClient>(
-    nh->get_node_base_interface(),
-    nh->get_node_topics_interface(),
-    nh->get_node_graph_interface(),
-    nh->get_node_services_interface());
+      nh->get_node_base_interface(), nh->get_node_topics_interface(),
+      nh->get_node_graph_interface(), nh->get_node_services_interface());
 
   parameter_event_sub_ = parameters_client_->on_parameter_event(
-    std::bind(&KinematicsHandler::on_parameter_event_callback, this, _1));
+      std::bind(&KinematicsHandler::on_parameter_event_callback, this, _1));
 
-  kinematics.min_speed_xy_sq_ = kinematics.min_speed_xy_ * kinematics.min_speed_xy_;
-  kinematics.max_speed_xy_sq_ = kinematics.max_speed_xy_ * kinematics.max_speed_xy_;
+  kinematics.min_speed_xy_sq_ =
+      kinematics.min_speed_xy_ * kinematics.min_speed_xy_;
+  kinematics.max_speed_xy_sq_ =
+      kinematics.max_speed_xy_ * kinematics.max_speed_xy_;
 
   update_kinematics(kinematics);
 }
 
-
-void
-KinematicsHandler::on_parameter_event_callback(
-  const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
-{
+void KinematicsHandler::on_parameter_event_callback(
+    const rcl_interfaces::msg::ParameterEvent::SharedPtr event) {
   KinematicParameters kinematics(*kinematics_.load());
 
-  for (auto & changed_parameter : event->changed_parameters) {
-    const auto & type = changed_parameter.value.type;
-    const auto & name = changed_parameter.name;
-    const auto & value = changed_parameter.value;
+  for (auto& changed_parameter : event->changed_parameters) {
+    const auto& type = changed_parameter.value.type;
+    const auto& name = changed_parameter.name;
+    const auto& value = changed_parameter.value;
 
     if (type == ParameterType::PARAMETER_DOUBLE) {
       if (name == plugin_name_ + ".min_vel_x") {
@@ -158,12 +157,14 @@ KinematicsHandler::on_parameter_event_callback(
         kinematics.max_vel_theta_ = value.double_value;
       } else if (name == plugin_name_ + ".min_speed_xy") {
         kinematics.min_speed_xy_ = value.double_value;
-        kinematics.min_speed_xy_sq_ = kinematics.min_speed_xy_ * kinematics.min_speed_xy_;
+        kinematics.min_speed_xy_sq_ =
+            kinematics.min_speed_xy_ * kinematics.min_speed_xy_;
       } else if (name == plugin_name_ + ".max_speed_xy") {
         kinematics.max_speed_xy_ = value.double_value;
       } else if (name == plugin_name_ + ".min_speed_theta") {
         kinematics.min_speed_theta_ = value.double_value;
-        kinematics.max_speed_xy_sq_ = kinematics.max_speed_xy_ * kinematics.max_speed_xy_;
+        kinematics.max_speed_xy_sq_ =
+            kinematics.max_speed_xy_ * kinematics.max_speed_xy_;
       } else if (name == plugin_name_ + ".acc_lim_x") {
         kinematics.acc_lim_x_ = value.double_value;
       } else if (name == plugin_name_ + ".acc_lim_y") {
@@ -182,8 +183,7 @@ KinematicsHandler::on_parameter_event_callback(
   update_kinematics(kinematics);
 }
 
-void KinematicsHandler::update_kinematics(KinematicParameters kinematics)
-{
+void KinematicsHandler::update_kinematics(KinematicParameters kinematics) {
   delete kinematics_.load();
   kinematics_.store(new KinematicParameters(kinematics));
 }

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -58,7 +58,7 @@ bool KinematicParameters::isValidSpeed(double x, double y, double theta)
   if (max_speed_xy_ >= 0.0 && vmag_sq > max_speed_xy_sq_ + EPSILON) {return false;}
   if (min_speed_xy_ >= 0.0 && vmag_sq + EPSILON < min_speed_xy_sq_ &&
     min_speed_theta_ >= 0.0 && fabs(theta) + EPSILON < min_speed_theta_) {return false;}
-  if (vmag_sq == 0.0 && theta == 0.0) {return false;}
+  
   return true;
 }
 

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -49,56 +49,77 @@ using rcl_interfaces::msg::ParameterType;
 using std::fabs;
 using std::placeholders::_1;
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 
-KinematicsHandler::KinematicsHandler() {
+KinematicsHandler::KinematicsHandler()
+{
   kinematics_.store(new KinematicParameters);
 }
 
-KinematicsHandler::~KinematicsHandler() { delete kinematics_.load(); }
+KinematicsHandler::~KinematicsHandler() {delete kinematics_.load();}
 
 void KinematicsHandler::initialize(
-    const nav2_util::LifecycleNode::SharedPtr& nh,
-    const std::string& plugin_name) {
+  const nav2_util::LifecycleNode::SharedPtr & nh,
+  const std::string & plugin_name)
+{
   plugin_name_ = plugin_name;
   // Special handling for renamed parameters
-  moveDeprecatedParameter<double>(nh, plugin_name + ".max_vel_theta",
-                                  "max_rot_vel");
-  moveDeprecatedParameter<double>(nh, plugin_name + ".min_speed_xy",
-                                  "min_trans_vel");
-  moveDeprecatedParameter<double>(nh, plugin_name + ".max_speed_xy",
-                                  "max_trans_vel");
-  moveDeprecatedParameter<double>(nh, plugin_name + ".min_speed_theta",
-                                  "min_rot_vel");
+  moveDeprecatedParameter<double>(
+    nh, plugin_name + ".max_vel_theta",
+    "max_rot_vel");
+  moveDeprecatedParameter<double>(
+    nh, plugin_name + ".min_speed_xy",
+    "min_trans_vel");
+  moveDeprecatedParameter<double>(
+    nh, plugin_name + ".max_speed_xy",
+    "max_trans_vel");
+  moveDeprecatedParameter<double>(
+    nh, plugin_name + ".min_speed_theta",
+    "min_rot_vel");
 
-  declare_parameter_if_not_declared(nh, plugin_name + ".min_vel_x",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".min_vel_y",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".max_vel_x",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".max_vel_y",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".max_vel_theta",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".min_speed_xy",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".max_speed_xy",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".min_speed_theta",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".acc_lim_x",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".acc_lim_y",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".acc_lim_theta",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".decel_lim_x",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".decel_lim_y",
-                                    rclcpp::ParameterValue(0.0));
-  declare_parameter_if_not_declared(nh, plugin_name + ".decel_lim_theta",
-                                    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".min_vel_x",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".min_vel_y",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".max_vel_x",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".max_vel_y",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".max_vel_theta",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".min_speed_xy",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".max_speed_xy",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".min_speed_theta",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".acc_lim_x",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".acc_lim_y",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".acc_lim_theta",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".decel_lim_x",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".decel_lim_y",
+    rclcpp::ParameterValue(0.0));
+  declare_parameter_if_not_declared(
+    nh, plugin_name + ".decel_lim_theta",
+    rclcpp::ParameterValue(0.0));
 
   KinematicParameters kinematics;
 
@@ -109,40 +130,43 @@ void KinematicsHandler::initialize(
   nh->get_parameter(plugin_name + ".max_vel_theta", kinematics.max_vel_theta_);
   nh->get_parameter(plugin_name + ".min_speed_xy", kinematics.min_speed_xy_);
   nh->get_parameter(plugin_name + ".max_speed_xy", kinematics.max_speed_xy_);
-  nh->get_parameter(plugin_name + ".min_speed_theta",
-                    kinematics.min_speed_theta_);
+  nh->get_parameter(
+    plugin_name + ".min_speed_theta",
+    kinematics.min_speed_theta_);
   nh->get_parameter(plugin_name + ".acc_lim_x", kinematics.acc_lim_x_);
   nh->get_parameter(plugin_name + ".acc_lim_y", kinematics.acc_lim_y_);
   nh->get_parameter(plugin_name + ".acc_lim_theta", kinematics.acc_lim_theta_);
   nh->get_parameter(plugin_name + ".decel_lim_x", kinematics.decel_lim_x_);
   nh->get_parameter(plugin_name + ".decel_lim_y", kinematics.decel_lim_y_);
-  nh->get_parameter(plugin_name + ".decel_lim_theta",
-                    kinematics.decel_lim_theta_);
+  nh->get_parameter(
+    plugin_name + ".decel_lim_theta",
+    kinematics.decel_lim_theta_);
 
   // Setup callback for changes to parameters.
   parameters_client_ = std::make_shared<rclcpp::AsyncParametersClient>(
-      nh->get_node_base_interface(), nh->get_node_topics_interface(),
-      nh->get_node_graph_interface(), nh->get_node_services_interface());
+    nh->get_node_base_interface(), nh->get_node_topics_interface(),
+    nh->get_node_graph_interface(), nh->get_node_services_interface());
 
   parameter_event_sub_ = parameters_client_->on_parameter_event(
-      std::bind(&KinematicsHandler::on_parameter_event_callback, this, _1));
+    std::bind(&KinematicsHandler::on_parameter_event_callback, this, _1));
 
   kinematics.min_speed_xy_sq_ =
-      kinematics.min_speed_xy_ * kinematics.min_speed_xy_;
+    kinematics.min_speed_xy_ * kinematics.min_speed_xy_;
   kinematics.max_speed_xy_sq_ =
-      kinematics.max_speed_xy_ * kinematics.max_speed_xy_;
+    kinematics.max_speed_xy_ * kinematics.max_speed_xy_;
 
   update_kinematics(kinematics);
 }
 
 void KinematicsHandler::on_parameter_event_callback(
-    const rcl_interfaces::msg::ParameterEvent::SharedPtr event) {
+  const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
+{
   KinematicParameters kinematics(*kinematics_.load());
 
-  for (auto& changed_parameter : event->changed_parameters) {
-    const auto& type = changed_parameter.value.type;
-    const auto& name = changed_parameter.name;
-    const auto& value = changed_parameter.value;
+  for (auto & changed_parameter : event->changed_parameters) {
+    const auto & type = changed_parameter.value.type;
+    const auto & name = changed_parameter.name;
+    const auto & value = changed_parameter.value;
 
     if (type == ParameterType::PARAMETER_DOUBLE) {
       if (name == plugin_name_ + ".min_vel_x") {
@@ -158,13 +182,13 @@ void KinematicsHandler::on_parameter_event_callback(
       } else if (name == plugin_name_ + ".min_speed_xy") {
         kinematics.min_speed_xy_ = value.double_value;
         kinematics.min_speed_xy_sq_ =
-            kinematics.min_speed_xy_ * kinematics.min_speed_xy_;
+          kinematics.min_speed_xy_ * kinematics.min_speed_xy_;
       } else if (name == plugin_name_ + ".max_speed_xy") {
         kinematics.max_speed_xy_ = value.double_value;
       } else if (name == plugin_name_ + ".min_speed_theta") {
         kinematics.min_speed_theta_ = value.double_value;
         kinematics.max_speed_xy_sq_ =
-            kinematics.max_speed_xy_ * kinematics.max_speed_xy_;
+          kinematics.max_speed_xy_ * kinematics.max_speed_xy_;
       } else if (name == plugin_name_ + ".acc_lim_x") {
         kinematics.acc_lim_x_ = value.double_value;
       } else if (name == plugin_name_ + ".acc_lim_y") {
@@ -183,7 +207,8 @@ void KinematicsHandler::on_parameter_event_callback(
   update_kinematics(kinematics);
 }
 
-void KinematicsHandler::update_kinematics(KinematicParameters kinematics) {
+void KinematicsHandler::update_kinematics(KinematicParameters kinematics)
+{
   delete kinematics_.load();
   kinematics_.store(new KinematicParameters(kinematics));
 }

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -52,16 +52,6 @@ using std::placeholders::_1;
 namespace dwb_plugins
 {
 
-bool KinematicParameters::isValidSpeed(double x, double y, double theta)
-{
-  double vmag_sq = x * x + y * y;
-  if (max_speed_xy_ >= 0.0 && vmag_sq > max_speed_xy_sq_ + EPSILON) {return false;}
-  if (min_speed_xy_ >= 0.0 && vmag_sq + EPSILON < min_speed_xy_sq_ &&
-    min_speed_theta_ >= 0.0 && fabs(theta) + EPSILON < min_speed_theta_) {return false;}
-  
-  return true;
-}
-
 KinematicsHandler::KinematicsHandler()
 {
   kinematics_.store(new KinematicParameters);
@@ -143,10 +133,6 @@ void KinematicsHandler::initialize(
   update_kinematics(kinematics);
 }
 
-bool KinematicsHandler::isValidSpeed(double x, double y, double theta)
-{
-  return kinematics_.load()->isValidSpeed(x, y, theta);
-}
 
 void
 KinematicsHandler::on_parameter_event_callback(

--- a/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -33,21 +33,19 @@
  */
 
 #include "dwb_plugins/limited_accel_generator.hpp"
-#include <vector>
 #include <memory>
 #include <string>
-#include "nav_2d_utils/parameters.hpp"
-#include "pluginlib/class_list_macros.hpp"
+#include <vector>
 #include "dwb_core/exceptions.hpp"
 #include "nav2_util/node_utils.hpp"
+#include "nav_2d_utils/parameters.hpp"
+#include "pluginlib/class_list_macros.hpp"
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 
 void LimitedAccelGenerator::initialize(
-  const nav2_util::LifecycleNode::SharedPtr & nh,
-  const std::string & plugin_name)
-{
+    const nav2_util::LifecycleNode::SharedPtr& nh,
+    const std::string& plugin_name) {
   plugin_name_ = plugin_name;
   StandardTrajectoryGenerator::initialize(nh, plugin_name_);
 
@@ -55,34 +53,33 @@ void LimitedAccelGenerator::initialize(
 
   if (nh->get_parameter(plugin_name + ".sim_period", acceleration_time_)) {
   } else {
-    double controller_frequency = nav_2d_utils::searchAndGetParam(
-      nh, "controller_frequency", 20.0);
+    double controller_frequency =
+        nav_2d_utils::searchAndGetParam(nh, "controller_frequency", 20.0);
     if (controller_frequency > 0) {
       acceleration_time_ = 1.0 / controller_frequency;
     } else {
       RCLCPP_WARN(
-        rclcpp::get_logger("LimitedAccelGenerator"),
-        "A controller_frequency less than or equal to 0 has been set. "
-        "Ignoring the parameter, assuming a rate of 20Hz");
+          rclcpp::get_logger("LimitedAccelGenerator"),
+          "A controller_frequency less than or equal to 0 has been set. "
+          "Ignoring the parameter, assuming a rate of 20Hz");
       acceleration_time_ = 0.05;
     }
   }
 }
 
-void LimitedAccelGenerator::startNewIteration(const nav_2d_msgs::msg::Twist2D & current_velocity)
-{
+void LimitedAccelGenerator::startNewIteration(
+    const nav_2d_msgs::msg::Twist2D& current_velocity) {
   // Limit our search space to just those within the limited acceleration_time
   velocity_iterator_->startNewIteration(current_velocity, acceleration_time_);
 }
 
 nav_2d_msgs::msg::Twist2D LimitedAccelGenerator::computeNewVelocity(
-  const nav_2d_msgs::msg::Twist2D & cmd_vel,
-  const nav_2d_msgs::msg::Twist2D & /*start_vel*/,
-  const double /*dt*/)
-{
+    const nav_2d_msgs::msg::Twist2D& cmd_vel,
+    const nav_2d_msgs::msg::Twist2D& /*start_vel*/, const double /*dt*/) {
   return cmd_vel;
 }
 
 }  // namespace dwb_plugins
 
-PLUGINLIB_EXPORT_CLASS(dwb_plugins::LimitedAccelGenerator, dwb_core::TrajectoryGenerator)
+PLUGINLIB_EXPORT_CLASS(dwb_plugins::LimitedAccelGenerator,
+                       dwb_core::TrajectoryGenerator)

--- a/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -41,11 +41,13 @@
 #include "nav_2d_utils/parameters.hpp"
 #include "pluginlib/class_list_macros.hpp"
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 
 void LimitedAccelGenerator::initialize(
-    const nav2_util::LifecycleNode::SharedPtr& nh,
-    const std::string& plugin_name) {
+  const nav2_util::LifecycleNode::SharedPtr & nh,
+  const std::string & plugin_name)
+{
   plugin_name_ = plugin_name;
   StandardTrajectoryGenerator::initialize(nh, plugin_name_);
 
@@ -54,32 +56,35 @@ void LimitedAccelGenerator::initialize(
   if (nh->get_parameter(plugin_name + ".sim_period", acceleration_time_)) {
   } else {
     double controller_frequency =
-        nav_2d_utils::searchAndGetParam(nh, "controller_frequency", 20.0);
+      nav_2d_utils::searchAndGetParam(nh, "controller_frequency", 20.0);
     if (controller_frequency > 0) {
       acceleration_time_ = 1.0 / controller_frequency;
     } else {
       RCLCPP_WARN(
-          rclcpp::get_logger("LimitedAccelGenerator"),
-          "A controller_frequency less than or equal to 0 has been set. "
-          "Ignoring the parameter, assuming a rate of 20Hz");
+        rclcpp::get_logger("LimitedAccelGenerator"),
+        "A controller_frequency less than or equal to 0 has been set. "
+        "Ignoring the parameter, assuming a rate of 20Hz");
       acceleration_time_ = 0.05;
     }
   }
 }
 
 void LimitedAccelGenerator::startNewIteration(
-    const nav_2d_msgs::msg::Twist2D& current_velocity) {
+  const nav_2d_msgs::msg::Twist2D & current_velocity)
+{
   // Limit our search space to just those within the limited acceleration_time
   velocity_iterator_->startNewIteration(current_velocity, acceleration_time_);
 }
 
 nav_2d_msgs::msg::Twist2D LimitedAccelGenerator::computeNewVelocity(
-    const nav_2d_msgs::msg::Twist2D& cmd_vel,
-    const nav_2d_msgs::msg::Twist2D& /*start_vel*/, const double /*dt*/) {
+  const nav_2d_msgs::msg::Twist2D & cmd_vel,
+  const nav_2d_msgs::msg::Twist2D & /*start_vel*/, const double /*dt*/)
+{
   return cmd_vel;
 }
 
 }  // namespace dwb_plugins
 
-PLUGINLIB_EXPORT_CLASS(dwb_plugins::LimitedAccelGenerator,
-                       dwb_core::TrajectoryGenerator)
+PLUGINLIB_EXPORT_CLASS(
+  dwb_plugins::LimitedAccelGenerator,
+  dwb_core::TrajectoryGenerator)

--- a/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
@@ -43,24 +43,27 @@
 #include "tf2/utils.h"
 #pragma GCC diagnostic pop
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 
 SimpleGoalChecker::SimpleGoalChecker()
-    : xy_goal_tolerance_(0.25),
-      yaw_goal_tolerance_(0.25),
-      stateful_(true),
-      check_xy_(true),
-      xy_goal_tolerance_sq_(0.0625) {}
+: xy_goal_tolerance_(0.25),
+  yaw_goal_tolerance_(0.25),
+  stateful_(true),
+  check_xy_(true),
+  xy_goal_tolerance_sq_(0.0625) {}
 
 void SimpleGoalChecker::initialize(
-    const rclcpp_lifecycle::LifecycleNode::SharedPtr &nh,
-    const std::string &plugin_name) {
+  const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
+  const std::string & plugin_name)
+{
   nav2_util::declare_parameter_if_not_declared(
-      nh, plugin_name + ".xy_goal_tolerance", rclcpp::ParameterValue(0.25));
+    nh, plugin_name + ".xy_goal_tolerance", rclcpp::ParameterValue(0.25));
   nav2_util::declare_parameter_if_not_declared(
-      nh, plugin_name + ".yaw_goal_tolerance", rclcpp::ParameterValue(0.25));
-  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".stateful",
-                                               rclcpp::ParameterValue(true));
+    nh, plugin_name + ".yaw_goal_tolerance", rclcpp::ParameterValue(0.25));
+  nav2_util::declare_parameter_if_not_declared(
+    nh, plugin_name + ".stateful",
+    rclcpp::ParameterValue(true));
 
   nh->get_parameter(plugin_name + ".xy_goal_tolerance", xy_goal_tolerance_);
   nh->get_parameter(plugin_name + ".yaw_goal_tolerance", yaw_goal_tolerance_);
@@ -69,15 +72,16 @@ void SimpleGoalChecker::initialize(
   xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
 }
 
-void SimpleGoalChecker::reset() { check_xy_ = true; }
+void SimpleGoalChecker::reset() {check_xy_ = true;}
 
 bool SimpleGoalChecker::isGoalReached(
-    const geometry_msgs::msg::Pose &query_pose,
-    const geometry_msgs::msg::Pose &goal_pose,
-    const geometry_msgs::msg::Twist &) {
+  const geometry_msgs::msg::Pose & query_pose,
+  const geometry_msgs::msg::Pose & goal_pose,
+  const geometry_msgs::msg::Twist &)
+{
   if (check_xy_) {
     double dx = query_pose.position.x - goal_pose.position.x,
-           dy = query_pose.position.y - goal_pose.position.y;
+      dy = query_pose.position.y - goal_pose.position.y;
     if (dx * dx + dy * dy > xy_goal_tolerance_sq_) {
       return false;
     }
@@ -88,7 +92,7 @@ bool SimpleGoalChecker::isGoalReached(
     }
   }
   double dyaw = angles::shortest_angular_distance(
-      tf2::getYaw(query_pose.orientation), tf2::getYaw(goal_pose.orientation));
+    tf2::getYaw(query_pose.orientation), tf2::getYaw(goal_pose.orientation));
   return fabs(dyaw) < yaw_goal_tolerance_;
 }
 

--- a/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/simple_goal_checker.cpp
@@ -32,42 +32,35 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dwb_plugins/simple_goal_checker.hpp"
 #include <memory>
 #include <string>
-#include "dwb_plugins/simple_goal_checker.hpp"
-#include "pluginlib/class_list_macros.hpp"
 #include "angles/angles.h"
 #include "nav2_util/node_utils.hpp"
+#include "pluginlib/class_list_macros.hpp"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #include "tf2/utils.h"
 #pragma GCC diagnostic pop
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 
 SimpleGoalChecker::SimpleGoalChecker()
-: xy_goal_tolerance_(0.25),
-  yaw_goal_tolerance_(0.25),
-  stateful_(true),
-  check_xy_(true),
-  xy_goal_tolerance_sq_(0.0625)
-{
-}
+    : xy_goal_tolerance_(0.25),
+      yaw_goal_tolerance_(0.25),
+      stateful_(true),
+      check_xy_(true),
+      xy_goal_tolerance_sq_(0.0625) {}
 
 void SimpleGoalChecker::initialize(
-  const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
-  const std::string & plugin_name)
-{
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr &nh,
+    const std::string &plugin_name) {
   nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".xy_goal_tolerance", rclcpp::ParameterValue(0.25));
+      nh, plugin_name + ".xy_goal_tolerance", rclcpp::ParameterValue(0.25));
   nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".yaw_goal_tolerance", rclcpp::ParameterValue(0.25));
-  nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".stateful", rclcpp::ParameterValue(true));
+      nh, plugin_name + ".yaw_goal_tolerance", rclcpp::ParameterValue(0.25));
+  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".stateful",
+                                               rclcpp::ParameterValue(true));
 
   nh->get_parameter(plugin_name + ".xy_goal_tolerance", xy_goal_tolerance_);
   nh->get_parameter(plugin_name + ".yaw_goal_tolerance", yaw_goal_tolerance_);
@@ -76,18 +69,15 @@ void SimpleGoalChecker::initialize(
   xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
 }
 
-void SimpleGoalChecker::reset()
-{
-  check_xy_ = true;
-}
+void SimpleGoalChecker::reset() { check_xy_ = true; }
 
 bool SimpleGoalChecker::isGoalReached(
-  const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
-  const geometry_msgs::msg::Twist &)
-{
+    const geometry_msgs::msg::Pose &query_pose,
+    const geometry_msgs::msg::Pose &goal_pose,
+    const geometry_msgs::msg::Twist &) {
   if (check_xy_) {
     double dx = query_pose.position.x - goal_pose.position.x,
-      dy = query_pose.position.y - goal_pose.position.y;
+           dy = query_pose.position.y - goal_pose.position.y;
     if (dx * dx + dy * dy > xy_goal_tolerance_sq_) {
       return false;
     }
@@ -98,8 +88,7 @@ bool SimpleGoalChecker::isGoalReached(
     }
   }
   double dyaw = angles::shortest_angular_distance(
-    tf2::getYaw(query_pose.orientation),
-    tf2::getYaw(goal_pose.orientation));
+      tf2::getYaw(query_pose.orientation), tf2::getYaw(goal_pose.orientation));
   return fabs(dyaw) < yaw_goal_tolerance_;
 }
 

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -45,29 +45,32 @@
 
 using nav_2d_utils::loadParameterWithDeprecation;
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 
 void StandardTrajectoryGenerator::initialize(
-    const nav2_util::LifecycleNode::SharedPtr& nh,
-    const std::string& plugin_name) {
+  const nav2_util::LifecycleNode::SharedPtr & nh,
+  const std::string & plugin_name)
+{
   plugin_name_ = plugin_name;
   kinematics_handler_ = std::make_shared<KinematicsHandler>();
   kinematics_handler_->initialize(nh, plugin_name_);
   initializeIterator(nh);
 
-  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".sim_time",
-                                               rclcpp::ParameterValue(1.7));
   nav2_util::declare_parameter_if_not_declared(
-      nh, plugin_name + ".discretize_by_time", rclcpp::ParameterValue(false));
+    nh, plugin_name + ".sim_time",
+    rclcpp::ParameterValue(1.7));
+  nav2_util::declare_parameter_if_not_declared(
+    nh, plugin_name + ".discretize_by_time", rclcpp::ParameterValue(false));
 
   nav2_util::declare_parameter_if_not_declared(
-      nh, plugin_name + ".time_granularity", rclcpp::ParameterValue(0.5));
+    nh, plugin_name + ".time_granularity", rclcpp::ParameterValue(0.5));
   nav2_util::declare_parameter_if_not_declared(
-      nh, plugin_name + ".linear_granularity", rclcpp::ParameterValue(0.5));
+    nh, plugin_name + ".linear_granularity", rclcpp::ParameterValue(0.5));
   nav2_util::declare_parameter_if_not_declared(
-      nh, plugin_name + ".angular_granularity", rclcpp::ParameterValue(0.025));
+    nh, plugin_name + ".angular_granularity", rclcpp::ParameterValue(0.025));
   nav2_util::declare_parameter_if_not_declared(
-      nh, plugin_name + ".include_last_point", rclcpp::ParameterValue(true));
+    nh, plugin_name + ".include_last_point", rclcpp::ParameterValue(true));
 
   /*
    * If discretize_by_time, then sim_granularity represents the amount of time
@@ -87,26 +90,31 @@ void StandardTrajectoryGenerator::initialize(
 }
 
 void StandardTrajectoryGenerator::initializeIterator(
-    const nav2_util::LifecycleNode::SharedPtr& nh) {
+  const nav2_util::LifecycleNode::SharedPtr & nh)
+{
   velocity_iterator_ = std::make_shared<XYThetaIterator>();
   velocity_iterator_->initialize(nh, kinematics_handler_, plugin_name_);
 }
 
 void StandardTrajectoryGenerator::startNewIteration(
-    const nav_2d_msgs::msg::Twist2D& current_velocity) {
+  const nav_2d_msgs::msg::Twist2D & current_velocity)
+{
   velocity_iterator_->startNewIteration(current_velocity, sim_time_);
 }
 
-bool StandardTrajectoryGenerator::hasMoreTwists() {
+bool StandardTrajectoryGenerator::hasMoreTwists()
+{
   return velocity_iterator_->hasMoreTwists();
 }
 
-nav_2d_msgs::msg::Twist2D StandardTrajectoryGenerator::nextTwist() {
+nav_2d_msgs::msg::Twist2D StandardTrajectoryGenerator::nextTwist()
+{
   return velocity_iterator_->nextTwist();
 }
 
 std::vector<double> StandardTrajectoryGenerator::getTimeSteps(
-    const nav_2d_msgs::msg::Twist2D& cmd_vel) {
+  const nav_2d_msgs::msg::Twist2D & cmd_vel)
+{
   std::vector<double> steps;
   if (discretize_by_time_) {
     steps.resize(ceil(sim_time_ / time_granularity_));
@@ -122,8 +130,10 @@ std::vector<double> StandardTrajectoryGenerator::getTimeSteps(
 
     // Pick the maximum of the two
     int num_steps =
-        ceil(std::max(projected_linear_distance / linear_granularity_,
-                      projected_angular_distance / angular_granularity_));
+      ceil(
+      std::max(
+        projected_linear_distance / linear_granularity_,
+        projected_angular_distance / angular_granularity_));
     steps.resize(num_steps);
   }
   if (steps.size() == 0) {
@@ -134,9 +144,10 @@ std::vector<double> StandardTrajectoryGenerator::getTimeSteps(
 }
 
 dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
-    const geometry_msgs::msg::Pose2D& start_pose,
-    const nav_2d_msgs::msg::Twist2D& start_vel,
-    const nav_2d_msgs::msg::Twist2D& cmd_vel) {
+  const geometry_msgs::msg::Pose2D & start_pose,
+  const nav_2d_msgs::msg::Twist2D & start_vel,
+  const nav_2d_msgs::msg::Twist2D & cmd_vel)
+{
   dwb_msgs::msg::Trajectory2D traj;
   traj.velocity = cmd_vel;
   //  simulate the trajectory
@@ -169,35 +180,41 @@ dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
  * change vel using acceleration limits to converge towards sample_target-vel
  */
 nav_2d_msgs::msg::Twist2D StandardTrajectoryGenerator::computeNewVelocity(
-    const nav_2d_msgs::msg::Twist2D& cmd_vel,
-    const nav_2d_msgs::msg::Twist2D& start_vel, const double dt) {
+  const nav_2d_msgs::msg::Twist2D & cmd_vel,
+  const nav_2d_msgs::msg::Twist2D & start_vel, const double dt)
+{
   KinematicParameters kinematics = kinematics_handler_->getKinematics();
   nav_2d_msgs::msg::Twist2D new_vel;
-  new_vel.x = projectVelocity(start_vel.x, kinematics.getAccX(),
-                              kinematics.getDecelX(), dt, cmd_vel.x);
-  new_vel.y = projectVelocity(start_vel.y, kinematics.getAccY(),
-                              kinematics.getDecelY(), dt, cmd_vel.y);
+  new_vel.x = projectVelocity(
+    start_vel.x, kinematics.getAccX(),
+    kinematics.getDecelX(), dt, cmd_vel.x);
+  new_vel.y = projectVelocity(
+    start_vel.y, kinematics.getAccY(),
+    kinematics.getDecelY(), dt, cmd_vel.y);
   new_vel.theta =
-      projectVelocity(start_vel.theta, kinematics.getAccTheta(),
-                      kinematics.getDecelTheta(), dt, cmd_vel.theta);
+    projectVelocity(
+    start_vel.theta, kinematics.getAccTheta(),
+    kinematics.getDecelTheta(), dt, cmd_vel.theta);
   return new_vel;
 }
 
 geometry_msgs::msg::Pose2D StandardTrajectoryGenerator::computeNewPosition(
-    const geometry_msgs::msg::Pose2D start_pose,
-    const nav_2d_msgs::msg::Twist2D& vel, const double dt) {
+  const geometry_msgs::msg::Pose2D start_pose,
+  const nav_2d_msgs::msg::Twist2D & vel, const double dt)
+{
   geometry_msgs::msg::Pose2D new_pose;
   new_pose.x = start_pose.x + (vel.x * cos(start_pose.theta) +
-                               vel.y * cos(M_PI_2 + start_pose.theta)) *
-                                  dt;
+    vel.y * cos(M_PI_2 + start_pose.theta)) *
+    dt;
   new_pose.y = start_pose.y + (vel.x * sin(start_pose.theta) +
-                               vel.y * sin(M_PI_2 + start_pose.theta)) *
-                                  dt;
+    vel.y * sin(M_PI_2 + start_pose.theta)) *
+    dt;
   new_pose.theta = start_pose.theta + vel.theta * dt;
   return new_pose;
 }
 
 }  // namespace dwb_plugins
 
-PLUGINLIB_EXPORT_CLASS(dwb_plugins::StandardTrajectoryGenerator,
-                       dwb_core::TrajectoryGenerator)
+PLUGINLIB_EXPORT_CLASS(
+  dwb_plugins::StandardTrajectoryGenerator,
+  dwb_core::TrajectoryGenerator)

--- a/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/standard_traj_generator.cpp
@@ -33,57 +33,50 @@
  */
 
 #include "dwb_plugins/standard_traj_generator.hpp"
-#include <string>
-#include <vector>
 #include <algorithm>
 #include <memory>
+#include <string>
+#include <vector>
+#include "dwb_core/exceptions.hpp"
 #include "dwb_plugins/xy_theta_iterator.hpp"
+#include "nav2_util/node_utils.hpp"
 #include "nav_2d_utils/parameters.hpp"
 #include "pluginlib/class_list_macros.hpp"
-#include "dwb_core/exceptions.hpp"
-#include "nav2_util/node_utils.hpp"
 
 using nav_2d_utils::loadParameterWithDeprecation;
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 
 void StandardTrajectoryGenerator::initialize(
-  const nav2_util::LifecycleNode::SharedPtr & nh,
-  const std::string & plugin_name)
-{
+    const nav2_util::LifecycleNode::SharedPtr& nh,
+    const std::string& plugin_name) {
   plugin_name_ = plugin_name;
   kinematics_handler_ = std::make_shared<KinematicsHandler>();
   kinematics_handler_->initialize(nh, plugin_name_);
   initializeIterator(nh);
 
+  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".sim_time",
+                                               rclcpp::ParameterValue(1.7));
   nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".sim_time", rclcpp::ParameterValue(1.7));
-  nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".discretize_by_time", rclcpp::ParameterValue(false));
+      nh, plugin_name + ".discretize_by_time", rclcpp::ParameterValue(false));
 
   nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".time_granularity", rclcpp::ParameterValue(0.5));
+      nh, plugin_name + ".time_granularity", rclcpp::ParameterValue(0.5));
   nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".linear_granularity", rclcpp::ParameterValue(0.5));
+      nh, plugin_name + ".linear_granularity", rclcpp::ParameterValue(0.5));
   nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".angular_granularity", rclcpp::ParameterValue(0.025));
+      nh, plugin_name + ".angular_granularity", rclcpp::ParameterValue(0.025));
   nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".include_last_point", rclcpp::ParameterValue(true));
+      nh, plugin_name + ".include_last_point", rclcpp::ParameterValue(true));
 
   /*
-   * If discretize_by_time, then sim_granularity represents the amount of time that should be between
-   *  two successive points on the trajectory.
+   * If discretize_by_time, then sim_granularity represents the amount of time
+   * that should be between two successive points on the trajectory.
    *
-   * If discretize_by_time is false, then sim_granularity is the maximum amount of distance between
-   *  two successive points on the trajectory, and angular_sim_granularity is the maximum amount of
-   *  angular distance between two successive points.
+   * If discretize_by_time is false, then sim_granularity is the maximum amount
+   * of distance between two successive points on the trajectory, and
+   * angular_sim_granularity is the maximum amount of angular distance between
+   * two successive points.
    */
   nh->get_parameter(plugin_name + ".sim_time", sim_time_);
   nh->get_parameter(plugin_name + ".discretize_by_time", discretize_by_time_);
@@ -94,48 +87,43 @@ void StandardTrajectoryGenerator::initialize(
 }
 
 void StandardTrajectoryGenerator::initializeIterator(
-  const nav2_util::LifecycleNode::SharedPtr & nh)
-{
+    const nav2_util::LifecycleNode::SharedPtr& nh) {
   velocity_iterator_ = std::make_shared<XYThetaIterator>();
   velocity_iterator_->initialize(nh, kinematics_handler_, plugin_name_);
 }
 
 void StandardTrajectoryGenerator::startNewIteration(
-  const nav_2d_msgs::msg::Twist2D & current_velocity)
-{
+    const nav_2d_msgs::msg::Twist2D& current_velocity) {
   velocity_iterator_->startNewIteration(current_velocity, sim_time_);
 }
 
-bool StandardTrajectoryGenerator::hasMoreTwists()
-{
+bool StandardTrajectoryGenerator::hasMoreTwists() {
   return velocity_iterator_->hasMoreTwists();
 }
 
-nav_2d_msgs::msg::Twist2D StandardTrajectoryGenerator::nextTwist()
-{
+nav_2d_msgs::msg::Twist2D StandardTrajectoryGenerator::nextTwist() {
   return velocity_iterator_->nextTwist();
 }
 
 std::vector<double> StandardTrajectoryGenerator::getTimeSteps(
-  const nav_2d_msgs::msg::Twist2D & cmd_vel)
-{
+    const nav_2d_msgs::msg::Twist2D& cmd_vel) {
   std::vector<double> steps;
   if (discretize_by_time_) {
     steps.resize(ceil(sim_time_ / time_granularity_));
   } else {  // discretize by distance
     double vmag = hypot(cmd_vel.x, cmd_vel.y);
 
-    // the distance the robot would travel in sim_time if it did not change velocity
+    // the distance the robot would travel in sim_time if it did not change
+    // velocity
     double projected_linear_distance = vmag * sim_time_;
 
     // the angle the robot would rotate in sim_time
     double projected_angular_distance = fabs(cmd_vel.theta) * sim_time_;
 
     // Pick the maximum of the two
-    int num_steps = ceil(
-      std::max(
-        projected_linear_distance / linear_granularity_,
-        projected_angular_distance / angular_granularity_));
+    int num_steps =
+        ceil(std::max(projected_linear_distance / linear_granularity_,
+                      projected_angular_distance / angular_granularity_));
     steps.resize(num_steps);
   }
   if (steps.size() == 0) {
@@ -146,10 +134,9 @@ std::vector<double> StandardTrajectoryGenerator::getTimeSteps(
 }
 
 dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
-  const geometry_msgs::msg::Pose2D & start_pose,
-  const nav_2d_msgs::msg::Twist2D & start_vel,
-  const nav_2d_msgs::msg::Twist2D & cmd_vel)
-{
+    const geometry_msgs::msg::Pose2D& start_pose,
+    const nav_2d_msgs::msg::Twist2D& start_vel,
+    const nav_2d_msgs::msg::Twist2D& cmd_vel) {
   dwb_msgs::msg::Trajectory2D traj;
   traj.velocity = cmd_vel;
   //  simulate the trajectory
@@ -182,39 +169,35 @@ dwb_msgs::msg::Trajectory2D StandardTrajectoryGenerator::generateTrajectory(
  * change vel using acceleration limits to converge towards sample_target-vel
  */
 nav_2d_msgs::msg::Twist2D StandardTrajectoryGenerator::computeNewVelocity(
-  const nav_2d_msgs::msg::Twist2D & cmd_vel,
-  const nav_2d_msgs::msg::Twist2D & start_vel, const double dt)
-{
+    const nav_2d_msgs::msg::Twist2D& cmd_vel,
+    const nav_2d_msgs::msg::Twist2D& start_vel, const double dt) {
   KinematicParameters kinematics = kinematics_handler_->getKinematics();
   nav_2d_msgs::msg::Twist2D new_vel;
-  new_vel.x = projectVelocity(
-    start_vel.x, kinematics.getAccX(),
-    kinematics.getDecelX(), dt, cmd_vel.x);
-  new_vel.y = projectVelocity(
-    start_vel.y, kinematics.getAccY(),
-    kinematics.getDecelY(), dt, cmd_vel.y);
-  new_vel.theta = projectVelocity(
-    start_vel.theta,
-    kinematics.getAccTheta(), kinematics.getDecelTheta(),
-    dt, cmd_vel.theta);
+  new_vel.x = projectVelocity(start_vel.x, kinematics.getAccX(),
+                              kinematics.getDecelX(), dt, cmd_vel.x);
+  new_vel.y = projectVelocity(start_vel.y, kinematics.getAccY(),
+                              kinematics.getDecelY(), dt, cmd_vel.y);
+  new_vel.theta =
+      projectVelocity(start_vel.theta, kinematics.getAccTheta(),
+                      kinematics.getDecelTheta(), dt, cmd_vel.theta);
   return new_vel;
 }
 
 geometry_msgs::msg::Pose2D StandardTrajectoryGenerator::computeNewPosition(
-  const geometry_msgs::msg::Pose2D start_pose,
-  const nav_2d_msgs::msg::Twist2D & vel, const double dt)
-{
+    const geometry_msgs::msg::Pose2D start_pose,
+    const nav_2d_msgs::msg::Twist2D& vel, const double dt) {
   geometry_msgs::msg::Pose2D new_pose;
-  new_pose.x = start_pose.x +
-    (vel.x * cos(start_pose.theta) + vel.y * cos(M_PI_2 + start_pose.theta)) * dt;
-  new_pose.y = start_pose.y +
-    (vel.x * sin(start_pose.theta) + vel.y * sin(M_PI_2 + start_pose.theta)) * dt;
+  new_pose.x = start_pose.x + (vel.x * cos(start_pose.theta) +
+                               vel.y * cos(M_PI_2 + start_pose.theta)) *
+                                  dt;
+  new_pose.y = start_pose.y + (vel.x * sin(start_pose.theta) +
+                               vel.y * sin(M_PI_2 + start_pose.theta)) *
+                                  dt;
   new_pose.theta = start_pose.theta + vel.theta * dt;
   return new_pose;
 }
 
 }  // namespace dwb_plugins
 
-PLUGINLIB_EXPORT_CLASS(
-  dwb_plugins::StandardTrajectoryGenerator,
-  dwb_core::TrajectoryGenerator)
+PLUGINLIB_EXPORT_CLASS(dwb_plugins::StandardTrajectoryGenerator,
+                       dwb_core::TrajectoryGenerator)

--- a/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
@@ -32,45 +32,44 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <cmath>
-#include <string>
-#include <memory>
 #include "dwb_plugins/stopped_goal_checker.hpp"
-#include "pluginlib/class_list_macros.hpp"
+#include <cmath>
+#include <memory>
+#include <string>
 #include "nav2_util/node_utils.hpp"
+#include "pluginlib/class_list_macros.hpp"
 
-using std::hypot;
 using std::fabs;
+using std::hypot;
 
-namespace dwb_plugins
-{
+namespace dwb_plugins {
 
 StoppedGoalChecker::StoppedGoalChecker()
-: SimpleGoalChecker(), rot_stopped_velocity_(0.25), trans_stopped_velocity_(0.25)
-{
-}
+    : SimpleGoalChecker(),
+      rot_stopped_velocity_(0.25),
+      trans_stopped_velocity_(0.25) {}
 
 void StoppedGoalChecker::initialize(
-  const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
-  const std::string & plugin_name)
-{
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr& nh,
+    const std::string& plugin_name) {
   SimpleGoalChecker::initialize(nh, plugin_name);
 
   nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".rot_stopped_velocity", rclcpp::ParameterValue(0.25));
+      nh, plugin_name + ".rot_stopped_velocity", rclcpp::ParameterValue(0.25));
   nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".trans_stopped_velocity", rclcpp::ParameterValue(0.25));
+      nh, plugin_name + ".trans_stopped_velocity",
+      rclcpp::ParameterValue(0.25));
 
-  nh->get_parameter(plugin_name + ".rot_stopped_velocity", rot_stopped_velocity_);
-  nh->get_parameter(plugin_name + ".trans_stopped_velocity", trans_stopped_velocity_);
+  nh->get_parameter(plugin_name + ".rot_stopped_velocity",
+                    rot_stopped_velocity_);
+  nh->get_parameter(plugin_name + ".trans_stopped_velocity",
+                    trans_stopped_velocity_);
 }
 
 bool StoppedGoalChecker::isGoalReached(
-  const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
-  const geometry_msgs::msg::Twist & velocity)
-{
+    const geometry_msgs::msg::Pose& query_pose,
+    const geometry_msgs::msg::Pose& goal_pose,
+    const geometry_msgs::msg::Twist& velocity) {
   bool ret = SimpleGoalChecker::isGoalReached(query_pose, goal_pose, velocity);
   if (!ret) {
     return ret;

--- a/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/stopped_goal_checker.cpp
@@ -42,34 +42,39 @@
 using std::fabs;
 using std::hypot;
 
-namespace dwb_plugins {
+namespace dwb_plugins
+{
 
 StoppedGoalChecker::StoppedGoalChecker()
-    : SimpleGoalChecker(),
-      rot_stopped_velocity_(0.25),
-      trans_stopped_velocity_(0.25) {}
+: SimpleGoalChecker(),
+  rot_stopped_velocity_(0.25),
+  trans_stopped_velocity_(0.25) {}
 
 void StoppedGoalChecker::initialize(
-    const rclcpp_lifecycle::LifecycleNode::SharedPtr& nh,
-    const std::string& plugin_name) {
+  const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh,
+  const std::string & plugin_name)
+{
   SimpleGoalChecker::initialize(nh, plugin_name);
 
   nav2_util::declare_parameter_if_not_declared(
-      nh, plugin_name + ".rot_stopped_velocity", rclcpp::ParameterValue(0.25));
+    nh, plugin_name + ".rot_stopped_velocity", rclcpp::ParameterValue(0.25));
   nav2_util::declare_parameter_if_not_declared(
-      nh, plugin_name + ".trans_stopped_velocity",
-      rclcpp::ParameterValue(0.25));
+    nh, plugin_name + ".trans_stopped_velocity",
+    rclcpp::ParameterValue(0.25));
 
-  nh->get_parameter(plugin_name + ".rot_stopped_velocity",
-                    rot_stopped_velocity_);
-  nh->get_parameter(plugin_name + ".trans_stopped_velocity",
-                    trans_stopped_velocity_);
+  nh->get_parameter(
+    plugin_name + ".rot_stopped_velocity",
+    rot_stopped_velocity_);
+  nh->get_parameter(
+    plugin_name + ".trans_stopped_velocity",
+    trans_stopped_velocity_);
 }
 
 bool StoppedGoalChecker::isGoalReached(
-    const geometry_msgs::msg::Pose& query_pose,
-    const geometry_msgs::msg::Pose& goal_pose,
-    const geometry_msgs::msg::Twist& velocity) {
+  const geometry_msgs::msg::Pose & query_pose,
+  const geometry_msgs::msg::Pose & goal_pose,
+  const geometry_msgs::msg::Twist & velocity)
+{
   bool ret = SimpleGoalChecker::isGoalReached(query_pose, goal_pose, velocity);
   if (!ret) {
     return ret;

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -33,90 +33,77 @@
  */
 
 #include "dwb_plugins/xy_theta_iterator.hpp"
+#include <cmath>
 #include <memory>
 #include <string>
-#include <cmath>
-#include "nav_2d_utils/parameters.hpp"
 #include "nav2_util/node_utils.hpp"
+#include "nav_2d_utils/parameters.hpp"
 
 #define EPSILON 1E-5
 
-namespace dwb_plugins
-{
-void XYThetaIterator::initialize(
-  const nav2_util::LifecycleNode::SharedPtr & nh, KinematicsHandler::Ptr kinematics,
-  const std::string & plugin_name)
-{
+namespace dwb_plugins {
+void XYThetaIterator::initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
+                                 KinematicsHandler::Ptr kinematics,
+                                 const std::string& plugin_name) {
   kinematics_handler_ = kinematics;
 
+  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".vx_samples",
+                                               rclcpp::ParameterValue(20));
+  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".vy_samples",
+                                               rclcpp::ParameterValue(5));
   nav2_util::declare_parameter_if_not_declared(
-    nh, plugin_name + ".vx_samples", rclcpp::ParameterValue(
-      20));
-  nav2_util::declare_parameter_if_not_declared(
-    nh, plugin_name + ".vy_samples", rclcpp::ParameterValue(
-      5));
-  nav2_util::declare_parameter_if_not_declared(
-    nh, plugin_name + ".vtheta_samples", rclcpp::ParameterValue(
-      20));
+      nh, plugin_name + ".vtheta_samples", rclcpp::ParameterValue(20));
 
   nh->get_parameter(plugin_name + ".vx_samples", vx_samples_);
   nh->get_parameter(plugin_name + ".vy_samples", vy_samples_);
   nh->get_parameter(plugin_name + ".vtheta_samples", vtheta_samples_);
-
-
 }
 
 void XYThetaIterator::startNewIteration(
-  const nav_2d_msgs::msg::Twist2D & current_velocity,
-  double dt)
-{
+    const nav_2d_msgs::msg::Twist2D& current_velocity, double dt) {
   KinematicParameters kinematics = kinematics_handler_->getKinematics();
   x_it_ = std::make_shared<OneDVelocityIterator>(
-    current_velocity.x, kinematics.getMinX(), kinematics.getMaxX(),
-    kinematics.getAccX(), kinematics.getDecelX(), dt, vx_samples_);
+      current_velocity.x, kinematics.getMinX(), kinematics.getMaxX(),
+      kinematics.getAccX(), kinematics.getDecelX(), dt, vx_samples_);
   y_it_ = std::make_shared<OneDVelocityIterator>(
-    current_velocity.y, kinematics.getMinY(), kinematics.getMaxY(),
-    kinematics.getAccY(), kinematics.getDecelY(), dt, vy_samples_);
-  th_it_ =
-    std::make_shared<OneDVelocityIterator>(
-    current_velocity.theta, kinematics.getMinTheta(), kinematics.getMaxTheta(),
-    kinematics.getAccTheta(), kinematics.getDecelTheta(), dt, vtheta_samples_);
+      current_velocity.y, kinematics.getMinY(), kinematics.getMaxY(),
+      kinematics.getAccY(), kinematics.getDecelY(), dt, vy_samples_);
+  th_it_ = std::make_shared<OneDVelocityIterator>(
+      current_velocity.theta, kinematics.getMinTheta(),
+      kinematics.getMaxTheta(), kinematics.getAccTheta(),
+      kinematics.getDecelTheta(), dt, vtheta_samples_);
   if (!isValidVelocity()) {
     iterateToValidVelocity();
   }
 }
 
-bool XYThetaIterator::isValidSpeed(double x, double y, double theta)
-{
+bool XYThetaIterator::isValidSpeed(double x, double y, double theta) {
   KinematicParameters kinematics = kinematics_handler_->getKinematics();
   double vmag_sq = x * x + y * y;
-  if (kinematics.getMaxSpeedXY() >= 0.0 && vmag_sq > kinematics.getMaxSpeedXY_SQ() + EPSILON) {
+  if (kinematics.getMaxSpeedXY() >= 0.0 &&
+      vmag_sq > kinematics.getMaxSpeedXY_SQ() + EPSILON) {
     return false;
   }
-  if (kinematics.getMinSpeedXY() >= 0.0 && vmag_sq + EPSILON < kinematics.getMinSpeedXY_SQ() &&
-    kinematics.getMinTheta() >= 0.0 && fabs(theta) + EPSILON < kinematics.getMinTheta())
-  {
+  if (kinematics.getMinSpeedXY() >= 0.0 &&
+      vmag_sq + EPSILON < kinematics.getMinSpeedXY_SQ() &&
+      kinematics.getMinTheta() >= 0.0 &&
+      fabs(theta) + EPSILON < kinematics.getMinTheta()) {
     return false;
   }
-  if (vmag_sq == 0.0 && th_it_->getVelocity() == 0.0) {return false;}
+  if (vmag_sq == 0.0 && th_it_->getVelocity() == 0.0) {
+    return false;
+  }
   return true;
-
 }
 
-bool XYThetaIterator::isValidVelocity()
-{
-  return isValidSpeed(
-    x_it_->getVelocity(), y_it_->getVelocity(),
-    th_it_->getVelocity());
+bool XYThetaIterator::isValidVelocity() {
+  return isValidSpeed(x_it_->getVelocity(), y_it_->getVelocity(),
+                      th_it_->getVelocity());
 }
 
-bool XYThetaIterator::hasMoreTwists()
-{
-  return x_it_ && !x_it_->isFinished();
-}
+bool XYThetaIterator::hasMoreTwists() { return x_it_ && !x_it_->isFinished(); }
 
-nav_2d_msgs::msg::Twist2D XYThetaIterator::nextTwist()
-{
+nav_2d_msgs::msg::Twist2D XYThetaIterator::nextTwist() {
   nav_2d_msgs::msg::Twist2D velocity;
   velocity.x = x_it_->getVelocity();
   velocity.y = y_it_->getVelocity();
@@ -127,8 +114,7 @@ nav_2d_msgs::msg::Twist2D XYThetaIterator::nextTwist()
   return velocity;
 }
 
-void XYThetaIterator::iterateToValidVelocity()
-{
+void XYThetaIterator::iterateToValidVelocity() {
   bool valid = false;
   while (!valid && hasMoreTwists()) {
     ++(*th_it_);

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -35,45 +35,79 @@
 #include "dwb_plugins/xy_theta_iterator.hpp"
 #include <memory>
 #include <string>
+#include <cmath>
 #include "nav_2d_utils/parameters.hpp"
 #include "nav2_util/node_utils.hpp"
 
+#define EPSILON 1E-5
+
 namespace dwb_plugins
 {
-void XYThetaIterator::initialize(const nav2_util::LifecycleNode::SharedPtr& nh, KinematicsHandler::Ptr kinematics,
-                                 const std::string& plugin_name)
+void XYThetaIterator::initialize(
+  const nav2_util::LifecycleNode::SharedPtr & nh, KinematicsHandler::Ptr kinematics,
+  const std::string & plugin_name)
 {
   kinematics_handler_ = kinematics;
 
-  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".vx_samples", rclcpp::ParameterValue(20));
-  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".vy_samples", rclcpp::ParameterValue(5));
-  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".vtheta_samples", rclcpp::ParameterValue(20));
+  nav2_util::declare_parameter_if_not_declared(
+    nh, plugin_name + ".vx_samples", rclcpp::ParameterValue(
+      20));
+  nav2_util::declare_parameter_if_not_declared(
+    nh, plugin_name + ".vy_samples", rclcpp::ParameterValue(
+      5));
+  nav2_util::declare_parameter_if_not_declared(
+    nh, plugin_name + ".vtheta_samples", rclcpp::ParameterValue(
+      20));
 
   nh->get_parameter(plugin_name + ".vx_samples", vx_samples_);
   nh->get_parameter(plugin_name + ".vy_samples", vy_samples_);
   nh->get_parameter(plugin_name + ".vtheta_samples", vtheta_samples_);
+
+
 }
 
-void XYThetaIterator::startNewIteration(const nav_2d_msgs::msg::Twist2D& current_velocity, double dt)
+void XYThetaIterator::startNewIteration(
+  const nav_2d_msgs::msg::Twist2D & current_velocity,
+  double dt)
 {
   KinematicParameters kinematics = kinematics_handler_->getKinematics();
-  x_it_ = std::make_shared<OneDVelocityIterator>(current_velocity.x, kinematics.getMinX(), kinematics.getMaxX(),
-                                                 kinematics.getAccX(), kinematics.getDecelX(), dt, vx_samples_);
-  y_it_ = std::make_shared<OneDVelocityIterator>(current_velocity.y, kinematics.getMinY(), kinematics.getMaxY(),
-                                                 kinematics.getAccY(), kinematics.getDecelY(), dt, vy_samples_);
+  x_it_ = std::make_shared<OneDVelocityIterator>(
+    current_velocity.x, kinematics.getMinX(), kinematics.getMaxX(),
+    kinematics.getAccX(), kinematics.getDecelX(), dt, vx_samples_);
+  y_it_ = std::make_shared<OneDVelocityIterator>(
+    current_velocity.y, kinematics.getMinY(), kinematics.getMaxY(),
+    kinematics.getAccY(), kinematics.getDecelY(), dt, vy_samples_);
   th_it_ =
-      std::make_shared<OneDVelocityIterator>(current_velocity.theta, kinematics.getMinTheta(), kinematics.getMaxTheta(),
-                                             kinematics.getAccTheta(), kinematics.getDecelTheta(), dt, vtheta_samples_);
-  if (!isValidVelocity())
-  {
+    std::make_shared<OneDVelocityIterator>(
+    current_velocity.theta, kinematics.getMinTheta(), kinematics.getMaxTheta(),
+    kinematics.getAccTheta(), kinematics.getDecelTheta(), dt, vtheta_samples_);
+  if (!isValidVelocity()) {
     iterateToValidVelocity();
   }
 }
 
+bool XYThetaIterator::isValidSpeed(double x, double y, double theta)
+{
+  KinematicParameters kinematics = kinematics_handler_->getKinematics();
+  double vmag_sq = x * x + y * y;
+  if (kinematics.getMaxSpeedXY() >= 0.0 && vmag_sq > kinematics.getMaxSpeedXY_SQ() + EPSILON) {
+    return false;
+  }
+  if (kinematics.getMinSpeedXY() >= 0.0 && vmag_sq + EPSILON < kinematics.getMinSpeedXY_SQ() &&
+    kinematics.getMinTheta() >= 0.0 && fabs(theta) + EPSILON < kinematics.getMinTheta())
+  {
+    return false;
+  }
+  if (vmag_sq == 0.0 && th_it_->getVelocity() == 0.0) {return false;}
+  return true;
+
+}
+
 bool XYThetaIterator::isValidVelocity()
 {
-  return ((x_it_->getVelocity() != 0.0 || y_it_->getVelocity() != 0.0 || th_it_->getVelocity() != 0.0) &&
-          kinematics_handler_->isValidSpeed(x_it_->getVelocity(), y_it_->getVelocity(), th_it_->getVelocity()));
+  return isValidSpeed(
+    x_it_->getVelocity(), y_it_->getVelocity(),
+    th_it_->getVelocity());
 }
 
 bool XYThetaIterator::hasMoreTwists()
@@ -96,15 +130,12 @@ nav_2d_msgs::msg::Twist2D XYThetaIterator::nextTwist()
 void XYThetaIterator::iterateToValidVelocity()
 {
   bool valid = false;
-  while (!valid && hasMoreTwists())
-  {
+  while (!valid && hasMoreTwists()) {
     ++(*th_it_);
-    if (th_it_->isFinished())
-    {
+    if (th_it_->isFinished()) {
       th_it_->reset();
       ++(*y_it_);
-      if (y_it_->isFinished())
-      {
+      if (y_it_->isFinished()) {
         y_it_->reset();
         ++(*x_it_);
       }

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -41,18 +41,23 @@
 
 #define EPSILON 1E-5
 
-namespace dwb_plugins {
-void XYThetaIterator::initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
-                                 KinematicsHandler::Ptr kinematics,
-                                 const std::string& plugin_name) {
+namespace dwb_plugins
+{
+void XYThetaIterator::initialize(
+  const nav2_util::LifecycleNode::SharedPtr & nh,
+  KinematicsHandler::Ptr kinematics,
+  const std::string & plugin_name)
+{
   kinematics_handler_ = kinematics;
 
-  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".vx_samples",
-                                               rclcpp::ParameterValue(20));
-  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".vy_samples",
-                                               rclcpp::ParameterValue(5));
   nav2_util::declare_parameter_if_not_declared(
-      nh, plugin_name + ".vtheta_samples", rclcpp::ParameterValue(20));
+    nh, plugin_name + ".vx_samples",
+    rclcpp::ParameterValue(20));
+  nav2_util::declare_parameter_if_not_declared(
+    nh, plugin_name + ".vy_samples",
+    rclcpp::ParameterValue(5));
+  nav2_util::declare_parameter_if_not_declared(
+    nh, plugin_name + ".vtheta_samples", rclcpp::ParameterValue(20));
 
   nh->get_parameter(plugin_name + ".vx_samples", vx_samples_);
   nh->get_parameter(plugin_name + ".vy_samples", vy_samples_);
@@ -60,34 +65,38 @@ void XYThetaIterator::initialize(const nav2_util::LifecycleNode::SharedPtr& nh,
 }
 
 void XYThetaIterator::startNewIteration(
-    const nav_2d_msgs::msg::Twist2D& current_velocity, double dt) {
+  const nav_2d_msgs::msg::Twist2D & current_velocity, double dt)
+{
   KinematicParameters kinematics = kinematics_handler_->getKinematics();
   x_it_ = std::make_shared<OneDVelocityIterator>(
-      current_velocity.x, kinematics.getMinX(), kinematics.getMaxX(),
-      kinematics.getAccX(), kinematics.getDecelX(), dt, vx_samples_);
+    current_velocity.x, kinematics.getMinX(), kinematics.getMaxX(),
+    kinematics.getAccX(), kinematics.getDecelX(), dt, vx_samples_);
   y_it_ = std::make_shared<OneDVelocityIterator>(
-      current_velocity.y, kinematics.getMinY(), kinematics.getMaxY(),
-      kinematics.getAccY(), kinematics.getDecelY(), dt, vy_samples_);
+    current_velocity.y, kinematics.getMinY(), kinematics.getMaxY(),
+    kinematics.getAccY(), kinematics.getDecelY(), dt, vy_samples_);
   th_it_ = std::make_shared<OneDVelocityIterator>(
-      current_velocity.theta, kinematics.getMinTheta(),
-      kinematics.getMaxTheta(), kinematics.getAccTheta(),
-      kinematics.getDecelTheta(), dt, vtheta_samples_);
+    current_velocity.theta, kinematics.getMinTheta(),
+    kinematics.getMaxTheta(), kinematics.getAccTheta(),
+    kinematics.getDecelTheta(), dt, vtheta_samples_);
   if (!isValidVelocity()) {
     iterateToValidVelocity();
   }
 }
 
-bool XYThetaIterator::isValidSpeed(double x, double y, double theta) {
+bool XYThetaIterator::isValidSpeed(double x, double y, double theta)
+{
   KinematicParameters kinematics = kinematics_handler_->getKinematics();
   double vmag_sq = x * x + y * y;
   if (kinematics.getMaxSpeedXY() >= 0.0 &&
-      vmag_sq > kinematics.getMaxSpeedXY_SQ() + EPSILON) {
+    vmag_sq > kinematics.getMaxSpeedXY_SQ() + EPSILON)
+  {
     return false;
   }
   if (kinematics.getMinSpeedXY() >= 0.0 &&
-      vmag_sq + EPSILON < kinematics.getMinSpeedXY_SQ() &&
-      kinematics.getMinTheta() >= 0.0 &&
-      fabs(theta) + EPSILON < kinematics.getMinTheta()) {
+    vmag_sq + EPSILON < kinematics.getMinSpeedXY_SQ() &&
+    kinematics.getMinTheta() >= 0.0 &&
+    fabs(theta) + EPSILON < kinematics.getMinTheta())
+  {
     return false;
   }
   if (vmag_sq == 0.0 && th_it_->getVelocity() == 0.0) {
@@ -96,14 +105,17 @@ bool XYThetaIterator::isValidSpeed(double x, double y, double theta) {
   return true;
 }
 
-bool XYThetaIterator::isValidVelocity() {
-  return isValidSpeed(x_it_->getVelocity(), y_it_->getVelocity(),
-                      th_it_->getVelocity());
+bool XYThetaIterator::isValidVelocity()
+{
+  return isValidSpeed(
+    x_it_->getVelocity(), y_it_->getVelocity(),
+    th_it_->getVelocity());
 }
 
-bool XYThetaIterator::hasMoreTwists() { return x_it_ && !x_it_->isFinished(); }
+bool XYThetaIterator::hasMoreTwists() {return x_it_ && !x_it_->isFinished();}
 
-nav_2d_msgs::msg::Twist2D XYThetaIterator::nextTwist() {
+nav_2d_msgs::msg::Twist2D XYThetaIterator::nextTwist()
+{
   nav_2d_msgs::msg::Twist2D velocity;
   velocity.x = x_it_->getVelocity();
   velocity.y = y_it_->getVelocity();
@@ -114,7 +126,8 @@ nav_2d_msgs::msg::Twist2D XYThetaIterator::nextTwist() {
   return velocity;
 }
 
-void XYThetaIterator::iterateToValidVelocity() {
+void XYThetaIterator::iterateToValidVelocity()
+{
   bool valid = false;
   while (!valid && hasMoreTwists()) {
     ++(*th_it_);

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -40,63 +40,46 @@
 
 namespace dwb_plugins
 {
-void XYThetaIterator::initialize(
-  const nav2_util::LifecycleNode::SharedPtr & nh,
-  KinematicsHandler::Ptr kinematics,
-  const std::string & plugin_name)
+void XYThetaIterator::initialize(const nav2_util::LifecycleNode::SharedPtr& nh, KinematicsHandler::Ptr kinematics,
+                                 const std::string& plugin_name)
 {
   kinematics_handler_ = kinematics;
 
-  nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".vx_samples", rclcpp::ParameterValue(20));
-  nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".vy_samples", rclcpp::ParameterValue(5));
-  nav2_util::declare_parameter_if_not_declared(
-    nh,
-    plugin_name + ".vtheta_samples", rclcpp::ParameterValue(20));
+  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".vx_samples", rclcpp::ParameterValue(20));
+  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".vy_samples", rclcpp::ParameterValue(5));
+  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".vtheta_samples", rclcpp::ParameterValue(20));
 
   nh->get_parameter(plugin_name + ".vx_samples", vx_samples_);
   nh->get_parameter(plugin_name + ".vy_samples", vy_samples_);
   nh->get_parameter(plugin_name + ".vtheta_samples", vtheta_samples_);
 }
 
-void XYThetaIterator::startNewIteration(
-  const nav_2d_msgs::msg::Twist2D & current_velocity,
-  double dt)
+void XYThetaIterator::startNewIteration(const nav_2d_msgs::msg::Twist2D& current_velocity, double dt)
 {
   KinematicParameters kinematics = kinematics_handler_->getKinematics();
-  x_it_ = std::make_shared<OneDVelocityIterator>(
-    current_velocity.x,
-    kinematics.getMinX(), kinematics.getMaxX(),
-    kinematics.getAccX(), kinematics.getDecelX(), dt, vx_samples_);
-  y_it_ = std::make_shared<OneDVelocityIterator>(
-    current_velocity.y,
-    kinematics.getMinY(), kinematics.getMaxY(),
-    kinematics.getAccY(), kinematics.getDecelY(), dt, vy_samples_);
-  th_it_ = std::make_shared<OneDVelocityIterator>(
-    current_velocity.theta,
-    kinematics.getMinTheta(), kinematics.getMaxTheta(),
-    kinematics.getAccTheta(), kinematics.getDecelTheta(),
-    dt, vtheta_samples_);
-  if (!isValidVelocity()) {
+  x_it_ = std::make_shared<OneDVelocityIterator>(current_velocity.x, kinematics.getMinX(), kinematics.getMaxX(),
+                                                 kinematics.getAccX(), kinematics.getDecelX(), dt, vx_samples_);
+  y_it_ = std::make_shared<OneDVelocityIterator>(current_velocity.y, kinematics.getMinY(), kinematics.getMaxY(),
+                                                 kinematics.getAccY(), kinematics.getDecelY(), dt, vy_samples_);
+  th_it_ =
+      std::make_shared<OneDVelocityIterator>(current_velocity.theta, kinematics.getMinTheta(), kinematics.getMaxTheta(),
+                                             kinematics.getAccTheta(), kinematics.getDecelTheta(), dt, vtheta_samples_);
+  if (!isValidVelocity())
+  {
     iterateToValidVelocity();
   }
 }
 
 bool XYThetaIterator::isValidVelocity()
 {
-  return kinematics_handler_->isValidSpeed(
-    x_it_->getVelocity(), y_it_->getVelocity(),
-    th_it_->getVelocity());
+  return ((x_it_->getVelocity() != 0.0 || y_it_->getVelocity() != 0.0 || th_it_->getVelocity() != 0.0) &&
+          kinematics_handler_->isValidSpeed(x_it_->getVelocity(), y_it_->getVelocity(), th_it_->getVelocity()));
 }
 
 bool XYThetaIterator::hasMoreTwists()
 {
   return x_it_ && !x_it_->isFinished();
 }
-
 
 nav_2d_msgs::msg::Twist2D XYThetaIterator::nextTwist()
 {
@@ -113,12 +96,15 @@ nav_2d_msgs::msg::Twist2D XYThetaIterator::nextTwist()
 void XYThetaIterator::iterateToValidVelocity()
 {
   bool valid = false;
-  while (!valid && hasMoreTwists()) {
+  while (!valid && hasMoreTwists())
+  {
     ++(*th_it_);
-    if (th_it_->isFinished()) {
+    if (th_it_->isFinished())
+    {
       th_it_->reset();
       ++(*y_it_);
-      if (y_it_->isFinished()) {
+      if (y_it_->isFinished())
+      {
         y_it_->reset();
         ++(*x_it_);
       }

--- a/nav2_dwb_controller/dwb_plugins/test/goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/goal_checker.cpp
@@ -35,22 +35,18 @@
 #include <memory>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "dwb_plugins/simple_goal_checker.hpp"
 #include "dwb_plugins/stopped_goal_checker.hpp"
-#include "nav_2d_utils/conversions.hpp"
+#include "gtest/gtest.h"
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav_2d_utils/conversions.hpp"
 
 using dwb_plugins::SimpleGoalChecker;
 using dwb_plugins::StoppedGoalChecker;
 
-void checkMacro(
-  nav2_core::GoalChecker & gc,
-  double x0, double y0, double theta0,
-  double x1, double y1, double theta1,
-  double xv, double yv, double thetav,
-  bool expected_result)
-{
+void checkMacro(nav2_core::GoalChecker &gc, double x0, double y0, double theta0,
+                double x1, double y1, double theta1, double xv, double yv,
+                double thetav, bool expected_result) {
   gc.reset();
   geometry_msgs::msg::Pose2D pose0, pose1;
   pose0.x = x0;
@@ -64,89 +60,72 @@ void checkMacro(
   v.y = yv;
   v.theta = thetav;
   if (expected_result) {
-    EXPECT_TRUE(
-      gc.isGoalReached(
-        nav_2d_utils::pose2DToPose(pose0),
-        nav_2d_utils::pose2DToPose(pose1), nav_2d_utils::twist2Dto3D(v)));
+    EXPECT_TRUE(gc.isGoalReached(nav_2d_utils::pose2DToPose(pose0),
+                                 nav_2d_utils::pose2DToPose(pose1),
+                                 nav_2d_utils::twist2Dto3D(v)));
   } else {
-    EXPECT_FALSE(
-      gc.isGoalReached(
-        nav_2d_utils::pose2DToPose(pose0),
-        nav_2d_utils::pose2DToPose(pose1), nav_2d_utils::twist2Dto3D(v)));
+    EXPECT_FALSE(gc.isGoalReached(nav_2d_utils::pose2DToPose(pose0),
+                                  nav_2d_utils::pose2DToPose(pose1),
+                                  nav_2d_utils::twist2Dto3D(v)));
   }
 }
 
-void sameResult(
-  nav2_core::GoalChecker & gc0, nav2_core::GoalChecker & gc1,
-  double x0, double y0, double theta0,
-  double x1, double y1, double theta1,
-  double xv, double yv, double thetav,
-  bool expected_result)
-{
-  checkMacro(gc0, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav, expected_result);
-  checkMacro(gc1, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav, expected_result);
+void sameResult(nav2_core::GoalChecker &gc0, nav2_core::GoalChecker &gc1,
+                double x0, double y0, double theta0, double x1, double y1,
+                double theta1, double xv, double yv, double thetav,
+                bool expected_result) {
+  checkMacro(gc0, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav,
+             expected_result);
+  checkMacro(gc1, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav,
+             expected_result);
 }
 
-void trueFalse(
-  nav2_core::GoalChecker & gc0, nav2_core::GoalChecker & gc1,
-  double x0, double y0, double theta0,
-  double x1, double y1, double theta1,
-  double xv, double yv, double thetav)
-{
+void trueFalse(nav2_core::GoalChecker &gc0, nav2_core::GoalChecker &gc1,
+               double x0, double y0, double theta0, double x1, double y1,
+               double theta1, double xv, double yv, double thetav) {
   checkMacro(gc0, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav, true);
   checkMacro(gc1, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav, false);
 }
-class TestLifecycleNode : public nav2_util::LifecycleNode
-{
-public:
-  explicit TestLifecycleNode(const std::string & name)
-  : nav2_util::LifecycleNode(name)
-  {
-  }
+class TestLifecycleNode : public nav2_util::LifecycleNode {
+ public:
+  explicit TestLifecycleNode(const std::string &name)
+      : nav2_util::LifecycleNode(name) {}
 
-  nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State &)
-  {
+  nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State &) {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 
-  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State &)
-  {
+  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State &) {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 
-  nav2_util::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &)
-  {
+  nav2_util::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &) {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 
-  nav2_util::CallbackReturn on_cleanup(const rclcpp_lifecycle::State &)
-  {
+  nav2_util::CallbackReturn on_cleanup(const rclcpp_lifecycle::State &) {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 
-  nav2_util::CallbackReturn onShutdown(const rclcpp_lifecycle::State &)
-  {
+  nav2_util::CallbackReturn onShutdown(const rclcpp_lifecycle::State &) {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 
-  nav2_util::CallbackReturn onError(const rclcpp_lifecycle::State &)
-  {
+  nav2_util::CallbackReturn onError(const rclcpp_lifecycle::State &) {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 };
 
-TEST(VelocityIterator, goal_checker_reset)
-{
+TEST(VelocityIterator, goal_checker_reset) {
   auto x = std::make_shared<TestLifecycleNode>("goal_checker");
 
-  nav2_core::GoalChecker * gc = new SimpleGoalChecker;
+  nav2_core::GoalChecker *gc = new SimpleGoalChecker;
   gc->reset();
   delete gc;
   EXPECT_TRUE(true);
 }
 
-TEST(VelocityIterator, two_checks)
-{
+TEST(VelocityIterator, two_checks) {
   auto x = std::make_shared<TestLifecycleNode>("goal_checker");
 
   SimpleGoalChecker gc;
@@ -164,8 +143,7 @@ TEST(VelocityIterator, two_checks)
   trueFalse(gc, sgc, 0, 0, 0, 0, 0, 0, 0, 0, 1);
 }
 
-int main(int argc, char ** argv)
-{
+int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/nav2_dwb_controller/dwb_plugins/test/goal_checker.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/goal_checker.cpp
@@ -44,9 +44,11 @@
 using dwb_plugins::SimpleGoalChecker;
 using dwb_plugins::StoppedGoalChecker;
 
-void checkMacro(nav2_core::GoalChecker &gc, double x0, double y0, double theta0,
-                double x1, double y1, double theta1, double xv, double yv,
-                double thetav, bool expected_result) {
+void checkMacro(
+  nav2_core::GoalChecker & gc, double x0, double y0, double theta0,
+  double x1, double y1, double theta1, double xv, double yv,
+  double thetav, bool expected_result)
+{
   gc.reset();
   geometry_msgs::msg::Pose2D pose0, pose1;
   pose0.x = x0;
@@ -60,58 +62,75 @@ void checkMacro(nav2_core::GoalChecker &gc, double x0, double y0, double theta0,
   v.y = yv;
   v.theta = thetav;
   if (expected_result) {
-    EXPECT_TRUE(gc.isGoalReached(nav_2d_utils::pose2DToPose(pose0),
-                                 nav_2d_utils::pose2DToPose(pose1),
-                                 nav_2d_utils::twist2Dto3D(v)));
+    EXPECT_TRUE(
+      gc.isGoalReached(
+        nav_2d_utils::pose2DToPose(pose0),
+        nav_2d_utils::pose2DToPose(pose1),
+        nav_2d_utils::twist2Dto3D(v)));
   } else {
-    EXPECT_FALSE(gc.isGoalReached(nav_2d_utils::pose2DToPose(pose0),
-                                  nav_2d_utils::pose2DToPose(pose1),
-                                  nav_2d_utils::twist2Dto3D(v)));
+    EXPECT_FALSE(
+      gc.isGoalReached(
+        nav_2d_utils::pose2DToPose(pose0),
+        nav_2d_utils::pose2DToPose(pose1),
+        nav_2d_utils::twist2Dto3D(v)));
   }
 }
 
-void sameResult(nav2_core::GoalChecker &gc0, nav2_core::GoalChecker &gc1,
-                double x0, double y0, double theta0, double x1, double y1,
-                double theta1, double xv, double yv, double thetav,
-                bool expected_result) {
-  checkMacro(gc0, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav,
-             expected_result);
-  checkMacro(gc1, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav,
-             expected_result);
+void sameResult(
+  nav2_core::GoalChecker & gc0, nav2_core::GoalChecker & gc1,
+  double x0, double y0, double theta0, double x1, double y1,
+  double theta1, double xv, double yv, double thetav,
+  bool expected_result)
+{
+  checkMacro(
+    gc0, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav,
+    expected_result);
+  checkMacro(
+    gc1, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav,
+    expected_result);
 }
 
-void trueFalse(nav2_core::GoalChecker &gc0, nav2_core::GoalChecker &gc1,
-               double x0, double y0, double theta0, double x1, double y1,
-               double theta1, double xv, double yv, double thetav) {
+void trueFalse(
+  nav2_core::GoalChecker & gc0, nav2_core::GoalChecker & gc1,
+  double x0, double y0, double theta0, double x1, double y1,
+  double theta1, double xv, double yv, double thetav)
+{
   checkMacro(gc0, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav, true);
   checkMacro(gc1, x0, y0, theta0, x1, y1, theta1, xv, yv, thetav, false);
 }
-class TestLifecycleNode : public nav2_util::LifecycleNode {
- public:
-  explicit TestLifecycleNode(const std::string &name)
-      : nav2_util::LifecycleNode(name) {}
+class TestLifecycleNode : public nav2_util::LifecycleNode
+{
+public:
+  explicit TestLifecycleNode(const std::string & name)
+  : nav2_util::LifecycleNode(name) {}
 
-  nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State &) {
+  nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State &)
+  {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 
-  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State &) {
+  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State &)
+  {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 
-  nav2_util::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &) {
+  nav2_util::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &)
+  {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 
-  nav2_util::CallbackReturn on_cleanup(const rclcpp_lifecycle::State &) {
+  nav2_util::CallbackReturn on_cleanup(const rclcpp_lifecycle::State &)
+  {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 
-  nav2_util::CallbackReturn onShutdown(const rclcpp_lifecycle::State &) {
+  nav2_util::CallbackReturn onShutdown(const rclcpp_lifecycle::State &)
+  {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 
-  nav2_util::CallbackReturn onError(const rclcpp_lifecycle::State &) {
+  nav2_util::CallbackReturn onError(const rclcpp_lifecycle::State &)
+  {
     return nav2_util::CallbackReturn::SUCCESS;
   }
 };
@@ -119,7 +138,7 @@ class TestLifecycleNode : public nav2_util::LifecycleNode {
 TEST(VelocityIterator, goal_checker_reset) {
   auto x = std::make_shared<TestLifecycleNode>("goal_checker");
 
-  nav2_core::GoalChecker *gc = new SimpleGoalChecker;
+  nav2_core::GoalChecker * gc = new SimpleGoalChecker;
   gc->reset();
   delete gc;
   EXPECT_TRUE(true);
@@ -143,7 +162,8 @@ TEST(VelocityIterator, two_checks) {
   trueFalse(gc, sgc, 0, 0, 0, 0, 0, 0, 0, 0, 1);
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char ** argv)
+{
   rclcpp::init(argc, argv);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
@@ -51,7 +51,8 @@ geometry_msgs::msg::Pose2D origin;
 nav_2d_msgs::msg::Twist2D zero;
 nav_2d_msgs::msg::Twist2D forward;
 
-std::vector<rclcpp::Parameter> getDefaultKinematicParameters() {
+std::vector<rclcpp::Parameter> getDefaultKinematicParameters()
+{
   std::vector<rclcpp::Parameter> parameters;
   parameters.push_back(rclcpp::Parameter("dwb.min_vel_x", 0.0));
   parameters.push_back(rclcpp::Parameter("dwb.max_vel_x", 0.55));
@@ -74,7 +75,8 @@ std::vector<rclcpp::Parameter> getDefaultKinematicParameters() {
 }
 
 rclcpp_lifecycle::LifecycleNode::SharedPtr makeTestNode(
-    const std::string& name) {
+  const std::string & name)
+{
   rclcpp::NodeOptions node_options = nav2_util::get_node_options_default();
   node_options.parameter_overrides(getDefaultKinematicParameters());
 
@@ -85,11 +87,13 @@ rclcpp_lifecycle::LifecycleNode::SharedPtr makeTestNode(
   return node;
 }
 
-void checkLimits(const std::vector<nav_2d_msgs::msg::Twist2D>& twists,
-                 double exp_min_x, double exp_max_x, double exp_min_y,
-                 double exp_max_y, double exp_min_theta, double exp_max_theta,
-                 double exp_max_xy = -1.0, double exp_min_xy = -1.0,
-                 double exp_min_speed_theta = -1.0) {
+void checkLimits(
+  const std::vector<nav_2d_msgs::msg::Twist2D> & twists,
+  double exp_min_x, double exp_max_x, double exp_min_y,
+  double exp_max_y, double exp_min_theta, double exp_max_theta,
+  double exp_max_xy = -1.0, double exp_min_xy = -1.0,
+  double exp_min_speed_theta = -1.0)
+{
   ASSERT_GT(twists.size(), 0u);
   nav_2d_msgs::msg::Twist2D first = twists[0];
 
@@ -108,8 +112,9 @@ void checkLimits(const std::vector<nav_2d_msgs::msg::Twist2D>& twists,
     max_xy = std::max(max_xy, hyp);
 
     if (exp_min_xy >= 0 && exp_min_speed_theta >= 0) {
-      EXPECT_TRUE(fabs(twist.theta) >= exp_min_speed_theta ||
-                  hyp >= exp_min_xy);
+      EXPECT_TRUE(
+        fabs(twist.theta) >= exp_min_speed_theta ||
+        hyp >= exp_min_xy);
     }
   }
   EXPECT_DOUBLE_EQ(min_x, exp_min_x);
@@ -123,7 +128,8 @@ void checkLimits(const std::vector<nav_2d_msgs::msg::Twist2D>& twists,
   }
 }
 
-double durationToSec(builtin_interfaces::msg::Duration d) {
+double durationToSec(builtin_interfaces::msg::Duration d)
+{
   return d.sec + d.nanosec * 1e-9;
 }
 
@@ -181,8 +187,9 @@ TEST(VelocityIterator, no_limits) {
   // vx_samples * vtheta_samples * vy_samples + added zero theta samples -
   // (0,0,0)
   EXPECT_EQ(twists.size(), 20u * 20u * 5u + 100u - 1u);
-  checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1), 0.0,
-              0.0);
+  checkLimits(
+    twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1), 0.0,
+    0.0);
 }
 
 TEST(VelocityIterator, no_limits_samples) {
@@ -197,10 +204,12 @@ TEST(VelocityIterator, no_limits_samples) {
   StandardTrajectoryGenerator gen;
   gen.initialize(nh, "dwb");
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
-  EXPECT_EQ(twists.size(),
-            static_cast<unsigned>(x_samples * y_samples * theta_samples - 1));
-  checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1), 0.0,
-              0.0);
+  EXPECT_EQ(
+    twists.size(),
+    static_cast<unsigned>(x_samples * y_samples * theta_samples - 1));
+  checkLimits(
+    twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1), 0.0,
+    0.0);
 }
 
 TEST(VelocityIterator, dwa_gen) {
@@ -211,8 +220,9 @@ TEST(VelocityIterator, dwa_gen) {
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
   // Same as no-limits since everything is within our velocity limits
   EXPECT_EQ(twists.size(), 20u * 20u * 5u + 100u - 1u);
-  checkLimits(twists, 0.0, 0.125, -0.1, 0.1, -0.16, 0.16, hypot(0.125, 0.1),
-              0.0, 0.1);
+  checkLimits(
+    twists, 0.0, 0.125, -0.1, 0.1, -0.16, 0.16, hypot(0.125, 0.1),
+    0.0, 0.1);
 }
 
 TEST(VelocityIterator, nonzero) {
@@ -226,33 +236,42 @@ TEST(VelocityIterator, nonzero) {
   initial.theta = 0.05;
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(initial);
   EXPECT_EQ(twists.size(), 2519u);
-  checkLimits(twists, 0.0, 0.225, -0.1, 0.045, -0.11000000000000003, 0.21,
-              0.24622144504490268, 0.0, 0.1);
+  checkLimits(
+    twists, 0.0, 0.225, -0.1, 0.045, -0.11000000000000003, 0.21,
+    0.24622144504490268, 0.0, 0.1);
 }
 
-void matchPose(const geometry_msgs::msg::Pose2D& a,
-               const geometry_msgs::msg::Pose2D& b) {
+void matchPose(
+  const geometry_msgs::msg::Pose2D & a,
+  const geometry_msgs::msg::Pose2D & b)
+{
   EXPECT_DOUBLE_EQ(a.x, b.x);
   EXPECT_DOUBLE_EQ(a.y, b.y);
   EXPECT_DOUBLE_EQ(a.theta, b.theta);
 }
 
-void matchPose(const geometry_msgs::msg::Pose2D& a, const double x,
-               const double y, const double theta) {
+void matchPose(
+  const geometry_msgs::msg::Pose2D & a, const double x,
+  const double y, const double theta)
+{
   EXPECT_DOUBLE_EQ(a.x, x);
   EXPECT_DOUBLE_EQ(a.y, y);
   EXPECT_DOUBLE_EQ(a.theta, theta);
 }
 
-void matchTwist(const nav_2d_msgs::msg::Twist2D& a,
-                const nav_2d_msgs::msg::Twist2D& b) {
+void matchTwist(
+  const nav_2d_msgs::msg::Twist2D & a,
+  const nav_2d_msgs::msg::Twist2D & b)
+{
   EXPECT_DOUBLE_EQ(a.x, b.x);
   EXPECT_DOUBLE_EQ(a.y, b.y);
   EXPECT_DOUBLE_EQ(a.theta, b.theta);
 }
 
-void matchTwist(const nav_2d_msgs::msg::Twist2D& a, const double x,
-                const double y, const double theta) {
+void matchTwist(
+  const nav_2d_msgs::msg::Twist2D & a, const double x,
+  const double y, const double theta)
+{
   EXPECT_DOUBLE_EQ(a.x, x);
   EXPECT_DOUBLE_EQ(a.y, y);
   EXPECT_DOUBLE_EQ(a.theta, theta);
@@ -266,7 +285,7 @@ TEST(TrajectoryGenerator, basic) {
   nh->set_parameters({rclcpp::Parameter("dwb.linear_granularity", 0.5)});
   gen.initialize(nh, "dwb");
   dwb_msgs::msg::Trajectory2D res =
-      gen.generateTrajectory(origin, forward, forward);
+    gen.generateTrajectory(origin, forward, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()), DEFAULT_SIM_TIME);
   int n = res.poses.size();
@@ -284,10 +303,11 @@ TEST(TrajectoryGenerator, basic_no_last_point) {
   nh->set_parameters({rclcpp::Parameter("dwb.linear_granularity", 0.5)});
   gen.initialize(nh, "dwb");
   dwb_msgs::msg::Trajectory2D res =
-      gen.generateTrajectory(origin, forward, forward);
+    gen.generateTrajectory(origin, forward, forward);
   matchTwist(res.velocity, forward);
-  EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()),
-                   DEFAULT_SIM_TIME / 2);
+  EXPECT_DOUBLE_EQ(
+    durationToSec(res.time_offsets.back()),
+    DEFAULT_SIM_TIME / 2);
   int n = res.poses.size();
   EXPECT_EQ(n, 3);
   ASSERT_GT(n, 0);
@@ -329,8 +349,9 @@ TEST(TrajectoryGenerator, holonomic) {
   ASSERT_GT(n, 0);
 
   matchPose(res.poses[0], origin);
-  matchPose(res.poses[n - 1], cmd.x * DEFAULT_SIM_TIME,
-            cmd.y * DEFAULT_SIM_TIME, 0);
+  matchPose(
+    res.poses[n - 1], cmd.x * DEFAULT_SIM_TIME,
+    cmd.y * DEFAULT_SIM_TIME, 0);
 }
 
 TEST(TrajectoryGenerator, twisty) {
@@ -351,8 +372,9 @@ TEST(TrajectoryGenerator, twisty) {
   ASSERT_GT(n, 0);
 
   matchPose(res.poses[0], origin);
-  matchPose(res.poses[n - 1], 0.5355173615993063, -0.29635287789821596,
-            cmd.theta * DEFAULT_SIM_TIME);
+  matchPose(
+    res.poses[n - 1], 0.5355173615993063, -0.29635287789821596,
+    cmd.theta * DEFAULT_SIM_TIME);
 }
 
 TEST(TrajectoryGenerator, sim_time) {
@@ -363,7 +385,7 @@ TEST(TrajectoryGenerator, sim_time) {
   StandardTrajectoryGenerator gen;
   gen.initialize(nh, "dwb");
   dwb_msgs::msg::Trajectory2D res =
-      gen.generateTrajectory(origin, forward, forward);
+    gen.generateTrajectory(origin, forward, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()), sim_time);
   int n = res.poses.size();
@@ -385,7 +407,7 @@ TEST(TrajectoryGenerator, accel) {
   gen.initialize(nh, "dwb");
 
   dwb_msgs::msg::Trajectory2D res =
-      gen.generateTrajectory(origin, zero, forward);
+    gen.generateTrajectory(origin, zero, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()), 5.0);
   ASSERT_EQ(res.poses.size(), 7u);
@@ -409,7 +431,7 @@ TEST(TrajectoryGenerator, dwa) {
   gen.initialize(nh, "dwb");
 
   dwb_msgs::msg::Trajectory2D res =
-      gen.generateTrajectory(origin, zero, forward);
+    gen.generateTrajectory(origin, zero, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()), 5.0);
   ASSERT_EQ(res.poses.size(), 7u);
@@ -421,7 +443,8 @@ TEST(TrajectoryGenerator, dwa) {
   matchPose(res.poses[5], 1.5, 0, 0);
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char ** argv)
+{
   forward.x = 0.3;
   rclcpp::init(0, nullptr);
   testing::InitGoogleTest(&argc, argv);

--- a/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/twist_gen.cpp
@@ -32,27 +32,26 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <cmath>
-#include <vector>
 #include <algorithm>
+#include <cmath>
 #include <string>
+#include <vector>
 
-#include "gtest/gtest.h"
-#include "dwb_plugins/standard_traj_generator.hpp"
-#include "dwb_plugins/limited_accel_generator.hpp"
 #include "dwb_core/exceptions.hpp"
+#include "dwb_plugins/limited_accel_generator.hpp"
+#include "dwb_plugins/standard_traj_generator.hpp"
+#include "gtest/gtest.h"
 #include "nav2_util/node_utils.hpp"
 
-using std::hypot;
-using std::fabs;
 using dwb_plugins::StandardTrajectoryGenerator;
+using std::fabs;
+using std::hypot;
 
 geometry_msgs::msg::Pose2D origin;
 nav_2d_msgs::msg::Twist2D zero;
 nav_2d_msgs::msg::Twist2D forward;
 
-std::vector<rclcpp::Parameter> getDefaultKinematicParameters()
-{
+std::vector<rclcpp::Parameter> getDefaultKinematicParameters() {
   std::vector<rclcpp::Parameter> parameters;
   parameters.push_back(rclcpp::Parameter("dwb.min_vel_x", 0.0));
   parameters.push_back(rclcpp::Parameter("dwb.max_vel_x", 0.55));
@@ -74,8 +73,8 @@ std::vector<rclcpp::Parameter> getDefaultKinematicParameters()
   return parameters;
 }
 
-rclcpp_lifecycle::LifecycleNode::SharedPtr makeTestNode(const std::string & name)
-{
+rclcpp_lifecycle::LifecycleNode::SharedPtr makeTestNode(
+    const std::string& name) {
   rclcpp::NodeOptions node_options = nav2_util::get_node_options_default();
   node_options.parameter_overrides(getDefaultKinematicParameters());
 
@@ -86,13 +85,11 @@ rclcpp_lifecycle::LifecycleNode::SharedPtr makeTestNode(const std::string & name
   return node;
 }
 
-void checkLimits(
-  const std::vector<nav_2d_msgs::msg::Twist2D> & twists,
-  double exp_min_x, double exp_max_x, double exp_min_y, double exp_max_y,
-  double exp_min_theta, double exp_max_theta,
-  double exp_max_xy = -1.0,
-  double exp_min_xy = -1.0, double exp_min_speed_theta = -1.0)
-{
+void checkLimits(const std::vector<nav_2d_msgs::msg::Twist2D>& twists,
+                 double exp_min_x, double exp_max_x, double exp_min_y,
+                 double exp_max_y, double exp_min_theta, double exp_max_theta,
+                 double exp_max_xy = -1.0, double exp_min_xy = -1.0,
+                 double exp_min_speed_theta = -1.0) {
   ASSERT_GT(twists.size(), 0u);
   nav_2d_msgs::msg::Twist2D first = twists[0];
 
@@ -111,7 +108,8 @@ void checkLimits(
     max_xy = std::max(max_xy, hyp);
 
     if (exp_min_xy >= 0 && exp_min_speed_theta >= 0) {
-      EXPECT_TRUE(fabs(twist.theta) >= exp_min_speed_theta || hyp >= exp_min_xy);
+      EXPECT_TRUE(fabs(twist.theta) >= exp_min_speed_theta ||
+                  hyp >= exp_min_xy);
     }
   }
   EXPECT_DOUBLE_EQ(min_x, exp_min_x);
@@ -125,13 +123,11 @@ void checkLimits(
   }
 }
 
-double durationToSec(builtin_interfaces::msg::Duration d)
-{
+double durationToSec(builtin_interfaces::msg::Duration d) {
   return d.sec + d.nanosec * 1e-9;
 }
 
-TEST(VelocityIterator, standard_gen)
-{
+TEST(VelocityIterator, standard_gen) {
   auto nh = makeTestNode("st_gen");
   StandardTrajectoryGenerator gen;
   gen.initialize(nh, "dwb");
@@ -140,8 +136,7 @@ TEST(VelocityIterator, standard_gen)
   checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, 0.55, 0.1, 0.4);
 }
 
-TEST(VelocityIterator, max_xy)
-{
+TEST(VelocityIterator, max_xy) {
   auto nh = makeTestNode("max_xy");
   nh->set_parameters({rclcpp::Parameter("dwb.max_speed_xy", 1.0)});
   StandardTrajectoryGenerator gen;
@@ -153,8 +148,7 @@ TEST(VelocityIterator, max_xy)
   checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1));
 }
 
-TEST(VelocityIterator, min_xy)
-{
+TEST(VelocityIterator, min_xy) {
   auto nh = makeTestNode("min_xy");
   nh->set_parameters({rclcpp::Parameter("dwb.min_speed_xy", -1.0)});
   StandardTrajectoryGenerator gen;
@@ -165,8 +159,7 @@ TEST(VelocityIterator, min_xy)
   checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0);
 }
 
-TEST(VelocityIterator, min_theta)
-{
+TEST(VelocityIterator, min_theta) {
   auto nh = makeTestNode("min_theta");
   nh->set_parameters({rclcpp::Parameter("dwb.min_speed_theta", -1.0)});
   StandardTrajectoryGenerator gen;
@@ -177,8 +170,7 @@ TEST(VelocityIterator, min_theta)
   checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0);
 }
 
-TEST(VelocityIterator, no_limits)
-{
+TEST(VelocityIterator, no_limits) {
   auto nh = makeTestNode("no_limits");
   nh->set_parameters({rclcpp::Parameter("dwb.max_speed_xy", -1.0)});
   nh->set_parameters({rclcpp::Parameter("dwb.min_speed_xy", -1.0)});
@@ -186,13 +178,14 @@ TEST(VelocityIterator, no_limits)
   StandardTrajectoryGenerator gen;
   gen.initialize(nh, "dwb");
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
-  // vx_samples * vtheta_samples * vy_samples + added zero theta samples - (0,0,0)
+  // vx_samples * vtheta_samples * vy_samples + added zero theta samples -
+  // (0,0,0)
   EXPECT_EQ(twists.size(), 20u * 20u * 5u + 100u - 1u);
-  checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1), 0.0, 0.0);
+  checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1), 0.0,
+              0.0);
 }
 
-TEST(VelocityIterator, no_limits_samples)
-{
+TEST(VelocityIterator, no_limits_samples) {
   auto nh = makeTestNode("no_limits_samples");
   nh->set_parameters({rclcpp::Parameter("dwb.max_speed_xy", -1.0)});
   nh->set_parameters({rclcpp::Parameter("dwb.min_speed_xy", -1.0)});
@@ -204,12 +197,13 @@ TEST(VelocityIterator, no_limits_samples)
   StandardTrajectoryGenerator gen;
   gen.initialize(nh, "dwb");
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
-  EXPECT_EQ(twists.size(), static_cast<unsigned>(x_samples * y_samples * theta_samples - 1));
-  checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1), 0.0, 0.0);
+  EXPECT_EQ(twists.size(),
+            static_cast<unsigned>(x_samples * y_samples * theta_samples - 1));
+  checkLimits(twists, 0.0, 0.55, -0.1, 0.1, -1.0, 1.0, hypot(0.55, 0.1), 0.0,
+              0.0);
 }
 
-TEST(VelocityIterator, dwa_gen)
-{
+TEST(VelocityIterator, dwa_gen) {
   auto nh = makeTestNode("dwa_gen");
   nh->set_parameters({rclcpp::Parameter("dwb.min_speed_theta", -1.0)});
   dwb_plugins::LimitedAccelGenerator gen;
@@ -217,11 +211,11 @@ TEST(VelocityIterator, dwa_gen)
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(zero);
   // Same as no-limits since everything is within our velocity limits
   EXPECT_EQ(twists.size(), 20u * 20u * 5u + 100u - 1u);
-  checkLimits(twists, 0.0, 0.125, -0.1, 0.1, -0.16, 0.16, hypot(0.125, 0.1), 0.0, 0.1);
+  checkLimits(twists, 0.0, 0.125, -0.1, 0.1, -0.16, 0.16, hypot(0.125, 0.1),
+              0.0, 0.1);
 }
 
-TEST(VelocityIterator, nonzero)
-{
+TEST(VelocityIterator, nonzero) {
   auto nh = makeTestNode("nonzero");
   nh->set_parameters({rclcpp::Parameter("dwb.min_speed_theta", -1.0)});
   dwb_plugins::LimitedAccelGenerator gen;
@@ -232,38 +226,33 @@ TEST(VelocityIterator, nonzero)
   initial.theta = 0.05;
   std::vector<nav_2d_msgs::msg::Twist2D> twists = gen.getTwists(initial);
   EXPECT_EQ(twists.size(), 2519u);
-  checkLimits(
-    twists, 0.0, 0.225, -0.1, 0.045, -0.11000000000000003, 0.21,
-    0.24622144504490268, 0.0, 0.1);
+  checkLimits(twists, 0.0, 0.225, -0.1, 0.045, -0.11000000000000003, 0.21,
+              0.24622144504490268, 0.0, 0.1);
 }
 
-void matchPose(const geometry_msgs::msg::Pose2D & a, const geometry_msgs::msg::Pose2D & b)
-{
+void matchPose(const geometry_msgs::msg::Pose2D& a,
+               const geometry_msgs::msg::Pose2D& b) {
   EXPECT_DOUBLE_EQ(a.x, b.x);
   EXPECT_DOUBLE_EQ(a.y, b.y);
   EXPECT_DOUBLE_EQ(a.theta, b.theta);
 }
 
-void matchPose(
-  const geometry_msgs::msg::Pose2D & a, const double x, const double y,
-  const double theta)
-{
+void matchPose(const geometry_msgs::msg::Pose2D& a, const double x,
+               const double y, const double theta) {
   EXPECT_DOUBLE_EQ(a.x, x);
   EXPECT_DOUBLE_EQ(a.y, y);
   EXPECT_DOUBLE_EQ(a.theta, theta);
 }
 
-void matchTwist(const nav_2d_msgs::msg::Twist2D & a, const nav_2d_msgs::msg::Twist2D & b)
-{
+void matchTwist(const nav_2d_msgs::msg::Twist2D& a,
+                const nav_2d_msgs::msg::Twist2D& b) {
   EXPECT_DOUBLE_EQ(a.x, b.x);
   EXPECT_DOUBLE_EQ(a.y, b.y);
   EXPECT_DOUBLE_EQ(a.theta, b.theta);
 }
 
-void matchTwist(
-  const nav_2d_msgs::msg::Twist2D & a, const double x, const double y,
-  const double theta)
-{
+void matchTwist(const nav_2d_msgs::msg::Twist2D& a, const double x,
+                const double y, const double theta) {
   EXPECT_DOUBLE_EQ(a.x, x);
   EXPECT_DOUBLE_EQ(a.y, y);
   EXPECT_DOUBLE_EQ(a.theta, theta);
@@ -271,13 +260,13 @@ void matchTwist(
 
 const double DEFAULT_SIM_TIME = 1.7;
 
-TEST(TrajectoryGenerator, basic)
-{
+TEST(TrajectoryGenerator, basic) {
   auto nh = makeTestNode("basic");
   StandardTrajectoryGenerator gen;
   nh->set_parameters({rclcpp::Parameter("dwb.linear_granularity", 0.5)});
   gen.initialize(nh, "dwb");
-  dwb_msgs::msg::Trajectory2D res = gen.generateTrajectory(origin, forward, forward);
+  dwb_msgs::msg::Trajectory2D res =
+      gen.generateTrajectory(origin, forward, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()), DEFAULT_SIM_TIME);
   int n = res.poses.size();
@@ -288,16 +277,17 @@ TEST(TrajectoryGenerator, basic)
   matchPose(res.poses[n - 1], DEFAULT_SIM_TIME * forward.x, 0, 0);
 }
 
-TEST(TrajectoryGenerator, basic_no_last_point)
-{
+TEST(TrajectoryGenerator, basic_no_last_point) {
   auto nh = makeTestNode("basic_no_last_point");
   StandardTrajectoryGenerator gen;
   nh->set_parameters({rclcpp::Parameter("dwb.include_last_point", false)});
   nh->set_parameters({rclcpp::Parameter("dwb.linear_granularity", 0.5)});
   gen.initialize(nh, "dwb");
-  dwb_msgs::msg::Trajectory2D res = gen.generateTrajectory(origin, forward, forward);
+  dwb_msgs::msg::Trajectory2D res =
+      gen.generateTrajectory(origin, forward, forward);
   matchTwist(res.velocity, forward);
-  EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()), DEFAULT_SIM_TIME / 2);
+  EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()),
+                   DEFAULT_SIM_TIME / 2);
   int n = res.poses.size();
   EXPECT_EQ(n, 3);
   ASSERT_GT(n, 0);
@@ -306,8 +296,7 @@ TEST(TrajectoryGenerator, basic_no_last_point)
   matchPose(res.poses[n - 2], 0.255, 0, 0);
 }
 
-TEST(TrajectoryGenerator, too_slow)
-{
+TEST(TrajectoryGenerator, too_slow) {
   auto nh = makeTestNode("too_slow");
   StandardTrajectoryGenerator gen;
   nh->set_parameters({rclcpp::Parameter("dwb.linear_granularity", 0.5)});
@@ -324,8 +313,7 @@ TEST(TrajectoryGenerator, too_slow)
   matchPose(res.poses[0], origin);
 }
 
-TEST(TrajectoryGenerator, holonomic)
-{
+TEST(TrajectoryGenerator, holonomic) {
   auto nh = makeTestNode("holonomic");
   StandardTrajectoryGenerator gen;
   nh->set_parameters({rclcpp::Parameter("dwb.linear_granularity", 0.5)});
@@ -341,11 +329,11 @@ TEST(TrajectoryGenerator, holonomic)
   ASSERT_GT(n, 0);
 
   matchPose(res.poses[0], origin);
-  matchPose(res.poses[n - 1], cmd.x * DEFAULT_SIM_TIME, cmd.y * DEFAULT_SIM_TIME, 0);
+  matchPose(res.poses[n - 1], cmd.x * DEFAULT_SIM_TIME,
+            cmd.y * DEFAULT_SIM_TIME, 0);
 }
 
-TEST(TrajectoryGenerator, twisty)
-{
+TEST(TrajectoryGenerator, twisty) {
   auto nh = makeTestNode("twisty");
   StandardTrajectoryGenerator gen;
   nh->set_parameters({rclcpp::Parameter("dwb.linear_granularity", 0.5)});
@@ -363,20 +351,19 @@ TEST(TrajectoryGenerator, twisty)
   ASSERT_GT(n, 0);
 
   matchPose(res.poses[0], origin);
-  matchPose(
-    res.poses[n - 1], 0.5355173615993063, -0.29635287789821596,
-    cmd.theta * DEFAULT_SIM_TIME);
+  matchPose(res.poses[n - 1], 0.5355173615993063, -0.29635287789821596,
+            cmd.theta * DEFAULT_SIM_TIME);
 }
 
-TEST(TrajectoryGenerator, sim_time)
-{
+TEST(TrajectoryGenerator, sim_time) {
   auto nh = makeTestNode("sim_time");
   const double sim_time = 2.5;
   nh->set_parameters({rclcpp::Parameter("dwb.sim_time", sim_time)});
   nh->set_parameters({rclcpp::Parameter("dwb.linear_granularity", 0.5)});
   StandardTrajectoryGenerator gen;
   gen.initialize(nh, "dwb");
-  dwb_msgs::msg::Trajectory2D res = gen.generateTrajectory(origin, forward, forward);
+  dwb_msgs::msg::Trajectory2D res =
+      gen.generateTrajectory(origin, forward, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()), sim_time);
   int n = res.poses.size();
@@ -387,8 +374,7 @@ TEST(TrajectoryGenerator, sim_time)
   matchPose(res.poses[n - 2], sim_time * forward.x, 0, 0);
 }
 
-TEST(TrajectoryGenerator, accel)
-{
+TEST(TrajectoryGenerator, accel) {
   auto nh = makeTestNode("accel");
   nh->set_parameters({rclcpp::Parameter("dwb.sim_time", 5.0)});
   nh->set_parameters({rclcpp::Parameter("dwb.discretize_by_time", true)});
@@ -398,7 +384,8 @@ TEST(TrajectoryGenerator, accel)
   StandardTrajectoryGenerator gen;
   gen.initialize(nh, "dwb");
 
-  dwb_msgs::msg::Trajectory2D res = gen.generateTrajectory(origin, zero, forward);
+  dwb_msgs::msg::Trajectory2D res =
+      gen.generateTrajectory(origin, zero, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()), 5.0);
   ASSERT_EQ(res.poses.size(), 7u);
@@ -410,8 +397,7 @@ TEST(TrajectoryGenerator, accel)
   matchPose(res.poses[5], 1.2, 0, 0);
 }
 
-TEST(TrajectoryGenerator, dwa)
-{
+TEST(TrajectoryGenerator, dwa) {
   auto nh = makeTestNode("dwa");
   nh->set_parameters({rclcpp::Parameter("dwb.sim_period", 1.0)});
   nh->set_parameters({rclcpp::Parameter("dwb.sim_time", 5.0)});
@@ -422,7 +408,8 @@ TEST(TrajectoryGenerator, dwa)
   dwb_plugins::LimitedAccelGenerator gen;
   gen.initialize(nh, "dwb");
 
-  dwb_msgs::msg::Trajectory2D res = gen.generateTrajectory(origin, zero, forward);
+  dwb_msgs::msg::Trajectory2D res =
+      gen.generateTrajectory(origin, zero, forward);
   matchTwist(res.velocity, forward);
   EXPECT_DOUBLE_EQ(durationToSec(res.time_offsets.back()), 5.0);
   ASSERT_EQ(res.poses.size(), 7u);
@@ -434,8 +421,7 @@ TEST(TrajectoryGenerator, dwa)
   matchPose(res.poses[5], 1.5, 0, 0);
 }
 
-int main(int argc, char ** argv)
-{
+int main(int argc, char** argv) {
   forward.x = 0.3;
   rclcpp::init(0, nullptr);
   testing::InitGoogleTest(&argc, argv);

--- a/nav2_dwb_controller/dwb_plugins/test/velocity_iterator_test.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/velocity_iterator_test.cpp
@@ -32,15 +32,14 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "gtest/gtest.h"
 #include "dwb_plugins/one_d_velocity_iterator.hpp"
+#include "gtest/gtest.h"
 
 using dwb_plugins::OneDVelocityIterator;
 
 const double EPSILON = 1e-3;
 
-TEST(VelocityIterator, basics)
-{
+TEST(VelocityIterator, basics) {
   OneDVelocityIterator it(2.0, 0.0, 5.0, 1.0, -1.0, 1.0, 2);
   EXPECT_FALSE(it.isFinished());
   EXPECT_NEAR(it.getVelocity(), 1.0, EPSILON);
@@ -56,33 +55,28 @@ TEST(VelocityIterator, basics)
   EXPECT_NEAR(it.getVelocity(), 1.0, EPSILON);
 }
 
-TEST(VelocityIterator, limits)
-{
+TEST(VelocityIterator, limits) {
   OneDVelocityIterator it(2.0, 1.5, 2.5, 1.0, -1.0, 1.0, 2);
   EXPECT_NEAR(it.getVelocity(), 1.5, EPSILON);
   ++it;
   EXPECT_NEAR(it.getVelocity(), 2.5, EPSILON);
 }
 
-TEST(VelocityIterator, acceleration)
-{
+TEST(VelocityIterator, acceleration) {
   OneDVelocityIterator it(2.0, 0.0, 5.0, 0.5, -0.5, 1.0, 2);
   EXPECT_NEAR(it.getVelocity(), 1.5, EPSILON);
   ++it;
   EXPECT_NEAR(it.getVelocity(), 2.5, EPSILON);
 }
 
-
-TEST(VelocityIterator, time)
-{
+TEST(VelocityIterator, time) {
   OneDVelocityIterator it(2.0, 0.0, 5.0, 1.0, -1.0, 0.5, 2);
   EXPECT_NEAR(it.getVelocity(), 1.5, EPSILON);
   ++it;
   EXPECT_NEAR(it.getVelocity(), 2.5, EPSILON);
 }
 
-TEST(VelocityIterator, samples)
-{
+TEST(VelocityIterator, samples) {
   OneDVelocityIterator it(2.0, 0.0, 5.0, 1.0, -1.0, 1.0, 3);
   EXPECT_NEAR(it.getVelocity(), 1.0, EPSILON);
   ++it;
@@ -93,9 +87,7 @@ TEST(VelocityIterator, samples)
   EXPECT_TRUE(it.isFinished());
 }
 
-
-TEST(VelocityIterator, samples2)
-{
+TEST(VelocityIterator, samples2) {
   OneDVelocityIterator it(2.0, 0.0, 5.0, 1.0, -1.0, 1.0, 5);
   EXPECT_NEAR(it.getVelocity(), 1.0, EPSILON);
   ++it;
@@ -110,8 +102,7 @@ TEST(VelocityIterator, samples2)
   EXPECT_TRUE(it.isFinished());
 }
 
-TEST(VelocityIterator, around_zero)
-{
+TEST(VelocityIterator, around_zero) {
   OneDVelocityIterator it(0.0, -5.0, 5.0, 1.0, -1.0, 1.0, 2);
   EXPECT_NEAR(it.getVelocity(), -1.0, EPSILON);
   ++it;
@@ -121,8 +112,7 @@ TEST(VelocityIterator, around_zero)
   ++it;
 }
 
-TEST(VelocityIterator, around_zero2)
-{
+TEST(VelocityIterator, around_zero2) {
   OneDVelocityIterator it(0.0, -5.0, 5.0, 1.0, -1.0, 1.0, 4);
   EXPECT_NEAR(it.getVelocity(), -1.0, EPSILON);
   ++it;
@@ -136,8 +126,7 @@ TEST(VelocityIterator, around_zero2)
   ++it;
 }
 
-int main(int argc, char ** argv)
-{
+int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/nav2_dwb_controller/dwb_plugins/test/velocity_iterator_test.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/velocity_iterator_test.cpp
@@ -126,7 +126,8 @@ TEST(VelocityIterator, around_zero2) {
   ++it;
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | ( #1642) |
| Primary OS tested on | (Ubuntu 18.04) |


---

## Description of contribution 

* Removed the zero velocity check from kinematic parameters. This allows critics/users to have zero velocities as valid.
* Moved the zero velocity check to one more level higher(xy_theta_iterator). This plugin can be overridden if needed.


