### PR TITLE
Initialize inflate_cone_ variable.

### DIFF
--- a/nav2_costmap_2d/plugins/range_sensor_layer.cpp
+++ b/nav2_costmap_2d/plugins/range_sensor_layer.cpp
@@ -63,7 +63,6 @@ void RangeSensorLayer::onInitialize()
   buffered_readings_ = 0;
   last_reading_time_ = clock_->now();
   default_value_ = to_cost(0.5);
-  inflate_cone_ = 1.0;
 
   matchSize();
   resetRange();
@@ -78,7 +77,7 @@ void RangeSensorLayer::onInitialize()
   declareParameter("phi", rclcpp::ParameterValue(1.2));
   node->get_parameter(name_ + "." + "phi", phi_v_);
   declareParameter("inflate_cone", rclcpp::ParameterValue(1.0));
-  node->get_parameter(name_ + "." + "phi", phi_v_);
+  node->get_parameter(name_ + "." + "inflate_cone", inflate_cone_);
   declareParameter("no_readings_timeout", rclcpp::ParameterValue(0.0));
   node->get_parameter(name_ + "." + "no_readings_timeout", no_readings_timeout_);
   declareParameter("clear_threshold", rclcpp::ParameterValue(0.2));

--- a/nav2_costmap_2d/plugins/range_sensor_layer.cpp
+++ b/nav2_costmap_2d/plugins/range_sensor_layer.cpp
@@ -63,6 +63,7 @@ void RangeSensorLayer::onInitialize()
   buffered_readings_ = 0;
   last_reading_time_ = clock_->now();
   default_value_ = to_cost(0.5);
+  inflate_cone_ = 1.0;
 
   matchSize();
   resetRange();

--- a/nav2_costmap_2d/test/integration/test_costmap_topic_collision_checker.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_topic_collision_checker.cpp
@@ -183,7 +183,7 @@ public:
     setPose(x, y, theta);
     publishFootprint();
     publishCostmap();
-    rclcpp::sleep_for(std::chrono::milliseconds(50));
+    rclcpp::sleep_for(std::chrono::milliseconds(1000));
     return collision_checker_->isCollisionFree(pose);
   }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1987  |
| Primary OS tested on | Ubuntu 20.04 in VirtualBox on Windows 10 |
| Robotic platform tested on | n.a. |

---

## Description of contribution in a few bullet points
Valgrind reported uninitialized variables in range_test. After this initialization valgrind does not report errors anymore.

## Description of documentation updates required from your changes
No documentation changes required.

---

## Future work that may be required in bullet points
The unit and integration tests are unstable. We still have to find what the problem is.