### PR TITLE
Fix logic in RoundRobinNode and RecoveryNode and add unit tests

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_BEHAVIOR_TREE__PLUGINS__CONTROL__ROUND_ROBIN_NODE_HPP_
+#define NAV2_BEHAVIOR_TREE__PLUGINS__CONTROL__ROUND_ROBIN_NODE_HPP_
+
+#include <string>
+
+#include "behaviortree_cpp_v3/control_node.h"
+#include "behaviortree_cpp_v3/bt_factory.h"
+
+namespace nav2_behavior_tree
+{
+
+/** @brief Type of sequence node that ticks children in a round-robin fashion
+ *
+ * Type of Control Node  | Child Returns Failure | Child Returns Running
+ * ---------------------------------------------------------------------
+ *  RoundRobin           |    Tick Next Child    | Return Running
+ *
+ * If the current child return failure, the next child is ticked and if the last child returns
+ * failure, the first child is ticked and the cycle continues until a child returns success
+ *
+ * As an example, let's say this node has 3 children: A, B and C. At the start,
+ * they are all IDLE.
+ * |    A    |    B    |    C    |
+ * --------------------------------
+ * |  IDLE   |  IDLE   |  IDLE   |
+ * | RUNNING |  IDLE   |  IDLE   |  - at first A gets ticked. Assume it returns RUNNING
+ *                                  - RoundRobin returns RUNNING and no other nodes are ticked.
+ * | FAILURE | RUNNING |  IDLE   |  - A returns FAILURE so B gets ticked and returns RUNNING
+ *                                  - RoundRobin returns RUNNING and C is not ticked yet
+ * | FAILURE | SUCCESS |  IDLE   |  - B returns SUCCESS, so RoundRobin halts all children and
+ *                                  - returns SUCCESS, next iteration will tick C.
+ * | RUNNING |  IDLE   | FAILURE |  - C returns FAILURE, so RoundRobin circles and ticks A.
+ *                                  - A returns RUNNING, so RoundRobin returns RUNNING.
+ *
+ * If all children return FAILURE, RoundRobin will return FAILURE
+ * and halt all children, ending the sequence.
+ *
+ * Usage in XML: <RoundRobin>
+ */
+class RoundRobinNode : public BT::ControlNode
+{
+public:
+  explicit RoundRobinNode(const std::string & name);
+  RoundRobinNode(const std::string & name, const BT::NodeConfiguration & config);
+  BT::NodeStatus tick() override;
+  void halt() override;
+  static BT::PortsList providedPorts() {return {};}
+
+private:
+  unsigned int current_child_idx_{0};
+  unsigned int num_failed_children_{0};
+};
+
+}  // namespace nav2_behavior_tree
+
+#endif  // NAV2_BEHAVIOR_TREE__PLUGINS__CONTROL__ROUND_ROBIN_NODE_HPP_

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -39,7 +39,7 @@ BT::NodeStatus RecoveryNode::tick()
 
   setStatus(BT::NodeStatus::RUNNING);
 
-  while (current_child_idx_ < children_count && retry_count_ < number_of_retries_) {
+  while (current_child_idx_ < children_count && retry_count_ <= number_of_retries_) {
     TreeNode * child_node = children_nodes_[current_child_idx_];
     const BT::NodeStatus child_status = child_node->executeTick();
 
@@ -55,7 +55,7 @@ BT::NodeStatus RecoveryNode::tick()
         case BT::NodeStatus::FAILURE:
           {
             // tick second child
-            if (retry_count_ <= number_of_retries_) {
+            if (retry_count_ < number_of_retries_) {
               current_child_idx_++;
               break;
             } else {

--- a/nav2_behavior_tree/test/plugins/control/CMakeLists.txt
+++ b/nav2_behavior_tree/test/plugins/control/CMakeLists.txt
@@ -5,3 +5,7 @@ ament_target_dependencies(test_control_recovery_node ${dependencies})
 ament_add_gtest(test_control_pipeline_sequence test_pipeline_sequence.cpp)
 target_link_libraries(test_control_pipeline_sequence nav2_pipeline_sequence_bt_node)
 ament_target_dependencies(test_control_pipeline_sequence ${dependencies})
+
+ament_add_gtest(test_control_round_robin_node test_round_robin_node.cpp)
+target_link_libraries(test_control_round_robin_node nav2_round_robin_node_bt_node)
+ament_target_dependencies(test_control_round_robin_node ${dependencies})

--- a/nav2_behavior_tree/test/plugins/control/test_round_robin_node.cpp
+++ b/nav2_behavior_tree/test/plugins/control/test_round_robin_node.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2020 Sarthak Mittal
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "../../test_behavior_tree_fixture.hpp"
+#include "../../test_dummy_tree_node.hpp"
+#include "nav2_behavior_tree/plugins/control/round_robin_node.hpp"
+
+class RoundRobinNodeTestFixture : public nav2_behavior_tree::BehaviorTreeTestFixture
+{
+public:
+  void SetUp() override
+  {
+    bt_node_ = std::make_shared<nav2_behavior_tree::RoundRobinNode>(
+      "round_robin", *config_);
+    first_child_ = std::make_shared<nav2_behavior_tree::DummyNode>();
+    second_child_ = std::make_shared<nav2_behavior_tree::DummyNode>();
+    third_child_ = std::make_shared<nav2_behavior_tree::DummyNode>();
+    bt_node_->addChild(first_child_.get());
+    bt_node_->addChild(second_child_.get());
+    bt_node_->addChild(third_child_.get());
+  }
+
+  void TearDown() override
+  {
+    first_child_.reset();
+    second_child_.reset();
+    third_child_.reset();
+    bt_node_.reset();
+  }
+
+protected:
+  static std::shared_ptr<nav2_behavior_tree::RoundRobinNode> bt_node_;
+  static std::shared_ptr<nav2_behavior_tree::DummyNode> first_child_;
+  static std::shared_ptr<nav2_behavior_tree::DummyNode> second_child_;
+  static std::shared_ptr<nav2_behavior_tree::DummyNode> third_child_;
+};
+
+std::shared_ptr<nav2_behavior_tree::RoundRobinNode> RoundRobinNodeTestFixture::bt_node_ = nullptr;
+std::shared_ptr<nav2_behavior_tree::DummyNode> RoundRobinNodeTestFixture::first_child_ = nullptr;
+std::shared_ptr<nav2_behavior_tree::DummyNode> RoundRobinNodeTestFixture::second_child_ = nullptr;
+std::shared_ptr<nav2_behavior_tree::DummyNode> RoundRobinNodeTestFixture::third_child_ = nullptr;
+
+TEST_F(RoundRobinNodeTestFixture, test_failure_on_idle_child)
+{
+  first_child_->changeStatus(BT::NodeStatus::IDLE);
+  EXPECT_THROW(bt_node_->executeTick(), BT::LogicError);
+}
+
+TEST_F(RoundRobinNodeTestFixture, test_failure)
+{
+  first_child_->changeStatus(BT::NodeStatus::FAILURE);
+  second_child_->changeStatus(BT::NodeStatus::RUNNING);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::RUNNING);
+
+  second_child_->changeStatus(BT::NodeStatus::FAILURE);
+  third_child_->changeStatus(BT::NodeStatus::RUNNING);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::RUNNING);
+
+  third_child_->changeStatus(BT::NodeStatus::FAILURE);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(third_child_->status(), BT::NodeStatus::IDLE);
+}
+
+TEST_F(RoundRobinNodeTestFixture, test_behavior)
+{
+  first_child_->changeStatus(BT::NodeStatus::RUNNING);
+  second_child_->changeStatus(BT::NodeStatus::IDLE);
+  third_child_->changeStatus(BT::NodeStatus::IDLE);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::RUNNING);
+
+  first_child_->changeStatus(BT::NodeStatus::FAILURE);
+  second_child_->changeStatus(BT::NodeStatus::RUNNING);
+  third_child_->changeStatus(BT::NodeStatus::IDLE);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::RUNNING);
+
+  first_child_->changeStatus(BT::NodeStatus::FAILURE);
+  second_child_->changeStatus(BT::NodeStatus::SUCCESS);
+  third_child_->changeStatus(BT::NodeStatus::IDLE);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::SUCCESS);
+
+  first_child_->changeStatus(BT::NodeStatus::IDLE);
+  second_child_->changeStatus(BT::NodeStatus::IDLE);
+  third_child_->changeStatus(BT::NodeStatus::RUNNING);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::RUNNING);
+
+  first_child_->changeStatus(BT::NodeStatus::RUNNING);
+  second_child_->changeStatus(BT::NodeStatus::IDLE);
+  third_child_->changeStatus(BT::NodeStatus::FAILURE);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::RUNNING);
+
+  first_child_->changeStatus(BT::NodeStatus::FAILURE);
+  second_child_->changeStatus(BT::NodeStatus::SUCCESS);
+  third_child_->changeStatus(BT::NodeStatus::FAILURE);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(third_child_->status(), BT::NodeStatus::IDLE);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  int all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1819 #1810 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Turtlebot3 gazebo simulation |

---

## Description of contribution in a few bullet points

* Fixes `RoundRobin` logic (if current child return failure tick next child until all fail or one succeeds)
* Fixes `RecoveryNode` error where actual number of retries performed = required number of retries - 1
* Adds unit tests for `RoundRobin`