### PR TITLE
allow "allow_unknown" parameter to be configurable

### DIFF
--- a/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
+++ b/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
@@ -144,7 +144,7 @@ protected:
   const std::string global_frame_{"map"};
 
   // Whether or not the planner should be allowed to plan through unknown space
-  const bool allow_unknown_{true};
+  bool allow_unknown_;
 
   // If the goal is obstructed, the tolerance specifies how many meters the planner
   // can relax the constraint in x and y before failing

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -52,6 +52,7 @@ NavfnPlanner::NavfnPlanner()
   // Declare this node's parameters
   declare_parameter("tolerance", rclcpp::ParameterValue(0.0));
   declare_parameter("use_astar", rclcpp::ParameterValue(false));
+  declare_parameter("allow_unknown", rclcpp::ParameterValue(false));
 
   tf_ = std::make_shared<tf2_ros::Buffer>(get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_);
@@ -70,6 +71,7 @@ NavfnPlanner::on_configure(const rclcpp_lifecycle::State & /*state*/)
   // Initialize parameters
   get_parameter("tolerance", tolerance_);
   get_parameter("use_astar", use_astar_);
+  get_parameter("allow_unknown;", allow_unknown_);
 
   getCostmap(costmap_);
   RCLCPP_DEBUG(get_logger(), "Costmap size: %d,%d",

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -52,7 +52,7 @@ NavfnPlanner::NavfnPlanner()
   // Declare this node's parameters
   declare_parameter("tolerance", rclcpp::ParameterValue(0.0));
   declare_parameter("use_astar", rclcpp::ParameterValue(false));
-  declare_parameter("allow_unknown", rclcpp::ParameterValue(false));
+  declare_parameter("allow_unknown", rclcpp::ParameterValue(true));
 
   tf_ = std::make_shared<tf2_ros::Buffer>(get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_);


### PR DESCRIPTION
set "allow_unknown" parameter in navfn_planner to be configurable

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |(#2134  |
| Primary OS tested on | (Ubuntu 18.04) |
| Robotic platform tested on | (My own robot) |

---

## Description of contribution in a few bullet points

I add some code to allow the parameter "allow_unknown" to be configured
