### PR TITLE
Add update step after clearing costmap in clear costmap services

### DIFF
--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -121,6 +121,8 @@ void ClearCostmapService::clearExceptRegion(const double reset_distance)
       clearLayerExceptRegion(costmap_layer, x, y, reset_distance);
     }
   }
+
+  costmap_.updateMap();
 }
 
 void ClearCostmapService::clearAroundRobot(double window_size_x, double window_size_y)
@@ -154,12 +156,14 @@ void ClearCostmapService::clearAroundRobot(double window_size_x, double window_s
   clear_poly.push_back(pt);
 
   costmap_.getCostmap()->setConvexPolygonCost(clear_poly, reset_value_);
+  costmap_.updateMap();
 }
 
 void ClearCostmapService::clearEntirely()
 {
   std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getCostmap()->getMutex()));
   costmap_.resetLayers();
+  costmap_.updateMap();
 }
 
 bool ClearCostmapService::isClearable(const string & layer_name) const


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1999 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | TurtleBot3 Gazebo Simulation |

---

## Description of contribution in a few bullet points

* Explicitly call the update costmap step after clearing costmap regions when clear costmap service is called