### PR TITLE
fix invalid memory access

### DIFF
--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -144,6 +144,13 @@ void TestNode::validatePointInflation(
           continue;
         }
 
+        if (dist == bin->first)
+        {
+          // Adding to our current bin could cause a reallocation
+          // Which appears to cause the iterator to get messed up
+          dist += 0.001;
+        }
+
         if (cell.x_ > 0) {
           CellData data(costmap->getIndex(cell.x_ - 1, cell.y_),
             cell.x_ - 1, cell.y_, cell.src_x_, cell.src_y_);

--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -144,8 +144,7 @@ void TestNode::validatePointInflation(
           continue;
         }
 
-        if (dist == bin->first)
-        {
+        if (dist == bin->first) {
           // Adding to our current bin could cause a reallocation
           // Which appears to cause the iterator to get messed up
           dist += 0.001;


### PR DESCRIPTION
this fix was applied as part of the noetic release of costmap_2d

https://github.com/ros-planning/navigation/commit/05d42ac1f8d164359f2f0da1d63d52e1d4b6ec05