### PR TITLE
Fix FollowPath path_updated issue (#1938)

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -134,6 +134,10 @@ public:
       on_tick();
 
       on_new_goal_received();
+
+      rclcpp::spin_some(node_);
+
+      return BT::NodeStatus::RUNNING;
     }
 
     // The following code corresponds to the "RUNNING" loop

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -134,10 +134,6 @@ public:
       on_tick();
 
       on_new_goal_received();
-
-      rclcpp::spin_some(node_);
-
-      return BT::NodeStatus::RUNNING;
     }
 
     // The following code corresponds to the "RUNNING" loop

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
@@ -45,9 +45,6 @@ public:
         BT::InputPort<std::string>("planner_id", ""),
       });
   }
-
-private:
-  bool first_time_{true};
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
@@ -37,12 +37,6 @@ void ComputePathToPoseAction::on_tick()
 BT::NodeStatus ComputePathToPoseAction::on_success()
 {
   setOutput("path", result_.result->path);
-
-  if (first_time_) {
-    first_time_ = false;
-  } else {
-    config().blackboard->set("path_updated", true);
-  }
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/follow_path_action.cpp
@@ -26,7 +26,6 @@ FollowPathAction::FollowPathAction(
   const BT::NodeConfiguration & conf)
 : BtActionNode<nav2_msgs::action::FollowPath>(xml_tag_name, action_name, conf)
 {
-  config().blackboard->set("path_updated", false);
 }
 
 void FollowPathAction::on_tick()
@@ -37,14 +36,14 @@ void FollowPathAction::on_tick()
 
 void FollowPathAction::on_wait_for_result()
 {
-  // Check if the goal has been updated
-  if (config().blackboard->get<bool>("path_updated")) {
-    // Reset the flag in the blackboard
-    config().blackboard->set("path_updated", false);
+  // Grab the new path
+  nav_msgs::msg::Path new_path;
+  getInput("path", new_path);
 
-    // Grab the new goal and set the flag so that we send the new goal to
+  // Check if it is not same with the current one
+  if (goal_.path != new_path) {
     // the action server on the next loop iteration
-    getInput("path", goal_.path);
+    goal_.path = new_path;
     goal_updated_ = true;
   }
 }

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
@@ -55,7 +55,6 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("path_updated", false);
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
 

--- a/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
@@ -50,7 +50,6 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("path_updated", false);
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
 

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
@@ -66,7 +66,6 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("path_updated", false);
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     BT::NodeBuilder builder =
@@ -130,7 +129,6 @@ TEST_F(ComputePathToPoseActionTestFixture, test_tick)
   config_->blackboard->set("goal", goal);
 
   // first tick should send the goal to our server
-  EXPECT_EQ(config_->blackboard->get<bool>("path_updated"), false);
   EXPECT_EQ(tree_->rootNode()->executeTick(), BT::NodeStatus::RUNNING);
   EXPECT_EQ(tree_->rootNode()->getInput<std::string>("planner_id"), std::string("GridBased"));
   EXPECT_EQ(action_server_->getCurrentGoal()->pose.pose.position.x, 1.0);
@@ -140,9 +138,6 @@ TEST_F(ComputePathToPoseActionTestFixture, test_tick)
   while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
     tree_->rootNode()->executeTick();
   }
-
-  // not set to true after the first goal
-  EXPECT_EQ(config_->blackboard->get<bool>("path_updated"), false);
 
   // check if returned path is correct
   nav_msgs::msg::Path path;
@@ -164,9 +159,6 @@ TEST_F(ComputePathToPoseActionTestFixture, test_tick)
   while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
     tree_->rootNode()->executeTick();
   }
-
-  // path is updated on new goal
-  EXPECT_EQ(config_->blackboard->get<bool>("path_updated"), true);
 
   config_->blackboard->get<nav_msgs::msg::Path>("path", path);
   EXPECT_EQ(path.poses.size(), 1u);

--- a/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
@@ -64,7 +64,6 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("path_updated", false);
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     BT::NodeBuilder builder =
@@ -119,9 +118,7 @@ TEST_F(FollowPathActionTestFixture, test_tick)
         </BehaviorTree>
       </root>)";
 
-  config_->blackboard->set<bool>("path_updated", true);
   tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
-  EXPECT_EQ(config_->blackboard->get<bool>("path_updated"), false);
 
   // set new path on blackboard
   nav_msgs::msg::Path path;
@@ -153,14 +150,10 @@ TEST_F(FollowPathActionTestFixture, test_tick)
   EXPECT_EQ(tree_->rootNode()->executeTick(), BT::NodeStatus::RUNNING);
   EXPECT_EQ(action_server_->getCurrentGoal()->path.poses.size(), 1u);
   EXPECT_EQ(action_server_->getCurrentGoal()->path.poses[0].pose.position.x, -2.5);
-  config_->blackboard->set<bool>("path_updated", true);
 
   while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
     tree_->rootNode()->executeTick();
   }
-
-  // path is updated on new goal
-  EXPECT_EQ(config_->blackboard->get<bool>("path_updated"), false);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
@@ -65,7 +65,6 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("path_updated", false);
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     BT::NodeBuilder builder =

--- a/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
@@ -50,7 +50,6 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("path_updated", false);
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     factory_->registerNodeType<nav2_behavior_tree::ReinitializeGlobalLocalizationService>(

--- a/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
@@ -55,7 +55,6 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("path_updated", false);
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
 

--- a/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
@@ -56,7 +56,6 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("path_updated", false);
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
 

--- a/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
@@ -45,7 +45,6 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("path_updated", false);
     config_->blackboard->set<bool>("initial_pose_received", false);
   }
 

--- a/nav2_behavior_tree/test/test_behavior_tree_fixture.hpp
+++ b/nav2_behavior_tree/test/test_behavior_tree_fixture.hpp
@@ -52,7 +52,6 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("path_updated", false);
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     transform_handler_->activate();

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -126,7 +126,6 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
   blackboard_->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", tf_);  // NOLINT
   blackboard_->set<std::chrono::milliseconds>("server_timeout", std::chrono::milliseconds(10));  // NOLINT
-  blackboard_->set<bool>("path_updated", false);  // NOLINT
   blackboard_->set<bool>("initial_pose_received", false);  // NOLINT
   blackboard_->set<int>("number_recoveries", 0);  // NOLINT
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1938 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | turtlebot |

---

## Description of contribution in a few bullet points

* Remove `path_updated` blackboard variable and use `path.header.stamp` to check if the path is updated or not
  * This change fixes both #809 and #1938

## Description of documentation updates required from your changes

* I think nothing

---

## Future work that may be required in bullet points

* if this change is okay, tests should be fixed. There are many tests that set/gets `path_udpated` to/from the blackboard