### PR TITLE
Feat/Dashing add map and frame topic

### DIFF
--- a/nav2_map_server/include/nav2_map_server/occ_grid_loader.hpp
+++ b/nav2_map_server/include/nav2_map_server/occ_grid_loader.hpp
@@ -31,7 +31,10 @@ namespace nav2_map_server
 class OccGridLoader : public nav2_util::LifecycleHelperInterface
 {
 public:
-  OccGridLoader(rclcpp_lifecycle::LifecycleNode::SharedPtr node, std::string & yaml_filename);
+  OccGridLoader(rclcpp_lifecycle::LifecycleNode::SharedPtr node
+    , std::string & yaml_filename
+    , std::string & topic_name
+    , std::string & frame_id);
   OccGridLoader() = delete;
   ~OccGridLoader();
 
@@ -46,6 +49,8 @@ protected:
 
   // The name of the YAML file from which to get the conversion parameters
   std::string yaml_filename_;
+  std::string topic_name_;
+  std::string frame_id_;
 
   typedef struct
   {
@@ -73,12 +78,6 @@ protected:
 
   // The message to publish on the occupancy grid topic
   std::unique_ptr<nav_msgs::msg::OccupancyGrid> msg_;
-
-  // The frame ID used in the returned OccupancyGrid message
-  static constexpr const char * frame_id_{"map"};
-
-  // The name for the topic on which the map will be published
-  static constexpr const char * topic_name_{"map"};
 
   // The name of the service for getting a map
   static constexpr const char * service_name_{"map"};

--- a/nav2_map_server/src/map_server.cpp
+++ b/nav2_map_server/src/map_server.cpp
@@ -35,6 +35,8 @@ MapServer::MapServer()
 
   // Declare the node parameters
   declare_parameter("yaml_filename", rclcpp::ParameterValue(std::string("map.yaml")));
+  declare_parameter("topic_name", rclcpp::ParameterValue(std::string("map")));
+  declare_parameter("frame_id", rclcpp::ParameterValue(std::string("map")));
 }
 
 MapServer::~MapServer()
@@ -49,7 +51,11 @@ MapServer::on_configure(const rclcpp_lifecycle::State & state)
 
   // Get the name of the YAML file to use
   std::string yaml_filename;
+  std::string topic_name;
+  std::string frame_id;
   get_parameter("yaml_filename", yaml_filename);
+  get_parameter("topic_name", topic_name);
+  get_parameter("frame_id", frame_id);
 
   // Make sure that there's a valid file there and open it up
   std::ifstream fin(yaml_filename.c_str());
@@ -71,7 +77,7 @@ MapServer::on_configure(const rclcpp_lifecycle::State & state)
 
   // Create the correct map loader for the specified map type
   if (map_type == "occupancy") {
-    map_loader_ = std::make_unique<OccGridLoader>(shared_from_this(), yaml_filename);
+    map_loader_ = std::make_unique<OccGridLoader>(shared_from_this(), yaml_filename, topic_name, frame_id);
   } else {
     std::string msg = "Cannot load unknown map type: '" + map_type + "'";
     throw std::runtime_error(msg);

--- a/nav2_map_server/src/occ_grid_loader.cpp
+++ b/nav2_map_server/src/occ_grid_loader.cpp
@@ -49,8 +49,14 @@ namespace nav2_map_server
 using nav2_util::geometry_utils::orientationAroundZAxis;
 
 OccGridLoader::OccGridLoader(
-  rclcpp_lifecycle::LifecycleNode::SharedPtr node, std::string & yaml_filename)
-: node_(node), yaml_filename_(yaml_filename)
+  rclcpp_lifecycle::LifecycleNode::SharedPtr node
+  , std::string & yaml_filename
+  , std::string & topic_name
+  , std::string & frame_id)
+  : node_(node)
+  , yaml_filename_(yaml_filename)
+  , topic_name_(topic_name)
+  , frame_id_(frame_id)
 {
   RCLCPP_INFO(node_->get_logger(), "OccGridLoader: Creating");
 }

--- a/nav2_map_server/test/unit/test_occ_grid.cpp
+++ b/nav2_map_server/test/unit/test_occ_grid.cpp
@@ -66,8 +66,11 @@ class TestMapLoader : public nav2_map_server::OccGridLoader
   FRIEND_TEST(MapLoaderTest, loadInvalidFile);
 
 public:
-  explicit TestMapLoader(nav2_util::LifecycleNode::SharedPtr node, std::string yaml_filename)
-  : OccGridLoader(node, yaml_filename)
+  explicit TestMapLoader(nav2_util::LifecycleNode::SharedPtr node
+    , std::string yaml_filename
+    , std::string topic_name
+    , std::string frame_id)
+  : OccGridLoader(node, yaml_filename, topic_name, frame_id)
   {
   }
 
@@ -121,7 +124,7 @@ public:
     params_file.close();
 
     node_ = std::make_shared<FakeMapServer>();
-    map_loader_ = std::make_unique<TestMapLoader>(node_, temp_name);
+    map_loader_ = std::make_unique<TestMapLoader>(node_, temp_name, std::string("map"), std::string("map"));
   }
 
 protected:


### PR DESCRIPTION
Signed-off-by: Spinnler Christian <christian.spinnler@siemens.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | (Debian) |
| Robotic platform tested on | - |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

In the dashing version of map_server it is not possible to use custom map and frame_id topics. I added support for this. 

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

New parameters are `topic_name` and `frame_id` which both default to "map".

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
