### PR TITLE
[Testing sprint] minor changes to lower redundent warnings 

### DIFF
--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -424,7 +424,6 @@ bool ControllerServer::getRobotPose(geometry_msgs::msg::PoseStamped & pose)
 {
   geometry_msgs::msg::PoseStamped current_pose;
   if (!costmap_ros_->getRobotPose(current_pose)) {
-    RCLCPP_ERROR(this->get_logger(), "Could not get robot pose");
     return false;
   }
   pose = current_pose;

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -288,12 +288,10 @@ PlannerServer::computePlan()
     result->planning_time = cycle_duration;
 
     if (max_planner_duration_ && cycle_duration.seconds() > max_planner_duration_) {
-      auto planner_period = 1 / max_planner_duration_;
-      auto cycle_period = 1 / cycle_duration.seconds();
       RCLCPP_WARN(
         get_logger(),
         "Planner loop missed its desired rate of %.4f Hz. Current loop rate is %.4f Hz",
-        planner_period, cycle_period);
+        1 / max_planner_duration_, 1 / cycle_duration.seconds());
     }
 
     action_server_->succeeded_current(result);

--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -202,6 +202,7 @@ def main(argv=sys.argv[1:]):
     test.cancel_goal()
 
     # a failure case
+    time.sleep(2)
     test.setWaypoints([[100.0, 100.0]])
     result = test.run(True)
     assert not result


### PR DESCRIPTION
#1810 

Collapsing lines that can be on 1 line where they make sense. Also removing a controller server warning that is covered by exceptions. Adding sleep to waypoint follower integration test to give some time for networking to die down 