### PR TITLE
smac_planner: fix goal checking in getAnalyticPath()

### DIFF
--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -411,7 +411,7 @@ AStarAlgorithm<NodeSE2>::NodePtr AStarAlgorithm<NodeSE2>::getAnalyticPath(
   prev = node;
   for (const auto & node_pose : possible_nodes) {
     const auto & n = node_pose.first;
-    if (!n->wasVisited()) {
+    if (!n->wasVisited() and n->getIndex()!=_goal->getIndex()) {
       // Make sure this node has not been visited by the regular algorithm.
       // If it has been, there is the (slight) chance that it is in the path we are expanding
       // from, so we should skip it.


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2040 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | my own simulation stack |

---

## Description of contribution in a few bullet points

* Added condition to exclude goal from poses added through analytic path expansion, because the goal is added always at the end and adding it twice causes infinite loops in the path


