### PR TITLE
Costmap lock while copying data in navfn planner

### DIFF
--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -174,12 +174,16 @@ NavfnPlanner::makePlan(
   // clear the starting cell within the costmap because we know it can't be an obstacle
   clearRobotCell(mx, my);
 
+  std::unique_lock<nav2_costmap_2d::Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
+
   // make sure to resize the underlying array that Navfn uses
   planner_->setNavArr(
     costmap_->getSizeInCellsX(),
     costmap_->getSizeInCellsY());
 
   planner_->setCostmap(costmap_->getCharMap(), true, allow_unknown_);
+
+  lock.unlock();
 
   int map_start[2];
   map_start[0] = mx;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1911 |
| Primary OS tested on | Ubuntu|

---

## Description of contribution in a few bullet points

* This avoids making a plan while the costmap layer is updating
---

## Design consideration

* This may happen with a custom planner plugin
* The following version could prevent such problem but may lock up costmap update longer time
https://github.com/CMU-cabot/navigation2/commit/ba6b87e60899e7f0ce960d74bef11ee21a2a01d0