### PR TITLE
Use current time to check if observation is out of date

### DIFF
--- a/nav2_costmap_2d/src/observation_buffer.cpp
+++ b/nav2_costmap_2d/src/observation_buffer.cpp
@@ -234,7 +234,7 @@ void ObservationBuffer::purgeStaleObservations()
       Observation & obs = *obs_it;
       // check if the observation is out of date... and if it is,
       // remove it and those that follow from the list
-      if ((last_updated_ - obs.cloud_->header.stamp) > observation_keep_time_) {
+      if ((nh_->now() - obs.cloud_->header.stamp) > observation_keep_time_) {
         observation_list_.erase(obs_it, observation_list_.end());
         return;
       }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/545 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | prototype |

## Issue:

Points remain in obstacle layer after we stopped publishing a point cloud on regular basis. Settings to reproduce:

```
      obstacle_layer:
        enabled: true
        observation_sources: pointcloud
        pointcloud:
          topic: "blabla"
          max_obstacle_height: 2.0
          data_type: "PointCloud2"
          expected_update_rate: 0.0
          observation_persistence: 1.0
          clearing: true
          marking: true
```

According to `observation_persistence: 1.0` the point clouds used by the obstacle layers should time-out after 1 second. 

## Analysis:

* `last_updated_` is updated on every new cloud that needs to be added to the buffer. 
* **purgeStaleObservations** checks the cloud's time stamp with `last_updated_`. 
* When we stop publishing a point cloud `last_updated_` will never be updated. 
* Hence the observations will not time-out and remain in the `observation_list_`.
* This may result in the following warning, when the robot drives away from the clouds in `observation_list_`:

`Sensor origin at (x, y) is out of map bounds. The costmap cannot raytrace for it.`

---



## Description of contribution in a few bullet points




* Fixed it by replacing `last_updated_` with `nh_->now()` in **purgeStaleObservations**




## Description of documentation updates required from your changes

* _None_

## Future work that may be required in bullet points

* _None_
