### PR TITLE
prototype of lifecycle bond system

### DIFF
--- a/doc/parameters/param_list.md
+++ b/doc/parameters/param_list.md
@@ -388,6 +388,7 @@ When `controller_plugins` parameter is not overridden, the following default plu
 | ----------| --------| ------------|
 | node_names | N/A | Ordered list of node names to bringup through lifecycle transition |
 | autostart | false | Whether to transition nodes to active state on startup |
+| bond_timeout_ms | 100 | Timeout for bond to fail if no connection can be found in milliseconds. If set to 0, it will be disabled. |
 
 # map_server
 

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -234,9 +234,6 @@ AmclNode::on_configure(const rclcpp_lifecycle::State & /*state*/)
   initParticleFilter();
   initLaserScan();
 
-  // create bond connection
-  createBond();
-
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
@@ -298,6 +295,9 @@ AmclNode::on_activate(const rclcpp_lifecycle::State & /*state*/)
   } else if (init_pose_received_on_inactive) {
     handleInitialPose(last_published_pose_);
   }
+
+  // create bond connection
+  createBond();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -234,6 +234,9 @@ AmclNode::on_configure(const rclcpp_lifecycle::State & /*state*/)
   initParticleFilter();
   initLaserScan();
 
+  // create bond connection
+  createBond();
+
   return nav2_util::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -136,9 +136,6 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
     return nav2_util::CallbackReturn::FAILURE;
   }
 
-  // create bond connection
-  createBond();
-
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
@@ -178,7 +175,10 @@ BtNavigator::on_activate(const rclcpp_lifecycle::State & /*state*/)
   RCLCPP_INFO(get_logger(), "Activating");
 
   action_server_->activate();
-
+  
+  // create bond connection
+  createBond();
+  
   return nav2_util::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -136,6 +136,9 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
     return nav2_util::CallbackReturn::FAILURE;
   }
 
+  // create bond connection
+  createBond();
+
   return nav2_util::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -45,6 +45,13 @@ ControllerServer::ControllerServer()
   declare_parameter("min_y_velocity_threshold", rclcpp::ParameterValue(0.0001));
   declare_parameter("min_theta_velocity_threshold", rclcpp::ParameterValue(0.0001));
 
+  get_parameter("controller_plugins", controller_ids_);
+  if (controller_ids_ == default_ids_) {
+    for (size_t i = 0; i < default_ids_.size(); ++i) {
+      declare_parameter(default_ids_[i] + ".plugin", default_types_[i]);
+    }
+  }
+
   // The costmap node is used in the implementation of the controller
   costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
     "local_costmap", std::string{get_namespace()}, "local_costmap");
@@ -63,12 +70,6 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
 {
   RCLCPP_INFO(get_logger(), "Configuring controller interface");
 
-  get_parameter("controller_plugins", controller_ids_);
-  if (controller_ids_ == default_ids_) {
-    for (size_t i = 0; i < default_ids_.size(); ++i) {
-      declare_parameter(default_ids_[i] + ".plugin", default_types_[i]);
-    }
-  }
   controller_types_.resize(controller_ids_.size());
 
   get_parameter("controller_frequency", controller_frequency_);

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -114,9 +114,6 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
     rclcpp_node_, "follow_path",
     std::bind(&ControllerServer::computeControl, this));
 
-  // create bond connection
-  createBond();
-
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
@@ -132,6 +129,9 @@ ControllerServer::on_activate(const rclcpp_lifecycle::State & state)
   }
   vel_publisher_->on_activate();
   action_server_->activate();
+
+  // create bond connection
+  createBond();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -114,6 +114,9 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
     rclcpp_node_, "follow_path",
     std::bind(&ControllerServer::computeControl, this));
 
+  // create bond connection
+  createBond();
+
   return nav2_util::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_lifecycle_manager/CMakeLists.txt
+++ b/nav2_lifecycle_manager/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(bondcpp REQUIRED)
 
 nav2_package()
 
@@ -38,6 +39,7 @@ set(dependencies
   std_msgs
   std_srvs
   tf2_geometry_msgs
+  bondcpp
 )
 
 ament_target_dependencies(${library_name}

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -26,6 +26,7 @@
 #include "std_srvs/srv/empty.hpp"
 #include "nav2_msgs/srv/manage_lifecycle_nodes.hpp"
 #include "std_srvs/srv/trigger.hpp"
+#include "bondcpp/bond.hpp"
 
 namespace nav2_lifecycle_manager
 {
@@ -121,6 +122,25 @@ protected:
    */
   void destroyLifecycleServiceClients();
 
+  // Support function for creating bond connections
+  /**
+   * @brief Support function for creating bond connections
+   */
+  void createBondConnections();
+
+  // Support function for killing bond connections
+  /**
+   * @brief Support function for killing bond connections
+   */
+  void destroyBondConnections();
+
+  // Support function for checking on bond connections
+  /**
+   * @ brief Support function for checking on bond connections
+   * will take down system if there's something non-responsive
+   */
+  void checkBondConnections();
+
   /**
    * @brief For a node, transition to the new target state
    */
@@ -139,6 +159,12 @@ protected:
 
   // A map of all nodes to be controlled
   std::map<std::string, std::shared_ptr<nav2_util::LifecycleServiceClient>> node_map_;
+
+  // A map of all nodes to check bond connection
+  std::map<std::string, std::shared_ptr<bond::Bond>> bond_map_;
+
+  // Timer thread to look at bond connections
+  rclcpp::TimerBase::SharedPtr bond_timer_;
 
   std::map<std::uint8_t, std::string> transition_label_map_;
 

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -122,6 +122,12 @@ protected:
    */
   void destroyLifecycleServiceClients();
 
+  // Support function for creating bond timer
+  /**
+   * @brief Support function for creating bond timer
+   */
+  void createBondTimer();
+
   // Support function for creating bond connections
   /**
    * @brief Support function for creating bond connections
@@ -165,6 +171,7 @@ protected:
 
   // Timer thread to look at bond connections
   rclcpp::TimerBase::SharedPtr bond_timer_;
+  std::chrono::milliseconds bond_timeout_;
 
   std::map<std::uint8_t, std::string> transition_label_map_;
 

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -170,7 +170,7 @@ protected:
   std::map<std::string, std::shared_ptr<bond::Bond>> bond_map_;
 
   // Timer thread to look at bond connections
-  rclcpp::TimerBase::SharedPtr bond_timer_;
+  std::shared_ptr<rclcpp::TimerBase> bond_timer_;
   std::chrono::milliseconds bond_timeout_;
 
   std::map<std::uint8_t, std::string> transition_label_map_;

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "nav2_util/lifecycle_service_client.hpp"
+#include "nav2_util/node_thread.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/empty.hpp"
 #include "nav2_msgs/srv/manage_lifecycle_nodes.hpp"
@@ -53,6 +54,8 @@ public:
 protected:
   // The ROS node to use when calling lifecycle services
   rclcpp::Node::SharedPtr service_client_node_;
+  rclcpp::Node::SharedPtr bond_client_node_;
+  std::unique_ptr<nav2_util::NodeThread> bond_node_thread_;
 
   // The services provided by this node
   rclcpp::Service<ManageLifecycleNodes>::SharedPtr manager_srv_;

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -163,15 +163,15 @@ protected:
    */
   void message(const std::string & msg);
 
-  // A map of all nodes to be controlled
-  std::map<std::string, std::shared_ptr<nav2_util::LifecycleServiceClient>> node_map_;
+  // Timer thread to look at bond connections
+  rclcpp::TimerBase::SharedPtr bond_timer_;
+  std::chrono::milliseconds bond_timeout_;
 
   // A map of all nodes to check bond connection
   std::map<std::string, std::shared_ptr<bond::Bond>> bond_map_;
 
-  // Timer thread to look at bond connections
-  std::shared_ptr<rclcpp::TimerBase> bond_timer_;
-  std::chrono::milliseconds bond_timeout_;
+  // A map of all nodes to be controlled
+  std::map<std::string, std::shared_ptr<nav2_util::LifecycleServiceClient>> node_map_;
 
   std::map<std::uint8_t, std::string> transition_label_map_;
 

--- a/nav2_lifecycle_manager/package.xml
+++ b/nav2_lifecycle_manager/package.xml
@@ -18,6 +18,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>bondcpp</build_depend>
   <build_depend>nav2_common</build_depend>
 
   <exec_depend>geometry_msgs</exec_depend>
@@ -28,6 +29,7 @@
   <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
+  <exec_depend>bondcpp</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -84,6 +84,7 @@ LifecycleManager::LifecycleManager()
 LifecycleManager::~LifecycleManager()
 {
   RCLCPP_INFO(get_logger(), "Destroying");
+  bond_timer_.reset();
 }
 
 void
@@ -319,7 +320,7 @@ LifecycleManager::createBondConnections()
 void
 LifecycleManager::checkBondConnections()
 {
-  if (!system_active_) {
+  if (!system_active_ || !rclcpp::ok()) {
     return;
   }
 

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -333,7 +333,7 @@ LifecycleManager::checkBondConnections()
     if (bond_map_[node_name]->isBroken()) {
       message(
         std::string(
-        "Have not received a heartbeat from " + node_name + "."));
+          "Have not received a heartbeat from " + node_name + "."));
 
       // if down, destroy
       RCLCPP_ERROR(

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -298,15 +298,20 @@ LifecycleManager::createBondConnections()
   for (auto & node_name : node_names_) {
     bond_map_[node_name] =
       std::make_shared<bond::Bond>("bond", node_name, service_client_node_);
-    bond_map_[node_name]->setHeartbeatTimeout(timeout_s);
-    bond_map_[node_name]->start();
+    auto & node_bond = bond_map_[node_name];
+    node_bond->setHeartbeatTimeout(timeout_s);
+    node_bond->start();
 
-    if (!bond_map_[node_name]->waitUntilFormed(rclcpp::Duration(timeout_ns))) {
+    RCLCPP_INFO(get_logger(), "Server %s trying to connect....", node_name.c_str());
+    node_bond->waitUntilFormed(rclcpp::Duration(timeout_ns));
+    if (node_bond->isBroken()) {
       RCLCPP_ERROR(
         get_logger(),
         "Server %s was unable to be reached after %0.2fs. "
         "This server may be misconfigured.",
         node_name.c_str(), timeout_s, node_name.c_str());
+    } else {
+      RCLCPP_INFO(get_logger(), "Server %s connected!", node_name.c_str());
     }
   }
 }

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -302,16 +302,16 @@ LifecycleManager::createBondConnections()
     node_bond->setHeartbeatTimeout(timeout_s);
     node_bond->start();
 
-    RCLCPP_INFO(get_logger(), "Server %s trying to connect....", node_name.c_str());
+    RCLCPP_INFO(get_logger(), "Server %s trying to connect to bond....", node_name.c_str());
     node_bond->waitUntilFormed(rclcpp::Duration(timeout_ns));
     if (node_bond->isBroken()) {
       RCLCPP_ERROR(
         get_logger(),
-        "Server %s was unable to be reached after %0.2fs. "
+        "Server %s was unable to be reached after %0.2fs by bond. "
         "This server may be misconfigured.",
         node_name.c_str(), timeout_s, node_name.c_str());
     } else {
-      RCLCPP_INFO(get_logger(), "Server %s connected!", node_name.c_str());
+      RCLCPP_INFO(get_logger(), "Server %s connected to bond!", node_name.c_str());
     }
   }
 }

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -309,7 +309,7 @@ LifecycleManager::createBondConnections()
         get_logger(),
         "Server %s was unable to be reached after %0.2fs by bond. "
         "This server may be misconfigured.",
-        node_name.c_str(), timeout_s, node_name.c_str());
+        node_name.c_str(), timeout_s);
     } else {
       RCLCPP_INFO(get_logger(), "Server %s connected to bond!", node_name.c_str());
     }

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -335,7 +335,7 @@ LifecycleManager::checkBondConnections()
         std::string(
           "Have not received a heartbeat from " + node_name + "."));
 
-      // if down, destroy
+      // if one is down, bring them all down
       RCLCPP_ERROR(
         get_logger(),
         "CRITICAL FAILURE: SERVER %s IS DOWN after not receiving a heartbeat for %i ms."

--- a/nav2_map_server/src/map_server/map_server.cpp
+++ b/nav2_map_server/src/map_server/map_server.cpp
@@ -116,9 +116,6 @@ MapServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     service_prefix + std::string(load_map_service_name_),
     std::bind(&MapServer::loadMapCallback, this, _1, _2, _3));
 
-  // create bond connection
-  createBond();
-
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
@@ -131,6 +128,9 @@ MapServer::on_activate(const rclcpp_lifecycle::State & /*state*/)
   occ_pub_->on_activate();
   auto occ_grid = std::make_unique<nav_msgs::msg::OccupancyGrid>(msg_);
   occ_pub_->publish(std::move(occ_grid));
+
+  // create bond connection
+  createBond();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }

--- a/nav2_map_server/src/map_server/map_server.cpp
+++ b/nav2_map_server/src/map_server/map_server.cpp
@@ -116,6 +116,9 @@ MapServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     service_prefix + std::string(load_map_service_name_),
     std::bind(&MapServer::loadMapCallback, this, _1, _2, _3));
 
+  // create bond connection
+  createBond();
+
   return nav2_util::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -135,6 +135,9 @@ PlannerServer::on_configure(const rclcpp_lifecycle::State & state)
     "compute_path_to_pose",
     std::bind(&PlannerServer::computePlan, this));
 
+  // create bond connection
+  createBond();
+
   return nav2_util::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -48,6 +48,13 @@ PlannerServer::PlannerServer()
   declare_parameter("planner_plugins", default_ids_);
   declare_parameter("expected_planner_frequency", 20.0);
 
+  get_parameter("planner_plugins", planner_ids_);
+  if (planner_ids_ == default_ids_) {
+    for (size_t i = 0; i < default_ids_.size(); ++i) {
+      declare_parameter(default_ids_[i] + ".plugin", default_types_[i]);
+    }
+  }
+
   // Setup the global costmap
   costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
     "global_costmap", std::string{get_namespace()}, "global_costmap");
@@ -79,12 +86,6 @@ PlannerServer::on_configure(const rclcpp_lifecycle::State & state)
 
   tf_ = costmap_ros_->getTfBuffer();
 
-  get_parameter("planner_plugins", planner_ids_);
-  if (planner_ids_ == default_ids_) {
-    for (size_t i = 0; i < default_ids_.size(); ++i) {
-      declare_parameter(default_ids_[i] + ".plugin", default_types_[i]);
-    }
-  }
   planner_types_.resize(planner_ids_.size());
 
   auto node = shared_from_this();

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -135,9 +135,6 @@ PlannerServer::on_configure(const rclcpp_lifecycle::State & state)
     "compute_path_to_pose",
     std::bind(&PlannerServer::computePlan, this));
 
-  // create bond connection
-  createBond();
-
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
@@ -154,6 +151,9 @@ PlannerServer::on_activate(const rclcpp_lifecycle::State & state)
   for (it = planners_.begin(); it != planners_.end(); ++it) {
     it->second->activate();
   }
+
+  // create bond connection
+  createBond();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }

--- a/nav2_recoveries/src/recovery_server.cpp
+++ b/nav2_recoveries/src/recovery_server.cpp
@@ -91,6 +91,9 @@ RecoveryServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
   recovery_types_.resize(recovery_ids_.size());
   loadRecoveryPlugins();
 
+  // create bond connection
+  createBond();
+
   return nav2_util::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_recoveries/src/recovery_server.cpp
+++ b/nav2_recoveries/src/recovery_server.cpp
@@ -91,9 +91,6 @@ RecoveryServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
   recovery_types_.resize(recovery_ids_.size());
   loadRecoveryPlugins();
 
-  // create bond connection
-  createBond();
-
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
@@ -129,6 +126,9 @@ RecoveryServer::on_activate(const rclcpp_lifecycle::State & /*state*/)
   for (iter = recoveries_.begin(); iter != recoveries_.end(); ++iter) {
     (*iter)->activate();
   }
+
+  // create bond connection
+  createBond();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }

--- a/nav2_recoveries/src/recovery_server.cpp
+++ b/nav2_recoveries/src/recovery_server.cpp
@@ -37,6 +37,13 @@ RecoveryServer::RecoveryServer()
   declare_parameter("cycle_frequency", rclcpp::ParameterValue(10.0));
   declare_parameter("recovery_plugins", default_ids_);
 
+  get_parameter("recovery_plugins", recovery_ids_);
+  if (recovery_ids_ == default_ids_) {
+    for (size_t i = 0; i < default_ids_.size(); ++i) {
+      declare_parameter(default_ids_[i] + ".plugin", default_types_[i]);
+    }
+  }
+
   declare_parameter(
     "global_frame",
     rclcpp::ParameterValue(std::string("odom")));
@@ -81,12 +88,6 @@ RecoveryServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     *costmap_sub_, *footprint_sub_, *tf_, this->get_name(),
     global_frame, robot_base_frame, transform_tolerance_);
 
-  get_parameter("recovery_plugins", recovery_ids_);
-  if (recovery_ids_ == default_ids_) {
-    for (size_t i = 0; i < default_ids_.size(); ++i) {
-      declare_parameter(default_ids_[i] + ".plugin", default_types_[i]);
-    }
-  }
   recovery_types_.resize(recovery_ids_.size());
   loadRecoveryPlugins();
 

--- a/nav2_util/CMakeLists.txt
+++ b/nav2_util/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(rclcpp_action REQUIRED)
 find_package(test_msgs REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(bondcpp REQUIRED)
 
 set(dependencies
     nav2_msgs
@@ -28,6 +29,7 @@ set(dependencies
     rclcpp_action
     test_msgs
     rclcpp_lifecycle
+    bondcpp
 )
 
 nav2_package()

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -22,6 +22,7 @@
 #include "nav2_util/node_thread.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "bondcpp/bond.hpp"
 
 namespace nav2_util
 {
@@ -40,7 +41,8 @@ public:
     const std::string & node_name,
     const std::string & namespace_ = "",
     bool use_rclcpp_node = false,
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions(),
+    bool use_bond = true);
   virtual ~LifecycleNode();
 
   typedef struct
@@ -124,6 +126,10 @@ public:
 protected:
   void print_lifecycle_node_notification();
 
+  void bondFormed();
+
+  void bondBroken();
+
   // Whether or not to create a local rclcpp::Node which can be used for ROS2 classes that don't
   // yet support lifecycle nodes
   bool use_rclcpp_node_;
@@ -133,6 +139,9 @@ protected:
 
   // When creating a local node, this class will launch a separate thread created to spin the node
   std::unique_ptr<NodeThread> rclcpp_thread_;
+
+  // Connection to tell that server is still up
+  std::unique_ptr<bond::Bond> bond_{nullptr};
 };
 
 }  // namespace nav2_util

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -122,12 +122,6 @@ public:
       rclcpp_lifecycle::LifecycleNode::shared_from_this());
   }
 
-  // Handle bond formed signal, may be overriden for specific actions
-  virtual void bondFormed();
-
-  // Handle bond broken signal, may be overriden for specific actions
-  virtual void bondBroken();
-
   // Create bond connection to lifecycle manager
   void createBond();
 

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -41,8 +41,7 @@ public:
     const std::string & node_name,
     const std::string & namespace_ = "",
     bool use_rclcpp_node = false,
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions(),
-    bool use_bond = true);
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   virtual ~LifecycleNode();
 
   typedef struct

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -122,12 +122,17 @@ public:
       rclcpp_lifecycle::LifecycleNode::shared_from_this());
   }
 
+  // Handle bond formed signal, may be overriden for specific actions
+  virtual void bondFormed();
+
+  // Handle bond broken signal, may be overriden for specific actions
+  virtual void bondBroken();
+
+  // Create bond connection to lifecycle manager
+  void createBond();
+
 protected:
   void print_lifecycle_node_notification();
-
-  void bondFormed();
-
-  void bondBroken();
 
   // Whether or not to create a local rclcpp::Node which can be used for ROS2 classes that don't
   // yet support lifecycle nodes

--- a/nav2_util/package.xml
+++ b/nav2_util/package.xml
@@ -21,6 +21,7 @@
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>lifecycle_msgs</depend>
+  <depend>bondcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>test_msgs</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/nav2_util/src/CMakeLists.txt
+++ b/nav2_util/src/CMakeLists.txt
@@ -20,6 +20,7 @@ ament_target_dependencies(${library_name}
   lifecycle_msgs
   rclcpp_lifecycle
   tf2_geometry_msgs
+  bondcpp
 )
 
 add_executable(lifecycle_bringup

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -78,11 +78,11 @@ LifecycleNode::~LifecycleNode()
 
 void LifecycleNode::createBond()
 {
-  RCLCPP_INFO(get_logger(), "Creating bond to lifecycle manager.");
+  RCLCPP_INFO(get_logger(), "Creating bond (%s) to lifecycle manager.", this->get_name().c_str());
 
   bond_ = std::make_unique<bond::Bond>(
     "bond",
-    "controller_server",
+    this->get_name(),
     shared_from_this(),
     std::bind(&LifecycleNode::bondBroken, this),
     std::bind(&LifecycleNode::bondFormed, this));

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -83,21 +83,9 @@ void LifecycleNode::createBond()
   bond_ = std::make_unique<bond::Bond>(
     "bond",
     this->get_name(),
-    shared_from_this(),
-    std::bind(&LifecycleNode::bondBroken, this),
-    std::bind(&LifecycleNode::bondFormed, this));
+    shared_from_this());
 
   bond_->start();
-}
-
-void LifecycleNode::bondFormed()
-{
-  RCLCPP_INFO(get_logger(), "Bond formed to lifecycle manager.");
-}
-
-void LifecycleNode::bondBroken()
-{
-  RCLCPP_INFO(get_logger(), "Bond broken by lifecycle manager!");
 }
 
 void LifecycleNode::print_lifecycle_node_notification()

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -77,10 +77,11 @@ void LifecycleNode::createBond()
   RCLCPP_INFO(get_logger(), "Creating bond (%s) to lifecycle manager.", this->get_name());
 
   bond_ = std::make_unique<bond::Bond>(
-    "bond",
+    std::string("bond"),
     this->get_name(),
     shared_from_this());
 
+  bond_->setHeartbeatPeriod(1.0);
   bond_->start();
 }
 

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -78,7 +78,7 @@ LifecycleNode::~LifecycleNode()
 
 void LifecycleNode::createBond()
 {
-  RCLCPP_INFO(get_logger(), "Creating bond (%s) to lifecycle manager.", this->get_name().c_str());
+  RCLCPP_INFO(get_logger(), "Creating bond (%s) to lifecycle manager.", this->get_name());
 
   bond_ = std::make_unique<bond::Bond>(
     "bond",

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -81,7 +81,8 @@ void LifecycleNode::createBond()
     this->get_name(),
     shared_from_this());
 
-  bond_->setHeartbeatPeriod(1.0);
+  bond_->setHeartbeatPeriod(0.10);
+  bond_->setHeartbeatTimeout(4.0);
   bond_->start();
 }
 

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -43,8 +43,7 @@ namespace nav2_util
 LifecycleNode::LifecycleNode(
   const std::string & node_name,
   const std::string & namespace_, bool use_rclcpp_node,
-  const rclcpp::NodeOptions & options,
-  bool use_bond)
+  const rclcpp::NodeOptions & options)
 : rclcpp_lifecycle::LifecycleNode(node_name, namespace_, options),
   use_rclcpp_node_(use_rclcpp_node)
 {
@@ -58,19 +57,18 @@ LifecycleNode::LifecycleNode(
       "_", namespace_, rclcpp::NodeOptions(options).arguments(new_args));
     rclcpp_thread_ = std::make_unique<NodeThread>(rclcpp_node_);
   }
+
   print_lifecycle_node_notification();
 
   // Setup bond connection with unique name
   // TODO shared from this will fail.
-  if (use_bond) {
-    bond_ = std::make_unique<bond::Bond>(
-      "bond",
-      node_name,
-      shared_from_this(),
-      std::bind(&LifecycleNode::bondBroken, this),
-      std::bind(&LifecycleNode::bondFormed, this));
-    bond_->start();
-  }
+  bond_ = std::make_unique<bond::Bond>(
+    "bond",
+    node_name,
+    shared_from_this(),
+    std::bind(&LifecycleNode::bondBroken, this),
+    std::bind(&LifecycleNode::bondFormed, this));
+  bond_->start();
 }
 
 LifecycleNode::~LifecycleNode()

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -59,16 +59,6 @@ LifecycleNode::LifecycleNode(
   }
 
   print_lifecycle_node_notification();
-
-  // Setup bond connection with unique name
-  // TODO shared from this will fail.
-  bond_ = std::make_unique<bond::Bond>(
-    "bond",
-    node_name,
-    shared_from_this(),
-    std::bind(&LifecycleNode::bondBroken, this),
-    std::bind(&LifecycleNode::bondFormed, this));
-  bond_->start();
 }
 
 LifecycleNode::~LifecycleNode()
@@ -84,6 +74,20 @@ LifecycleNode::~LifecycleNode()
     on_deactivate(get_current_state());
     on_cleanup(get_current_state());
   }
+}
+
+void LifecycleNode::createBond()
+{
+  RCLCPP_INFO(get_logger(), "Creating bond to lifecycle manager.");
+
+  bond_ = std::make_unique<bond::Bond>(
+    "bond",
+    "controller_server",
+    shared_from_this(),
+    std::bind(&LifecycleNode::bondBroken, this),
+    std::bind(&LifecycleNode::bondFormed, this));
+
+  bond_->start();
 }
 
 void LifecycleNode::bondFormed()

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -63,10 +63,6 @@ LifecycleNode::LifecycleNode(
 
 LifecycleNode::~LifecycleNode()
 {
-  if (bond_) {
-    bond_->breakBond();
-  }
-
   // In case this lifecycle node wasn't properly shut down, do it here
   if (get_current_state().id() ==
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -61,9 +61,6 @@ WaypointFollower::on_configure(const rclcpp_lifecycle::State & /*state*/)
     get_node_waitables_interface(),
     "FollowWaypoints", std::bind(&WaypointFollower::followWaypoints, this), false);
 
-  // create bond connection
-  createBond();
-
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
@@ -73,6 +70,9 @@ WaypointFollower::on_activate(const rclcpp_lifecycle::State & /*state*/)
   RCLCPP_INFO(get_logger(), "Activating");
 
   action_server_->activate();
+
+  // create bond connection
+  createBond();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -61,6 +61,9 @@ WaypointFollower::on_configure(const rclcpp_lifecycle::State & /*state*/)
     get_node_waitables_interface(),
     "FollowWaypoints", std::bind(&WaypointFollower::followWaypoints, this), false);
 
+  // create bond connection
+  createBond();
+
   return nav2_util::CallbackReturn::SUCCESS;
 }
 

--- a/tools/ros2_dependencies.repos
+++ b/tools/ros2_dependencies.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/ros-perception/vision_opencv.git
     version: ros2
+  ros/bond_core:
+    type: git
+    url: https://github.com/SteveMacenski/bond_core.git
+    version: lifecycle_support


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1754 |
| Primary OS tested on | Ubuntu, |
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points

* Added bond support to the major lifecycle servers 
* Kills all the nodes if one of the critical relevant nodes fails, then will wait for stimulus to restart up  
* Parameterized to be able to disable
* If misconfigured (e.x. can't communicate to a non-existent server) will bring down everything for safety

## Description of documentation updates required from your changes

* Add to migration guide 
* Add capability docs to let people know this is happening and why

---

## Future work that may be required in bullet points

Before end of WIP:
- [x] test working basic (timeouts work and settable/disableable, will actually bring system down, can be brought back up, clean shutdown and startup, no false alarms, delayed/no connection on startup clean warn)
- [x] should keep the bond option or always?
- [x] If always (and if misconfigured) how does it handle never connecting on startup (or delayed connection)?
- [x] Make sure all forms of shutdown have this triggered to break the bond
- [x] option for duration before killing (which could be set inf to disable)
