### PR TITLE
Fix max path cycles for case where map has larger Y dimension than X dimension

### DIFF
--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -320,7 +320,8 @@ NavfnPlanner::getPlanFromPotential(
 
   planner_->setStart(map_goal);
 
-  const int& max_cycles = (costmap_->getSizeInCellsX() >= costmap_->getSizeInCellsY()) ? (costmap_->getSizeInCellsX() * 4) : (costmap_->getSizeInCellsY() * 4);
+  const int & max_cycles = (costmap_->getSizeInCellsX() >= costmap_->getSizeInCellsY()) ?
+    (costmap_->getSizeInCellsX() * 4) : (costmap_->getSizeInCellsY() * 4);
 
   int path_len = planner_->calcPath(max_cycles);
   if (path_len == 0) {

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -320,7 +320,9 @@ NavfnPlanner::getPlanFromPotential(
 
   planner_->setStart(map_goal);
 
-  int path_len = planner_->calcPath((costmap_->getSizeInCellsX() >= costmap_->getSizeInCellsY()) ? (costmap_->getSizeInCellsX() * 4) : (costmap_->getSizeInCellsY() * 4));
+  const int& max_cycles = (costmap_->getSizeInCellsX() >= costmap_->getSizeInCellsY()) ? (costmap_->getSizeInCellsX() * 4) : (costmap_->getSizeInCellsY() * 4);
+
+  int path_len = planner_->calcPath(max_cycles);
   if (path_len == 0) {
     return false;
   }

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -320,7 +320,7 @@ NavfnPlanner::getPlanFromPotential(
 
   planner_->setStart(map_goal);
 
-  int path_len = planner_->calcPath(costmap_->getSizeInCellsX() * 4);
+  int path_len = planner_->calcPath((costmap_->getSizeInCellsX() >= costmap_->getSizeInCellsY()) ? (costmap_->getSizeInCellsX() * 4) : (costmap_->getSizeInCellsY() * 4));
   if (path_len == 0) {
     return false;
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/2016 |
| Primary OS tested on | (Raspbian Buster) |
| Robotic platform tested on | (Raspberry Pi 4 + RPLIDAR A1 + Roomba) |

---

## Description of contribution in a few bullet points

My test environment is much larger in length than width, I was frequently getting failed path plans when issuing commands that traversed the length of the environment.  I noticed the max cycles to run NavFn::calcPath is derived from the X dimension alone, I changed it to be depending on whether the X or Y dimension is larger. 
