### PR TITLE
attempt at bringing up CI (2158)

### DIFF
--- a/nav2_bringup/bringup/worlds/waffle.model
+++ b/nav2_bringup/bringup/worlds/waffle.model
@@ -137,7 +137,7 @@
             </linear_acceleration>
           </imu>
           <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
-            <initial_orientation_as_reference>true</initial_orientation_as_reference>
+            <initial_orientation_as_reference>false</initial_orientation_as_reference>
             <ros>
               <!-- <namespace>/tb3</namespace> -->
               <remapping>~/out:=imu</remapping>

--- a/nav2_bringup/bringup/worlds/waffle.model
+++ b/nav2_bringup/bringup/worlds/waffle.model
@@ -137,6 +137,7 @@
             </linear_acceleration>
           </imu>
           <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
+            <initial_orientation_as_reference>true</initial_orientation_as_reference>
             <ros>
               <!-- <namespace>/tb3</namespace> -->
               <remapping>~/out:=imu</remapping>

--- a/nav2_system_tests/models/turtlebot3_waffle/model-1_4.sdf
+++ b/nav2_system_tests/models/turtlebot3_waffle/model-1_4.sdf
@@ -87,7 +87,7 @@
           </linear_acceleration>
         </imu>
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
-          <initial_orientation_as_reference>true</initial_orientation_as_reference>
+          <initial_orientation_as_reference>false</initial_orientation_as_reference>
           <ros>
             <!-- <namespace>/tb3</namespace> -->
             <remapping>~/out:=imu</remapping>

--- a/nav2_system_tests/models/turtlebot3_waffle/model-1_4.sdf
+++ b/nav2_system_tests/models/turtlebot3_waffle/model-1_4.sdf
@@ -87,6 +87,7 @@
           </linear_acceleration>
         </imu>
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
+          <initial_orientation_as_reference>true</initial_orientation_as_reference>
           <ros>
             <!-- <namespace>/tb3</namespace> -->
             <remapping>~/out:=imu</remapping>

--- a/nav2_system_tests/models/turtlebot3_waffle/model.sdf
+++ b/nav2_system_tests/models/turtlebot3_waffle/model.sdf
@@ -87,7 +87,7 @@
           </linear_acceleration>
         </imu>
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
-          <initial_orientation_as_reference>true</initial_orientation_as_reference>
+          <initial_orientation_as_reference>false</initial_orientation_as_reference>
           <ros>
             <!-- <namespace>/tb3</namespace> -->
             <remapping>~/out:=imu</remapping>

--- a/nav2_system_tests/models/turtlebot3_waffle/model.sdf
+++ b/nav2_system_tests/models/turtlebot3_waffle/model.sdf
@@ -87,6 +87,7 @@
           </linear_acceleration>
         </imu>
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
+          <initial_orientation_as_reference>true</initial_orientation_as_reference>
           <ros>
             <!-- <namespace>/tb3</namespace> -->
             <remapping>~/out:=imu</remapping>

--- a/nav2_system_tests/models/turtlebot3_waffle_depth_camera/model.sdf
+++ b/nav2_system_tests/models/turtlebot3_waffle_depth_camera/model.sdf
@@ -77,6 +77,7 @@
           </linear_acceleration>
         </imu>
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
+          <initial_orientation_as_reference>true</initial_orientation_as_reference>
           <ros>
             <!-- <namespace>/tb3</namespace> -->
             <remapping>~/out:=imu</remapping>

--- a/nav2_system_tests/models/turtlebot3_waffle_depth_camera/model.sdf
+++ b/nav2_system_tests/models/turtlebot3_waffle_depth_camera/model.sdf
@@ -77,7 +77,7 @@
           </linear_acceleration>
         </imu>
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
-          <initial_orientation_as_reference>true</initial_orientation_as_reference>
+          <initial_orientation_as_reference>false</initial_orientation_as_reference>
           <ros>
             <!-- <namespace>/tb3</namespace> -->
             <remapping>~/out:=imu</remapping>

--- a/nav2_system_tests/src/costmap_filters/keepout_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/keepout_params.yaml
@@ -261,8 +261,8 @@ planner_server:
     GridBased:
       plugin: "nav2_navfn_planner/NavfnPlanner"
       tolerance: 0.5
-      use_astar: false
-      allow_unknown: true
+      use_astar: False
+      allow_unknown: True
 
 planner_server_rclcpp_node:
   ros__parameters:

--- a/nav2_system_tests/src/costmap_filters/speed_global_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/speed_global_params.yaml
@@ -264,8 +264,8 @@ planner_server:
     GridBased:
       plugin: "nav2_navfn_planner/NavfnPlanner"
       tolerance: 0.5
-      use_astar: false
-      allow_unknown: true
+      use_astar: False
+      allow_unknown: True
 
 planner_server_rclcpp_node:
   ros__parameters:

--- a/nav2_system_tests/src/costmap_filters/speed_local_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/speed_local_params.yaml
@@ -259,8 +259,8 @@ planner_server:
     GridBased:
       plugin: "nav2_navfn_planner/NavfnPlanner"
       tolerance: 0.5
-      use_astar: false
-      allow_unknown: true
+      use_astar: False
+      allow_unknown: True
 
 planner_server_rclcpp_node:
   ros__parameters:

--- a/nav2_system_tests/src/costmap_filters/test_keepout_launch.py
+++ b/nav2_system_tests/src/costmap_filters/test_keepout_launch.py
@@ -23,6 +23,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess, IncludeLaunchDescription, SetEnvironmentVariable
+from launch.launch_context import LaunchContext
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 from launch_testing.legacy import LaunchTestService
@@ -54,6 +55,8 @@ def generate_launch_description():
         param_rewrites=param_substitutions,
         convert_types=True)
 
+    context = LaunchContext()
+    new_yaml = configured_params.perform(context)
     return LaunchDescription([
         SetEnvironmentVariable('RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1'),
 
@@ -91,14 +94,14 @@ def generate_launch_description():
             executable='map_server',
             name='filter_mask_server',
             output='screen',
-            parameters=[configured_params]),
+            parameters=[new_yaml]),
 
         Node(
             package='nav2_map_server',
             executable='costmap_filter_info_server',
             name='costmap_filter_info_server',
             output='screen',
-            parameters=[configured_params]),
+            parameters=[new_yaml]),
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
@@ -107,7 +110,7 @@ def generate_launch_description():
                               'use_namespace': 'False',
                               'map': map_yaml_file,
                               'use_sim_time': 'True',
-                              'params_file': configured_params,
+                              'params_file': new_yaml,
                               'bt_xml_file': bt_navigator_xml,
                               'autostart': 'True'}.items()),
     ])

--- a/nav2_system_tests/src/costmap_filters/test_speed_launch.py
+++ b/nav2_system_tests/src/costmap_filters/test_speed_launch.py
@@ -23,6 +23,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess, IncludeLaunchDescription, SetEnvironmentVariable
+from launch.launch_context import LaunchContext
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 from launch_testing.legacy import LaunchTestService
@@ -52,7 +53,8 @@ def generate_launch_description():
         root_key='',
         param_rewrites=param_substitutions,
         convert_types=True)
-
+    context = LaunchContext()
+    new_yaml = configured_params.perform(context)
     return LaunchDescription([
         SetEnvironmentVariable('RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1'),
 
@@ -90,14 +92,14 @@ def generate_launch_description():
             executable='map_server',
             name='filter_mask_server',
             output='screen',
-            parameters=[configured_params]),
+            parameters=[new_yaml]),
 
         Node(
             package='nav2_map_server',
             executable='costmap_filter_info_server',
             name='costmap_filter_info_server',
             output='screen',
-            parameters=[configured_params]),
+            parameters=[new_yaml]),
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
@@ -106,7 +108,7 @@ def generate_launch_description():
                               'use_namespace': 'False',
                               'map': map_yaml_file,
                               'use_sim_time': 'True',
-                              'params_file': configured_params,
+                              'params_file': new_yaml,
                               'bt_xml_file': bt_navigator_xml,
                               'autostart': 'True'}.items()),
     ])

--- a/nav2_system_tests/src/costmap_filters/tester_node.py
+++ b/nav2_system_tests/src/costmap_filters/tester_node.py
@@ -96,14 +96,14 @@ class NavTester(Node):
         self.goal_pub = self.create_publisher(PoseStamped, 'goal_pose', 10)
 
         transient_local_qos = QoSProfile(
-          durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
-          reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-          history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+          durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+          reliability=QoSReliabilityPolicy.RELIABLE,
+          history=QoSHistoryPolicy.KEEP_LAST,
           depth=1)
 
         volatile_qos = QoSProfile(
           durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_VOLATILE,
-          reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+          reliability=QoSReliabilityPolicy.RELIABLE,
           history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
           depth=1)
 

--- a/nav2_system_tests/src/system/CMakeLists.txt
+++ b/nav2_system_tests/src/system/CMakeLists.txt
@@ -1,6 +1,3 @@
-# NOTE: The ASTAR=True does not work currently due to remapping not functioning
-# All set to false, A* testing of NavFn happens in the planning test portion
-
 ament_add_test(test_bt_navigator
   GENERATE_RESULT_FOR_RETURN_CODE_ZERO
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_system_launch.py"

--- a/nav2_system_tests/src/system/tester_node.py
+++ b/nav2_system_tests/src/system/tester_node.py
@@ -54,9 +54,9 @@ class NavTester(Node):
         self.goal_pub = self.create_publisher(PoseStamped, 'goal_pose', 10)
 
         pose_qos = QoSProfile(
-          durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
-          reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-          history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+          durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+          reliability=QoSReliabilityPolicy.RELIABLE,
+          history=QoSHistoryPolicy.KEEP_LAST,
           depth=1)
 
         self.model_pose_sub = self.create_subscription(PoseWithCovarianceStamped,

--- a/nav2_system_tests/src/system_failure/test_system_failure_launch.py
+++ b/nav2_system_tests/src/system_failure/test_system_failure_launch.py
@@ -23,6 +23,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess, IncludeLaunchDescription, SetEnvironmentVariable
+from launch.launch_context import LaunchContext
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 from launch_testing.legacy import LaunchTestService
@@ -50,6 +51,8 @@ def generate_launch_description():
         param_rewrites=param_substitutions,
         convert_types=True)
 
+    context = LaunchContext()
+    new_yaml = configured_params.perform(context)
     return LaunchDescription([
         SetEnvironmentVariable('RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1'),
 
@@ -80,7 +83,7 @@ def generate_launch_description():
                               'use_namespace': 'False',
                               'map': map_yaml_file,
                               'use_sim_time': 'True',
-                              'params_file': configured_params,
+                              'params_file': new_yaml,
                               'bt_xml_file': bt_navigator_xml,
                               'autostart': 'True'}.items()),
     ])

--- a/nav2_system_tests/src/system_failure/tester_node.py
+++ b/nav2_system_tests/src/system_failure/tester_node.py
@@ -50,9 +50,9 @@ class NavTester(Node):
         self.goal_pub = self.create_publisher(PoseStamped, 'goal_pose', 10)
 
         pose_qos = QoSProfile(
-          durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
-          reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-          history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+          durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+          reliability=QoSReliabilityPolicy.RELIABLE,
+          history=QoSHistoryPolicy.KEEP_LAST,
           depth=1)
 
         self.model_pose_sub = self.create_subscription(PoseWithCovarianceStamped,

--- a/nav2_system_tests/src/waypoint_follower/test_case_py.launch
+++ b/nav2_system_tests/src/waypoint_follower/test_case_py.launch
@@ -21,6 +21,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess, IncludeLaunchDescription, SetEnvironmentVariable
+from launch.launch_context import LaunchContext
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 from launch_testing.legacy import LaunchTestService
@@ -46,6 +47,8 @@ def generate_launch_description():
         param_rewrites='',
         convert_types=True)
 
+    context = LaunchContext()
+    new_yaml = configured_params.perform(context)
     return LaunchDescription([
         SetEnvironmentVariable('RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1'),
 
@@ -75,7 +78,7 @@ def generate_launch_description():
             launch_arguments={
                               'map': map_yaml_file,
                               'use_sim_time': 'True',
-                              'params_file': configured_params,
+                              'params_file': new_yaml,
                               'bt_xml_file': bt_navigator_xml,
                               'autostart': 'True'}.items()),
     ])

--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -40,9 +40,9 @@ class WaypointFollowerTest(Node):
         self.goal_handle = None
 
         pose_qos = QoSProfile(
-          durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
-          reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-          history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+          durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+          reliability=QoSReliabilityPolicy.RELIABLE,
+          history=QoSHistoryPolicy.KEEP_LAST,
           depth=1)
 
         self.model_pose_sub = self.create_subscription(PoseWithCovarianceStamped,

--- a/nav2_system_tests/worlds/turtlebot3_ros2_demo.world
+++ b/nav2_system_tests/worlds/turtlebot3_ros2_demo.world
@@ -137,6 +137,7 @@
             </linear_acceleration>
           </imu>
           <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
+            <initial_orientation_as_reference>true</initial_orientation_as_reference>
             <ros>
               <!-- <namespace>/tb3</namespace> -->
               <remapping>~/out:=imu</remapping>

--- a/nav2_system_tests/worlds/turtlebot3_ros2_demo.world
+++ b/nav2_system_tests/worlds/turtlebot3_ros2_demo.world
@@ -137,7 +137,7 @@
             </linear_acceleration>
           </imu>
           <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
-            <initial_orientation_as_reference>true</initial_orientation_as_reference>
+            <initial_orientation_as_reference>false</initial_orientation_as_reference>
             <ros>
               <!-- <namespace>/tb3</namespace> -->
               <remapping>~/out:=imu</remapping>

--- a/nav2_system_tests/worlds/turtlebot3_ros2_demo_obstacle.world
+++ b/nav2_system_tests/worlds/turtlebot3_ros2_demo_obstacle.world
@@ -137,6 +137,7 @@
             </linear_acceleration>
           </imu>
           <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
+            <initial_orientation_as_reference>true</initial_orientation_as_reference>
             <ros>
               <!-- <namespace>/tb3</namespace> -->
               <remapping>~/out:=imu</remapping>

--- a/nav2_system_tests/worlds/turtlebot3_ros2_demo_obstacle.world
+++ b/nav2_system_tests/worlds/turtlebot3_ros2_demo_obstacle.world
@@ -137,7 +137,7 @@
             </linear_acceleration>
           </imu>
           <plugin name="my_imu_plugin" filename="libgazebo_ros_imu_sensor.so">
-            <initial_orientation_as_reference>true</initial_orientation_as_reference>
+            <initial_orientation_as_reference>false</initial_orientation_as_reference>
             <ros>
               <!-- <namespace>/tb3</namespace> -->
               <remapping>~/out:=imu</remapping>


### PR DESCRIPTION
Performing context updates on parameters  probably (?) causing `Original error: parameter 'GridBased.use_astar' has invalid type: expected [bool] got [string]`. 

Updating warning that occasionally crashes test on rclpy QoS updates

Adding some context in service publisher timeouts

Future:
- Switch to cyclone in CI?
- debug gazebo crashes
- rcl lifecycle / rcl rmw crash debugging with eprosima
- gazebo gzserver rather than the .so file call
