### PR TITLE
Speed is inverted when dist is negative

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
@@ -37,7 +37,7 @@ public:
   {
     return providedBasicPorts(
       {
-        BT::InputPort<double>("backup_dist", -0.15, "Distance to backup"),
+        BT::InputPort<double>("backup_dist", 0.15, "Distance to backup"),
         BT::InputPort<double>("backup_speed", 0.025, "Speed at which to backup")
       });
   }

--- a/nav2_behavior_tree/plugins/action/back_up_action.cpp
+++ b/nav2_behavior_tree/plugins/action/back_up_action.cpp
@@ -31,10 +31,6 @@ BackUpAction::BackUpAction(
   double speed;
   getInput("backup_speed", speed);
 
-  // Silently ensure, that speed and distance are positive values
-  speed = std::fabs(speed);
-  dist = std::fabs(dist);
-
   // Populate the input message
   goal_.target.x = dist;
   goal_.target.y = 0.0;

--- a/nav2_behavior_tree/plugins/action/back_up_action.cpp
+++ b/nav2_behavior_tree/plugins/action/back_up_action.cpp
@@ -31,13 +31,12 @@ BackUpAction::BackUpAction(
   double speed;
   getInput("backup_speed", speed);
 
-  // silently fix, vector direction determined by distance sign
-  if (speed < 0.0) {
-    speed *= -1.0;
-  }
+  // Silently ensure, that speed and distance are positive values
+  speed = std::fabs(speed);
+  dist = std::fabs(dist);
 
   // Populate the input message
-  goal_.target.x = dist;
+  goal_.target.x = -dist;
   goal_.target.y = 0.0;
   goal_.target.z = 0.0;
   goal_.speed = speed;

--- a/nav2_behavior_tree/plugins/action/back_up_action.cpp
+++ b/nav2_behavior_tree/plugins/action/back_up_action.cpp
@@ -36,7 +36,7 @@ BackUpAction::BackUpAction(
   dist = std::fabs(dist);
 
   // Populate the input message
-  goal_.target.x = -dist;
+  goal_.target.x = dist;
   goal_.target.y = 0.0;
   goal_.target.z = 0.0;
   goal_.speed = speed;

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
@@ -114,7 +114,7 @@ TEST_F(BackUpActionTestFixture, test_ports)
       </root>)";
 
   tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
-  EXPECT_EQ(tree_->rootNode()->getInput<double>("backup_dist"), -0.15);
+  EXPECT_EQ(tree_->rootNode()->getInput<double>("backup_dist"), 0.15);
   EXPECT_EQ(tree_->rootNode()->getInput<double>("backup_speed"), 0.025);
 
   xml_txt =
@@ -136,7 +136,7 @@ TEST_F(BackUpActionTestFixture, test_tick)
     R"(
       <root main_tree_to_execute = "MainTree" >
         <BehaviorTree ID="MainTree">
-            <BackUp backup_dist="2" backup_speed="-0.26" />
+            <BackUp backup_dist="2" backup_speed="0.26" />
         </BehaviorTree>
       </root>)";
 

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
@@ -146,7 +146,7 @@ TEST_F(BackUpActionTestFixture, test_tick)
   EXPECT_EQ(config_->blackboard->get<int>("number_recoveries"), 1);
 
   auto goal = action_server_->getCurrentGoal();
-  EXPECT_EQ(goal->target.x, 2.0);
+  EXPECT_EQ(goal->target.x, -2.0);
   EXPECT_EQ(goal->speed, 0.26f);
 }
 

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
@@ -146,7 +146,7 @@ TEST_F(BackUpActionTestFixture, test_tick)
   EXPECT_EQ(config_->blackboard->get<int>("number_recoveries"), 1);
 
   auto goal = action_server_->getCurrentGoal();
-  EXPECT_EQ(goal->target.x, -2.0);
+  EXPECT_EQ(goal->target.x, 2.0);
   EXPECT_EQ(goal->speed, 0.26f);
 }
 

--- a/nav2_recoveries/plugins/back_up.cpp
+++ b/nav2_recoveries/plugins/back_up.cpp
@@ -51,8 +51,9 @@ Status BackUp::onRun(const std::shared_ptr<const BackUpAction::Goal> command)
       "will only move in X.");
   }
 
-  command_x_ = command->target.x;
-  command_speed_ = command->speed;
+  // Silently ensure that both the speed and direction are positive.
+  command_x_ = std::fabs(command->target.x);
+  command_speed_ = std::fabs(command->speed);
 
   if (!nav2_util::getCurrentPose(
       initial_pose_, *tf_, global_frame_, robot_base_frame_,
@@ -83,7 +84,7 @@ Status BackUp::onCycleUpdate()
   feedback_->distance_traveled = distance;
   action_server_->publish_feedback(feedback_);
 
-  if (distance >= abs(command_x_)) {
+  if (distance >= command_x_) {
     stopRobot();
     return Status::SUCCEEDED;
   }
@@ -92,7 +93,7 @@ Status BackUp::onCycleUpdate()
   auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>();
   cmd_vel->linear.y = 0.0;
   cmd_vel->angular.z = 0.0;
-  command_x_ < 0 ? cmd_vel->linear.x = -command_speed_ : cmd_vel->linear.x = command_speed_;
+  cmd_vel->linear.x = -command_speed_;
 
   geometry_msgs::msg::Pose2D pose2d;
   pose2d.x = current_pose.pose.position.x;


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  #1896 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo |

---

## Description of contribution in a few bullet points
* Fixes that backup_action_node cannot enter a negative speed and therefore the action cannot backed up.
* Changed to invert speed when distance is negative (robot should go forward) similar to backup recovery node.
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
