### PR TITLE
return failure on plugin failure in on_configure

### DIFF
--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -118,6 +118,7 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
     RCLCPP_FATAL(
       get_logger(),
       "Failed to create progress_checker. Exception: %s", ex.what());
+    return nav2_util::CallbackReturn::FAILURE;
   }
   try {
     goal_checker_type_ = nav2_util::get_plugin_type_param(node, goal_checker_id_);
@@ -130,6 +131,7 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
     RCLCPP_FATAL(
       get_logger(),
       "Failed to create goal_checker. Exception: %s", ex.what());
+    return nav2_util::CallbackReturn::FAILURE;
   }
 
   for (size_t i = 0; i != controller_ids_.size(); i++) {
@@ -148,6 +150,7 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
       RCLCPP_FATAL(
         get_logger(),
         "Failed to create controller. Exception: %s", ex.what());
+      return nav2_util::CallbackReturn::FAILURE;
     }
   }
 

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -102,6 +102,7 @@ PlannerServer::on_configure(const rclcpp_lifecycle::State & state)
       RCLCPP_FATAL(
         get_logger(), "Failed to create global planner. Exception: %s",
         ex.what());
+      return nav2_util::CallbackReturn::FAILURE;
     }
   }
 

--- a/nav2_recoveries/include/nav2_recoveries/recovery_server.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery_server.hpp
@@ -37,7 +37,7 @@ public:
   RecoveryServer();
   ~RecoveryServer();
 
-  void loadRecoveryPlugins();
+  bool loadRecoveryPlugins();
 
 protected:
   // Implement the lifecycle interface

--- a/nav2_recoveries/src/recovery_server.cpp
+++ b/nav2_recoveries/src/recovery_server.cpp
@@ -90,13 +90,15 @@ RecoveryServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     global_frame, robot_base_frame, transform_tolerance_);
 
   recovery_types_.resize(recovery_ids_.size());
-  loadRecoveryPlugins();
+  if (!loadRecoveryPlugins()) {
+    return nav2_util::CallbackReturn::FAILURE;
+  }
 
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
 
-void
+bool
 RecoveryServer::loadRecoveryPlugins()
 {
   auto node = shared_from_this();
@@ -114,9 +116,11 @@ RecoveryServer::loadRecoveryPlugins()
         get_logger(), "Failed to create recovery %s of type %s."
         " Exception: %s", recovery_ids_[i].c_str(), recovery_types_[i].c_str(),
         ex.what());
-      exit(-1);
+      return false;
     }
   }
+
+  return true;
 }
 
 nav2_util::CallbackReturn


### PR DESCRIPTION
To be honest, I'm a little embarrassed that it never occurred to me until now to utilize the return codes of the lifecycle state transition to cleanly fault bringup on a fatal issue like not being able to find a plugin.

  