### PR TITLE
a workaround patch for #1652

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -214,7 +214,10 @@ protected:
     auto send_goal_options = typename rclcpp_action::Client<ActionT>::SendGoalOptions();
     send_goal_options.result_callback =
       [this](const typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult & result) {
-        if (result.code != rclcpp_action::ResultCode::ABORTED) {
+        // TODO(#1652): a work around until rcl_action interface is updated
+        // if goal ids are not matched, the older goal call this callback so ignore the result
+        // if matched, it must be processed (including aborted)
+        if (this->goal_handle_->get_goal_id() == result.goal_id) {
           goal_result_available_ = true;
           result_ = result;
         }


### PR DESCRIPTION
Signed-off-by: Daisuke Sato <daisukes@cmu.edu>
---
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1652  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | turtlebot |

---

## Description of contribution in a few bullet points

* fix the issue BT action node does not abort #1652 for temporary until rcl interface is updated 

## Description of documentation updates required from your changes

N/A

---

## Future work that may be required in bullet points

* #1652 still needs to be tracked