### PR TITLE
Fix format strings in calls to RCLCPP macros

### DIFF
--- a/nav2_behavior_tree/plugins/condition/is_stuck_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_stuck_condition.cpp
@@ -85,7 +85,7 @@ void IsStuckCondition::logStuck(const std::string & msg) const
     return;
   }
 
-  RCLCPP_INFO(node_->get_logger(), msg);
+  RCLCPP_INFO(node_->get_logger(), msg.c_str());
   prev_msg = msg;
 }
 

--- a/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
@@ -43,7 +43,7 @@ SpeedController::SpeedController(
 
   if (min_rate_ <= 0.0 || max_rate_ <= 0.0) {
     std::string err_msg = "SpeedController node cannot have rate <= 0.0";
-    RCLCPP_FATAL(node_->get_logger(), err_msg);
+    RCLCPP_FATAL(node_->get_logger(), err_msg.c_str());
     throw BT::BehaviorTreeException(err_msg);
   }
 

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -281,16 +281,16 @@ void SpeedFilter::process(
     if (speed_limit_ < 0.0) {
       RCLCPP_WARN(
         logger_,
-        "SpeedFilter: Speed limit in filter_mask[%i, %i] is less than 0%, "
-        "which can not be true. Setting it to 0% value.",
+        "SpeedFilter: Speed limit in filter_mask[%i, %i] is less than 0%%, "
+        "which can not be true. Setting it to 0%% value.",
         mask_robot_i, mask_robot_j);
       speed_limit_ = NO_SPEED_LIMIT;
     }
     if (speed_limit_ > 100.0) {
       RCLCPP_WARN(
         logger_,
-        "SpeedFilter: Speed limit in filter_mask[%i, %i] is higher than 100%, "
-        "which can not be true. Setting it to 100% value.",
+        "SpeedFilter: Speed limit in filter_mask[%i, %i] is higher than 100%%, "
+        "which can not be true. Setting it to 100%% value.",
         mask_robot_i, mask_robot_j);
       speed_limit_ = 100.0;
     }

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -68,7 +68,7 @@ void ClearCostmapService::clearExceptRegionCallback(
 {
   RCLCPP_INFO(
     logger_,
-    "Received request to clear except a region the " + costmap_.getName());
+    ("Received request to clear except a region the " + costmap_.getName()).c_str());
 
   clearRegion(request->reset_distance, true);
 }
@@ -88,7 +88,7 @@ void ClearCostmapService::clearEntireCallback(
 {
   RCLCPP_INFO(
     logger_,
-    "Received request to clear entirely the " + costmap_.getName());
+    ("Received request to clear entirely the " + costmap_.getName()).c_str());
 
   clearEntirely();
 }

--- a/nav2_map_server/test/component/test_map_saver_publisher.cpp
+++ b/nav2_map_server/test/component/test_map_saver_publisher.cpp
@@ -35,7 +35,7 @@ public:
     nav_msgs::msg::OccupancyGrid msg;
     LOAD_MAP_STATUS status = loadMapFromYaml(pub_map_file, msg);
     if (status != LOAD_MAP_SUCCESS) {
-      RCLCPP_ERROR(get_logger(), "Can not load %s map file", pub_map_file);
+      RCLCPP_ERROR(get_logger(), "Can not load %s map file", pub_map_file.c_str());
       return;
     }
 

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -255,7 +255,7 @@ PlannerServer::computePlan()
 
     RCLCPP_DEBUG(
       get_logger(),
-      "Found valid path of size %u to (%.2f, %.2f)",
+      "Found valid path of size %lu to (%.2f, %.2f)",
       result->path.poses.size(), goal->pose.pose.position.x,
       goal->pose.pose.position.y);
 

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -344,7 +344,7 @@ bool PlannerTester::defaultPlannerRandomTests(
 
   RCLCPP_INFO(
     this->get_logger(),
-    "Tested with %u tests. Planner failed on %u. Test time %u ms",
+    "Tested with %u tests. Planner failed on %u. Test time %ld ms",
     number_tests, num_fail, elapsed.count());
 
   if ((num_fail / number_tests) > acceptable_fail_ratio) {
@@ -368,7 +368,7 @@ bool PlannerTester::plannerTest(
   // Then request to compute a path
   TaskStatus status = createPlan(goal, path);
 
-  RCLCPP_DEBUG(this->get_logger(), "Path request status: %d", status);
+  RCLCPP_DEBUG(this->get_logger(), "Path request status: %d", static_cast<int8_t>(status));
 
   if (status == TaskStatus::FAILED) {
     return false;

--- a/nav2_util/src/costmap.cpp
+++ b/nav2_util/src/costmap.cpp
@@ -39,7 +39,7 @@ Costmap::Costmap(
 {
   if (lethal_threshold_ < 0. || lethal_threshold_ > 100.) {
     RCLCPP_WARN(
-      node_->get_logger(), "Costmap: Lethal threshold set to %.2f, it should be within"
+      node_->get_logger(), "Costmap: Lethal threshold set to %d, it should be within"
       " bounds 0-100. This could result in potential collisions!", lethal_threshold_);
     // lethal_threshold_ = std::max(std::min(lethal_threshold_, 100), 0);
   }

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -253,7 +253,7 @@ WaypointFollower::followWaypoints()
       new_goal = true;
       if (goal_index >= goal->poses.size()) {
         RCLCPP_INFO(
-          get_logger(), "Completed all %i waypoints requested.",
+          get_logger(), "Completed all %lu waypoints requested.",
           goal->poses.size());
         result->missed_waypoints = failed_ids_;
         action_server_->succeeded_current(result);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | (Ubuntu 20.04) |
| Robotic platform tested on | (none) |

---

## Description of contribution in a few bullet points

* Fixed incorrect format (printf) options in multiple locations. I found these formatting mistakes by building against the latest main branch of the core ros2 libraries.

## Description of documentation updates required from your changes
none

---

## Future work that may be required in bullet points

none
