### PR TITLE
Bug in clearArea function from costmap_layer

### DIFF
--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -66,15 +66,14 @@ void CostmapLayer::clearArea(int start_x, int start_y, int end_x, int end_y, boo
   current_ = false;
   unsigned char * grid = getCharMap();
   for (int x = 0; x < static_cast<int>(getSizeInCellsX()); x++) {
-    bool xrange = x > start_x && x < end_x;
+    bool xrange = x >= start_x && x <= end_x;
 
     for (int y = 0; y < static_cast<int>(getSizeInCellsY()); y++) {
-      if ((xrange && y > start_y && y < end_y) != invert) {
-        continue;
-      }
-      int index = getIndex(x, y);
-      if (grid[index] != NO_INFORMATION) {
-        grid[index] = NO_INFORMATION;
+      if (xrange && y >= start_y && y <= end_y) {
+        int index = getIndex(x, y);
+        if (grid[index] != NO_INFORMATION) {
+          grid[index] = NO_INFORMATION;
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu 20.04 Foxy |
| Robotic platform tested on | tb3 Gazebo |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
I am working in a nav2 layer. Trying to clear an area between iterations I used clearArea method from costmap_layer, and it was not work correctly. Here you have the default behavior.
![clearArea_default](https://user-images.githubusercontent.com/10533506/103933267-5feced00-5123-11eb-9b77-ff1cca20b7cf.gif)
And here you have the behavior after the fix.

![clearArea_fixed](https://user-images.githubusercontent.com/10533506/103933388-97f43000-5123-11eb-8f0b-cc7765db80f5.gif)


## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

None

---