### PR TITLE
Fix nav2_bt_navigator cleanup

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -214,6 +214,7 @@ BtNavigator::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
 
   action_server_.reset();
   plugin_lib_names_.clear();
+  current_bt_xml_filename_.clear();
   blackboard_.reset();
   bt_->haltAllActions(tree_.rootNode());
   bt_.reset();


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  #1893 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | TurtleBot3 Gazebo |

---

## Description of contribution in a few bullet points

* Tiny fix in `nav2_bt_navigator` cleanup to clear `current_bt_xml_filename_` which prevented `BtNavigator::loadBehaviorTree` to load a BT with the latest blackboard