### PR TITLE
supporting multiple goal checkers

### DIFF
--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -90,7 +90,8 @@ controller_server:
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
     progress_checker_plugin: "progress_checker"
-    goal_checker_plugin: "goal_checker"
+    goal_checker_plugins: ["goal_checker", "precise_goal_checker"]
+    current_goal_checker: "goal_checker" # it his param is not specified "goal_checker" is selected by default
     controller_plugins: ["FollowPath"]
 
     # Progress checker parameters
@@ -103,6 +104,11 @@ controller_server:
       plugin: "nav2_controller::SimpleGoalChecker"
       xy_goal_tolerance: 0.25
       yaw_goal_tolerance: 0.25
+      stateful: True
+    precise_goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.1
+      yaw_goal_tolerance: 0.1
       stateful: True
     # DWB parameters
     FollowPath:

--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -47,6 +47,7 @@ class ControllerServer : public nav2_util::LifecycleNode
 {
 public:
   using ControllerMap = std::unordered_map<std::string, nav2_core::Controller::Ptr>;
+  using GoalCheckerMap = std::unordered_map<std::string, nav2_core::GoalChecker::Ptr>;
 
   /**
    * @brief Constructor for nav2_controller::ControllerServer
@@ -130,6 +131,15 @@ protected:
   bool findControllerId(const std::string & c_name, std::string & name);
 
   /**
+   * @brief Find the valid goal checker ID name for the specified parameter
+   *
+   * @param c_name The goal checker name
+   * @param name Reference to the name to use for goal checking if any valid available
+   * @return bool Whether it found a valid goal checker to use
+   */
+  bool findGoalCheckerId(const std::string & c_name, std::string & name);
+
+  /**
    * @brief Assigns path to controller
    * @param path Path received from action server
    */
@@ -207,11 +217,12 @@ protected:
 
   // Goal Checker Plugin
   pluginlib::ClassLoader<nav2_core::GoalChecker> goal_checker_loader_;
-  nav2_core::GoalChecker::Ptr goal_checker_;
-  std::string default_goal_checker_id_;
-  std::string default_goal_checker_type_;
-  std::string goal_checker_id_;
-  std::string goal_checker_type_;
+  GoalCheckerMap goal_checkers_;
+  std::vector<std::string> default_goal_checker_ids_;
+  std::vector<std::string> default_goal_checker_types_;
+  std::vector<std::string> goal_checker_ids_;
+  std::vector<std::string> goal_checker_types_;
+  std::string goal_checker_ids_concat_, current_goal_checker_;
 
   // Controller Plugins
   pluginlib::ClassLoader<nav2_core::Controller> lp_loader_;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

Supporting multiple goal checkers in controller_server and switch between them dynamically.
Motivation; at the current moment there isnt (AFAIK) any mechanism to update dynamically the goal checker or the goal checker parameters at runtime.

This pull request for main is a correction of the same pull request made for foxy previously (https://github.com/ros-planning/navigation2/pull/2098)

| Info |  |
| ------ | ----------- |
| Ticket(s) this addresses   | no associated ticket |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation turtlebot waffle) |

---

## Description of contribution in a few bullet points

* This is a basic functionality to support multiple goal checkers in the controller_server (in the same way it is supported multiple controllers )

* This initial proposal uses a controller_server parameter to store the "current_goal_checker" (alternatively it could be in the FollowPath action request like it is the controller_id).

* It is provided with a "nav_params.yaml configuration" with a second "goal checker" to show how it is used. But that could be removed final pull request.

## Description of documentation updates required from your changes

No documentation change should be required at (least in the c++ code)
- "documentation chunks" were copied from "multiple controller" support, for example "findGoalCheckerId"
---

## Future work that may be required in bullet points

* if the "parameter approach" is not convenient it could be replaced by an additional field in the FollowAction request
