### PR TITLE
Fix trajectory publisher not publishing unless subscribed to evaluation

### DIFF
--- a/nav2_dwb_controller/dwb_core/src/publisher.cpp
+++ b/nav2_dwb_controller/dwb_core/src/publisher.cpp
@@ -156,16 +156,13 @@ DWBPublisher::on_cleanup()
 void
 DWBPublisher::publishEvaluation(std::shared_ptr<dwb_msgs::msg::LocalPlanEvaluation> results)
 {
-  if (eval_pub_->get_subscription_count() < 1) {return;}
-
-  if (results == nullptr) {return;}
-
-  if (publish_evaluation_) {
-    auto msg = std::make_unique<dwb_msgs::msg::LocalPlanEvaluation>(*results);
-    eval_pub_->publish(std::move(msg));
+  if (results) {
+    if (publish_evaluation_ && eval_pub_->get_subscription_count() > 0) {
+      auto msg = std::make_unique<dwb_msgs::msg::LocalPlanEvaluation>(*results);
+      eval_pub_->publish(std::move(msg));
+    }
+    publishTrajectories(*results);
   }
-
-  publishTrajectories(*results);
 }
 
 void


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | simulation |

---

## Description of contribution in a few bullet points

dwb_controller has a parameter `publish_trajectories` to publish the scored trajectories on the `marker` topic. This publisher is enabled by default, but does not actually publish anything unless something also subscribes to another topic called `evaluation`. This is due to the `publishTrajectories` method being called from the `publishEvaluation` method, while `publishEvaluation` returns early when there are no subscribers.

## Description of documentation updates required from your changes

As far as I could find, there's no documentation referring to the trajectory topic. IMO the topic name could also be improved from `marker` to something like `trajectories`, but that could be a different PR.

## Future work that may be required in bullet points

* For clarity and consistency, the other publish methods in the same class could be changed in the same way.
* I think the publish methods could be refactored to use STL algorithms instead of for loops, possibly opening opportunities to optimizations.
