### PR TITLE
Add support of absolute limits to Speed Filter

### DIFF
--- a/doc/parameters/param_list.md
+++ b/doc/parameters/param_list.md
@@ -474,7 +474,7 @@ When `controller_plugins`\`progress_checker_plugin`\`goal_checker_plugin` parame
 
 | Parameter | Default | Description |
 | ----------| --------| ------------|
-| type | 0 | Type of costmap filter used. This is an enum for the type of filter this should be interpreted as. We provide the following pre-defined types: 0 - keepout zones / preferred lanes filter; 1 - speed filter, speed limit is specified in % of maximum speed; 2 - speed filter, speed limit is specified in absolute value (not implemented yet) |
+| type | 0 | Type of costmap filter used. This is an enum for the type of filter this should be interpreted as. We provide the following pre-defined types: 0 - keepout zones / preferred lanes filter; 1 - speed filter, speed limit is specified in % of maximum speed; 2 - speed filter, speed limit is specified in absolute value (m/s) |
 | filter_info_topic | "costmap_filter_info" | Topic to publish costmap filter information to |
 | mask_topic | "filter_mask" | Topic to publish filter mask to. The value of this parameter should be in accordance with `topic_name` parameter of `map_server` tuned to filter mask publishing |
 | base | 0.0 | Base of `OccupancyGrid` mask value -> filter space value linear conversion which is being proceeded as: `filter_space_value = base + multiplier * mask_value` |

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -467,7 +467,7 @@ void ControllerServer::speedLimitCallback(const nav2_msgs::msg::SpeedLimit::Shar
 {
   ControllerMap::iterator it;
   for (it = controllers_.begin(); it != controllers_.end(); ++it) {
-    it->second->setSpeedLimit(msg->percentage, msg->speed_limit);
+    it->second->setSpeedLimit(msg->speed_limit, msg->percentage);
   }
 }
 

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -467,11 +467,7 @@ void ControllerServer::speedLimitCallback(const nav2_msgs::msg::SpeedLimit::Shar
 {
   ControllerMap::iterator it;
   for (it = controllers_.begin(); it != controllers_.end(); ++it) {
-    if (!msg->percentage) {
-      RCLCPP_ERROR(get_logger(), "Speed limit in absolute values is not implemented yet");
-      return;
-    }
-    it->second->setSpeedLimit(msg->speed_limit);
+    it->second->setSpeedLimit(msg->percentage, msg->speed_limit);
   }
 }
 

--- a/nav2_core/include/nav2_core/controller.hpp
+++ b/nav2_core/include/nav2_core/controller.hpp
@@ -115,12 +115,12 @@ public:
 
   /**
    * @brief Limits the maximum linear speed of the robot.
-   * @param percentage Setting speed limit in percentage if true
-   * or in absolute values in false case.
    * @param speed_limit expressed in absolute value (in m/s)
    * or in percentage from maximum robot speed.
+   * @param percentage Setting speed limit in percentage if true
+   * or in absolute values in false case.
    */
-  virtual void setSpeedLimit(const bool & percentage, const double & speed_limit) = 0;
+  virtual void setSpeedLimit(const double & speed_limit, const bool & percentage) = 0;
 };
 
 }  // namespace nav2_core

--- a/nav2_core/include/nav2_core/controller.hpp
+++ b/nav2_core/include/nav2_core/controller.hpp
@@ -115,9 +115,12 @@ public:
 
   /**
    * @brief Limits the maximum linear speed of the robot.
-   * @param speed_limit expressed in percentage from maximum robot speed.
+   * @param percentage Setting speed limit in percentage if true
+   * or in absolute values in false case.
+   * @param speed_limit expressed in absolute value (in m/s)
+   * or in percentage from maximum robot speed.
    */
-  virtual void setSpeedLimit(const double & speed_limit) = 0;
+  virtual void setSpeedLimit(const bool & percentage, const double & speed_limit) = 0;
 };
 
 }  // namespace nav2_core

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -112,6 +112,7 @@ private:
   std::string global_frame_;  // Frame of currnet layer (master_grid)
 
   double base_, multiplier_;
+  bool percentage_;
   double speed_limit_, speed_limit_prev_;
 };
 

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -90,6 +90,7 @@ void SpeedFilter::initializeFilter(
   // Reset speed conversion states
   base_ = BASE_DEFAULT;
   multiplier_ = MULTIPLIER_DEFAULT;
+  percentage_ = true;
 }
 
 void SpeedFilter::filterInfoCallback(
@@ -120,15 +121,19 @@ void SpeedFilter::filterInfoCallback(
   multiplier_ = msg->multiplier;
   if (msg->type == SPEED_FILTER_PERCENT) {
     // Using speed limit in % of maximum speed
+    percentage_ = true;
     RCLCPP_INFO(
       logger_,
       "SpeedFilter: Using expressed in a percent from maximum speed"
       "speed_limit = %f + filter_mask_data * %f",
       base_, multiplier_);
   } else if (msg->type == SPEED_FILTER_ABSOLUTE) {
-    // Speed limit in absolute values is not implemented yet
-    RCLCPP_ERROR(logger_, "SpeedFilter: Speed limit in absolute values is not implemented yet");
-    return;
+    // Using speed limit in m/s
+    percentage_ = false;
+    RCLCPP_INFO(
+      logger_,
+      "SpeedFilter: Using absolute speed_limit = %f + filter_mask_data * %f",
+      base_, multiplier_);
   } else {
     RCLCPP_ERROR(logger_, "SpeedFilter: Mode is not supported");
     return;
@@ -278,30 +283,48 @@ void SpeedFilter::process(
   } else {
     // Normal case: speed_mask_data in range of [1..100]
     speed_limit_ = speed_mask_data * multiplier_ + base_;
-    if (speed_limit_ < 0.0) {
-      RCLCPP_WARN(
-        logger_,
-        "SpeedFilter: Speed limit in filter_mask[%i, %i] is less than 0%%, "
-        "which can not be true. Setting it to 0%% value.",
-        mask_robot_i, mask_robot_j);
-      speed_limit_ = NO_SPEED_LIMIT;
-    }
-    if (speed_limit_ > 100.0) {
-      RCLCPP_WARN(
-        logger_,
-        "SpeedFilter: Speed limit in filter_mask[%i, %i] is higher than 100%%, "
-        "which can not be true. Setting it to 100%% value.",
-        mask_robot_i, mask_robot_j);
-      speed_limit_ = 100.0;
+    if (percentage_) {
+      if (speed_limit_ < 0.0) {
+        RCLCPP_WARN(
+          logger_,
+          "SpeedFilter: Speed limit in filter_mask[%i, %i] is less than 0%%, "
+          "which can not be true. Setting it to no-limit value.",
+          mask_robot_i, mask_robot_j);
+        speed_limit_ = NO_SPEED_LIMIT;
+      }
+      if (speed_limit_ > 100.0) {
+        RCLCPP_WARN(
+          logger_,
+          "SpeedFilter: Speed limit in filter_mask[%i, %i] is higher than 100%%, "
+          "which can not be true. Setting it to no-limit value.",
+          mask_robot_i, mask_robot_j);
+        speed_limit_ = NO_SPEED_LIMIT;
+      }
+    } else {
+      if (speed_limit_ < 0.0) {
+        RCLCPP_WARN(
+          logger_,
+          "SpeedFilter: Speed limit in filter_mask[%i, %i] is less than 0 m/s, "
+          "which can not be true. Setting it to no-limit value.",
+          mask_robot_i, mask_robot_j);
+        speed_limit_ = NO_SPEED_LIMIT;
+      }
     }
   }
 
   if (speed_limit_ != speed_limit_prev_) {
     if (speed_limit_ != NO_SPEED_LIMIT) {
-      RCLCPP_DEBUG(
-        logger_,
-        "SpeedFilter: Speed limit is set to %f%% of maximum speed",
-        speed_limit_);
+      if (percentage_) {
+        RCLCPP_DEBUG(
+          logger_,
+          "SpeedFilter: Speed limit is set to %f%% of maximum speed",
+          speed_limit_);
+      } else {
+        RCLCPP_DEBUG(
+          logger_,
+          "SpeedFilter: Speed limit is set to %f m/s",
+          speed_limit_);
+      }
     } else {
       RCLCPP_DEBUG(logger_, "SpeedFilter: Speed limit is set to its default value");
     }
@@ -311,7 +334,7 @@ void SpeedFilter::process(
       std::make_unique<nav2_msgs::msg::SpeedLimit>();
     msg->header.frame_id = global_frame_;
     msg->header.stamp = clock_->now();
-    msg->percentage = true;
+    msg->percentage = percentage_;
     msg->speed_limit = speed_limit_;
     speed_limit_pub_->publish(std::move(msg));
 

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/dwb_local_planner.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/dwb_local_planner.hpp
@@ -133,15 +133,15 @@ public:
 
   /**
    * @brief Limits the maximum linear speed of the robot.
-   * @param percentage Setting speed limit in percentage if true
-   * or in absolute values in false case.
    * @param speed_limit expressed in absolute value (in m/s)
    * or in percentage from maximum robot speed.
+   * @param percentage Setting speed limit in percentage if true
+   * or in absolute values in false case.
    */
-  void setSpeedLimit(const bool & percentage, const double & speed_limit) override
+  void setSpeedLimit(const double & speed_limit, const bool & percentage) override
   {
     if (traj_generator_) {
-      traj_generator_->setSpeedLimit(percentage, speed_limit);
+      traj_generator_->setSpeedLimit(speed_limit, percentage);
     }
   }
 

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/dwb_local_planner.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/dwb_local_planner.hpp
@@ -133,12 +133,15 @@ public:
 
   /**
    * @brief Limits the maximum linear speed of the robot.
-   * @param speed_limit expressed in percentage from maximum robot speed.
+   * @param percentage Setting speed limit in percentage if true
+   * or in absolute values in false case.
+   * @param speed_limit expressed in absolute value (in m/s)
+   * or in percentage from maximum robot speed.
    */
-  void setSpeedLimit(const double & speed_limit) override
+  void setSpeedLimit(const bool & percentage, const double & speed_limit) override
   {
     if (traj_generator_) {
-      traj_generator_->setSpeedLimit(speed_limit);
+      traj_generator_->setSpeedLimit(percentage, speed_limit);
     }
   }
 

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_generator.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_generator.hpp
@@ -126,9 +126,12 @@ public:
 
   /**
    * @brief Limits the maximum linear speed of the robot.
-   * @param speed_limit expressed in percentage from maximum robot speed.
+   * @param percentage Setting speed limit in percentage if true
+   * or in absolute values in false case.
+   * @param speed_limit expressed in absolute value (in m/s)
+   * or in percentage from maximum robot speed.
    */
-  virtual void setSpeedLimit(const double & speed_limit) = 0;
+  virtual void setSpeedLimit(const bool & percentage, const double & speed_limit) = 0;
 };
 
 }  // namespace dwb_core

--- a/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_generator.hpp
+++ b/nav2_dwb_controller/dwb_core/include/dwb_core/trajectory_generator.hpp
@@ -126,12 +126,12 @@ public:
 
   /**
    * @brief Limits the maximum linear speed of the robot.
-   * @param percentage Setting speed limit in percentage if true
-   * or in absolute values in false case.
    * @param speed_limit expressed in absolute value (in m/s)
    * or in percentage from maximum robot speed.
+   * @param percentage Setting speed limit in percentage if true
+   * or in absolute values in false case.
    */
-  virtual void setSpeedLimit(const bool & percentage, const double & speed_limit) = 0;
+  virtual void setSpeedLimit(const double & speed_limit, const bool & percentage) = 0;
 };
 
 }  // namespace dwb_core

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -113,7 +113,7 @@ public:
 
   inline KinematicParameters getKinematics() {return *kinematics_.load();}
 
-  void setSpeedLimit(const double & speed_limit);
+  void setSpeedLimit(const bool & percentage, const double & speed_limit);
 
   using Ptr = std::shared_ptr<KinematicsHandler>;
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -113,7 +113,7 @@ public:
 
   inline KinematicParameters getKinematics() {return *kinematics_.load();}
 
-  void setSpeedLimit(const bool & percentage, const double & speed_limit);
+  void setSpeedLimit(const double & speed_limit, const bool & percentage);
 
   using Ptr = std::shared_ptr<KinematicsHandler>;
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -70,12 +70,15 @@ public:
 
   /**
    * @brief Limits the maximum linear speed of the robot.
-   * @param speed_limit expressed in percentage from maximum robot speed.
+   * @param percentage Setting speed limit in percentage if true
+   * or in absolute values in false case.
+   * @param speed_limit expressed in absolute value (in m/s)
+   * or in percentage from maximum robot speed.
    */
-  void setSpeedLimit(const double & speed_limit) override
+  void setSpeedLimit(const bool & percentage, const double & speed_limit) override
   {
     if (kinematics_handler_) {
-      kinematics_handler_->setSpeedLimit(speed_limit);
+      kinematics_handler_->setSpeedLimit(percentage, speed_limit);
     }
   }
 

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/standard_traj_generator.hpp
@@ -70,15 +70,15 @@ public:
 
   /**
    * @brief Limits the maximum linear speed of the robot.
-   * @param percentage Setting speed limit in percentage if true
-   * or in absolute values in false case.
    * @param speed_limit expressed in absolute value (in m/s)
    * or in percentage from maximum robot speed.
+   * @param percentage Setting speed limit in percentage if true
+   * or in absolute values in false case.
    */
-  void setSpeedLimit(const bool & percentage, const double & speed_limit) override
+  void setSpeedLimit(const double & speed_limit, const bool & percentage) override
   {
     if (kinematics_handler_) {
-      kinematics_handler_->setSpeedLimit(percentage, speed_limit);
+      kinematics_handler_->setSpeedLimit(speed_limit, percentage);
     }
   }
 

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -154,7 +154,7 @@ void KinematicsHandler::setSpeedLimit(
         // Handling components and angular velocity changes:
         // Max velocities are being changed in the same proportion
         // as absolute linear speed changed in order to preserve
-        // robot movng trajectories to be the same after speed change.
+        // robot moving trajectories to be the same after speed change.
         const double ratio = speed_limit / kinematics.base_max_speed_xy_;
         kinematics.max_vel_x_ = kinematics.base_max_vel_x_ * ratio;
         kinematics.max_vel_y_ = kinematics.base_max_vel_y_ * ratio;

--- a/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp
@@ -130,7 +130,7 @@ void KinematicsHandler::initialize(
 }
 
 void KinematicsHandler::setSpeedLimit(
-  const bool & percentage, const double & speed_limit)
+  const double & speed_limit, const bool & percentage)
 {
   KinematicParameters kinematics(*kinematics_.load());
 
@@ -151,16 +151,14 @@ void KinematicsHandler::setSpeedLimit(
       // Speed limit is expressed in absolute value
       if (speed_limit < kinematics.base_max_speed_xy_) {
         kinematics.max_speed_xy_ = speed_limit;
-        // Handling angular velocity changes: Max angular velocity is being changed
-        // in the same proportion as linear speed changed.
+        // Handling components and angular velocity changes:
+        // Max velocities are being changed in the same proportion
+        // as absolute linear speed changed in order to preserve
+        // robot movng trajectories to be the same after speed change.
         const double ratio = speed_limit / kinematics.base_max_speed_xy_;
+        kinematics.max_vel_x_ = kinematics.base_max_vel_x_ * ratio;
+        kinematics.max_vel_y_ = kinematics.base_max_vel_y_ * ratio;
         kinematics.max_vel_theta_ = kinematics.base_max_vel_theta_ * ratio;
-      }
-      if (speed_limit < kinematics.base_max_vel_x_) {
-        kinematics.max_vel_x_ = speed_limit;
-      }
-      if (speed_limit < kinematics.base_max_vel_y_) {
-        kinematics.max_vel_y_ = speed_limit;
       }
     }
   }

--- a/nav2_dwb_controller/dwb_plugins/test/speed_limit_test.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/speed_limit_test.cpp
@@ -103,7 +103,7 @@ TEST_F(TestNode, TestPercentLimit)
   EXPECT_NEAR(kp.getMaxSpeedXY(), MAX_VEL_LINEAR, EPSILON);
 
   // Set speed limit 30% from maximum robot speed
-  kh.setSpeedLimit(true, 30);
+  kh.setSpeedLimit(30, true);
 
   // Update KinematicParameters values from KinematicsHandler
   kp = kh.getKinematics();
@@ -113,7 +113,7 @@ TEST_F(TestNode, TestPercentLimit)
   EXPECT_NEAR(kp.getMaxSpeedXY(), MAX_VEL_LINEAR * 0.3, EPSILON);
 
   // Restore maximum speed to its default
-  kh.setSpeedLimit(true, nav2_costmap_2d::NO_SPEED_LIMIT);
+  kh.setSpeedLimit(nav2_costmap_2d::NO_SPEED_LIMIT, true);
 
   // Update KinematicParameters values from KinematicsHandler
   kp = kh.getKinematics();
@@ -135,27 +135,17 @@ TEST_F(TestNode, TestAbsoluteLimit)
   EXPECT_NEAR(kp.getMaxSpeedXY(), MAX_VEL_LINEAR, EPSILON);
 
   // Set speed limit 35.0 m/s
-  kh.setSpeedLimit(false, 35.0);
+  kh.setSpeedLimit(35.0, false);
 
   // Update KinematicParameters values from KinematicsHandler
   kp = kh.getKinematics();
-  EXPECT_NEAR(kp.getMaxX(), 35.0, EPSILON);
-  EXPECT_NEAR(kp.getMaxY(), 30.0, EPSILON);
+  EXPECT_NEAR(kp.getMaxX(), MAX_VEL_X * 35.0 / MAX_VEL_LINEAR, EPSILON);
+  EXPECT_NEAR(kp.getMaxY(), MAX_VEL_Y * 35.0 / MAX_VEL_LINEAR, EPSILON);
   EXPECT_NEAR(kp.getMaxTheta(), MAX_VEL_THETA * 35.0 / MAX_VEL_LINEAR, EPSILON);
   EXPECT_NEAR(kp.getMaxSpeedXY(), 35.0, EPSILON);
 
-  // Set speed limit 15.0 m/s
-  kh.setSpeedLimit(false, 15.0);
-
-  // Update KinematicParameters values from KinematicsHandler
-  kp = kh.getKinematics();
-  EXPECT_NEAR(kp.getMaxX(), 15.0, EPSILON);
-  EXPECT_NEAR(kp.getMaxY(), 15.0, EPSILON);
-  EXPECT_NEAR(kp.getMaxTheta(), MAX_VEL_THETA * 15.0 / MAX_VEL_LINEAR, EPSILON);
-  EXPECT_NEAR(kp.getMaxSpeedXY(), 15.0, EPSILON);
-
   // Restore maximum speed to its default
-  kh.setSpeedLimit(false, nav2_costmap_2d::NO_SPEED_LIMIT);
+  kh.setSpeedLimit(nav2_costmap_2d::NO_SPEED_LIMIT, false);
 
   // Update KinematicParameters values from KinematicsHandler
   kp = kh.getKinematics();

--- a/nav2_dwb_controller/dwb_plugins/test/speed_limit_test.cpp
+++ b/nav2_dwb_controller/dwb_plugins/test/speed_limit_test.cpp
@@ -103,7 +103,7 @@ TEST_F(TestNode, TestPercentLimit)
   EXPECT_NEAR(kp.getMaxSpeedXY(), MAX_VEL_LINEAR, EPSILON);
 
   // Set speed limit 30% from maximum robot speed
-  kh.setSpeedLimit(30);
+  kh.setSpeedLimit(true, 30);
 
   // Update KinematicParameters values from KinematicsHandler
   kp = kh.getKinematics();
@@ -113,7 +113,49 @@ TEST_F(TestNode, TestPercentLimit)
   EXPECT_NEAR(kp.getMaxSpeedXY(), MAX_VEL_LINEAR * 0.3, EPSILON);
 
   // Restore maximum speed to its default
-  kh.setSpeedLimit(nav2_costmap_2d::NO_SPEED_LIMIT);
+  kh.setSpeedLimit(true, nav2_costmap_2d::NO_SPEED_LIMIT);
+
+  // Update KinematicParameters values from KinematicsHandler
+  kp = kh.getKinematics();
+  EXPECT_NEAR(kp.getMaxX(), MAX_VEL_X, EPSILON);
+  EXPECT_NEAR(kp.getMaxY(), MAX_VEL_Y, EPSILON);
+  EXPECT_NEAR(kp.getMaxTheta(), MAX_VEL_THETA, EPSILON);
+  EXPECT_NEAR(kp.getMaxSpeedXY(), MAX_VEL_LINEAR, EPSILON);
+}
+
+TEST_F(TestNode, TestAbsoluteLimit)
+{
+  dwb_plugins::KinematicsHandler kh;
+  kh.initialize(node_, NODE_NAME);
+
+  dwb_plugins::KinematicParameters kp = kh.getKinematics();
+  EXPECT_NEAR(kp.getMaxX(), MAX_VEL_X, EPSILON);
+  EXPECT_NEAR(kp.getMaxY(), MAX_VEL_Y, EPSILON);
+  EXPECT_NEAR(kp.getMaxTheta(), MAX_VEL_THETA, EPSILON);
+  EXPECT_NEAR(kp.getMaxSpeedXY(), MAX_VEL_LINEAR, EPSILON);
+
+  // Set speed limit 35.0 m/s
+  kh.setSpeedLimit(false, 35.0);
+
+  // Update KinematicParameters values from KinematicsHandler
+  kp = kh.getKinematics();
+  EXPECT_NEAR(kp.getMaxX(), 35.0, EPSILON);
+  EXPECT_NEAR(kp.getMaxY(), 30.0, EPSILON);
+  EXPECT_NEAR(kp.getMaxTheta(), MAX_VEL_THETA * 35.0 / MAX_VEL_LINEAR, EPSILON);
+  EXPECT_NEAR(kp.getMaxSpeedXY(), 35.0, EPSILON);
+
+  // Set speed limit 15.0 m/s
+  kh.setSpeedLimit(false, 15.0);
+
+  // Update KinematicParameters values from KinematicsHandler
+  kp = kh.getKinematics();
+  EXPECT_NEAR(kp.getMaxX(), 15.0, EPSILON);
+  EXPECT_NEAR(kp.getMaxY(), 15.0, EPSILON);
+  EXPECT_NEAR(kp.getMaxTheta(), MAX_VEL_THETA * 15.0 / MAX_VEL_LINEAR, EPSILON);
+  EXPECT_NEAR(kp.getMaxSpeedXY(), 15.0, EPSILON);
+
+  // Restore maximum speed to its default
+  kh.setSpeedLimit(false, nav2_costmap_2d::NO_SPEED_LIMIT);
 
   // Update KinematicParameters values from KinematicsHandler
   kp = kh.getKinematics();

--- a/nav2_msgs/msg/CostmapFilterInfo.msg
+++ b/nav2_msgs/msg/CostmapFilterInfo.msg
@@ -2,7 +2,7 @@ std_msgs/Header header
 # Type of plugin used (keepout filter, speed limit in m/s, speed limit in percent, etc...)
 # 0: keepout/lanes filter
 # 1: speed limit filter in % of maximum speed
-# 2: speed limit filter in absolute values
+# 2: speed limit filter in absolute values (m/s)
 uint8 type
 # Name of filter mask topic
 string filter_mask_topic

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -99,9 +99,12 @@ public:
 
   /**
    * @brief Limits the maximum linear speed of the robot.
-   * @param speed_limit expressed in percentage from maximum robot speed.
+   * @param speed_limit expressed in absolute value (in m/s)
+   * or in percentage from maximum robot speed.
+   * @param percentage Setting speed limit in percentage if true
+   * or in absolute values in false case.
    */
-  void setSpeedLimit(const double & speed_limit) override;
+  void setSpeedLimit(const double & speed_limit, const bool & percentage) override;
 
 protected:
   /**
@@ -221,7 +224,7 @@ protected:
   nav2_costmap_2d::Costmap2D * costmap_;
   rclcpp::Logger logger_ {rclcpp::get_logger("RegulatedPurePursuitController")};
 
-  double desired_linear_vel_;
+  double desired_linear_vel_, base_desired_linear_vel_;
   double lookahead_dist_;
   double rotate_to_heading_angular_vel_;
   double max_lookahead_dist_;

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -22,6 +22,7 @@
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp"
+#include "nav2_costmap_2d/costmap_filters/filter_values.hpp"
 
 class RclCppFixture
 {
@@ -112,9 +113,16 @@ TEST(RegulatedPurePursuitTest, basicAPI)
   EXPECT_EQ(ctrl->getPlan().poses[0].header.frame_id, std::string("fake_frame"));
 
   // set speed limit
-  EXPECT_NE(ctrl->getSpeed(), 0.51);
-  ctrl->setSpeedLimit(0.51);
+  const double base_speed = ctrl->getSpeed();
+  EXPECT_EQ(ctrl->getSpeed(), base_speed);
+  ctrl->setSpeedLimit(0.51, false);
   EXPECT_EQ(ctrl->getSpeed(), 0.51);
+  ctrl->setSpeedLimit(nav2_costmap_2d::NO_SPEED_LIMIT, false);
+  EXPECT_EQ(ctrl->getSpeed(), base_speed);
+  ctrl->setSpeedLimit(30, true);
+  EXPECT_EQ(ctrl->getSpeed(), base_speed * 0.3);
+  ctrl->setSpeedLimit(nav2_costmap_2d::NO_SPEED_LIMIT, true);
+  EXPECT_EQ(ctrl->getSpeed(), base_speed);
 }
 
 TEST(RegulatedPurePursuitTest, createCarrotMsg)


### PR DESCRIPTION
According to public [discussions](https://discourse.ros.org/t/nav2-speed-restriction-support-now-available/18068/2), we are choosing the following solution to support speed limits expressed in absolute values:

> _Solution #1:_
> 
> Encode maximum linear velocity in a filter mask. Then restrict maximum angular velocity in the same proportion as it was changed for maximum linear velocity.
> 
> For example, a robot has 100 m/s max linear velocity and 20 rad/s max angular velocity allowed by its construction. Robot enters in a speed restriction area having 15 m/s speed restriction. This means, that maximum linear velocity will be restricted by this value, and maximum angular velocity by ( 15m/s / 100m/s ) * 20rad/s = 3rad/s. This will be a restriction of maximum angular velocity for this robot.
> 
> This solution is similar to restricting the speed in a percent value approach, but it is suitable for heterogeneous systems, where we have different kinds of robots.

This following PR implements this solution.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #1263 |
| Primary OS tested on | Ubuntu 20.04 with ROS2 Foxy (rolling build) onboard |
| Robotic platform tested on | Gazebo simulation of TB3 |