### PR TITLE
Move definitions in tf_help to separate src cpp file

### DIFF
--- a/nav2_dwb_controller/nav_2d_utils/CMakeLists.txt
+++ b/nav2_dwb_controller/nav_2d_utils/CMakeLists.txt
@@ -43,7 +43,15 @@ ament_target_dependencies(path_ops
   ${dependencies}
 )
 
-install(TARGETS conversions path_ops
+add_library(tf_help SHARED
+  src/tf_help.cpp
+)
+
+ament_target_dependencies(tf_help
+  ${dependencies}
+)
+
+install(TARGETS conversions path_ops tf_help
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -60,7 +68,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(conversions path_ops)
+ament_export_libraries(conversions path_ops tf_help)
 ament_export_dependencies(${dependencies})
 
 ament_package()

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/tf_help.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/tf_help.hpp
@@ -56,9 +56,9 @@ namespace nav_2d_utils
    * @return True if successful transform
    */
   bool transformPose(
-    const std::shared_ptr<tf2_ros::Buffer> tf, 
+    const std::shared_ptr<tf2_ros::Buffer> tf,
     const std::string frame,
-    const geometry_msgs::msg::PoseStamped & in_pose, 
+    const geometry_msgs::msg::PoseStamped & in_pose,
     geometry_msgs::msg::PoseStamped & out_pose,
     rclcpp::Duration & transform_tolerance
   );
@@ -74,9 +74,9 @@ namespace nav_2d_utils
    * @return True if successful transform
    */
   bool transformPose(
-    const std::shared_ptr<tf2_ros::Buffer> tf, 
+    const std::shared_ptr<tf2_ros::Buffer> tf,
     const std::string frame,
-    const nav_2d_msgs::msg::Pose2DStamped & in_pose, 
+    const nav_2d_msgs::msg::Pose2DStamped & in_pose,
     nav_2d_msgs::msg::Pose2DStamped & out_pose,
     rclcpp::Duration & transform_tolerance
   );

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/tf_help.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/tf_help.hpp
@@ -45,41 +45,41 @@
 
 namespace nav_2d_utils
 {
-  /**
-   * @brief Transform a PoseStamped from one frame to another while catching exceptions
-   *
-   * Also returns immediately if the frames are equal.
-   * @param tf Smart pointer to TFListener
-   * @param frame Frame to transform the pose into
-   * @param in_pose Pose to transform
-   * @param out_pose Place to store the resulting transformed pose
-   * @return True if successful transform
-   */
-  bool transformPose(
-    const std::shared_ptr<tf2_ros::Buffer> tf,
-    const std::string frame,
-    const geometry_msgs::msg::PoseStamped & in_pose,
-    geometry_msgs::msg::PoseStamped & out_pose,
-    rclcpp::Duration & transform_tolerance
-  );
+/**
+ * @brief Transform a PoseStamped from one frame to another while catching exceptions
+ *
+ * Also returns immediately if the frames are equal.
+ * @param tf Smart pointer to TFListener
+ * @param frame Frame to transform the pose into
+ * @param in_pose Pose to transform
+ * @param out_pose Place to store the resulting transformed pose
+ * @return True if successful transform
+ */
+bool transformPose(
+  const std::shared_ptr<tf2_ros::Buffer> tf,
+  const std::string frame,
+  const geometry_msgs::msg::PoseStamped & in_pose,
+  geometry_msgs::msg::PoseStamped & out_pose,
+  rclcpp::Duration & transform_tolerance
+);
 
-  /**
-   * @brief Transform a Pose2DStamped from one frame to another while catching exceptions
-   *
-   * Also returns immediately if the frames are equal.
-   * @param tf Smart pointer to TFListener
-   * @param frame Frame to transform the pose into
-   * @param in_pose Pose to transform
-   * @param out_pose Place to store the resulting transformed pose
-   * @return True if successful transform
-   */
-  bool transformPose(
-    const std::shared_ptr<tf2_ros::Buffer> tf,
-    const std::string frame,
-    const nav_2d_msgs::msg::Pose2DStamped & in_pose,
-    nav_2d_msgs::msg::Pose2DStamped & out_pose,
-    rclcpp::Duration & transform_tolerance
-  );
+/**
+ * @brief Transform a Pose2DStamped from one frame to another while catching exceptions
+ *
+ * Also returns immediately if the frames are equal.
+ * @param tf Smart pointer to TFListener
+ * @param frame Frame to transform the pose into
+ * @param in_pose Pose to transform
+ * @param out_pose Place to store the resulting transformed pose
+ * @return True if successful transform
+ */
+bool transformPose(
+  const std::shared_ptr<tf2_ros::Buffer> tf,
+  const std::string frame,
+  const nav_2d_msgs::msg::Pose2DStamped & in_pose,
+  nav_2d_msgs::msg::Pose2DStamped & out_pose,
+  rclcpp::Duration & transform_tolerance
+);
 
 }  // namespace nav_2d_utils
 

--- a/nav2_dwb_controller/nav_2d_utils/src/tf_help.cpp
+++ b/nav2_dwb_controller/nav_2d_utils/src/tf_help.cpp
@@ -63,8 +63,7 @@ bool transformPose(
     );
     if (
       (rclcpp::Time(in_pose.header.stamp) - rclcpp::Time(transform.header.stamp)) >
-      transform_tolerance
-    )
+      transform_tolerance)
     {
       RCLCPP_ERROR(
         rclcpp::get_logger("tf_help"),

--- a/nav2_dwb_controller/nav_2d_utils/src/tf_help.cpp
+++ b/nav2_dwb_controller/nav_2d_utils/src/tf_help.cpp
@@ -32,15 +32,17 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <memory>
+#include <string>
 #include "nav_2d_utils/tf_help.hpp"
 
 namespace nav_2d_utils
 {
 
   bool transformPose(
-    const std::shared_ptr<tf2_ros::Buffer> tf, 
+    const std::shared_ptr<tf2_ros::Buffer> tf,
     const std::string frame,
-    const geometry_msgs::msg::PoseStamped & in_pose, 
+    const geometry_msgs::msg::PoseStamped & in_pose,
     geometry_msgs::msg::PoseStamped & out_pose,
     rclcpp::Duration & transform_tolerance
   )
@@ -55,8 +57,8 @@ namespace nav_2d_utils
       return true;
     } catch (tf2::ExtrapolationException & ex) {
       auto transform = tf->lookupTransform(
-        frame, 
-        in_pose.header.frame_id, 
+        frame,
+        in_pose.header.frame_id,
         tf2::TimePointZero
       );
       if (
@@ -73,9 +75,9 @@ namespace nav_2d_utils
         RCLCPP_ERROR(
           rclcpp::get_logger("tf_help"),
           "Data time: %ds %uns, Transform time: %ds %uns",
-          in_pose.header.stamp.sec, 
+          in_pose.header.stamp.sec,
           in_pose.header.stamp.nanosec,
-          transform.header.stamp.sec, 
+          transform.header.stamp.sec,
           transform.header.stamp.nanosec
         );
         return false;
@@ -86,7 +88,7 @@ namespace nav_2d_utils
     } catch (tf2::TransformException & ex) {
       RCLCPP_ERROR(
         rclcpp::get_logger("tf_help"),
-        "Exception in transformPose: %s", 
+        "Exception in transformPose: %s",
         ex.what()
       );
       return false;
@@ -95,9 +97,9 @@ namespace nav_2d_utils
   }
 
   bool transformPose(
-    const std::shared_ptr<tf2_ros::Buffer> tf, 
+    const std::shared_ptr<tf2_ros::Buffer> tf,
     const std::string frame,
-    const nav_2d_msgs::msg::Pose2DStamped & in_pose, 
+    const nav_2d_msgs::msg::Pose2DStamped & in_pose,
     nav_2d_msgs::msg::Pose2DStamped & out_pose,
     rclcpp::Duration & transform_tolerance
   )
@@ -111,4 +113,4 @@ namespace nav_2d_utils
     }
     return ret;
   }
-}
+}  // namespace nav_2d_utils

--- a/nav2_dwb_controller/nav_2d_utils/src/tf_help.cpp
+++ b/nav2_dwb_controller/nav_2d_utils/src/tf_help.cpp
@@ -32,55 +32,83 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef NAV_2D_UTILS__TF_HELP_HPP_
-#define NAV_2D_UTILS__TF_HELP_HPP_
-
-#include <string>
-#include <memory>
-#include "tf2_ros/buffer.h"
-#include "nav_2d_utils/conversions.hpp"
-#include "geometry_msgs/msg/pose_stamped.hpp"
-#include "nav_2d_msgs/msg/pose2_d_stamped.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "nav_2d_utils/tf_help.hpp"
 
 namespace nav_2d_utils
 {
-  /**
-   * @brief Transform a PoseStamped from one frame to another while catching exceptions
-   *
-   * Also returns immediately if the frames are equal.
-   * @param tf Smart pointer to TFListener
-   * @param frame Frame to transform the pose into
-   * @param in_pose Pose to transform
-   * @param out_pose Place to store the resulting transformed pose
-   * @return True if successful transform
-   */
+
   bool transformPose(
     const std::shared_ptr<tf2_ros::Buffer> tf, 
     const std::string frame,
     const geometry_msgs::msg::PoseStamped & in_pose, 
     geometry_msgs::msg::PoseStamped & out_pose,
     rclcpp::Duration & transform_tolerance
-  );
+  )
+  {
+    if (in_pose.header.frame_id == frame) {
+      out_pose = in_pose;
+      return true;
+    }
 
-  /**
-   * @brief Transform a Pose2DStamped from one frame to another while catching exceptions
-   *
-   * Also returns immediately if the frames are equal.
-   * @param tf Smart pointer to TFListener
-   * @param frame Frame to transform the pose into
-   * @param in_pose Pose to transform
-   * @param out_pose Place to store the resulting transformed pose
-   * @return True if successful transform
-   */
+    try {
+      tf->transform(in_pose, out_pose, frame);
+      return true;
+    } catch (tf2::ExtrapolationException & ex) {
+      auto transform = tf->lookupTransform(
+        frame, 
+        in_pose.header.frame_id, 
+        tf2::TimePointZero
+      );
+      if (
+        (rclcpp::Time(in_pose.header.stamp) - rclcpp::Time(transform.header.stamp)) >
+        transform_tolerance
+      )
+      {
+        RCLCPP_ERROR(
+          rclcpp::get_logger("tf_help"),
+          "Transform data too old when converting from %s to %s",
+          in_pose.header.frame_id.c_str(),
+          frame.c_str()
+        );
+        RCLCPP_ERROR(
+          rclcpp::get_logger("tf_help"),
+          "Data time: %ds %uns, Transform time: %ds %uns",
+          in_pose.header.stamp.sec, 
+          in_pose.header.stamp.nanosec,
+          transform.header.stamp.sec, 
+          transform.header.stamp.nanosec
+        );
+        return false;
+      } else {
+        tf2::doTransform(in_pose, out_pose, transform);
+        return true;
+      }
+    } catch (tf2::TransformException & ex) {
+      RCLCPP_ERROR(
+        rclcpp::get_logger("tf_help"),
+        "Exception in transformPose: %s", 
+        ex.what()
+      );
+      return false;
+    }
+    return false;
+  }
+
   bool transformPose(
     const std::shared_ptr<tf2_ros::Buffer> tf, 
     const std::string frame,
     const nav_2d_msgs::msg::Pose2DStamped & in_pose, 
     nav_2d_msgs::msg::Pose2DStamped & out_pose,
     rclcpp::Duration & transform_tolerance
-  );
+  )
+  {
+    geometry_msgs::msg::PoseStamped in_3d_pose = pose2DToPoseStamped(in_pose);
+    geometry_msgs::msg::PoseStamped out_3d_pose;
 
-}  // namespace nav_2d_utils
-
-#endif  // NAV_2D_UTILS__TF_HELP_HPP_
+    bool ret = transformPose(tf, frame, in_3d_pose, out_3d_pose, transform_tolerance);
+    if (ret) {
+      out_pose = poseStampedToPose2D(out_3d_pose);
+    }
+    return ret;
+  }
+}

--- a/nav2_dwb_controller/nav_2d_utils/src/tf_help.cpp
+++ b/nav2_dwb_controller/nav_2d_utils/src/tf_help.cpp
@@ -39,78 +39,78 @@
 namespace nav_2d_utils
 {
 
-  bool transformPose(
-    const std::shared_ptr<tf2_ros::Buffer> tf,
-    const std::string frame,
-    const geometry_msgs::msg::PoseStamped & in_pose,
-    geometry_msgs::msg::PoseStamped & out_pose,
-    rclcpp::Duration & transform_tolerance
-  )
-  {
-    if (in_pose.header.frame_id == frame) {
-      out_pose = in_pose;
-      return true;
-    }
+bool transformPose(
+  const std::shared_ptr<tf2_ros::Buffer> tf,
+  const std::string frame,
+  const geometry_msgs::msg::PoseStamped & in_pose,
+  geometry_msgs::msg::PoseStamped & out_pose,
+  rclcpp::Duration & transform_tolerance
+)
+{
+  if (in_pose.header.frame_id == frame) {
+    out_pose = in_pose;
+    return true;
+  }
 
-    try {
-      tf->transform(in_pose, out_pose, frame);
-      return true;
-    } catch (tf2::ExtrapolationException & ex) {
-      auto transform = tf->lookupTransform(
-        frame,
-        in_pose.header.frame_id,
-        tf2::TimePointZero
-      );
-      if (
-        (rclcpp::Time(in_pose.header.stamp) - rclcpp::Time(transform.header.stamp)) >
-        transform_tolerance
-      )
-      {
-        RCLCPP_ERROR(
-          rclcpp::get_logger("tf_help"),
-          "Transform data too old when converting from %s to %s",
-          in_pose.header.frame_id.c_str(),
-          frame.c_str()
-        );
-        RCLCPP_ERROR(
-          rclcpp::get_logger("tf_help"),
-          "Data time: %ds %uns, Transform time: %ds %uns",
-          in_pose.header.stamp.sec,
-          in_pose.header.stamp.nanosec,
-          transform.header.stamp.sec,
-          transform.header.stamp.nanosec
-        );
-        return false;
-      } else {
-        tf2::doTransform(in_pose, out_pose, transform);
-        return true;
-      }
-    } catch (tf2::TransformException & ex) {
+  try {
+    tf->transform(in_pose, out_pose, frame);
+    return true;
+  } catch (tf2::ExtrapolationException & ex) {
+    auto transform = tf->lookupTransform(
+      frame,
+      in_pose.header.frame_id,
+      tf2::TimePointZero
+    );
+    if (
+      (rclcpp::Time(in_pose.header.stamp) - rclcpp::Time(transform.header.stamp)) >
+      transform_tolerance
+    )
+    {
       RCLCPP_ERROR(
         rclcpp::get_logger("tf_help"),
-        "Exception in transformPose: %s",
-        ex.what()
+        "Transform data too old when converting from %s to %s",
+        in_pose.header.frame_id.c_str(),
+        frame.c_str()
+      );
+      RCLCPP_ERROR(
+        rclcpp::get_logger("tf_help"),
+        "Data time: %ds %uns, Transform time: %ds %uns",
+        in_pose.header.stamp.sec,
+        in_pose.header.stamp.nanosec,
+        transform.header.stamp.sec,
+        transform.header.stamp.nanosec
       );
       return false;
+    } else {
+      tf2::doTransform(in_pose, out_pose, transform);
+      return true;
     }
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("tf_help"),
+      "Exception in transformPose: %s",
+      ex.what()
+    );
     return false;
   }
+  return false;
+}
 
-  bool transformPose(
-    const std::shared_ptr<tf2_ros::Buffer> tf,
-    const std::string frame,
-    const nav_2d_msgs::msg::Pose2DStamped & in_pose,
-    nav_2d_msgs::msg::Pose2DStamped & out_pose,
-    rclcpp::Duration & transform_tolerance
-  )
-  {
-    geometry_msgs::msg::PoseStamped in_3d_pose = pose2DToPoseStamped(in_pose);
-    geometry_msgs::msg::PoseStamped out_3d_pose;
+bool transformPose(
+  const std::shared_ptr<tf2_ros::Buffer> tf,
+  const std::string frame,
+  const nav_2d_msgs::msg::Pose2DStamped & in_pose,
+  nav_2d_msgs::msg::Pose2DStamped & out_pose,
+  rclcpp::Duration & transform_tolerance
+)
+{
+  geometry_msgs::msg::PoseStamped in_3d_pose = pose2DToPoseStamped(in_pose);
+  geometry_msgs::msg::PoseStamped out_3d_pose;
 
-    bool ret = transformPose(tf, frame, in_3d_pose, out_3d_pose, transform_tolerance);
-    if (ret) {
-      out_pose = poseStampedToPose2D(out_3d_pose);
-    }
-    return ret;
+  bool ret = transformPose(tf, frame, in_3d_pose, out_3d_pose, transform_tolerance);
+  if (ret) {
+    out_pose = poseStampedToPose2D(out_3d_pose);
   }
+  return ret;
+}
 }  // namespace nav_2d_utils


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1879 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | gazebo simulation of turtlebot3 on eloquent |

---

## Description of contribution in a few bullet points

* Moved definitions of nav_2d_util::transformPose into separate cpp file to avoid multiple definition compilation error
* Added library to CMakeLists

## Future work that may be required in bullet points

Noticed a few other methods in nav_2d_util were also defined in header files. These too could cause an issue if included in multiple src files.
