### PR TITLE
[WIP] A* dynamic tests to work as advertised

### DIFF
--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -41,7 +41,7 @@ def generate_launch_description():
     params_file = os.path.join(bringup_dir, 'params', 'nav2_params.yaml')
 
     # Replace the `use_astar` setting on the params file
-    param_substitutions = {'GridBased.use_astar': os.getenv('ASTAR')}
+    param_substitutions = {'planner_server.ros__parameters.GridBased.use_astar': os.getenv('ASTAR')}
     configured_params = RewrittenYaml(
         source_file=params_file,
         root_key='',


### PR DESCRIPTION
#1810 

Looks like from test coverage docs that we're not actually testing A* at all even though set in the parameter remapping. I think we're missing the full namespacing from it to count. Seeing if this will fix things. If not, we'll have to reassess how to get A* coverage. 