### PR TITLE
[Foxy] More Windows build fix.

### DIFF
--- a/nav2_bt_navigator/src/ros_topic_logger.cpp
+++ b/nav2_bt_navigator/src/ros_topic_logger.cpp
@@ -43,7 +43,7 @@ void RosTopicLogger::callback(
   event.timestamp =
     tf2_ros::toMsg(std::chrono::time_point<std::chrono::high_resolution_clock>(timestamp));
 #else
-  event.timestamp = tf2_ros::toMsg(timestamp);
+  event.timestamp = tf2_ros::toMsg(tf2::TimePoint(timestamp));
 #endif
   event.node_name = node.name();
   event.previous_status = toStr(prev_status, false);

--- a/nav2_costmap_2d/package.xml
+++ b/nav2_costmap_2d/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>nav2_common</build_depend>
 
+  <depend>angles</depend>
   <depend>geometry_msgs</depend>
   <depend>laser_geometry</depend>
   <depend>map_msgs</depend>

--- a/nav2_dwb_controller/nav_2d_utils/CMakeLists.txt
+++ b/nav2_dwb_controller/nav_2d_utils/CMakeLists.txt
@@ -47,6 +47,10 @@ add_library(tf_help SHARED
   src/tf_help.cpp
 )
 
+target_link_libraries(tf_help
+  conversions
+)
+
 ament_target_dependencies(tf_help
   ${dependencies}
 )

--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -78,7 +78,7 @@ char * dirname(char * path)
     /* This assignment is ill-designed but the XPG specs require to
        return a string containing "." in any case no directory part is
        found and so a static and constant string is required.  */
-    path = reinterpret_cast<char *>(dot);
+    path = const_cast<char *>(&dot[0]);
   }
 
   return path;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Windows |
| Robotic platform tested on | Turtlebot3 Simulation |

---

## Description of contribution in a few bullet points

* Those build breaks are found by building against [release-foxy-20200807](https://github.com/ros2/ros2/blob/release-foxy-20200807/ros2.repos).
* `tf_help` has a linkage dependency on `conversions` for the usage of `poseStampedToPose2D`.
* Fixed a time\duration conversion build break in `ros_topic_logger.cpp`.
* Added the missing dependency `angles` for `nav2_costmap_2d`.

## Description of documentation updates required from your changes

N/A

---

## Future work that may be required in bullet points

N/A