### PR TITLE
Fix SmacPlanner memory leaks and costmap downsampler test

### DIFF
--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -34,9 +34,8 @@ class CostmapDownsampler
 public:
   /**
    * @brief A constructor for CostmapDownsampler
-   * @param node Lifecycle node pointer
    */
-  explicit CostmapDownsampler(const nav2_util::LifecycleNode::SharedPtr & node);
+  CostmapDownsampler();
 
   /**
    * @brief A destructor for CostmapDownsampler
@@ -45,12 +44,14 @@ public:
 
   /**
    * @brief Initialize the downsampled costmap object and the ROS publisher
+   * @param node Lifecycle node pointer
    * @param global_frame The ID of the global frame used by the costmap
    * @param topic_name The name of the topic to publish the downsampled costmap
    * @param costmap The costmap we want to downsample
    * @param downsampling_factor Multiplier for the costmap resolution
    */
   void initialize(
+    const nav2_util::LifecycleNode::WeakPtr & node,
     const std::string & global_frame,
     const std::string & topic_name,
     nav2_costmap_2d::Costmap2D * const costmap,
@@ -106,7 +107,6 @@ protected:
   unsigned int _downsampling_factor;
   float _downsampled_resolution;
   std::string _topic_name;
-  nav2_util::LifecycleNode::SharedPtr _node;
   nav2_costmap_2d::Costmap2D * _costmap;
   std::unique_ptr<nav2_costmap_2d::Costmap2D> _downsampled_costmap;
   std::unique_ptr<nav2_costmap_2d::Costmap2DPublisher> _downsampled_costmap_pub;

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -43,14 +43,14 @@ public:
   ~CostmapDownsampler();
 
   /**
-   * @brief Initialize the downsampled costmap object and the ROS publisher
+   * @brief Configure the downsampled costmap object and the ROS publisher
    * @param node Lifecycle node pointer
    * @param global_frame The ID of the global frame used by the costmap
    * @param topic_name The name of the topic to publish the downsampled costmap
    * @param costmap The costmap we want to downsample
    * @param downsampling_factor Multiplier for the costmap resolution
    */
-  void initialize(
+  void on_configure(
     const nav2_util::LifecycleNode::WeakPtr & node,
     const std::string & global_frame,
     const std::string & topic_name,
@@ -60,18 +60,17 @@ public:
   /**
    * @brief Activate the publisher of the downsampled costmap
    */
-  void activatePublisher()
-  {
-    _downsampled_costmap_pub->on_activate();
-  }
+  void on_activate();
 
   /**
    * @brief Deactivate the publisher of the downsampled costmap
    */
-  void deactivatePublisher()
-  {
-    _downsampled_costmap_pub->on_deactivate();
-  }
+  void on_deactivate();
+
+  /**
+   * @brief Cleanup the publisher of the downsampled costmap
+   */
+  void on_cleanup();
 
   /**
    * @brief Downsample the given costmap by the downsampling factor, and publish the downsampled costmap
@@ -106,7 +105,6 @@ protected:
   unsigned int _downsampled_size_y;
   unsigned int _downsampling_factor;
   float _downsampled_resolution;
-  std::string _topic_name;
   nav2_costmap_2d::Costmap2D * _costmap;
   std::unique_ptr<nav2_costmap_2d::Costmap2D> _downsampled_costmap;
   std::unique_ptr<nav2_costmap_2d::Costmap2DPublisher> _downsampled_costmap_pub;

--- a/smac_planner/include/smac_planner/smac_planner.hpp
+++ b/smac_planner/include/smac_planner/smac_planner.hpp
@@ -111,7 +111,8 @@ public:
 protected:
   std::unique_ptr<AStarAlgorithm<NodeSE2>> _a_star;
   std::unique_ptr<Smoother> _smoother;
-  nav2_util::LifecycleNode::SharedPtr _node;
+  rclcpp::Clock::SharedPtr _clock;
+  rclcpp::Logger _logger{rclcpp::get_logger("SmacPlanner")};
   nav2_costmap_2d::Costmap2D * _costmap;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
   std::string _global_frame, _name;

--- a/smac_planner/include/smac_planner/smac_planner_2d.hpp
+++ b/smac_planner/include/smac_planner/smac_planner_2d.hpp
@@ -106,7 +106,8 @@ protected:
   std::unique_ptr<Smoother> _smoother;
   nav2_costmap_2d::Costmap2D * _costmap;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
-  nav2_util::LifecycleNode::SharedPtr _node;
+  rclcpp::Clock::SharedPtr _clock;
+  rclcpp::Logger _logger{rclcpp::get_logger("SmacPlanner2D")};
   std::string _global_frame, _name;
   float _tolerance;
   int _downsampling_factor;

--- a/smac_planner/src/costmap_downsampler.cpp
+++ b/smac_planner/src/costmap_downsampler.cpp
@@ -22,9 +22,8 @@
 namespace smac_planner
 {
 
-CostmapDownsampler::CostmapDownsampler(const nav2_util::LifecycleNode::SharedPtr & node)
-: _node(node),
-  _costmap(nullptr),
+CostmapDownsampler::CostmapDownsampler()
+: _costmap(nullptr),
   _downsampled_costmap(nullptr),
   _downsampled_costmap_pub(nullptr)
 {
@@ -35,6 +34,7 @@ CostmapDownsampler::~CostmapDownsampler()
 }
 
 void CostmapDownsampler::initialize(
+  const nav2_util::LifecycleNode::WeakPtr & node,
   const std::string & global_frame,
   const std::string & topic_name,
   nav2_costmap_2d::Costmap2D * const costmap,
@@ -50,7 +50,7 @@ void CostmapDownsampler::initialize(
     _costmap->getOriginX(), _costmap->getOriginY(), UNKNOWN);
 
   _downsampled_costmap_pub = std::make_unique<nav2_costmap_2d::Costmap2DPublisher>(
-    _node, _downsampled_costmap.get(), global_frame, _topic_name, false);
+    node, _downsampled_costmap.get(), global_frame, _topic_name, false);
 }
 
 nav2_costmap_2d::Costmap2D * CostmapDownsampler::downsample(
@@ -74,10 +74,7 @@ nav2_costmap_2d::Costmap2D * CostmapDownsampler::downsample(
     }
   }
 
-  if (_node->count_subscribers(_topic_name) > 0) {
-    _downsampled_costmap_pub->publishCostmap();
-  }
-
+  _downsampled_costmap_pub->publishCostmap();
   return _downsampled_costmap.get();
 }
 

--- a/smac_planner/src/costmap_downsampler.cpp
+++ b/smac_planner/src/costmap_downsampler.cpp
@@ -33,14 +33,13 @@ CostmapDownsampler::~CostmapDownsampler()
 {
 }
 
-void CostmapDownsampler::initialize(
+void CostmapDownsampler::on_configure(
   const nav2_util::LifecycleNode::WeakPtr & node,
   const std::string & global_frame,
   const std::string & topic_name,
   nav2_costmap_2d::Costmap2D * const costmap,
   const unsigned int & downsampling_factor)
 {
-  _topic_name = topic_name;
   _costmap = costmap;
   _downsampling_factor = downsampling_factor;
   updateCostmapSize();
@@ -50,7 +49,24 @@ void CostmapDownsampler::initialize(
     _costmap->getOriginX(), _costmap->getOriginY(), UNKNOWN);
 
   _downsampled_costmap_pub = std::make_unique<nav2_costmap_2d::Costmap2DPublisher>(
-    node, _downsampled_costmap.get(), global_frame, _topic_name, false);
+    node, _downsampled_costmap.get(), global_frame, topic_name, false);
+}
+
+void CostmapDownsampler::on_activate()
+{
+  _downsampled_costmap_pub->on_activate();
+}
+
+void CostmapDownsampler::on_deactivate()
+{
+  _downsampled_costmap_pub->on_deactivate();
+}
+
+void CostmapDownsampler::on_cleanup()
+{
+  _costmap = nullptr;
+  _downsampled_costmap.reset();
+  _downsampled_costmap_pub.reset();
 }
 
 nav2_costmap_2d::Costmap2D * CostmapDownsampler::downsample(

--- a/smac_planner/src/smac_planner.cpp
+++ b/smac_planner/src/smac_planner.cpp
@@ -163,7 +163,7 @@ void SmacPlanner::configure(
   if (_downsample_costmap && _downsampling_factor > 1) {
     std::string topic_name = "downsampled_costmap";
     _costmap_downsampler = std::make_unique<CostmapDownsampler>();
-    _costmap_downsampler->initialize(
+    _costmap_downsampler->on_configure(
       node, _global_frame, topic_name, _costmap, _downsampling_factor);
   }
 
@@ -185,7 +185,7 @@ void SmacPlanner::activate()
     _name.c_str());
   _raw_plan_publisher->on_activate();
   if (_costmap_downsampler) {
-    _costmap_downsampler->activatePublisher();
+    _costmap_downsampler->on_activate();
   }
 }
 
@@ -196,7 +196,7 @@ void SmacPlanner::deactivate()
     _name.c_str());
   _raw_plan_publisher->on_deactivate();
   if (_costmap_downsampler) {
-    _costmap_downsampler->deactivatePublisher();
+    _costmap_downsampler->on_deactivate();
   }
 }
 
@@ -207,6 +207,7 @@ void SmacPlanner::cleanup()
     _name.c_str());
   _a_star.reset();
   _smoother.reset();
+  _costmap_downsampler->on_cleanup();
   _costmap_downsampler.reset();
   _raw_plan_publisher.reset();
 }

--- a/smac_planner/src/smac_planner.cpp
+++ b/smac_planner/src/smac_planner.cpp
@@ -31,7 +31,6 @@ using namespace std::chrono;  // NOLINT
 SmacPlanner::SmacPlanner()
 : _a_star(nullptr),
   _smoother(nullptr),
-  _node(nullptr),
   _costmap(nullptr),
   _costmap_downsampler(nullptr)
 {
@@ -40,7 +39,7 @@ SmacPlanner::SmacPlanner()
 SmacPlanner::~SmacPlanner()
 {
   RCLCPP_INFO(
-    _node->get_logger(), "Destroying plugin %s of type SmacPlanner",
+    _logger, "Destroying plugin %s of type SmacPlanner",
     _name.c_str());
 }
 
@@ -49,7 +48,9 @@ void SmacPlanner::configure(
   std::string name, std::shared_ptr<tf2_ros::Buffer>/*tf*/,
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros)
 {
-  _node = parent.lock();
+  auto node = parent.lock();
+  _logger = node->get_logger();
+  _clock = node->get_clock();
   _costmap = costmap_ros->getCostmap();
   _name = name;
   _global_frame = costmap_ros->getGlobalFrameID();
@@ -64,62 +65,62 @@ void SmacPlanner::configure(
 
   // General planner params
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".tolerance", rclcpp::ParameterValue(0.125));
-  _tolerance = static_cast<float>(_node->get_parameter(name + ".tolerance").as_double());
+    node, name + ".tolerance", rclcpp::ParameterValue(0.125));
+  _tolerance = static_cast<float>(node->get_parameter(name + ".tolerance").as_double());
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".downsample_costmap", rclcpp::ParameterValue(true));
-  _node->get_parameter(name + ".downsample_costmap", _downsample_costmap);
+    node, name + ".downsample_costmap", rclcpp::ParameterValue(true));
+  node->get_parameter(name + ".downsample_costmap", _downsample_costmap);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".downsampling_factor", rclcpp::ParameterValue(1));
-  _node->get_parameter(name + ".downsampling_factor", _downsampling_factor);
+    node, name + ".downsampling_factor", rclcpp::ParameterValue(1));
+  node->get_parameter(name + ".downsampling_factor", _downsampling_factor);
 
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".angle_quantization_bins", rclcpp::ParameterValue(1));
-  _node->get_parameter(name + ".angle_quantization_bins", angle_quantizations);
+    node, name + ".angle_quantization_bins", rclcpp::ParameterValue(1));
+  node->get_parameter(name + ".angle_quantization_bins", angle_quantizations);
   _angle_bin_size = 2.0 * M_PI / angle_quantizations;
   _angle_quantizations = static_cast<unsigned int>(angle_quantizations);
 
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".allow_unknown", rclcpp::ParameterValue(true));
-  _node->get_parameter(name + ".allow_unknown", allow_unknown);
+    node, name + ".allow_unknown", rclcpp::ParameterValue(true));
+  node->get_parameter(name + ".allow_unknown", allow_unknown);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".max_iterations", rclcpp::ParameterValue(-1));
-  _node->get_parameter(name + ".max_iterations", max_iterations);
+    node, name + ".max_iterations", rclcpp::ParameterValue(-1));
+  node->get_parameter(name + ".max_iterations", max_iterations);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".smooth_path", rclcpp::ParameterValue(false));
-  _node->get_parameter(name + ".smooth_path", smooth_path);
+    node, name + ".smooth_path", rclcpp::ParameterValue(false));
+  node->get_parameter(name + ".smooth_path", smooth_path);
 
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".minimum_turning_radius", rclcpp::ParameterValue(0.2));
-  _node->get_parameter(name + ".minimum_turning_radius", search_info.minimum_turning_radius);
+    node, name + ".minimum_turning_radius", rclcpp::ParameterValue(0.2));
+  node->get_parameter(name + ".minimum_turning_radius", search_info.minimum_turning_radius);
 
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".reverse_penalty", rclcpp::ParameterValue(2.0));
-  _node->get_parameter(name + ".reverse_penalty", search_info.reverse_penalty);
+    node, name + ".reverse_penalty", rclcpp::ParameterValue(2.0));
+  node->get_parameter(name + ".reverse_penalty", search_info.reverse_penalty);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".change_penalty", rclcpp::ParameterValue(0.5));
-  _node->get_parameter(name + ".change_penalty", search_info.change_penalty);
+    node, name + ".change_penalty", rclcpp::ParameterValue(0.5));
+  node->get_parameter(name + ".change_penalty", search_info.change_penalty);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".non_straight_penalty", rclcpp::ParameterValue(1.05));
-  _node->get_parameter(name + ".non_straight_penalty", search_info.non_straight_penalty);
+    node, name + ".non_straight_penalty", rclcpp::ParameterValue(1.05));
+  node->get_parameter(name + ".non_straight_penalty", search_info.non_straight_penalty);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".cost_penalty", rclcpp::ParameterValue(1.2));
-  _node->get_parameter(name + ".cost_penalty", search_info.cost_penalty);
+    node, name + ".cost_penalty", rclcpp::ParameterValue(1.2));
+  node->get_parameter(name + ".cost_penalty", search_info.cost_penalty);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".analytic_expansion_ratio", rclcpp::ParameterValue(2.0));
-  _node->get_parameter(name + ".analytic_expansion_ratio", search_info.analytic_expansion_ratio);
+    node, name + ".analytic_expansion_ratio", rclcpp::ParameterValue(2.0));
+  node->get_parameter(name + ".analytic_expansion_ratio", search_info.analytic_expansion_ratio);
 
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".max_planning_time_ms", rclcpp::ParameterValue(5000.0));
-  _node->get_parameter(name + ".max_planning_time_ms", _max_planning_time);
+    node, name + ".max_planning_time_ms", rclcpp::ParameterValue(5000.0));
+  node->get_parameter(name + ".max_planning_time_ms", _max_planning_time);
 
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".motion_model_for_search", rclcpp::ParameterValue(std::string("DUBIN")));
-  _node->get_parameter(name + ".motion_model_for_search", motion_model_for_search);
+    node, name + ".motion_model_for_search", rclcpp::ParameterValue(std::string("DUBIN")));
+  node->get_parameter(name + ".motion_model_for_search", motion_model_for_search);
   MotionModel motion_model = fromString(motion_model_for_search);
   if (motion_model == MotionModel::UNKNOWN) {
     RCLCPP_WARN(
-      _node->get_logger(),
+      _logger,
       "Unable to get MotionModel search type. Given '%s', "
       "valid options are MOORE, VON_NEUMANN, DUBIN, REEDS_SHEPP.",
       motion_model_for_search.c_str());
@@ -127,14 +128,14 @@ void SmacPlanner::configure(
 
   if (max_on_approach_iterations <= 0) {
     RCLCPP_INFO(
-      _node->get_logger(), "On approach iteration selected as <= 0, "
+      _logger, "On approach iteration selected as <= 0, "
       "disabling tolerance and on approach iterations.");
     max_on_approach_iterations = std::numeric_limits<int>::max();
   }
 
   if (max_iterations <= 0) {
     RCLCPP_INFO(
-      _node->get_logger(), "maximum iteration selected as <= 0, "
+      _logger, "maximum iteration selected as <= 0, "
       "disabling maximum iterations.");
     max_iterations = std::numeric_limits<int>::max();
   }
@@ -153,22 +154,23 @@ void SmacPlanner::configure(
 
   if (smooth_path) {
     _smoother = std::make_unique<Smoother>();
-    _optimizer_params.get(_node.get(), name);
-    _smoother_params.get(_node.get(), name);
+    _optimizer_params.get(node.get(), name);
+    _smoother_params.get(node.get(), name);
     _smoother_params.max_curvature = 1.0f / minimum_turning_radius_global_coords;
     _smoother->initialize(_optimizer_params);
   }
 
   if (_downsample_costmap && _downsampling_factor > 1) {
     std::string topic_name = "downsampled_costmap";
-    _costmap_downsampler = std::make_unique<CostmapDownsampler>(_node);
-    _costmap_downsampler->initialize(_global_frame, topic_name, _costmap, _downsampling_factor);
+    _costmap_downsampler = std::make_unique<CostmapDownsampler>();
+    _costmap_downsampler->initialize(
+      node, _global_frame, topic_name, _costmap, _downsampling_factor);
   }
 
-  _raw_plan_publisher = _node->create_publisher<nav_msgs::msg::Path>("unsmoothed_plan", 1);
+  _raw_plan_publisher = node->create_publisher<nav_msgs::msg::Path>("unsmoothed_plan", 1);
 
   RCLCPP_INFO(
-    _node->get_logger(), "Configured plugin %s of type SmacPlanner with "
+    _logger, "Configured plugin %s of type SmacPlanner with "
     "tolerance %.2f, maximum iterations %i, "
     "max on approach iterations %i, and %s. Using motion model: %s.",
     _name.c_str(), _tolerance, max_iterations, max_on_approach_iterations,
@@ -179,7 +181,7 @@ void SmacPlanner::configure(
 void SmacPlanner::activate()
 {
   RCLCPP_INFO(
-    _node->get_logger(), "Activating plugin %s of type SmacPlanner",
+    _logger, "Activating plugin %s of type SmacPlanner",
     _name.c_str());
   _raw_plan_publisher->on_activate();
   if (_costmap_downsampler) {
@@ -190,7 +192,7 @@ void SmacPlanner::activate()
 void SmacPlanner::deactivate()
 {
   RCLCPP_INFO(
-    _node->get_logger(), "Deactivating plugin %s of type SmacPlanner",
+    _logger, "Deactivating plugin %s of type SmacPlanner",
     _name.c_str());
   _raw_plan_publisher->on_deactivate();
   if (_costmap_downsampler) {
@@ -201,7 +203,7 @@ void SmacPlanner::deactivate()
 void SmacPlanner::cleanup()
 {
   RCLCPP_INFO(
-    _node->get_logger(), "Cleaning up plugin %s of type SmacPlanner",
+    _logger, "Cleaning up plugin %s of type SmacPlanner",
     _name.c_str());
   _a_star.reset();
   _smoother.reset();
@@ -251,7 +253,7 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
 
   // Setup message
   nav_msgs::msg::Path plan;
-  plan.header.stamp = _node->now();
+  plan.header.stamp = _clock->now();
   plan.header.frame_id = _global_frame;
   geometry_msgs::msg::PoseStamped pose;
   pose.header = plan.header;
@@ -282,7 +284,7 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
 
   if (!error.empty()) {
     RCLCPP_WARN(
-      _node->get_logger(),
+      _logger,
       "%s: failed to create plan, %s.",
       _name.c_str(), error.c_str());
     return plan;
@@ -304,7 +306,7 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
   }
 
   // Publish raw path for debug
-  if (_node->count_subscribers(_raw_plan_publisher->get_topic_name()) > 0) {
+  if (_raw_plan_publisher->get_subscription_count() > 0) {
     _raw_plan_publisher->publish(plan);
   }
 
@@ -328,7 +330,7 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
   // Smooth plan
   if (!_smoother->smooth(path_world, costmap, _smoother_params)) {
     RCLCPP_WARN(
-      _node->get_logger(),
+      _logger,
       "%s: failed to smooth plan, Ceres could not find a usable solution to optimize.",
       _name.c_str());
     return plan;

--- a/smac_planner/src/smac_planner_2d.cpp
+++ b/smac_planner/src/smac_planner_2d.cpp
@@ -134,7 +134,7 @@ void SmacPlanner2D::configure(
   if (_downsample_costmap && _downsampling_factor > 1) {
     std::string topic_name = "downsampled_costmap";
     _costmap_downsampler = std::make_unique<CostmapDownsampler>();
-    _costmap_downsampler->initialize(
+    _costmap_downsampler->on_configure(
       node, _global_frame, topic_name, _costmap, _downsampling_factor);
   }
 
@@ -156,7 +156,7 @@ void SmacPlanner2D::activate()
     _name.c_str());
   _raw_plan_publisher->on_activate();
   if (_costmap_downsampler) {
-    _costmap_downsampler->activatePublisher();
+    _costmap_downsampler->on_activate();
   }
 }
 
@@ -167,7 +167,7 @@ void SmacPlanner2D::deactivate()
     _name.c_str());
   _raw_plan_publisher->on_deactivate();
   if (_costmap_downsampler) {
-    _costmap_downsampler->deactivatePublisher();
+    _costmap_downsampler->on_deactivate();
   }
 }
 
@@ -178,6 +178,7 @@ void SmacPlanner2D::cleanup()
     _name.c_str());
   _a_star.reset();
   _smoother.reset();
+  _costmap_downsampler->on_cleanup();
   _costmap_downsampler.reset();
   _raw_plan_publisher.reset();
 }

--- a/smac_planner/src/smac_planner_2d.cpp
+++ b/smac_planner/src/smac_planner_2d.cpp
@@ -30,15 +30,14 @@ SmacPlanner2D::SmacPlanner2D()
 : _a_star(nullptr),
   _smoother(nullptr),
   _costmap(nullptr),
-  _costmap_downsampler(nullptr),
-  _node(nullptr)
+  _costmap_downsampler(nullptr)
 {
 }
 
 SmacPlanner2D::~SmacPlanner2D()
 {
   RCLCPP_INFO(
-    _node->get_logger(), "Destroying plugin %s of type SmacPlanner2D",
+    _logger, "Destroying plugin %s of type SmacPlanner2D",
     _name.c_str());
 }
 
@@ -47,7 +46,9 @@ void SmacPlanner2D::configure(
   std::string name, std::shared_ptr<tf2_ros::Buffer>/*tf*/,
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros)
 {
-  _node = parent.lock();
+  auto node = parent.lock();
+  _logger = node->get_logger();
+  _clock = node->get_clock();
   _costmap = costmap_ros->getCostmap();
   _name = name;
   _global_frame = costmap_ros->getGlobalFrameID();
@@ -61,42 +62,42 @@ void SmacPlanner2D::configure(
 
   // General planner params
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".tolerance", rclcpp::ParameterValue(0.125));
-  _tolerance = static_cast<float>(_node->get_parameter(name + ".tolerance").as_double());
+    node, name + ".tolerance", rclcpp::ParameterValue(0.125));
+  _tolerance = static_cast<float>(node->get_parameter(name + ".tolerance").as_double());
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".downsample_costmap", rclcpp::ParameterValue(true));
-  _node->get_parameter(name + ".downsample_costmap", _downsample_costmap);
+    node, name + ".downsample_costmap", rclcpp::ParameterValue(true));
+  node->get_parameter(name + ".downsample_costmap", _downsample_costmap);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".downsampling_factor", rclcpp::ParameterValue(1));
-  _node->get_parameter(name + ".downsampling_factor", _downsampling_factor);
+    node, name + ".downsampling_factor", rclcpp::ParameterValue(1));
+  node->get_parameter(name + ".downsampling_factor", _downsampling_factor);
 
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".allow_unknown", rclcpp::ParameterValue(true));
-  _node->get_parameter(name + ".allow_unknown", allow_unknown);
+    node, name + ".allow_unknown", rclcpp::ParameterValue(true));
+  node->get_parameter(name + ".allow_unknown", allow_unknown);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".max_iterations", rclcpp::ParameterValue(-1));
-  _node->get_parameter(name + ".max_iterations", max_iterations);
+    node, name + ".max_iterations", rclcpp::ParameterValue(-1));
+  node->get_parameter(name + ".max_iterations", max_iterations);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".max_on_approach_iterations", rclcpp::ParameterValue(1000));
-  _node->get_parameter(name + ".max_on_approach_iterations", max_on_approach_iterations);
+    node, name + ".max_on_approach_iterations", rclcpp::ParameterValue(1000));
+  node->get_parameter(name + ".max_on_approach_iterations", max_on_approach_iterations);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".smooth_path", rclcpp::ParameterValue(false));
-  _node->get_parameter(name + ".smooth_path", smooth_path);
+    node, name + ".smooth_path", rclcpp::ParameterValue(false));
+  node->get_parameter(name + ".smooth_path", smooth_path);
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".minimum_turning_radius", rclcpp::ParameterValue(0.2));
-  _node->get_parameter(name + ".minimum_turning_radius", minimum_turning_radius);
+    node, name + ".minimum_turning_radius", rclcpp::ParameterValue(0.2));
+  node->get_parameter(name + ".minimum_turning_radius", minimum_turning_radius);
 
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".max_planning_time_ms", rclcpp::ParameterValue(1000.0));
-  _node->get_parameter(name + ".max_planning_time_ms", _max_planning_time);
+    node, name + ".max_planning_time_ms", rclcpp::ParameterValue(1000.0));
+  node->get_parameter(name + ".max_planning_time_ms", _max_planning_time);
 
   nav2_util::declare_parameter_if_not_declared(
-    _node, name + ".motion_model_for_search", rclcpp::ParameterValue(std::string("MOORE")));
-  _node->get_parameter(name + ".motion_model_for_search", motion_model_for_search);
+    node, name + ".motion_model_for_search", rclcpp::ParameterValue(std::string("MOORE")));
+  node->get_parameter(name + ".motion_model_for_search", motion_model_for_search);
   MotionModel motion_model = fromString(motion_model_for_search);
   if (motion_model == MotionModel::UNKNOWN) {
     RCLCPP_WARN(
-      _node->get_logger(),
+      _logger,
       "Unable to get MotionModel search type. Given '%s', "
       "valid options are MOORE, VON_NEUMANN, DUBIN, REEDS_SHEPP.",
       motion_model_for_search.c_str());
@@ -104,14 +105,14 @@ void SmacPlanner2D::configure(
 
   if (max_on_approach_iterations <= 0) {
     RCLCPP_INFO(
-      _node->get_logger(), "On approach iteration selected as <= 0, "
+      _logger, "On approach iteration selected as <= 0, "
       "disabling tolerance and on approach iterations.");
     max_on_approach_iterations = std::numeric_limits<int>::max();
   }
 
   if (max_iterations <= 0) {
     RCLCPP_INFO(
-      _node->get_logger(), "maximum iteration selected as <= 0, "
+      _logger, "maximum iteration selected as <= 0, "
       "disabling maximum iterations.");
     max_iterations = std::numeric_limits<int>::max();
   }
@@ -124,22 +125,23 @@ void SmacPlanner2D::configure(
 
   if (smooth_path) {
     _smoother = std::make_unique<Smoother>();
-    _optimizer_params.get(_node.get(), name);
-    _smoother_params.get(_node.get(), name);
+    _optimizer_params.get(node.get(), name);
+    _smoother_params.get(node.get(), name);
     _smoother_params.max_curvature = 1.0f / minimum_turning_radius;
     _smoother->initialize(_optimizer_params);
   }
 
   if (_downsample_costmap && _downsampling_factor > 1) {
     std::string topic_name = "downsampled_costmap";
-    _costmap_downsampler = std::make_unique<CostmapDownsampler>(_node);
-    _costmap_downsampler->initialize(_global_frame, topic_name, _costmap, _downsampling_factor);
+    _costmap_downsampler = std::make_unique<CostmapDownsampler>();
+    _costmap_downsampler->initialize(
+      node, _global_frame, topic_name, _costmap, _downsampling_factor);
   }
 
-  _raw_plan_publisher = _node->create_publisher<nav_msgs::msg::Path>("unsmoothed_plan", 1);
+  _raw_plan_publisher = node->create_publisher<nav_msgs::msg::Path>("unsmoothed_plan", 1);
 
   RCLCPP_INFO(
-    _node->get_logger(), "Configured plugin %s of type SmacPlanner2D with "
+    _logger, "Configured plugin %s of type SmacPlanner2D with "
     "tolerance %.2f, maximum iterations %i, "
     "max on approach iterations %i, and %s. Using motion model: %s.",
     _name.c_str(), _tolerance, max_iterations, max_on_approach_iterations,
@@ -150,7 +152,7 @@ void SmacPlanner2D::configure(
 void SmacPlanner2D::activate()
 {
   RCLCPP_INFO(
-    _node->get_logger(), "Activating plugin %s of type SmacPlanner2D",
+    _logger, "Activating plugin %s of type SmacPlanner2D",
     _name.c_str());
   _raw_plan_publisher->on_activate();
   if (_costmap_downsampler) {
@@ -161,7 +163,7 @@ void SmacPlanner2D::activate()
 void SmacPlanner2D::deactivate()
 {
   RCLCPP_INFO(
-    _node->get_logger(), "Deactivating plugin %s of type SmacPlanner2D",
+    _logger, "Deactivating plugin %s of type SmacPlanner2D",
     _name.c_str());
   _raw_plan_publisher->on_deactivate();
   if (_costmap_downsampler) {
@@ -172,7 +174,7 @@ void SmacPlanner2D::deactivate()
 void SmacPlanner2D::cleanup()
 {
   RCLCPP_INFO(
-    _node->get_logger(), "Cleaning up plugin %s of type SmacPlanner2D",
+    _logger, "Cleaning up plugin %s of type SmacPlanner2D",
     _name.c_str());
   _a_star.reset();
   _smoother.reset();
@@ -212,7 +214,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
 
   // Setup message
   nav_msgs::msg::Path plan;
-  plan.header.stamp = _node->now();
+  plan.header.stamp = _clock->now();
   plan.header.frame_id = _global_frame;
   geometry_msgs::msg::PoseStamped pose;
   pose.header = plan.header;
@@ -243,7 +245,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
 
   if (!error.empty()) {
     RCLCPP_WARN(
-      _node->get_logger(),
+      _logger,
       "%s: failed to create plan, %s.",
       _name.c_str(), error.c_str());
     return plan;
@@ -268,7 +270,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
   }
 
   // Publish raw path for debug
-  if (_node->count_subscribers(_raw_plan_publisher->get_topic_name()) > 0) {
+  if (_raw_plan_publisher->get_subscription_count() > 0) {
     _raw_plan_publisher->publish(plan);
   }
 
@@ -292,7 +294,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
   // Smooth plan
   if (!_smoother->smooth(path_world, costmap, _smoother_params)) {
     RCLCPP_WARN(
-      _node->get_logger(),
+      _logger,
       "%s: failed to smooth plan, Ceres could not find a usable solution to optimize.",
       _name.c_str());
     return plan;

--- a/smac_planner/test/test_costmap_downsampler.cpp
+++ b/smac_planner/test/test_costmap_downsampler.cpp
@@ -13,7 +13,6 @@
 // limitations under the License. Reserved.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -30,80 +29,20 @@ public:
 };
 RclCppFixture g_rclcppfixture;
 
-class TestNode : public nav2_util::LifecycleNode
-{
-public:
-  TestNode()
-  : nav2_util::LifecycleNode("CostmapDownsamplerTest"),
-    costmap_(nullptr),
-    downsampler_(nullptr) {}
-
-  void setCostmap(nav2_costmap_2d::Costmap2D * const costmap)
-  {
-    costmap_ = costmap;
-  }
-
-  std::shared_ptr<smac_planner::CostmapDownsampler> getDownsampler()
-  {
-    return downsampler_;
-  }
-
-protected:
-  nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override
-  {
-    RCLCPP_INFO(get_logger(), "Configuring");
-    downsampler_ = std::make_shared<smac_planner::CostmapDownsampler>();
-    downsampler_->on_configure(shared_from_this(), "map", "unused_topic", costmap_, 2);
-    return nav2_util::CallbackReturn::SUCCESS;
-  }
-
-  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override
-  {
-    RCLCPP_INFO(get_logger(), "Activating");
-    downsampler_->on_activate();
-    return nav2_util::CallbackReturn::SUCCESS;
-  }
-
-  nav2_util::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override
-  {
-    RCLCPP_INFO(get_logger(), "Deactivating");
-    downsampler_->on_deactivate();
-    return nav2_util::CallbackReturn::SUCCESS;
-  }
-
-  nav2_util::CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override
-  {
-    RCLCPP_INFO(get_logger(), "Cleaning up");
-    downsampler_->on_cleanup();
-    return nav2_util::CallbackReturn::SUCCESS;
-  }
-
-private:
-  nav2_costmap_2d::Costmap2D * costmap_;
-  std::shared_ptr<smac_planner::CostmapDownsampler> downsampler_;
-};
-
 TEST(CostmapDownsampler, costmap_downsample_test)
 {
-  auto node = std::make_shared<TestNode>();
+  nav2_util::LifecycleNode::SharedPtr node = std::make_shared<nav2_util::LifecycleNode>(
+    "CostmapDownsamplerTest");
+  smac_planner::CostmapDownsampler downsampler;
 
   // create basic costmap
   nav2_costmap_2d::Costmap2D costmapA(10, 10, 0.05, 0.0, 0.0, 0);
   costmapA.setCost(0, 0, 100);
   costmapA.setCost(5, 5, 50);
 
-  // set costmap for testing
-  node->setCostmap(&costmapA);
-
-  // configure and activate test node
-  node->configure();
-  node->activate();
-
-  // get downsampler
-  auto downsampler = node->getDownsampler();
-
   // downsample it
-  nav2_costmap_2d::Costmap2D * downsampledCostmapA = downsampler->downsample(2);
+  downsampler.on_configure(node, "map", "unused_topic", &costmapA, 2);
+  nav2_costmap_2d::Costmap2D * downsampledCostmapA = downsampler.downsample(2);
 
   // validate it
   EXPECT_EQ(downsampledCostmapA->getCost(0, 0), 100);
@@ -111,34 +50,18 @@ TEST(CostmapDownsampler, costmap_downsample_test)
   EXPECT_EQ(downsampledCostmapA->getSizeInCellsX(), 5u);
   EXPECT_EQ(downsampledCostmapA->getSizeInCellsY(), 5u);
 
-  // deactivate and cleanup test node
-  node->deactivate();
-  node->cleanup();
-
   // give it another costmap of another size
   nav2_costmap_2d::Costmap2D costmapB(4, 4, 0.10, 0.0, 0.0, 0);
 
-  // set costmap for testing
-  node->setCostmap(&costmapB);
-
-  // configure and activate test node
-  node->configure();
-  node->activate();
-
-  // get downsampler
-  downsampler = node->getDownsampler();
-
   // downsample it
-  nav2_costmap_2d::Costmap2D * downsampledCostmapB = downsampler->downsample(4);
+  downsampler.on_configure(node, "map", "unused_topic", &costmapB, 4);
+  downsampler.on_activate();
+  nav2_costmap_2d::Costmap2D * downsampledCostmapB = downsampler.downsample(4);
+  downsampler.on_deactivate();
 
   // validate size
   EXPECT_EQ(downsampledCostmapB->getSizeInCellsX(), 1u);
   EXPECT_EQ(downsampledCostmapB->getSizeInCellsY(), 1u);
 
-  downsampler->resizeCostmap();
-
-  // deactivate and cleanup test node
-  node->deactivate();
-  node->cleanup();
-  node->shutdown();
+  downsampler.resizeCostmap();
 }

--- a/smac_planner/test/test_costmap_downsampler.cpp
+++ b/smac_planner/test/test_costmap_downsampler.cpp
@@ -35,7 +35,7 @@ TEST(CostmapDownsampler, costmap_downsample_test)
 {
   nav2_util::LifecycleNode::SharedPtr node = std::make_shared<nav2_util::LifecycleNode>(
     "CostmapDownsamplerTest");
-  smac_planner::CostmapDownsampler downsampler(node);
+  smac_planner::CostmapDownsampler downsampler{};
   auto map_sub = nav2_costmap_2d::CostmapSubscriber(node, "unused_topic");
 
   // create basic costmap
@@ -44,7 +44,7 @@ TEST(CostmapDownsampler, costmap_downsample_test)
   costmapA.setCost(5, 5, 50);
 
   // downsample it
-  downsampler.initialize("map", "unused_topic", &costmapA, 2);
+  downsampler.initialize(node, "map", "unused_topic", &costmapA, 2);
   nav2_costmap_2d::Costmap2D * downsampledCostmapA = downsampler.downsample(2);
 
   // validate it
@@ -57,7 +57,7 @@ TEST(CostmapDownsampler, costmap_downsample_test)
   nav2_costmap_2d::Costmap2D costmapB(4, 4, 0.10, 0.0, 0.0, 0);
 
   // downsample it
-  downsampler.initialize("map", "unused_topic", &costmapB, 4);
+  downsampler.initialize(node, "map", "unused_topic", &costmapB, 4);
   downsampler.activatePublisher();
   nav2_costmap_2d::Costmap2D * downsampledCostmapB = downsampler.downsample(4);
   downsampler.deactivatePublisher();

--- a/smac_planner/test/test_costmap_downsampler.cpp
+++ b/smac_planner/test/test_costmap_downsampler.cpp
@@ -19,7 +19,6 @@
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
-#include "nav2_costmap_2d/costmap_subscriber.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 #include "smac_planner/costmap_downsampler.hpp"
 
@@ -31,21 +30,80 @@ public:
 };
 RclCppFixture g_rclcppfixture;
 
+class TestNode : public nav2_util::LifecycleNode
+{
+public:
+  TestNode()
+  : nav2_util::LifecycleNode("CostmapDownsamplerTest"),
+    costmap_(nullptr),
+    downsampler_(nullptr) {}
+
+  void setCostmap(nav2_costmap_2d::Costmap2D * const costmap)
+  {
+    costmap_ = costmap;
+  }
+
+  std::shared_ptr<smac_planner::CostmapDownsampler> getDownsampler()
+  {
+    return downsampler_;
+  }
+
+protected:
+  nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override
+  {
+    RCLCPP_INFO(get_logger(), "Configuring");
+    downsampler_ = std::make_shared<smac_planner::CostmapDownsampler>();
+    downsampler_->on_configure(shared_from_this(), "map", "unused_topic", costmap_, 2);
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+
+  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override
+  {
+    RCLCPP_INFO(get_logger(), "Activating");
+    downsampler_->on_activate();
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+
+  nav2_util::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override
+  {
+    RCLCPP_INFO(get_logger(), "Deactivating");
+    downsampler_->on_deactivate();
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+
+  nav2_util::CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override
+  {
+    RCLCPP_INFO(get_logger(), "Cleaning up");
+    downsampler_->on_cleanup();
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+
+private:
+  nav2_costmap_2d::Costmap2D * costmap_;
+  std::shared_ptr<smac_planner::CostmapDownsampler> downsampler_;
+};
+
 TEST(CostmapDownsampler, costmap_downsample_test)
 {
-  nav2_util::LifecycleNode::SharedPtr node = std::make_shared<nav2_util::LifecycleNode>(
-    "CostmapDownsamplerTest");
-  smac_planner::CostmapDownsampler downsampler{};
-  auto map_sub = nav2_costmap_2d::CostmapSubscriber(node, "unused_topic");
+  auto node = std::make_shared<TestNode>();
 
   // create basic costmap
   nav2_costmap_2d::Costmap2D costmapA(10, 10, 0.05, 0.0, 0.0, 0);
   costmapA.setCost(0, 0, 100);
   costmapA.setCost(5, 5, 50);
 
+  // set costmap for testing
+  node->setCostmap(&costmapA);
+
+  // configure and activate test node
+  node->configure();
+  node->activate();
+
+  // get downsampler
+  auto downsampler = node->getDownsampler();
+
   // downsample it
-  downsampler.initialize(node, "map", "unused_topic", &costmapA, 2);
-  nav2_costmap_2d::Costmap2D * downsampledCostmapA = downsampler.downsample(2);
+  nav2_costmap_2d::Costmap2D * downsampledCostmapA = downsampler->downsample(2);
 
   // validate it
   EXPECT_EQ(downsampledCostmapA->getCost(0, 0), 100);
@@ -53,18 +111,34 @@ TEST(CostmapDownsampler, costmap_downsample_test)
   EXPECT_EQ(downsampledCostmapA->getSizeInCellsX(), 5u);
   EXPECT_EQ(downsampledCostmapA->getSizeInCellsY(), 5u);
 
+  // deactivate and cleanup test node
+  node->deactivate();
+  node->cleanup();
+
   // give it another costmap of another size
   nav2_costmap_2d::Costmap2D costmapB(4, 4, 0.10, 0.0, 0.0, 0);
 
+  // set costmap for testing
+  node->setCostmap(&costmapB);
+
+  // configure and activate test node
+  node->configure();
+  node->activate();
+
+  // get downsampler
+  downsampler = node->getDownsampler();
+
   // downsample it
-  downsampler.initialize(node, "map", "unused_topic", &costmapB, 4);
-  downsampler.activatePublisher();
-  nav2_costmap_2d::Costmap2D * downsampledCostmapB = downsampler.downsample(4);
-  downsampler.deactivatePublisher();
+  nav2_costmap_2d::Costmap2D * downsampledCostmapB = downsampler->downsample(4);
 
   // validate size
   EXPECT_EQ(downsampledCostmapB->getSizeInCellsX(), 1u);
   EXPECT_EQ(downsampledCostmapB->getSizeInCellsY(), 1u);
 
-  downsampler.resizeCostmap();
+  downsampler->resizeCostmap();
+
+  // deactivate and cleanup test node
+  node->deactivate();
+  node->cleanup();
+  node->shutdown();
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | TurtleBot3 Gazebo Simulation |

---

## Description of contribution in a few bullet points

* Fix `shared_ptr` cyclic dependencies in `SmacPlanner` and `CostmapDownsampler` as per #1900
* Refactor `CostmapDownsampler` to have `on_` type functions to configure, activate, deactivate, and cleanup costmap publisher stuff
* Fix `CostmapDownsampler` test which has been failing on Cyclone DDS (#2043)