### PR TITLE
Costmap plugins declare if not declared for reset capabilities

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -305,15 +305,15 @@ Costmap2DROS::getParameters()
   get_parameter("width", map_width_meters_);
   get_parameter("plugins", plugin_names_);
 
+  auto node = shared_from_this();
+
   if (plugin_names_ == default_plugins_) {
     for (size_t i = 0; i < default_plugins_.size(); ++i) {
-      declare_parameter(default_plugins_[i] + ".plugin", default_types_[i]);
+      nav2_util::declare_parameter_if_not_declared(
+        node, default_plugins_[i] + ".plugin", default_types_[i]);
     }
   }
   plugin_types_.resize(plugin_names_.size());
-
-  // Semantic checks...
-  auto node = shared_from_this();
 
   // 1. All plugins must have 'plugin' param defined in their namespace to define the plugin type
   for (size_t i = 0; i < plugin_names_.size(); ++i) {

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -310,7 +310,7 @@ Costmap2DROS::getParameters()
   if (plugin_names_ == default_plugins_) {
     for (size_t i = 0; i < default_plugins_.size(); ++i) {
       nav2_util::declare_parameter_if_not_declared(
-        node, default_plugins_[i] + ".plugin", default_types_[i]);
+        node, default_plugins_[i] + ".plugin", rclcpp::ParameterValue(default_types_[i]));
     }
   }
   plugin_types_.resize(plugin_names_.size());


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1917 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation  |

---

## Description of contribution in a few bullet points

* Declare if not declared the plugin parameter when getting plugins for costmap_2d

## Description of documentation updates required from your changes

* N/A

---
