### PR TITLE
Awaited action server result

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -191,6 +191,16 @@ public:
           node_->get_logger(),
           "Failed to cancel action server for %s", action_name_.c_str());
       }
+
+      auto result_future = action_client_->async_get_result(goal_handle_);
+      if (rclcpp::spin_until_future_complete(node_, result_future) !=
+        rclcpp::FutureReturnCode::SUCCESS)
+      {
+        RCLCPP_ERROR(
+          node_->get_logger(),
+          "Failed to result from action server %s", action_name_.c_str());
+      }
+
     }
 
     setStatus(BT::NodeStatus::IDLE);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | simulation |

---

## Description of contribution in a few bullet points

When a BT_action_node is halted it does not await the result of the goal.
This leads to a crash of the action server in case a new behaviour tree is loaded immediately after halting (for example when the BT is executed in an action server itself, and different BTs can be run).
The reason for this is that the SimpleActionServer sends a goal response even after the cancel request is accepted.
When the action client is removed before it has received the response the sending action server crashes.
This MR also awaits the goal response, preventing the action server from crashing.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
