### PR TITLE
changed argument to remapping

### DIFF
--- a/nav2_bringup/nav2_gazebo_spawner/nav2_gazebo_spawner/nav2_gazebo_spawner.py
+++ b/nav2_bringup/nav2_gazebo_spawner/nav2_gazebo_spawner/nav2_gazebo_spawner.py
@@ -83,7 +83,7 @@ def main():
             break
 
     ros_params = plugin.find('ros')
-    ros_tf_remap = ET.SubElement(ros_params, 'argument')
+    ros_tf_remap = ET.SubElement(ros_params, 'remapping')
     ros_tf_remap.text = '/tf:=/' + args.robot_namespace + '/tf'
 
     # Set data for request


### PR DESCRIPTION
A small change, if you use 'argument' instead of 'remapping' you get the following warning:

`[gzserver-1] [WARN] [rcl]: Found remap rule '/tf:=/robot1/tf'. This syntax is deprecated. Use '--ros-args --remap /tf:=/robot1/tf' instead.`

Using 'argument' still works, but as it states it's deprecated. This one word change removes the error.
