### PR TITLE
Fix InflationLayer resource locking problem (#1931)

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -40,6 +40,7 @@
 
 #include <map>
 #include <vector>
+#include <mutex>
 
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/layer.hpp"
@@ -77,7 +78,7 @@ class InflationLayer : public Layer
 public:
   InflationLayer();
 
-  ~InflationLayer() override = default;
+  ~InflationLayer();
 
   void onInitialize() override;
   void updateBounds(
@@ -113,6 +114,13 @@ public:
       cost = static_cast<unsigned char>((INSCRIBED_INFLATED_OBSTACLE - 1) * factor);
     }
     return cost;
+  }
+
+  // Provide a typedef to ease future code maintenance
+  typedef std::recursive_mutex mutex_t;
+  mutex_t * getMutex()
+  {
+    return access_;
   }
 
 protected:
@@ -184,6 +192,7 @@ private:
 
   // Indicates that the entire costmap should be reinflated next time around.
   bool need_reinflation_;
+  mutex_t * access_;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -71,6 +71,12 @@ InflationLayer::InflationLayer()
   last_max_x_(std::numeric_limits<double>::max()),
   last_max_y_(std::numeric_limits<double>::max())
 {
+  access_ = new mutex_t();
+}
+
+InflationLayer::~InflationLayer()
+{
+  delete access_;
 }
 
 void
@@ -160,6 +166,7 @@ InflationLayer::updateCosts(
   int max_i,
   int max_j)
 {
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (!enabled_ || (cell_inflation_radius_ == 0)) {
     return;
   }
@@ -305,6 +312,7 @@ InflationLayer::enqueue(
 void
 InflationLayer::computeCaches()
 {
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (cell_inflation_radius_ == 0) {
     return;
   }


### PR DESCRIPTION
I resubmit this PR because of the merging issue.
https://github.com/ros-planning/navigation2/pull/1936#issuecomment-675092401

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1931  |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | tb3 |

---

## Description of contribution in a few bullet points

* fix resource locking problem of InflationLayer

## Description of documentation updates required from your changes

N/A

