### PR TITLE
Controllers should not be influenced by time jumps or slew

### DIFF
--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -283,7 +283,7 @@ void ControllerServer::computeControl()
     setPlannerPath(action_server_->get_current_goal()->path);
     progress_checker_->reset();
 
-    rclcpp::GenericRate<std::chrono::steady_clock> loop_rate(controller_frequency_);
+    rclcpp::WallRate loop_rate(controller_frequency_);
     while (rclcpp::ok()) {
       if (action_server_ == nullptr || !action_server_->is_server_active()) {
         RCLCPP_DEBUG(get_logger(), "Action server unavailable or inactive. Stopping.");

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -283,7 +283,7 @@ void ControllerServer::computeControl()
     setPlannerPath(action_server_->get_current_goal()->path);
     progress_checker_->reset();
 
-    rclcpp::Rate loop_rate(controller_frequency_);
+    rclcpp::GenericRate<std::chrono::steady_clock> loop_rate(controller_frequency_);
     while (rclcpp::ok()) {
       if (action_server_ == nullptr || !action_server_->is_server_active()) {
         RCLCPP_DEBUG(get_logger(), "Action server unavailable or inactive. Stopping.");

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -382,7 +382,7 @@ Costmap2DROS::mapUpdateLoop(double frequency)
 
   RCLCPP_DEBUG(get_logger(), "Entering loop");
 
-  rclcpp::Rate r(frequency);    // 200ms by default
+  rclcpp::GenericRate<std::chrono::steady_clock> r(frequency);    // 200ms by default
 
   while (rclcpp::ok() && !map_update_thread_shutdown_) {
     nav2_util::ExecutionTimer timer;

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -382,7 +382,7 @@ Costmap2DROS::mapUpdateLoop(double frequency)
 
   RCLCPP_DEBUG(get_logger(), "Entering loop");
 
-  rclcpp::GenericRate<std::chrono::steady_clock> r(frequency);    // 200ms by default
+  rclcpp::WallRate r(frequency);    // 200ms by default
 
   while (rclcpp::ok() && !map_update_thread_shutdown_) {
     nav2_util::ExecutionTimer timer;

--- a/nav2_recoveries/include/nav2_recoveries/recovery.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery.hpp
@@ -197,7 +197,7 @@ protected:
     // Initialize the ActionT result
     auto result = std::make_shared<typename ActionT::Result>();
 
-    rclcpp::GenericRate<std::chrono::steady_clock> loop_rate(cycle_frequency_);
+    rclcpp::WallRate loop_rate(cycle_frequency_);
 
     while (rclcpp::ok()) {
       if (action_server_->is_cancel_requested()) {

--- a/nav2_recoveries/include/nav2_recoveries/recovery.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery.hpp
@@ -197,7 +197,7 @@ protected:
     // Initialize the ActionT result
     auto result = std::make_shared<typename ActionT::Result>();
 
-    rclcpp::Rate loop_rate(cycle_frequency_);
+    rclcpp::GenericRate<std::chrono::steady_clock> loop_rate(cycle_frequency_);
 
     while (rclcpp::ok()) {
       if (action_server_->is_cancel_requested()) {

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -132,7 +132,7 @@ WaypointFollower::followWaypoints()
     return;
   }
 
-  rclcpp::Rate r(loop_rate_);
+  rclcpp::GenericRate<std::chrono::steady_clock> r(loop_rate_);
   uint32_t goal_index = 0;
   bool new_goal = true;
 

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -132,7 +132,7 @@ WaypointFollower::followWaypoints()
     return;
   }
 
-  rclcpp::GenericRate<std::chrono::steady_clock> r(loop_rate_);
+  rclcpp::WallRate r(loop_rate_);
   uint32_t goal_index = 0;
   bool new_goal = true;
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | simulation |

---

## Description of contribution in a few bullet points

- `rclcpp::Rate` is used for controlling the frequency in a few parts of the code.
- `rclcpp::Rate` uses [`std::chrono::system_clock`](https://en.cppreference.com/w/cpp/chrono/system_clock) which is meant to represent wall time. Due to unevitable clock drift on the local system in combination with time synchronisation mechnism's like NTP this clock can tick at a slower or faster rate to stay synchronized with the actual wall time or even jump both forwards and backwards in time in case of bigger offsets.
- `rclcpp::Rate` does not have a mechanism to deal with time jumps, so for example if the time jumps backwards 10 seconds, it will wait for 10 seconds plus the configured interval of the `Rate`.

This contribution changes the use of `rclcpp::Rate` to `rclcpp::GenericRate<std::chrono::steady_clock>` to use the monotonic [`steady_clock`](https://en.cppreference.com/w/cpp/chrono/steady_clock) instead. This clock never jumps and is better suited for measuring intervals.

A possible point of discussion would be why I did not use `rclcpp::WallRate`, which is an alias for `rclcpp::GenericRate<std::chrono::steady_clock>`. The reason is that I find the name `WallRate` very misleading, since `steady_clock` specifically does not follow wall time. In my opinion it should be renamed to `SteadyRate` or something like that, but that's a different discussion.

## Description of documentation updates required from your changes

N/A. (?)