### PR TITLE
Replace dashing tags to eloquent for building scripts

### DIFF
--- a/release_branch.Dockerfile
+++ b/release_branch.Dockerfile
@@ -4,11 +4,11 @@
 # Example build command:
 # export CMAKE_BUILD_TYPE=Debug
 # docker build -t nav2:release_branch \
-#   --build-arg FROM_IMAGE=dashing \
+#   --build-arg FROM_IMAGE=eloquent \
 #   --build-arg CMAKE_BUILD_TYPE \
 #   -f Dockerfile.release_branch ./
 
-ARG FROM_IMAGE=dashing
+ARG FROM_IMAGE=eloquent
 FROM ros:$FROM_IMAGE
 
 RUN rosdep update

--- a/tools/build_all.sh
+++ b/tools/build_all.sh
@@ -7,10 +7,10 @@
 # set at the time we start the last step, the ros1_bridge build.
 
 if [ "$ROS2_DISTRO" = "" ]; then
-	export ROS2_DISTRO=dashing
+	export ROS2_DISTRO=eloquent
 fi
-if [ "$ROS2_DISTRO" != "dashing" ]; then
-	echo "ROS2_DISTRO variable must be set to dashing"
+if [ "$ROS2_DISTRO" != "eloquent" ]; then
+	echo "ROS2_DISTRO variable must be set to eloquent"
 	exit 1
 fi
 

--- a/tools/initial_ros_setup.sh
+++ b/tools/initial_ros_setup.sh
@@ -4,10 +4,10 @@ ENABLE_BUILD=true
 ENABLE_ROS2=true
 
 if [ "$ROS2_DISTRO" = "" ]; then
-  export ROS2_DISTRO=dashing
+  export ROS2_DISTRO=eloquent
 fi
-if [ "$ROS2_DISTRO" != "dashing" ]; then
-  echo "ROS2_DISTRO variable must be set to dashing"
+if [ "$ROS2_DISTRO" != "eloquent" ]; then
+  echo "ROS2_DISTRO variable must be set to eloquent"
   exit 1
 fi
 
@@ -24,7 +24,7 @@ for opt in "$@" ; do
     *)
       echo "Invalid option: $opt"
       echo "Valid options:"
-      echo "--no-ros2       Uses the binary distribution of ROS2 dashing"
+      echo "--no-ros2       Uses the binary distribution of ROS2 eloquent"
       echo "--download-only Skips the build step and only downloads the code"
       exit 1
     ;;


### PR DESCRIPTION
Build scripts for Eloquent branch has 'dashing' as ROS2_DISTRO, instead of 'eloquent'. 

