### PR TITLE
Fix build on macOS (10.x / 11.x)

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -406,7 +406,7 @@ AmclNode::checkLaserReceived()
     RCLCPP_WARN(
       get_logger(), "Laser scan has not been received"
       " (and thus no pose updates have been published)."
-      " Verify that data is being published on the %s topic.", scan_topic_);
+      " Verify that data is being published on the %s topic.", scan_topic_.c_str());
     return;
   }
 
@@ -415,7 +415,7 @@ AmclNode::checkLaserReceived()
     RCLCPP_WARN(
       get_logger(), "No laser scan received (and thus no pose updates have been published) for %f"
       " seconds.  Verify that data is being published on the %s topic.",
-      d.nanoseconds() * 1e-9, scan_topic_);
+      d.nanoseconds() * 1e-9, scan_topic_.c_str());
   }
 }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -36,11 +36,11 @@ public:
     const BT::NodeConfiguration & conf)
   : BT::ActionNodeBase(xml_tag_name, conf), action_name_(action_name)
   {
-    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+    node_ = config().blackboard->template get<rclcpp::Node::SharedPtr>("node");
 
     // Get the required items from the blackboard
     server_timeout_ =
-      config().blackboard->get<std::chrono::milliseconds>("server_timeout");
+      config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
     getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
 
     // Initialize the input and output messages
@@ -245,9 +245,9 @@ protected:
   void increment_recovery_count()
   {
     int recovery_count = 0;
-    config().blackboard->get<int>("number_recoveries", recovery_count);  // NOLINT
+    config().blackboard->template get<int>("number_recoveries", recovery_count);  // NOLINT
     recovery_count += 1;
-    config().blackboard->set<int>("number_recoveries", recovery_count);  // NOLINT
+    config().blackboard->template set<int>("number_recoveries", recovery_count);  // NOLINT
   }
 
   std::string action_name_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -35,11 +35,11 @@ public:
     const BT::NodeConfiguration & conf)
   : BT::SyncActionNode(service_node_name, conf), service_node_name_(service_node_name)
   {
-    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+    node_ = config().blackboard->template get<rclcpp::Node::SharedPtr>("node");
 
     // Get the required items from the blackboard
     server_timeout_ =
-      config().blackboard->get<std::chrono::milliseconds>("server_timeout");
+      config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
     getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
 
     // Now that we have node_ to use, create the service client for this BT service
@@ -126,9 +126,9 @@ protected:
   void increment_recovery_count()
   {
     int recovery_count = 0;
-    config().blackboard->get<int>("number_recoveries", recovery_count);  // NOLINT
+    config().blackboard->template get<int>("number_recoveries", recovery_count);  // NOLINT
     recovery_count += 1;
-    config().blackboard->set<int>("number_recoveries", recovery_count);  // NOLINT
+    config().blackboard->template set<int>("number_recoveries", recovery_count);  // NOLINT
   }
 
   std::string service_name_, service_node_name_;

--- a/nav2_bt_navigator/src/ros_topic_logger.cpp
+++ b/nav2_bt_navigator/src/ros_topic_logger.cpp
@@ -42,11 +42,15 @@ void RosTopicLogger::callback(
 
   // BT timestamps are a duration since the epoch. Need to convert to a time_point
   // before converting to a msg.
-#ifndef _WIN32
+#if defined(__linux__)
   event.timestamp =
     tf2_ros::toMsg(std::chrono::time_point<std::chrono::high_resolution_clock>(timestamp));
-#else
+#elif defined(__APPLE__)
+  event.timestamp = tf2_ros::toMsg(tf2::TimePoint(timestamp));
+#elif defined(_WIN32)
   event.timestamp = tf2_ros::toMsg(timestamp);
+#else
+#error "Not implemented"
 #endif
   event.node_name = node.name();
   event.previous_status = toStr(prev_status, false);

--- a/nav2_bt_navigator/src/ros_topic_logger.cpp
+++ b/nav2_bt_navigator/src/ros_topic_logger.cpp
@@ -42,16 +42,7 @@ void RosTopicLogger::callback(
 
   // BT timestamps are a duration since the epoch. Need to convert to a time_point
   // before converting to a msg.
-#if defined(__linux__)
-  event.timestamp =
-    tf2_ros::toMsg(std::chrono::time_point<std::chrono::high_resolution_clock>(timestamp));
-#elif defined(__APPLE__)
   event.timestamp = tf2_ros::toMsg(tf2::TimePoint(timestamp));
-#elif defined(_WIN32)
-  event.timestamp = tf2_ros::toMsg(timestamp);
-#else
-#error "Not implemented"
-#endif
   event.node_name = node.name();
   event.previous_status = toStr(prev_status, false);
   event.current_status = toStr(status, false);

--- a/nav2_costmap_2d/include/nav2_costmap_2d/observation.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/observation.hpp
@@ -60,6 +60,11 @@ public:
   }
 
   /**
+    * @brief  Explicitly define copy assignment operator for Observation as it has a user-declared destructor
+    */
+  Observation & operator=(const Observation &) = default;
+
+  /**
    * @brief  Creates an observation from an origin point and a point cloud
    * @param origin The origin point of the observation
    * @param cloud The point cloud of the observation

--- a/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.hpp
@@ -49,11 +49,6 @@
 #include "nav2_costmap_2d/observation.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 
-/**
- * private field 'tf_tolerance_' is not yet used which causes compilation failure
- * when using flag -Werror with Clang 12
- */
-#pragma GCC diagnostic ignored "-Wunused-private-field"
 
 namespace nav2_costmap_2d
 {
@@ -86,7 +81,7 @@ public:
     double min_obstacle_height, double max_obstacle_height, double obstacle_range,
     double raytrace_range, tf2_ros::Buffer & tf2_buffer, std::string global_frame,
     std::string sensor_frame,
-    double tf_tolerance);
+    tf2::Duration tf_tolerance);
 
   /**
    * @brief  Destructor... cleans up
@@ -152,7 +147,7 @@ private:
   double min_obstacle_height_, max_obstacle_height_;
   std::recursive_mutex lock_;  ///< @brief A lock for accessing data in callbacks safely
   double obstacle_range_, raytrace_range_;
-  double tf_tolerance_;
+  tf2::Duration tf_tolerance_;
 };
 }  // namespace nav2_costmap_2d
 #endif  // NAV2_COSTMAP_2D__OBSERVATION_BUFFER_HPP_

--- a/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.hpp
@@ -49,6 +49,12 @@
 #include "nav2_costmap_2d/observation.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 
+/**
+ * private field 'tf_tolerance_' is not yet used which causes compilation failure
+ * when using flag -Werror with Clang 12
+ */
+#pragma GCC diagnostic ignored "-Wunused-private-field"
+
 namespace nav2_costmap_2d
 {
 /**

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -179,7 +179,7 @@ void ObstacleLayer::onInitialize()
           node, topic, observation_keep_time, expected_update_rate,
           min_obstacle_height,
           max_obstacle_height, obstacle_range, raytrace_range, *tf_, global_frame_,
-          sensor_frame, transform_tolerance)));
+          sensor_frame, tf2::durationFromSec(transform_tolerance))));
 
     // check if we'll add this buffer to our marking observation buffers
     if (marking) {

--- a/nav2_costmap_2d/src/observation_buffer.cpp
+++ b/nav2_costmap_2d/src/observation_buffer.cpp
@@ -55,7 +55,7 @@ ObservationBuffer::ObservationBuffer(
   double expected_update_rate,
   double min_obstacle_height, double max_obstacle_height, double obstacle_range,
   double raytrace_range, tf2_ros::Buffer & tf2_buffer, std::string global_frame,
-  std::string sensor_frame, double tf_tolerance)
+  std::string sensor_frame, tf2::Duration tf_tolerance)
 : tf2_buffer_(tf2_buffer),
   observation_keep_time_(rclcpp::Duration::from_seconds(observation_keep_time)),
   expected_update_rate_(rclcpp::Duration::from_seconds(expected_update_rate)),
@@ -95,7 +95,7 @@ void ObservationBuffer::bufferCloud(const sensor_msgs::msg::PointCloud2 & cloud)
     local_origin.point.x = 0;
     local_origin.point.y = 0;
     local_origin.point.z = 0;
-    tf2_buffer_.transform(local_origin, global_origin, global_frame_);
+    tf2_buffer_.transform(local_origin, global_origin, global_frame_, tf_tolerance_);
     tf2::convert(global_origin.point, observation_list_.front().origin_);
 
     // make sure to pass on the raytrace/obstacle range
@@ -106,7 +106,7 @@ void ObservationBuffer::bufferCloud(const sensor_msgs::msg::PointCloud2 & cloud)
     sensor_msgs::msg::PointCloud2 global_frame_cloud;
 
     // transform the point cloud
-    tf2_buffer_.transform(cloud, global_frame_cloud, global_frame_);
+    tf2_buffer_.transform(cloud, global_frame_cloud, global_frame_, tf_tolerance_);
     global_frame_cloud.header.stamp = cloud.header.stamp;
 
     // now we need to remove observations from the cloud that are below

--- a/nav2_dwb_controller/nav_2d_utils/CMakeLists.txt
+++ b/nav2_dwb_controller/nav_2d_utils/CMakeLists.txt
@@ -25,6 +25,7 @@ set(dependencies
   tf2_geometry_msgs
   nav2_msgs
   nav2_util
+  nav_2d_msgs
 )
 
 include_directories(
@@ -52,6 +53,8 @@ add_library(tf_help SHARED
 ament_target_dependencies(tf_help
   ${dependencies}
 )
+
+target_link_libraries(tf_help conversions)
 
 install(TARGETS conversions path_ops tf_help
         ARCHIVE DESTINATION lib

--- a/nav2_recoveries/include/nav2_recoveries/recovery.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery.hpp
@@ -111,7 +111,7 @@ public:
 
     collision_checker_ = collision_checker;
 
-    vel_pub_ = node->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
+    vel_pub_ = node->template create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
 
     onConfigure();
   }

--- a/nav2_util/src/dump_params.cpp
+++ b/nav2_util/src/dump_params.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <libgen.h>
+
 #include <iomanip>
 #include <iostream>
 #include <memory>

--- a/nav2_waypoint_follower/include/nav2_waypoint_follower/plugins/photo_at_waypoint.hpp
+++ b/nav2_waypoint_follower/include/nav2_waypoint_follower/plugins/photo_at_waypoint.hpp
@@ -31,6 +31,13 @@
 #include "image_transport/image_transport.hpp"
 
 
+/**
+ * While C++17 isn't the project standard. We have to force LLVM/CLang
+ * to ignore deprecated declarations
+ */
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+
 namespace nav2_waypoint_follower
 {
 

--- a/nav2_waypoint_follower/include/nav2_waypoint_follower/plugins/photo_at_waypoint.hpp
+++ b/nav2_waypoint_follower/include/nav2_waypoint_follower/plugins/photo_at_waypoint.hpp
@@ -15,6 +15,13 @@
 #ifndef NAV2_WAYPOINT_FOLLOWER__PLUGINS__PHOTO_AT_WAYPOINT_HPP_
 #define NAV2_WAYPOINT_FOLLOWER__PLUGINS__PHOTO_AT_WAYPOINT_HPP_
 
+/**
+ * While C++17 isn't the project standard. We have to force LLVM/CLang
+ * to ignore deprecated declarations
+ */
+#define _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM
+
+
 #include <experimental/filesystem>
 #include <mutex>
 #include <string>
@@ -29,13 +36,6 @@
 #include "opencv4/opencv2/opencv.hpp"
 #include "cv_bridge/cv_bridge.h"
 #include "image_transport/image_transport.hpp"
-
-
-/**
- * While C++17 isn't the project standard. We have to force LLVM/CLang
- * to ignore deprecated declarations
- */
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 
 namespace nav2_waypoint_follower

--- a/nav2_waypoint_follower/package.xml
+++ b/nav2_waypoint_follower/package.xml
@@ -7,10 +7,12 @@
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <license>Apache-2.0</license>
 
-  <depend>tf2_ros</depend>
-
   <buildtool_depend>ament_cmake</buildtool_depend>
+
   <depend>nav2_common</depend>
+  <depend>cv_bridge</depend>
+  <depend>pluginlib</depend>
+  <depend>image_transport</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_lifecycle</depend>
@@ -18,6 +20,7 @@
   <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>
   <depend>nav2_core</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -352,7 +352,7 @@ AStarAlgorithm<NodeSE2>::NodePtr AStarAlgorithm<NodeSE2>::getAnalyticPath(
   float d = node->motion_table.state_space->distance(from(), to());
   NodePtr prev(node);
   // A move of sqrt(2) is guaranteed to be in a new cell
-  constexpr float sqrt_2 = std::sqrt(2.);
+  static const float sqrt_2 = std::sqrt(2.);
   unsigned int num_intervals = std::floor(d / sqrt_2);
 
   using PossibleNode = std::pair<NodePtr, Coordinates>;


### PR DESCRIPTION
---

## Basic Info

macOS : 11.0.1 (20B5022a)
Build tools : Apple Clang 12.0.x
ROS2 : Foxy (Patch release 3)

---

## Description of contribution in a few bullet points

Building navigation2 on latest macOS 11 (Big Sur) is now possible with a ros2 foxy environment. Previous macOS versions should also work but remains untested. This PR adresses the following fatal build errors (with tests set to OFF) :


#### nav2_util
```
--- stderr: nav2_util
/Users/ewen/ros_ws/navigation2/nav2_util/src/dump_params.cpp:351:33: error: use of undeclared identifier 'basename'
      std::cout << "Usage: " << basename(argv[0]) << "\n";
```

#### nav2_amcl
```
--- stderr: nav2_amcl
/Users/ewen/ros_ws/navigation2/nav2_amcl/src/amcl_node.cpp:404:64: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
      " Verify that data is being published on the %s topic.", scan_topic_);
                                                               ^
/Users/ewen/ros_ws/navigation2/nav2_amcl/src/amcl_node.cpp:413:31: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
      d.nanoseconds() * 1e-9, scan_topic_);
```

#### nav2_behavior_tree
```
--- stderr: nav2_behavior_tree
In file included from /Users/ewen/ros_ws/navigation2/nav2_behavior_tree/plugins/action/reinitialize_global_localization_service.cpp:16:
In file included from /Users/ewen/ros_ws/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/reinitialize_global_localization_service.hpp:20:
/Users/ewen/ros_ws/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp:38:34: error: use 'template' keyword to treat 'get' as a dependent template name
    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
                                 ^
                                 template
/Users/ewen/ros_ws/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp:42:28: error: use 'template' keyword to treat 'get' as a dependent template name
      config().blackboard->get<std::chrono::milliseconds>("server_timeout");
                           ^
                           template
/Users/ewen/ros_ws/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp:129:26: error: use 'template' keyword to treat 'get' as a dependent template name
    config().blackboard->get<int>("number_recoveries", recovery_count);  // NOLINT
                         ^
                         template
/Users/ewen/ros_ws/navigation2/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp:131:26: error: use 'template' keyword to treat 'set' as a dependent template name
    config().blackboard->set<int>("number_recoveries", recovery_count);  // NOLINT
                         ^
                         template
```

#### nav2_costmap_2d
```
--- stderr: nav2_costmap_2d
In file included from /Users/ewen/ros_ws/navigation2/nav2_costmap_2d/plugins/obstacle_layer.cpp:39:
In file included from /Users/ewen/ros_ws/navigation2/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp:58:
In file included from /Users/ewen/ros_ws/navigation2/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.hpp:49:
/Users/ewen/ros_ws/navigation2/nav2_costmap_2d/include/nav2_costmap_2d/observation.hpp:57:11: error: definition of implicit copy assignment operator for 'Observation' is deprecated because it has a user-declared destructor [-Werror,-Wdeprecated]
  virtual ~Observation()
          ^
```

#### nav2_bt_navigator
```
--- stderr: nav2_bt_navigator
/Users/ewen/ros_ws/navigation2/nav2_bt_navigator/src/ros_topic_logger.cpp:44:5: error: no matching function for call to 'toMsg'
    tf2_ros::toMsg(std::chrono::time_point<std::chrono::high_resolution_clock>(timestamp));
    ^~~~~~~~~~~~~~
/Users/ewen/ros2_foxy/install/tf2_ros/include/tf2_ros/buffer_interface.h:48:40: note: candidate function not viable: no known conversion from 'time_point<std::chrono::high_resolution_clock, [...]>' to 'const time_point<std::chrono::system_clock, [...]>' for 1st argument
  inline builtin_interfaces::msg::Time toMsg(const tf2::TimePoint & t)
                                       ^
/Users/ewen/ros2_foxy/install/tf2_ros/include/tf2_ros/buffer_interface.h:67:44: note: candidate function not viable: no known conversion from 'std::chrono::time_point<std::chrono::high_resolution_clock>' (aka 'time_point<std::__1::chrono::steady_clock>') to 'const tf2::Duration' (aka 'const duration<long long, ratio<1LL, 1000000000LL> >') for 1st argument
  inline builtin_interfaces::msg::Duration toMsg(const tf2::Duration & t)
```

#### smac_planner
```
--- stderr: smac_planner
/Users/ewen/ros_ws/navigation2/smac_planner/src/a_star.cpp:355:19: error: constexpr variable 'sqrt_2' must be initialized by a constant expression
  constexpr float sqrt_2 = std::sqrt(2.);
                  ^        ~~~~~~~~~~~~~
/Users/ewen/ros_ws/navigation2/smac_planner/src/a_star.cpp:355:28: note: non-constexpr function 'sqrt' cannot be used in a constant expression
  constexpr float sqrt_2 = std::sqrt(2.);
```

## Description of documentation updates required from your changes

(Optional) Add instructions for installing dependencies and building for macOS.

```bash
# Install dependencies with Homebrew
brew install ompl

# Create build workspace
mkdir -p ~/ros_ws/src
cd ~/ros_ws/src
git clone https://github.com/BehaviorTree/BehaviorTree.CPP.git
git clone -b ros2 https://github.com/ros/angles.git
git clone -b foxy-devel https://github.com/ros-planning/navigation2.git

# Build without tests
colcon build --symlink-install --cmake-args "-DBUILD_TESTING=OFF"
```
---

## Future work that may be required in bullet points

Fix warnings in smac_planner 

```
In file included from /Users/ewen/ros_ws/navigation2/smac_planner/src/smac_planner_2d.cpp:21:
In file included from /Users/ewen/ros_ws/navigation2/smac_planner/include/smac_planner/smac_planner_2d.hpp:23:
In file included from /Users/ewen/ros_ws/navigation2/smac_planner/include/smac_planner/smoother.hpp:26:
/Users/ewen/ros_ws/navigation2/smac_planner/include/smac_planner/smoother_cost_function.hpp:139:24: warning: using the result of an assignment as a condition without
      parentheses [-Wparentheses]
      if (valid_coords = _costmap->worldToMap(xi[0], xi[1], mx, my)) {
          ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/ewen/ros_ws/navigation2/smac_planner/include/smac_planner/smoother_cost_function.hpp:139:24: note: place parentheses around the assignment to silence this warning
      if (valid_coords = _costmap->worldToMap(xi[0], xi[1], mx, my)) {
                       ^
          (                                                        )
/Users/ewen/ros_ws/navigation2/smac_planner/include/smac_planner/smoother_cost_function.hpp:139:24: note: use '==' to turn this assignment into an equality comparison
      if (valid_coords = _costmap->worldToMap(xi[0], xi[1], mx, my)) {
                       ^
                       ==
1 warning generated.

/Users/ewen/ros_ws/navigation2/smac_planner/src/a_star.cpp:433:19: warning: unused parameter 'node' [-Wunused-parameter]
  const NodePtr & node,
                  ^
/Users/ewen/ros_ws/navigation2/smac_planner/src/a_star.cpp:434:22: warning: unused parameter 'node_getter' [-Wunused-parameter]
  const NodeGetter & node_getter)
                     ^

In file included from /Users/ewen/ros_ws/navigation2/smac_planner/src/a_star.cpp:33:
In file included from /Users/ewen/ros_ws/navigation2/smac_planner/include/smac_planner/a_star.hpp:30:
/Users/ewen/ros_ws/navigation2/smac_planner/include/smac_planner/node_se2.hpp:178:3: warning: definition of implicit copy constructor for 'NodeSE2' is deprecated because it has
      a user-declared destructor [-Wdeprecated]
  ~NodeSE2();
  ^

In file included from /Users/ewen/ros_ws/navigation2/smac_planner/src/a_star.cpp:33:
In file included from /Users/ewen/ros_ws/navigation2/smac_planner/include/smac_planner/a_star.hpp:29:
/Users/ewen/ros_ws/navigation2/smac_planner/include/smac_planner/node_2d.hpp:69:3: warning: definition of implicit copy constructor for 'Node2D' is deprecated because it has a
      user-declared destructor [-Wdeprecated]
  ~Node2D();
  ^
