### PR TITLE
Action goal checker callback (wip)

### DIFF
--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -96,6 +96,8 @@ protected:
    */
   void navigateToPose();
 
+  bool goalCheckerCallback(std::shared_ptr<const typename Action::Goal> goal);
+
   /**
    * @brief Goal pose initialization on the blackboard
    */

--- a/nav2_system_tests/CMakeLists.txt
+++ b/nav2_system_tests/CMakeLists.txt
@@ -61,6 +61,7 @@ if(BUILD_TESTING)
   add_subdirectory(src/recoveries/backup)
   add_subdirectory(src/costmap_filters)
   install(DIRECTORY maps DESTINATION share/${PROJECT_NAME})
+  install(DIRECTORY behavior_trees DESTINATION share/${PROJECT_NAME})
 
 endif()
 

--- a/nav2_system_tests/behavior_trees/missing_end_root_tag.xmlbad
+++ b/nav2_system_tests/behavior_trees/missing_end_root_tag.xmlbad
@@ -1,0 +1,31 @@
+<!--
+  This Behavior Tree replans the global path periodically at 1 Hz and it also has
+  recovery actions.
+-->
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <RateController hz="1.0">
+          <RecoveryNode number_of_retries="1" name="ComputePathToPose">
+            <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"/>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="{path}" controller_id="FollowPath"/>
+          <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
+        </RecoveryNode>
+      </PipelineSequence>
+      <ReactiveFallback name="RecoveryFallback">
+        <GoalUpdated/>
+        <SequenceStar name="RecoveryActions">
+          <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+          <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+          <Spin spin_dist="1.57"/>
+          <Wait wait_duration="5"/>
+        </SequenceStar>
+      </ReactiveFallback>
+    </RecoveryNode>
+  </BehaviorTree>
+<!--/root-->


### PR DESCRIPTION
Adding a new callback function into SimpleActionServer.
This callback is optional, so no ABI breaking changes here.
BT_Navigator for instance uses this to check if a BT.XML is accessible and therefor can REJECT the goal even before it further processes it.

This callback can be used by any other Action server and is template based (Action independent).
Could also come in handy for #1971 -> check if there is currently another goal happening that is using another current_bt_ than the one from the new goal. Therefor REJECTING the request and not PREEMTING the current BT (or some other behavior that has yet to be decided from/in #1971 )

This callback is called during the initial `goal request` (also see the action design docs):

![design-action-call](https://design.ros2.org/img/actions/interaction_example_0.png)

So instead of the ACCEPT here, the goal checker could initiate a REJECT inside this Service-Request. This could save some time. But bigger checks like (Can I get a path to this goal) probably would exceed the acceptable lifespan of a service request? 

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1971 #2010 ) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | headless gazebo simulation in docker with system_tests |
| DDS | probably Fast-RTPS (what lives in the main.release-Docker?) |

---

## Description of contribution in a few bullet points


* I tried to add this feature according to the coding-style used in this scope (taking into account different typedefs and namespaces)


## Description of documentation updates required from your changes


* Added inline code description 
* Add tutorial on how to use it (based on this PR example of usage)


---

## Future work that may be required in bullet points


* Add proper Tests for this, so it does not compromise the system integrity 

