### PR TITLE
Return time which was taken to compute the motion plan via ComputePat…

### DIFF
--- a/nav2_msgs/action/BackUp.action
+++ b/nav2_msgs/action/BackUp.action
@@ -3,6 +3,6 @@ geometry_msgs/Point target
 float32 speed
 ---
 #result definition
-std_msgs/Empty result
+builtin_interfaces/Duration total_elapsed_time
 ---
 float32 distance_traveled

--- a/nav2_msgs/action/ComputePathToPose.action
+++ b/nav2_msgs/action/ComputePathToPose.action
@@ -4,5 +4,6 @@ string planner_id
 ---
 #result definition
 nav_msgs/Path path
+builtin_interfaces/Duration planning_time
 ---
 #feedback

--- a/nav2_msgs/action/DummyRecovery.action
+++ b/nav2_msgs/action/DummyRecovery.action
@@ -2,6 +2,6 @@
 std_msgs/String command
 ---
 #result definition
-std_msgs/Empty result
+builtin_interfaces/Duration total_elapsed_time
 ---
 #feedback

--- a/nav2_msgs/action/Spin.action
+++ b/nav2_msgs/action/Spin.action
@@ -2,6 +2,6 @@
 float32 target_yaw
 ---
 #result definition
-std_msgs/Empty result
+builtin_interfaces/Duration total_elapsed_time
 ---
 float32 angular_distance_traveled

--- a/nav2_msgs/action/Wait.action
+++ b/nav2_msgs/action/Wait.action
@@ -2,7 +2,7 @@
 builtin_interfaces/Duration time
 ---
 #result definition
-std_msgs/Empty result
+builtin_interfaces/Duration total_elapsed_time
 ---
 #feedback
 builtin_interfaces/Duration time_left

--- a/nav2_planner/include/nav2_planner/planner_server.hpp
+++ b/nav2_planner/include/nav2_planner/planner_server.hpp
@@ -119,6 +119,9 @@ protected:
   double max_planner_duration_;
   std::string planner_ids_concat_;
 
+  // Clock
+  rclcpp::Clock steady_clock_{RCL_STEADY_TIME};
+
   // TF buffer
   std::shared_ptr<tf2_ros::Buffer> tf_;
 

--- a/nav2_recoveries/test/test_recoveries.cpp
+++ b/nav2_recoveries/test/test_recoveries.cpp
@@ -232,6 +232,27 @@ TEST_F(RecoveryTest, testingSequentialFailures)
   SUCCEED();
 }
 
+TEST_F(RecoveryTest, testingTotalElapsedTimeIsGratherThanZeroIfStarted)
+{
+  ASSERT_TRUE(sendCommand("Testing success"));
+  EXPECT_GT(getResult().result->total_elapsed_time.sec, 0.0);
+  SUCCEED();
+}
+
+TEST_F(RecoveryTest, testingTotalElapsedTimeIsZeroIfFailureOnInit)
+{
+  ASSERT_TRUE(sendCommand("Testing failure on init"));
+  EXPECT_EQ(getResult().result->total_elapsed_time.sec, 0.0);
+  SUCCEED();
+}
+
+TEST_F(RecoveryTest, testingTotalElapsedTimeIsZeroIfFailureOnRun)
+{
+  ASSERT_TRUE(sendCommand("Testing failure on run"));
+  EXPECT_EQ(getResult().result->total_elapsed_time.sec, 0.0);
+  SUCCEED();
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
# Basic Info

| Info |  |
| ------ | ----------- |
| Ticket(s) this addresses   | #200 |
| Primary OS tested on | Ubuntu 20.04 |

Next step to solving the upper mentioned issue (previous step https://github.com/ros-planning/navigation2/pull/1801)

---

Added new field to the result of the action message

---

I'm not sure, how can I properly test this feature? Does **ComputePathToPoseAction** class needed some changes?
