### PR TITLE
[test sprint] generate report for nav2_system_tests included in coverage report

### DIFF
--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -78,8 +78,6 @@ lcov \
     "${PWD}/*/nav2_msgs/*" \
   --remove ${LCOVDIR}/workspace_coverage.info \
     "${PWD}/*/nav_2d_msgs/*" \
-  --remove ${LCOVDIR}/workspace_coverage.info \
-    "${PWD}/*/nav2_system_tests/*" \
   --output-file ${LCOVDIR}/project_coverage.info \
   --rc lcov_branch_coverage=0
 


### PR DESCRIPTION
#1810 

Right now its not included, I'm curious what it will say if it is included. Its technically test that's being covered, I'd like to know if that should be counting in our statistics.