### PR TITLE
fix boundary point exclusion in convexFillCells

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d.cpp
+++ b/nav2_costmap_2d/src/costmap_2d.cpp
@@ -467,7 +467,7 @@ void Costmap2D::convexFillCells(
 
     MapLocation pt;
     // loop though cells in the column
-    for (unsigned int y = min_pt.y; y < max_pt.y; ++y) {
+    for (unsigned int y = min_pt.y; y <= max_pt.y; ++y) {
       pt.x = x;
       pt.y = y;
       polygon_cells.push_back(pt);


### PR DESCRIPTION
## Description of contribution in a few bullet points

equivalent of [this ros-navigation pull request](https://github.com/ros-planning/navigation/pull/1095):

> A bug in the function that returns all the cells contained in a (convex) polygon:
> 
> - sorts all the points along the polygon outline by x coordinate
> - for all points with same x coordinate, find min and max y coordinate
> - for that x coordinate, considers all points between min and max y coordinate to be within the polygon
> 
> The bug is that the maximum y coordinate also needs to be included.