### PR TITLE
Supporting multiple goal checkers in controller_server

### DIFF
--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -90,7 +90,8 @@ controller_server:
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
     progress_checker_plugin: "progress_checker"
-    goal_checker_plugin: "goal_checker"
+    goal_checker_plugins: ["goal_checker", "precise_goal_checker"]
+    current_goal_checker: "goal_checker" # it his param is not specified "goal_checker" is selected by default
     controller_plugins: ["FollowPath"]
 
     # Progress checker parameters
@@ -103,6 +104,11 @@ controller_server:
       plugin: "nav2_controller::SimpleGoalChecker"
       xy_goal_tolerance: 0.25
       yaw_goal_tolerance: 0.25
+      stateful: True
+    precise_goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.1
+      yaw_goal_tolerance: 0.1
       stateful: True
     # DWB parameters
     FollowPath:

--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -47,6 +47,7 @@ class ControllerServer : public nav2_util::LifecycleNode
 {
 public:
   using ControllerMap = std::unordered_map<std::string, nav2_core::Controller::Ptr>;
+  using GoalCheckerMap = std::unordered_map<std::string, nav2_core::GoalChecker::Ptr>;
 
   /**
    * @brief Constructor for nav2_controller::ControllerServer
@@ -130,6 +131,15 @@ protected:
   bool findControllerId(const std::string & c_name, std::string & name);
 
   /**
+   * @brief Find the valid goal checker ID name for the specified parameter
+   *
+   * @param c_name The goal checker name
+   * @param name Reference to the name to use for goal checking if any valid available
+   * @return bool Whether it found a valid goal checker to use
+   */
+  bool findGoalCheckerId(const std::string & c_name, std::string & name);
+
+  /**
    * @brief Assigns path to controller
    * @param path Path received from action server
    */
@@ -207,11 +217,12 @@ protected:
 
   // Goal Checker Plugin
   pluginlib::ClassLoader<nav2_core::GoalChecker> goal_checker_loader_;
-  nav2_core::GoalChecker::Ptr goal_checker_;
-  std::string default_goal_checker_id_;
-  std::string default_goal_checker_type_;
-  std::string goal_checker_id_;
-  std::string goal_checker_type_;
+  GoalCheckerMap goal_checkers_;
+  std::vector<std::string> default_goal_checker_ids_;
+  std::vector<std::string> default_goal_checker_types_;
+  std::vector<std::string> goal_checker_ids_;
+  std::vector<std::string> goal_checker_types_;
+  std::string goal_checker_ids_concat_, current_goal_checker_;
 
   // Controller Plugins
   pluginlib::ClassLoader<nav2_core::Controller> lp_loader_;

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -36,8 +36,8 @@ ControllerServer::ControllerServer()
   default_progress_checker_id_{"progress_checker"},
   default_progress_checker_type_{"nav2_controller::SimpleProgressChecker"},
   goal_checker_loader_("nav2_core", "nav2_core::GoalChecker"),
-  default_goal_checker_id_{"goal_checker"},
-  default_goal_checker_type_{"nav2_controller::SimpleGoalChecker"},
+  default_goal_checker_ids_{"goal_checker"},
+  default_goal_checker_types_{"nav2_controller::SimpleGoalChecker"},
   lp_loader_("nav2_core", "nav2_core::Controller"),
   default_ids_{"FollowPath"},
   default_types_{"dwb_core::DWBLocalPlanner"}
@@ -47,7 +47,8 @@ ControllerServer::ControllerServer()
   declare_parameter("controller_frequency", 20.0);
 
   declare_parameter("progress_checker_plugin", default_progress_checker_id_);
-  declare_parameter("goal_checker_plugin", default_goal_checker_id_);
+  declare_parameter("goal_checker_plugins", default_goal_checker_ids_);
+  declare_parameter("current_goal_checker", current_goal_checker_);
   declare_parameter("controller_plugins", default_ids_);
   declare_parameter("min_x_velocity_threshold", rclcpp::ParameterValue(0.0001));
   declare_parameter("min_y_velocity_threshold", rclcpp::ParameterValue(0.0001));
@@ -79,11 +80,15 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
       node, default_progress_checker_id_ + ".plugin",
       rclcpp::ParameterValue(default_progress_checker_type_));
   }
-  get_parameter("goal_checker_plugin", goal_checker_id_);
-  if (goal_checker_id_ == default_goal_checker_id_) {
+
+  RCLCPP_INFO(get_logger(), "getting goal checker plugins..");
+  get_parameter("goal_checker_plugins", goal_checker_ids_);
+  if (goal_checker_ids_ == default_goal_checker_ids_) {
+    for (size_t i = 0; i < default_goal_checker_ids_.size(); ++i) {
     nav2_util::declare_parameter_if_not_declared(
-      node, default_goal_checker_id_ + ".plugin",
-      rclcpp::ParameterValue(default_goal_checker_type_));
+      node, default_goal_checker_ids_[i] + ".plugin",
+      rclcpp::ParameterValue(default_goal_checker_types_[i]));
+    }
   }
 
   get_parameter("controller_plugins", controller_ids_);
@@ -94,7 +99,19 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
         rclcpp::ParameterValue(default_types_[i]));
     }
   }
+
+  RCLCPP_INFO(get_logger(), "creating goal checkers if not declared");
+  get_parameter("goal_checkers_plugin", controller_ids_);
+  if (controller_ids_ == default_ids_) {
+    for (size_t i = 0; i < default_ids_.size(); ++i) {
+      nav2_util::declare_parameter_if_not_declared(
+        node, default_ids_[i] + ".plugin",
+        rclcpp::ParameterValue(default_types_[i]));
+    }
+  }
+
   controller_types_.resize(controller_ids_.size());
+  goal_checker_types_.resize(goal_checker_ids_.size());
 
   get_parameter("controller_frequency", controller_frequency_);
   get_parameter("min_x_velocity_threshold", min_x_velocity_threshold_);
@@ -116,18 +133,33 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
       get_logger(),
       "Failed to create progress_checker. Exception: %s", ex.what());
   }
-  try {
-    goal_checker_type_ = nav2_util::get_plugin_type_param(node, goal_checker_id_);
-    goal_checker_ = goal_checker_loader_.createUniqueInstance(goal_checker_type_);
-    RCLCPP_INFO(
-      get_logger(), "Created goal_checker : %s of type %s",
-      goal_checker_id_.c_str(), goal_checker_type_.c_str());
-    goal_checker_->initialize(node, goal_checker_id_);
-  } catch (const pluginlib::PluginlibException & ex) {
-    RCLCPP_FATAL(
-      get_logger(),
-      "Failed to create goal_checker. Exception: %s", ex.what());
+
+  RCLCPP_INFO(get_logger(), "instanciating goal checkers if not declared");
+  for (size_t i = 0; i != goal_checker_ids_.size(); i++) {
+    try {
+      RCLCPP_INFO_STREAM(get_logger(), "goal checker id "<< i<<": "<< goal_checker_ids_[i]);
+      goal_checker_types_[i] = nav2_util::get_plugin_type_param(node, goal_checker_ids_[i]);
+      RCLCPP_INFO_STREAM(get_logger(), "goal checker "<< i<<" type: "<< goal_checker_types_[i]);
+      nav2_core::GoalChecker::Ptr goal_checker = goal_checker_loader_.createUniqueInstance(goal_checker_types_[i]);
+      RCLCPP_INFO(
+        get_logger(), "Created goal_checker : %s of type %s",
+        goal_checker_ids_[i].c_str(), goal_checker_types_[i].c_str());
+      goal_checker->initialize(node, goal_checker_ids_[i]);
+      goal_checkers_.insert({goal_checker_ids_[i], goal_checker});
+    } catch (const pluginlib::PluginlibException & ex) {
+      RCLCPP_FATAL(
+        get_logger(),
+        "Failed to create goal_checker. Exception: %s", ex.what());
+    }
   }
+
+  for (size_t i = 0; i != goal_checkers_.size(); i++) {
+    goal_checker_ids_concat_ += goal_checker_ids_[i] + std::string(" ");
+  }
+
+  RCLCPP_INFO(
+    get_logger(),
+    "Controller Server has %s goal checkers available.", goal_checker_ids_concat_.c_str());
 
   for (size_t i = 0; i != controller_ids_.size(); i++) {
     try {
@@ -219,7 +251,12 @@ ControllerServer::on_cleanup(const rclcpp_lifecycle::State & state)
   odom_sub_.reset();
   vel_publisher_.reset();
   action_server_.reset();
-  goal_checker_->reset();
+  
+  GoalCheckerMap::iterator itgc;
+  for (itgc = goal_checkers_.begin(); itgc != goal_checkers_.end(); ++itgc) {
+    itgc->second->reset();
+  }
+  
 
   return nav2_util::CallbackReturn::SUCCESS;
 }
@@ -257,6 +294,33 @@ bool ControllerServer::findControllerId(
   return true;
 }
 
+bool ControllerServer::findGoalCheckerId(
+  const std::string & c_name,
+  std::string & current_goal_checker)
+{
+  if (goal_checkers_.find(c_name) == goal_checkers_.end()) {
+    if (goal_checkers_.size() == 1 && c_name.empty()) {
+      RCLCPP_WARN_ONCE(
+        get_logger(), "No goal checker was specified in parameter 'current_goal_checker'."
+        " Server will use only plugin loaded %s. "
+        "This warning will appear once.", goal_checker_ids_concat_.c_str());
+      current_goal_checker = goal_checkers_.begin()->first;
+    } else {
+      RCLCPP_ERROR(
+        get_logger(), "FollowPath called with goal_checker name %s in parameter 'current_goal_checker', "
+        "which does not exist. Available goal checkers are %s.",
+        c_name.c_str(), goal_checker_ids_concat_.c_str());
+      return false;
+    }
+  } else {
+    RCLCPP_DEBUG(get_logger(), "Selected goal checker: %s.", c_name.c_str());
+    current_goal_checker = c_name;
+  }
+
+  return true;
+}
+
+
 void ControllerServer::computeControl()
 {
   RCLCPP_INFO(get_logger(), "Received a goal, begin computing control effort.");
@@ -266,6 +330,16 @@ void ControllerServer::computeControl()
     std::string current_controller;
     if (findControllerId(c_name, current_controller)) {
       current_controller_ = current_controller;
+    } else {
+      action_server_->terminate_current();
+      return;
+    }
+    
+    std::string gc_name ;
+    get_parameter("current_goal_checker", gc_name);
+    std::string current_goal_checker;
+    if (findGoalCheckerId(gc_name, current_goal_checker)) {
+      current_goal_checker_ = current_goal_checker;
     } else {
       action_server_->terminate_current();
       return;
@@ -334,7 +408,7 @@ void ControllerServer::setPlannerPath(const nav_msgs::msg::Path & path)
   nav_2d_utils::transformPose(
     costmap_ros_->getTfBuffer(), costmap_ros_->getGlobalFrameID(),
     end_pose, end_pose, tolerance);
-  goal_checker_->reset();
+  goal_checkers_[current_goal_checker_]->reset();
 
   RCLCPP_DEBUG(
     get_logger(), "Path end point is (%.2f, %.2f)",
@@ -424,7 +498,7 @@ bool ControllerServer::isGoalReached()
 
   nav_2d_msgs::msg::Twist2D twist = getThresholdedTwist(odom_sub_->getTwist());
   geometry_msgs::msg::Twist velocity = nav_2d_utils::twist2Dto3D(twist);
-  return goal_checker_->isGoalReached(pose.pose, end_pose_, velocity);
+  return goal_checkers_[current_goal_checker_]->isGoalReached(pose.pose, end_pose_, velocity);
 }
 
 bool ControllerServer::getRobotPose(geometry_msgs::msg::PoseStamped & pose)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

Supporting multiple goal checkers in controller_server and switch between them dynamically.
Motivation; at the current moment there isnt (AFAIK) any mechanism to update dynamically the goal checker or the goal checker parameters at runtime.

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | no associated ticket |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation turtlebot waffle) |

---

## Description of contribution in a few bullet points

* This is a basic functionality to support multiple goal checkers in the controller_server (in the same way it is supported multiple controllers )

* This initial proposal uses a controller_server parameter to store the "current_goal_checker" (alternatively it could be in the FollowPath action request like it is the controller_id).

* It is provided with a "nav_params.yaml configuration" with a second "goal checker" to show how it is used. But that could be removed final pull request.

## Description of documentation updates required from your changes

No documentation change should be required at (least in the c++ code)
- "documentation chunks" were copied from "multiple controller" support, for example "findGoalCheckerId"
---

## Future work that may be required in bullet points

* if the "parameter approach" is not convenient it could be replaced by an additional field in the FollowAction request
