### PR TITLE
Successor PR for #1993, Introduces A plugin interface to define behaviours at waypoint arrivals when using nav2_waypoint_follower

### DIFF
--- a/doc/parameters/param_list.md
+++ b/doc/parameters/param_list.md
@@ -490,6 +490,16 @@ When `planner_plugins` parameter is not overridden, the following default plugin
 | ----------| --------| ------------|
 | stop_on_failure | true | Whether to fail action task if a single waypoint fails. If false, will continue to next waypoint. |
 | loop_rate | 20 | Rate to check for results from current navigation task |
+| waypoint_task_executor_plugin | `waypoint_task_executor` | Name of plugin to be loaded for executing waypoint tasks.|
+
+## WaitAtWaypoint plugin
+
+* `<waypoint task executor>`: Name corresponding to the `nav2_waypoint_follower::WaitAtWaypoint` plugin. 
+
+| Parameter | Default | Description |
+| ----------| --------| ------------|
+| `<waypoint task executor>`.enabled | true | Whether it is enabled |
+| `<waypoint task executor>`.waypoint_pause_duration | 0 | Amount of time in milliseconds, for robot to sleep/wait after each waypoint is reached. If zero, robot will directly continue to next waypoint. |
 
 # recoveries
 

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -280,3 +280,13 @@ recoveries_server:
 robot_state_publisher:
   ros__parameters:
     use_sim_time: True
+
+waypoint_follower:
+  ros__parameters:
+    loop_rate: 20
+    stop_on_failure: false
+    waypoint_task_executor_plugin: "waypoint_task_executor"   
+    waypoint_task_executor:
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: True
+      waypoint_pause_duration: 0

--- a/nav2_core/include/nav2_core/waypoint_task_executor.hpp
+++ b/nav2_core/include/nav2_core/waypoint_task_executor.hpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2020 Fetullah Atas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef NAV2_CORE__WAYPOINT_TASK_EXECUTOR_HPP_
+#define NAV2_CORE__WAYPOINT_TASK_EXECUTOR_HPP_
+#pragma once
+
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+
+namespace nav2_core
+{
+/**
+ * @brief Base class for creating a plugin in order to perform a specific task at waypoint arrivals.
+ *
+ */
+class WaypointTaskExecutor
+{
+public:
+  /**
+   * @brief Construct a new Simple Task Execution At Waypoint Base object
+   *
+   */
+  WaypointTaskExecutor() {}
+
+  /**
+   * @brief Destroy the Simple Task Execution At Waypoint Base object
+   *
+   */
+  virtual ~WaypointTaskExecutor() {}
+
+  /**
+   * @brief Override this to setup your pub, sub or any ros services that you will use in the plugin.
+   *
+   * @param parent parent node that plugin will be created within(for an example see nav_waypoint_follower)
+   * @param plugin_name plugin name comes from parameters in yaml file
+   */
+  virtual void initialize(
+    const rclcpp_lifecycle::LifecycleNode::WeakPtr & parent,
+    const std::string & plugin_name) = 0;
+
+  /**
+   * @brief Override this to define the body of your task that you would like to execute once the robot arrived to waypoint
+   *
+   * @param curr_pose current pose of the robot
+   * @param curr_waypoint_index current waypoint, that robot just arrived
+   * @return true if task execution was successful
+   * @return false if task execution failed
+   */
+  virtual bool processAtWaypoint(
+    const geometry_msgs::msg::PoseStamped & curr_pose, const int & curr_waypoint_index) = 0;
+};
+}  // namespace nav2_core
+#endif  // NAV2_CORE__WAYPOINT_TASK_EXECUTOR_HPP_

--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -115,6 +115,7 @@ class WaypointFollowerTest(Node):
         if len(result.missed_waypoints) > 0:
             self.info_msg('Goal failed to process all waypoints,'
                           ' missed {0} wps.'.format(len(result.missed_waypoints)))
+            return False
 
         self.info_msg('Goal succeeded!')
         return True

--- a/nav2_waypoint_follower/CMakeLists.txt
+++ b/nav2_waypoint_follower/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(nav_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(nav2_core REQUIRED)
+find_package(pluginlib REQUIRED)
 
 nav2_package()
 
@@ -37,6 +39,8 @@ set(dependencies
   nav2_msgs
   nav2_util
   tf2_ros
+  nav2_core
+  pluginlib
 )
 
 ament_target_dependencies(${executable_name}
@@ -49,7 +53,12 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
-install(TARGETS ${library_name}
+add_library(simple_waypoint_task_executor SHARED plugins/wait_at_waypoint.cpp)
+ament_target_dependencies(simple_waypoint_task_executor ${dependencies})
+# prevent pluginlib from using boost
+target_compile_definitions(simple_waypoint_task_executor PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
+install(TARGETS ${library_name} simple_waypoint_task_executor
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -69,5 +78,8 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
+ament_export_libraries(simple_waypoint_task_executor)
+
+pluginlib_export_plugin_description_file(nav2_waypoint_follower plugins.xml)
 
 ament_package()

--- a/nav2_waypoint_follower/include/nav2_waypoint_follower/plugins/wait_at_waypoint.hpp
+++ b/nav2_waypoint_follower/include/nav2_waypoint_follower/plugins/wait_at_waypoint.hpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2020 Fetullah Atas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_WAYPOINT_FOLLOWER__PLUGINS__WAIT_AT_WAYPOINT_HPP_
+#define NAV2_WAYPOINT_FOLLOWER__PLUGINS__WAIT_AT_WAYPOINT_HPP_
+#pragma once
+
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "nav2_core/waypoint_task_executor.hpp"
+
+namespace nav2_waypoint_follower
+{
+
+/**
+ * @brief Simple plugin based on WaypointTaskExecutor, lets robot to sleep for a
+ *        specified amount of time at waypoint arrival. You can reference this class to define
+ *        your own task and rewrite the body for it.
+ *
+ */
+class WaitAtWaypoint : public nav2_core::WaypointTaskExecutor
+{
+public:
+/**
+ * @brief Construct a new Wait At Waypoint Arrival object
+ *
+ */
+  WaitAtWaypoint();
+
+  /**
+   * @brief Destroy the Wait At Waypoint Arrival object
+   *
+   */
+  ~WaitAtWaypoint();
+
+  /**
+   * @brief declares and loads parameters used (waypoint_pause_duration_)
+   *
+   * @param parent parent node that plugin will be created withing(waypoint_follower in this case)
+   * @param plugin_name
+   */
+  void initialize(
+    const rclcpp_lifecycle::LifecycleNode::WeakPtr & parent,
+    const std::string & plugin_name);
+
+
+  /**
+   * @brief Override this to define the body of your task that you would like to execute once the robot arrived to waypoint
+   *
+   * @param curr_pose current pose of the robot
+   * @param curr_waypoint_index current waypoint, that robot just arrived
+   * @return true if task execution was successful
+   * @return false if task execution failed
+   */
+  bool processAtWaypoint(
+    const geometry_msgs::msg::PoseStamped & curr_pose, const int & curr_waypoint_index);
+
+protected:
+  // the robot will sleep waypoint_pause_duration_ milliseconds
+  int waypoint_pause_duration_;
+  bool is_enabled_;
+  rclcpp::Logger logger_{rclcpp::get_logger("nav2_waypoint_follower")};
+};
+
+}  // namespace nav2_waypoint_follower
+#endif  // NAV2_WAYPOINT_FOLLOWER__PLUGINS__WAIT_AT_WAYPOINT_HPP_

--- a/nav2_waypoint_follower/include/nav2_waypoint_follower/waypoint_follower.hpp
+++ b/nav2_waypoint_follower/include/nav2_waypoint_follower/waypoint_follower.hpp
@@ -26,6 +26,11 @@
 #include "nav2_util/simple_action_server.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 
+#include "nav2_util/node_utils.hpp"
+#include "nav2_core/waypoint_task_executor.hpp"
+#include "pluginlib/class_loader.hpp"
+#include "pluginlib/class_list_macros.hpp"
+
 namespace nav2_waypoint_follower
 {
 
@@ -119,6 +124,14 @@ protected:
   ActionStatus current_goal_status_;
   int loop_rate_;
   std::vector<int> failed_ids_;
+
+  // Task Execution At Waypoint Plugin
+  pluginlib::ClassLoader<nav2_core::WaypointTaskExecutor>
+  waypoint_task_executor_loader_;
+  pluginlib::UniquePtr<nav2_core::WaypointTaskExecutor>
+  waypoint_task_executor_;
+  std::string waypoint_task_executor_id_;
+  std::string waypoint_task_executor_type_;
 };
 
 }  // namespace nav2_waypoint_follower

--- a/nav2_waypoint_follower/package.xml
+++ b/nav2_waypoint_follower/package.xml
@@ -17,11 +17,13 @@
   <depend>nav_msgs</depend>
   <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>
+  <depend>nav2_core</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>
+    <nav2_waypoint_follower plugin="${prefix}/plugins.xml" />
   </export>
 </package>

--- a/nav2_waypoint_follower/plugins.xml
+++ b/nav2_waypoint_follower/plugins.xml
@@ -1,0 +1,7 @@
+<class_libraries>
+  <library path="simple_waypoint_task_executor">
+    <class type="nav2_waypoint_follower::WaitAtWaypoint" base_class_type="nav2_core::WaypointTaskExecutor">
+      <description>Lets robot sleep for a specified amount of time at waypoint arrival</description>
+    </class>
+  </library>
+</class_libraries>

--- a/nav2_waypoint_follower/plugins/wait_at_waypoint.cpp
+++ b/nav2_waypoint_follower/plugins/wait_at_waypoint.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2020 Fetullah Atas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pluginlib/class_list_macros.hpp>
+#include <string>
+#include <exception>
+
+#include "nav2_util/node_utils.hpp"
+#include "nav2_waypoint_follower/plugins/wait_at_waypoint.hpp"
+
+namespace nav2_waypoint_follower
+{
+WaitAtWaypoint::WaitAtWaypoint()
+: waypoint_pause_duration_(0),
+  is_enabled_(true)
+{
+}
+
+WaitAtWaypoint::~WaitAtWaypoint()
+{
+}
+
+void WaitAtWaypoint::initialize(
+  const rclcpp_lifecycle::LifecycleNode::WeakPtr & parent,
+  const std::string & plugin_name)
+{
+  auto node = parent.lock();
+  if (!node) {
+    throw std::runtime_error{"Failed to lock node  in wait at waypoint plugin!"};
+  }
+  logger_ = node->get_logger();
+  nav2_util::declare_parameter_if_not_declared(
+    node,
+    plugin_name + ".waypoint_pause_duration",
+    rclcpp::ParameterValue(0));
+  nav2_util::declare_parameter_if_not_declared(
+    node,
+    plugin_name + ".enabled",
+    rclcpp::ParameterValue(true));
+  node->get_parameter(
+    plugin_name + ".waypoint_pause_duration",
+    waypoint_pause_duration_);
+  node->get_parameter(
+    plugin_name + ".enabled",
+    is_enabled_);
+  if (waypoint_pause_duration_ == 0) {
+    is_enabled_ = false;
+    RCLCPP_INFO(
+      logger_,
+      "Waypoint pause duration is set to zero, disabling task executor plugin.");
+  } else if (!is_enabled_) {
+    RCLCPP_INFO(
+      logger_, "Waypoint task executor plugin is disabled.");
+  }
+}
+
+bool WaitAtWaypoint::processAtWaypoint(
+  const geometry_msgs::msg::PoseStamped & /*curr_pose*/, const int & curr_waypoint_index)
+{
+  if (!is_enabled_) {
+    return false;
+  }
+  RCLCPP_INFO(
+    logger_, "Arrived at %i'th waypoint, sleeping for %i milliseconds",
+    curr_waypoint_index,
+    waypoint_pause_duration_);
+  rclcpp::sleep_for(std::chrono::milliseconds(waypoint_pause_duration_));
+  return true;
+}
+}  // namespace nav2_waypoint_follower
+PLUGINLIB_EXPORT_CLASS(
+  nav2_waypoint_follower::WaitAtWaypoint,
+  nav2_core::WaypointTaskExecutor)

--- a/nav2_waypoint_follower/plugins/wait_at_waypoint.cpp
+++ b/nav2_waypoint_follower/plugins/wait_at_waypoint.cpp
@@ -37,7 +37,7 @@ void WaitAtWaypoint::initialize(
 {
   auto node = parent.lock();
   if (!node) {
-    throw std::runtime_error{"Failed to lock node  in wait at waypoint plugin!"};
+    throw std::runtime_error{"Failed to lock node in wait at waypoint plugin!"};
   }
   logger_ = node->get_logger();
   nav2_util::declare_parameter_if_not_declared(
@@ -69,7 +69,7 @@ bool WaitAtWaypoint::processAtWaypoint(
   const geometry_msgs::msg::PoseStamped & /*curr_pose*/, const int & curr_waypoint_index)
 {
   if (!is_enabled_) {
-    return false;
+    return true;
   }
   RCLCPP_INFO(
     logger_, "Arrived at %i'th waypoint, sleeping for %i milliseconds",

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -222,7 +222,6 @@ WaypointFollower::followWaypoints()
       RCLCPP_INFO(
         get_logger(), "Succeeded processing waypoint %i, processing waypoint task execution",
         goal_index);
-      auto node = shared_from_this();
       bool is_task_executed = waypoint_task_executor_->processAtWaypoint(
         goal->poses[goal_index], goal_index);
       RCLCPP_INFO(

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -227,7 +227,22 @@ WaypointFollower::followWaypoints()
         goal->poses[goal_index], goal_index);
       RCLCPP_INFO(
         get_logger(), "Task execution at waypoint %i %s", goal_index,
-        is_task_executed ? "succeeded" : "failed!", "moving to the next");
+        is_task_executed ? "succeeded" : "failed!");
+      // if task execution was failed and stop_on_failure_ is on , terminate action
+      if ((is_task_executed == false) && (stop_on_failure_ == true)) {
+        RCLCPP_WARN(
+          get_logger(), "Failed to execute task at waypoint %i "
+          " stop on failure is enabled."
+          " Terminating action.", goal_index);
+        result->missed_waypoints = failed_ids_;
+        action_server_->terminate_current(result);
+        failed_ids_.clear();
+        return;
+      } else {
+        RCLCPP_INFO(
+          get_logger(), "Handled task execution on waypoint %i,"
+          " moving to next.", goal_index);
+      }
     }
 
     if (current_goal_status_ != ActionStatus::PROCESSING &&

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -25,12 +25,20 @@ namespace nav2_waypoint_follower
 {
 
 WaypointFollower::WaypointFollower()
-: nav2_util::LifecycleNode("WaypointFollower", "", false)
+: nav2_util::LifecycleNode("WaypointFollower", "", false),
+  waypoint_task_executor_loader_("nav2_waypoint_follower",
+    "nav2_core::WaypointTaskExecutor")
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
   declare_parameter("stop_on_failure", true);
   declare_parameter("loop_rate", 20);
+  nav2_util::declare_parameter_if_not_declared(
+    this, std::string("waypoint_task_executor_plugin"),
+    rclcpp::ParameterValue(std::string("waypoint_task_executor")));
+  nav2_util::declare_parameter_if_not_declared(
+    this, std::string("waypoint_task_executor_plugin.plugin"),
+    rclcpp::ParameterValue(std::string("nav2_waypoint_follower::WaitAtWaypoint")));
 }
 
 WaypointFollower::~WaypointFollower()
@@ -42,8 +50,11 @@ WaypointFollower::on_configure(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Configuring");
 
+  auto node = shared_from_this();
+
   stop_on_failure_ = get_parameter("stop_on_failure").as_bool();
   loop_rate_ = get_parameter("loop_rate").as_int();
+  waypoint_task_executor_id_ = get_parameter("waypoint_task_executor_plugin").as_string();
 
   std::vector<std::string> new_args = rclcpp::NodeOptions().arguments();
   new_args.push_back("--ros-args");
@@ -62,6 +73,22 @@ WaypointFollower::on_configure(const rclcpp_lifecycle::State & /*state*/)
     get_node_logging_interface(),
     get_node_waitables_interface(),
     "FollowWaypoints", std::bind(&WaypointFollower::followWaypoints, this));
+
+  try {
+    waypoint_task_executor_type_ = nav2_util::get_plugin_type_param(
+      this,
+      waypoint_task_executor_id_);
+    waypoint_task_executor_ = waypoint_task_executor_loader_.createUniqueInstance(
+      waypoint_task_executor_type_);
+    RCLCPP_INFO(
+      get_logger(), "Created waypoint_task_executor : %s of type %s",
+      waypoint_task_executor_id_.c_str(), waypoint_task_executor_type_.c_str());
+    waypoint_task_executor_->initialize(node, waypoint_task_executor_id_);
+  } catch (const pluginlib::PluginlibException & ex) {
+    RCLCPP_FATAL(
+      get_logger(),
+      "Failed to create waypoint_task_executor. Exception: %s", ex.what());
+  }
 
   return nav2_util::CallbackReturn::SUCCESS;
 }
@@ -193,8 +220,14 @@ WaypointFollower::followWaypoints()
       }
     } else if (current_goal_status_ == ActionStatus::SUCCEEDED) {
       RCLCPP_INFO(
-        get_logger(), "Succeeded processing waypoint %i, "
-        "moving to next.", goal_index);
+        get_logger(), "Succeeded processing waypoint %i, processing waypoint task execution",
+        goal_index);
+      auto node = shared_from_this();
+      bool is_task_executed = waypoint_task_executor_->processAtWaypoint(
+        goal->poses[goal_index], goal_index);
+      RCLCPP_INFO(
+        get_logger(), "Task execution at waypoint %i %s", goal_index,
+        is_task_executed ? "succeeded" : "failed!", "moving to the next");
     }
 
     if (current_goal_status_ != ActionStatus::PROCESSING &&

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -229,7 +229,8 @@ WaypointFollower::followWaypoints()
         get_logger(), "Task execution at waypoint %i %s", goal_index,
         is_task_executed ? "succeeded" : "failed!");
       // if task execution was failed and stop_on_failure_ is on , terminate action
-      if ((is_task_executed == false) && (stop_on_failure_ == true)) {
+      if (!is_task_executed && stop_on_failure_) {
+        failed_ids_.push_back(goal_index);
         RCLCPP_WARN(
           get_logger(), "Failed to execute task at waypoint %i "
           " stop on failure is enabled."


### PR DESCRIPTION
Signed-off-by: jediofgever <fetulahatas1@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
Successor PR for https://github.com/ros-planning/navigation2/pull/1993, 
https://github.com/ros-planning/navigation2/pull/1993 was mistakenly targeted to distro(`foxy-devel`) branch and it became difficult to track the changes and merge the new code into `main`, This PR includes reviewed and modified changes through discussions in https://github.com/ros-planning/navigation2/pull/1993

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (https://github.com/ros-planning/navigation2/issues/1992) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (Gazebo simulation of Turtlebot3) |

---

## Description of contribution in a few bullet points

 
* Added a plugin interface to `nav2_waypoint_follower`, with aim of executing a task on arrival of waypoints. 
* Added a plugin that was inherited from introduced interface, the plugin simply lets robot to wait for a specified amount of time after arriving at waypoint. 
* Users will be able to inherit from the base plugin interface and define their own specific tasks to be executed on arrival of waypoints. 
 

## Description of documentation updates required from your changes

 
* Added new plugin so updated `docs` and `nav2_params.yaml` 
* Opened a new PR at [navigation.ros.org](https://github.com/ros-planning/navigation.ros.org), in order to update website to include documentation and onformation related to the introduced plugin 


---

## Future work that may be required in bullet points
 
* A  future work could be writing a tutorial on how to add a plugin inherited from the plugin interface that has been introduced by this PR
 