### PR TITLE
Bunches of random new tests

### DIFF
--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -66,10 +66,7 @@ PlannerServer::PlannerServer()
 PlannerServer::~PlannerServer()
 {
   RCLCPP_INFO(get_logger(), "Destroying");
-  PlannerMap::iterator it;
-  for (it = planners_.begin(); it != planners_.end(); ++it) {
-    it->second.reset();
-  }
+  planners_.clear();
 }
 
 nav2_util::CallbackReturn

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -67,6 +67,10 @@ void PlannerTester::activate()
   // The navfn wrapper
   auto state = rclcpp_lifecycle::State();
   planner_tester_ = std::make_shared<NavFnPlannerTester>();
+  planner_tester_->declare_parameter(
+    "GridBased.use_astar", rclcpp::ParameterValue(true));
+  planner_tester_->set_parameter(
+    rclcpp::Parameter(std::string("GridBased.use_astar"), rclcpp::ParameterValue(true)));
   planner_tester_->onConfigure(state);
   publishRobotTransform();
   map_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("map", 1);

--- a/nav2_system_tests/src/system/CMakeLists.txt
+++ b/nav2_system_tests/src/system/CMakeLists.txt
@@ -1,3 +1,6 @@
+# NOTE: The ASTAR=True does not work currently due to remapping not functioning
+# All set to false, A* testing of NavFn happens in the planning test portion
+
 ament_add_test(test_bt_navigator
   GENERATE_RESULT_FOR_RETURN_CODE_ZERO
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_system_launch.py"
@@ -9,7 +12,7 @@ ament_add_test(test_bt_navigator
     TEST_WORLD=${PROJECT_SOURCE_DIR}/worlds/turtlebot3_ros2_demo.world
     GAZEBO_MODEL_PATH=${PROJECT_SOURCE_DIR}/models
     BT_NAVIGATOR_XML=navigate_w_replanning_and_recovery.xml
-    ASTAR=True
+    ASTAR=False
 )
 
 ament_add_test(test_bt_navigator_with_dijkstra
@@ -37,7 +40,7 @@ ament_add_test(test_dynamic_obstacle
     TEST_WORLD=${PROJECT_SOURCE_DIR}/worlds/turtlebot3_ros2_demo_obstacle.world
     GAZEBO_MODEL_PATH=${PROJECT_SOURCE_DIR}/models
     BT_NAVIGATOR_XML=navigate_w_replanning_and_recovery.xml
-    ASTAR=True
+    ASTAR=False
 )
 
 # ament_add_test(test_multi_robot

--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -41,7 +41,8 @@ def generate_launch_description():
     params_file = os.path.join(bringup_dir, 'params', 'nav2_params.yaml')
 
     # Replace the `use_astar` setting on the params file
-    param_substitutions = {'planner_server.ros__parameters.GridBased.use_astar': os.getenv('ASTAR')}
+    param_substitutions = {
+        'planner_server.ros__parameters.GridBased.use_astar': os.getenv('ASTAR')}
     configured_params = RewrittenYaml(
         source_file=params_file,
         root_key='',

--- a/nav2_system_tests/src/system/test_system_launch.py
+++ b/nav2_system_tests/src/system/test_system_launch.py
@@ -41,7 +41,7 @@ def generate_launch_description():
     params_file = os.path.join(bringup_dir, 'params', 'nav2_params.yaml')
 
     # Replace the `use_astar` setting on the params file
-    param_substitutions = {'GridBased.use_astar': os.getenv('ASTAR')}
+    param_substitutions = {'planner_server.ros__parameters.GridBased.use_astar': os.getenv('ASTAR')}
     configured_params = RewrittenYaml(
         source_file=params_file,
         root_key='',

--- a/nav2_system_tests/src/system/tester_node.py
+++ b/nav2_system_tests/src/system/tester_node.py
@@ -228,12 +228,8 @@ def run_all_tests(robot_tester):
         robot_tester.wait_for_node_active('bt_navigator')
         result = robot_tester.runNavigateAction()
 
-    # TODO(orduno) Test sending the navigation request through the topic interface.
-    #              Need to update tester to receive multiple goal poses.
-    #              Need to fix bug with shutting down while bt_navigator
-    #              is still running.
-    # if (result):
-        # result = test_RobotMovesToGoal(robot_tester)
+    if (result):
+        result = test_RobotMovesToGoal(robot_tester)
 
     # Add more tests here if desired
 

--- a/nav2_waypoint_follower/include/nav2_waypoint_follower/waypoint_follower.hpp
+++ b/nav2_waypoint_follower/include/nav2_waypoint_follower/waypoint_follower.hpp
@@ -120,6 +120,7 @@ protected:
   std::unique_ptr<ActionServer> action_server_;
   ActionClient::SharedPtr nav_to_pose_client_;
   rclcpp::Node::SharedPtr client_node_;
+  std::shared_future<rclcpp_action::ClientGoalHandle<ClientT>::SharedPtr> future_goal_handle_;
   bool stop_on_failure_;
   ActionStatus current_goal_status_;
   int loop_rate_;

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -139,7 +139,8 @@ WaypointFollower::followWaypoints()
   while (rclcpp::ok()) {
     // Check if asked to stop processing action
     if (action_server_->is_cancel_requested()) {
-      RCLCPP_INFO(get_logger(), "Cancelling action.");
+      auto cancel_future = nav_to_pose_client_->async_cancel_all_goals();
+      rclcpp::spin_until_future_complete(client_node_, cancel_future);
       action_server_->terminate_all();
       return;
     }
@@ -163,7 +164,7 @@ WaypointFollower::followWaypoints()
         std::bind(&WaypointFollower::resultCallback, this, std::placeholders::_1);
       send_goal_options.goal_response_callback =
         std::bind(&WaypointFollower::goalResponseCallback, this, std::placeholders::_1);
-      auto future_goal_handle =
+      future_goal_handle_ =
         nav_to_pose_client_->async_send_goal(client_goal, send_goal_options);
       current_goal_status_ = ActionStatus::PROCESSING;
     }


### PR DESCRIPTION
#1810 

Looks like from test coverage docs that we're not actually testing A* at all even though set in the parameter remapping. I think we're missing the full namespacing from it to count. Seeing if this will fix things. If not, we'll have to reassess how to get A* coverage. 

cleaner destruction of planner server, add preemption and cancel coverage for waypoint follower and cancel for bt navigator coverage, A* coverage via planner tests, topic-based navigation
