### PR TITLE
Fixing multiple waypoint follower nodes on network, resolves #1937

### DIFF
--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -20,8 +20,6 @@
 #include <string>
 #include <utility>
 
-// TODO(stevemacenski): Add capability for reading in yaml file and executing
-
 namespace nav2_waypoint_follower
 {
 
@@ -47,9 +45,13 @@ WaypointFollower::on_configure(const rclcpp_lifecycle::State & /*state*/)
   stop_on_failure_ = get_parameter("stop_on_failure").as_bool();
   loop_rate_ = get_parameter("loop_rate").as_int();
 
-  // use suffix '_rclcpp_node' to keep parameter file consistency #1773
+  std::vector<std::string> new_args = rclcpp::NodeOptions().arguments();
+  new_args.push_back("--ros-args");
+  new_args.push_back("-r");
+  new_args.push_back(std::string("__node:=") + this->get_name() + "_rclcpp_node");
+  new_args.push_back("--");
   client_node_ = std::make_shared<rclcpp::Node>(
-    std::string(get_name()) + std::string("_rclcpp_node"));
+    "_", "", rclcpp::NodeOptions().arguments(new_args));
 
   nav_to_pose_client_ = rclcpp_action::create_client<ClientT>(
     client_node_, "navigate_to_pose");


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1937|
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Sim |

---

## Description of contribution in a few bullet points

* Changed the way we define the name of the node, which as memory serves for client / secondary nodes has to be done a little bit of a funky way. I think there's some hacky solution in rclcpp for remapping the node names in the C++ code to launch that effects the entire process' nodes not just the object of that name. 

## Description of documentation updates required from your changes

* N/A 

---

## Future work that may be required in bullet points

* N/A
