### PR TITLE
Update angular velocity after constraining linear velocity

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -235,9 +235,7 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
     curvature = 2.0 * carrot_pose.pose.position.y / carrot_dist2;
   }
 
-  // Apply curvature to angular velocity
   linear_vel = desired_linear_vel_;
-  angular_vel = desired_linear_vel_ * curvature;
 
   // Make sure we're in compliance with basic constraints
   double angle_to_heading;
@@ -251,6 +249,9 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
       fabs(lookahead_dist - sqrt(carrot_dist2)),
       lookahead_dist, curvature, speed,
       costAtPose(pose.pose.position.x, pose.pose.position.y), linear_vel);
+
+      // Apply curvature to angular velocity after constraining linear velocity
+      angular_vel = linear_vel * curvature;
   }
 
   // Collision checking on this velocity heading


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2152  |
| Primary OS tested on | Ubuntu 18.04
| Robotic platform tested on | Turtlebot simulation

---

![Screen Recording 2021-02-02 at 6 48 48 AM](https://user-images.githubusercontent.com/10333131/106648248-065acf80-65b6-11eb-80ed-4621f133afa6.gif)
The green trajectory is the old behavior and the yellow trajectory is the new behavior in which angular velocity is updated.

The new behavior ensures the robot moves towards the lookahead point more closely. In the case of the old behavior, as seen in the GIF, it generates a trajectory that makes the robot take a cut (i.e. move with a higher angular speed) while turning which leads it much closer to the obstacle and could potentially lead to a collision.



Signed-off-by: Shrijit Singh <shrijitsingh99@gmail.com>