### PR TITLE
[WIP] removing rviz plugins from test coverage since its not a production run-time component

### DIFF
--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -80,6 +80,8 @@ lcov \
     "${PWD}/*/nav_2d_msgs/*" \
   --remove ${LCOVDIR}/workspace_coverage.info \
     "${PWD}/*/nav2_system_tests/*" \
+  --remove ${LCOVDIR}/workspace_coverage.info \
+    "${PWD}/*/nav2_rviz_plugins/*" \
   --output-file ${LCOVDIR}/project_coverage.info \
   --rc lcov_branch_coverage=0
 

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -69,6 +69,7 @@ lcov \
 # Remove files in the build subdirectory.
 # Those are generated files (like messages, services, etc)
 # And system tests, which are themselves all test artifacts
+# And rviz plugins, which are not used for real navigation
 lcov \
   --remove ${LCOVDIR}/workspace_coverage.info \
     "${PWD}/build/*" \


### PR DESCRIPTION
#1810 

We exclude navigation system tests because they're not run-time tools use on someone's robot during an actual use. The rviz plugins are a similar analog, only used for entry level testing, not used when actually on someone's robot for use. We should consider if it makes sense to exclude this as well.

CC @naiveHobo - thoughts?