### PR TITLE
Loop fix

### DIFF
--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -386,7 +386,7 @@ AStarAlgorithm<NodeSE2>::NodePtr AStarAlgorithm<NodeSE2>::getAnalyticPath(
       Coordinates initial_node_coords = next->pose;
       proposed_coordinates = {static_cast<float>(reals[0]), static_cast<float>(reals[1]), angle};
       next->setPose(proposed_coordinates);
-      if (next->isNodeValid(_traverse_unknown, _collision_checker) && next != prev) {
+      if (next->isNodeValid(_traverse_unknown, _collision_checker) && next != prev && !next->wasVisited()) {
         // Save the node, and its previous coordinates in case we need to abort
         possible_nodes.emplace_back(next, initial_node_coords);
         prev = next;

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -412,10 +412,12 @@ AStarAlgorithm<NodeSE2>::NodePtr AStarAlgorithm<NodeSE2>::getAnalyticPath(
   for (const auto & node_pose : possible_nodes) {
     const auto & n = node_pose.first;
     n->parent = prev;
+    n->visited();
     prev = n;
   }
   if (_goal != prev) {
     _goal->parent = prev;
+    _goal->visited();
   }
   return _goal;
 }

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -414,7 +414,9 @@ AStarAlgorithm<NodeSE2>::NodePtr AStarAlgorithm<NodeSE2>::getAnalyticPath(
     n->parent = prev;
     prev = n;
   }
-  _goal->parent = prev;
+  if (_goal != prev) {
+    _goal->parent = prev;
+  }
   return _goal;
 }
 


### PR DESCRIPTION
This PR does three things in the analytic expansion phase of Hybrid A*:

* checks to see that nodes on the analytic path haven't already been visited (this could result in a loop)
* checks that the goal node is not made a parent of itself (this will result in an infinite loop)
* marks the nodes as visited for the sake of completeness (e.g. in case further processing is done on the path in future)

This is not confirmed to fix the problems reported in #2040 but we should be doing them anyway.