### PR TITLE
Improve NavigationToPose action feedback

### DIFF
--- a/nav2_bringup/bringup/launch/tb3_simulation_launch.py
+++ b/nav2_bringup/bringup/launch/tb3_simulation_launch.py
@@ -76,7 +76,8 @@ def generate_launch_description():
 
     declare_map_yaml_cmd = DeclareLaunchArgument(
         'map',
-        default_value=os.path.join(bringup_dir, 'maps', 'turtlebot3_world.yaml'),
+        default_value=os.path.join(
+            bringup_dir, 'maps', 'turtlebot3_world.yaml'),
         description='Full path to map file to load')
 
     declare_use_sim_time_cmd = DeclareLaunchArgument(
@@ -102,7 +103,8 @@ def generate_launch_description():
 
     declare_rviz_config_file_cmd = DeclareLaunchArgument(
         'rviz_config_file',
-        default_value=os.path.join(bringup_dir, 'rviz', 'nav2_default_view.rviz'),
+        default_value=os.path.join(
+            bringup_dir, 'rviz', 'nav2_default_view.rviz'),
         description='Full path to the RVIZ config file to use')
 
     declare_use_simulator_cmd = DeclareLaunchArgument(
@@ -141,7 +143,8 @@ def generate_launch_description():
         cwd=[launch_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(PythonExpression([use_simulator, ' and not ', headless])),
+        condition=IfCondition(PythonExpression(
+            [use_simulator, ' and not ', headless])),
         cmd=['gzclient'],
         cwd=[launch_dir], output='screen')
 
@@ -159,14 +162,16 @@ def generate_launch_description():
         arguments=[urdf])
 
     rviz_cmd = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(os.path.join(launch_dir, 'rviz_launch.py')),
+        PythonLaunchDescriptionSource(
+            os.path.join(launch_dir, 'rviz_launch.py')),
         condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False',
                           'rviz_config': rviz_config_file}.items())
 
     bringup_cmd = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(os.path.join(launch_dir, 'bringup_launch.py')),
+        PythonLaunchDescriptionSource(
+            os.path.join(launch_dir, 'bringup_launch.py')),
         launch_arguments={'namespace': namespace,
                           'use_namespace': use_namespace,
                           'slam': slam,

--- a/nav2_bringup/bringup/launch/tb3_simulation_launch.py
+++ b/nav2_bringup/bringup/launch/tb3_simulation_launch.py
@@ -76,8 +76,7 @@ def generate_launch_description():
 
     declare_map_yaml_cmd = DeclareLaunchArgument(
         'map',
-        default_value=os.path.join(
-            bringup_dir, 'maps', 'turtlebot3_world.yaml'),
+        default_value=os.path.join(bringup_dir, 'maps', 'turtlebot3_world.yaml'),
         description='Full path to map file to load')
 
     declare_use_sim_time_cmd = DeclareLaunchArgument(
@@ -103,8 +102,7 @@ def generate_launch_description():
 
     declare_rviz_config_file_cmd = DeclareLaunchArgument(
         'rviz_config_file',
-        default_value=os.path.join(
-            bringup_dir, 'rviz', 'nav2_default_view.rviz'),
+        default_value=os.path.join(bringup_dir, 'rviz', 'nav2_default_view.rviz'),
         description='Full path to the RVIZ config file to use')
 
     declare_use_simulator_cmd = DeclareLaunchArgument(
@@ -143,8 +141,7 @@ def generate_launch_description():
         cwd=[launch_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(PythonExpression(
-            [use_simulator, ' and not ', headless])),
+        condition=IfCondition(PythonExpression([use_simulator, ' and not ', headless])),
         cmd=['gzclient'],
         cwd=[launch_dir], output='screen')
 
@@ -162,16 +159,14 @@ def generate_launch_description():
         arguments=[urdf])
 
     rviz_cmd = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(launch_dir, 'rviz_launch.py')),
+        PythonLaunchDescriptionSource(os.path.join(launch_dir, 'rviz_launch.py')),
         condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False',
                           'rviz_config': rviz_config_file}.items())
 
     bringup_cmd = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(launch_dir, 'bringup_launch.py')),
+        PythonLaunchDescriptionSource(os.path.join(launch_dir, 'bringup_launch.py')),
         launch_arguments={'namespace': namespace,
                           'use_namespace': use_namespace,
                           'slam': slam,

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -147,7 +147,7 @@ protected:
   // Metrics for feedback
   rclcpp::Time start_time_;
   double current_linear_speed_;
-  rclcpp::Duration estimated_navigation_time_remaining_;
+  rclcpp::Duration estimated_time_remaining_;
   std::string robot_frame_;
   std::string global_frame_;
   double transform_tolerance_;

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -146,8 +146,6 @@ protected:
 
   // Metrics for feedback
   rclcpp::Time start_time_;
-  double current_linear_speed_;
-  rclcpp::Duration estimated_time_remaining_;
   std::string robot_frame_;
   std::string global_frame_;
   double transform_tolerance_;

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -24,6 +24,7 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_msgs/action/navigate_to_pose.hpp"
 #include "nav_msgs/msg/path.hpp"
+#include "nav2_util/odometry_utils.hpp"
 #include "nav2_util/simple_action_server.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "tf2_ros/transform_listener.h"
@@ -130,6 +131,9 @@ protected:
   // Libraries to pull plugins (BT Nodes) from
   std::vector<std::string> plugin_lib_names_;
 
+  // Odometry smoother object
+  std::unique_ptr<nav2_util::OdomSmoother> odom_smoother_;
+
   // A client that we'll use to send a command message to our own task server
   rclcpp_action::Client<Action>::SharedPtr self_client_;
 
@@ -142,6 +146,8 @@ protected:
 
   // Metrics for feedback
   rclcpp::Time start_time_;
+  double current_linear_speed_;
+  rclcpp::Duration estimated_navigation_time_remaining_;
   std::string robot_frame_;
   std::string global_frame_;
   double transform_tolerance_;

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -34,7 +34,7 @@ BtNavigator::BtNavigator()
 : nav2_util::LifecycleNode("bt_navigator", "", false),
   start_time_(0),
   current_linear_speed_(0.0),
-  estimated_navigation_time_remaining_(rclcpp::Duration::from_seconds(0.0))
+  estimated_time_remaining_(rclcpp::Duration::from_seconds(0.0))
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
@@ -289,14 +289,14 @@ BtNavigator::navigateToPose()
         nav2_util::geometry_utils::calculate_path_length(current_path);
 
       if (distance_remaining <= transform_tolerance_) {
-        estimated_navigation_time_remaining_ = rclcpp::Duration::from_seconds(0.0);
+        estimated_time_remaining_ = rclcpp::Duration::from_seconds(0.0);
       } else {
         // Get current speed
         current_linear_speed_ = odom_smoother_->getTwist().linear.x;
 
-        // Calculate estimated time taken to goal if speed is higher than 1mm/s
-        if (std::abs(current_linear_speed_) > 0.05) {
-          estimated_navigation_time_remaining_ =
+        // Calculate estimated time taken to goal if speed is higher than 5mm/s
+        if (std::abs(current_linear_speed_) > 0.005) {
+          estimated_time_remaining_ =
             rclcpp::Duration::from_seconds(distance_remaining / std::abs(current_linear_speed_));
         }
       }
@@ -304,7 +304,7 @@ BtNavigator::navigateToPose()
       int recovery_count = 0;
       blackboard_->get<int>("number_recoveries", recovery_count);
       feedback_msg->distance_remaining = distance_remaining;
-      feedback_msg->estimated_navigation_time_remaining = estimated_navigation_time_remaining_;
+      feedback_msg->estimated_time_remaining = estimated_time_remaining_;
       feedback_msg->number_of_recoveries = recovery_count;
       feedback_msg->navigation_time = now() - start_time_;
       action_server_->publish_feedback(feedback_msg);

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -22,7 +22,7 @@
 #include <vector>
 #include <set>
 
-#include "nav2_util/geometry_utils.hpp"
+// #include "nav2_util/geometry_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
 #include "nav2_behavior_tree/bt_conversions.hpp"
 #include "nav2_bt_navigator/ros_topic_logger.hpp"
@@ -104,7 +104,7 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
     "goal_pose",
     rclcpp::SystemDefaultsQoS(),
     std::bind(&BtNavigator::onGoalPoseReceived, this, std::placeholders::_1));
-  
+
   // Odometry smoother object for getting current speed
   odom_smoother_ = std::make_unique<nav2_util::OdomSmoother>(client_node_, 0.3);
 
@@ -285,20 +285,17 @@ BtNavigator::navigateToPose()
       blackboard_->get("path", current_path);
 
       // Calculate distance on the path
-      double distance_remaining = nav2_util::geometry_utils::calculate_distance_to_goal(current_path);
+      double distance_remaining =
+        nav2_util::geometry_utils::calculate_distance_to_goal(current_path);
 
-      if (distance_remaining <= transform_tolerance_)
-      {
+      if (distance_remaining <= transform_tolerance_) {
         estimated_navigation_time_remaining_ = rclcpp::Duration::from_seconds(0.0);
-      } 
-      else
-      {
+      } else {
         // Get current speed
         current_linear_speed_ = odom_smoother_->getTwist().linear.x;
 
         // Calculate estimated time taken to goal if speed is higher than 1mm/s
-        if (std::abs(current_linear_speed_) > 0.05)
-        {
+        if (std::abs(current_linear_speed_) > 0.05) {
           estimated_navigation_time_remaining_ =
             rclcpp::Duration::from_seconds(distance_remaining / std::abs(current_linear_speed_));
         }

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -275,8 +275,22 @@ BtNavigator::navigateToPose()
       geometry_msgs::msg::PoseStamped goal_pose;
       blackboard_->get("goal", goal_pose);
 
+      // Get current path points
+      nav_msgs::msg::Path current_path;
+      blackboard_->get("path", current_path);
+
+      // Calculate distance on the path
+
+      // Get current speed
+
+      // Calculate estimated time taken to goal
+
+      // TODO (Deepak): Update this to add path distance computation
       feedback_msg->distance_remaining = nav2_util::geometry_utils::euclidean_distance(
         feedback_msg->current_pose.pose, goal_pose.pose);
+
+      // feedback_msg->estimated_navigation_time_remaining = nav2_util::geometry_utils::
+      //   estimate_navigation_time_remaining(distance, current_velocity);
 
       int recovery_count = 0;
       blackboard_->get<int>("number_recoveries", recovery_count);

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -22,7 +22,7 @@
 #include <vector>
 #include <set>
 
-// #include "nav2_util/geometry_utils.hpp"
+#include "nav2_util/geometry_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
 #include "nav2_behavior_tree/bt_conversions.hpp"
 #include "nav2_bt_navigator/ros_topic_logger.hpp"
@@ -286,7 +286,7 @@ BtNavigator::navigateToPose()
 
       // Calculate distance on the path
       double distance_remaining =
-        nav2_util::geometry_utils::calculate_distance_to_goal(current_path);
+        nav2_util::geometry_utils::calculate_path_length(current_path);
 
       if (distance_remaining <= transform_tolerance_) {
         estimated_navigation_time_remaining_ = rclcpp::Duration::from_seconds(0.0);

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -32,9 +32,7 @@ namespace nav2_bt_navigator
 
 BtNavigator::BtNavigator()
 : nav2_util::LifecycleNode("bt_navigator", "", false),
-  start_time_(0),
-  current_linear_speed_(0.0),
-  estimated_time_remaining_(rclcpp::Duration::from_seconds(0.0))
+  start_time_(0)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
@@ -290,42 +288,40 @@ BtNavigator::navigateToPose()
         [&current_pose, &current_path]() {
           size_t closest_pose_idx = 0;
           double curr_min_dist = std::numeric_limits<double>::max();
-          for (auto curr_it = current_path.poses.begin(); curr_it != current_path.poses.end(); ++curr_it) {
-            double curr_dist = nav2_util::geometry_utils::euclidean_distance(current_pose, *curr_it);
+          for (size_t curr_idx = 0; curr_idx < current_path.poses.size(); ++curr_idx) {
+            double curr_dist = nav2_util::geometry_utils::euclidean_distance(
+              current_pose, current_path.poses[curr_idx]);
             if (curr_dist < curr_min_dist) {
               curr_min_dist = curr_dist;
-              closest_pose_idx = curr_it - current_path.poses.begin();
+              closest_pose_idx = curr_idx;
             }
           }
           return closest_pose_idx;
         };
 
-      size_t closest_pose_idx = find_closest_pose_idx();
-
       // Calculate distance on the path
       double distance_remaining =
-        nav2_util::geometry_utils::calculate_path_length(current_path, closest_pose_idx);
+        nav2_util::geometry_utils::calculate_path_length(current_path, find_closest_pose_idx());
 
-      if (distance_remaining <= transform_tolerance_) {
-        estimated_time_remaining_ = rclcpp::Duration::from_seconds(0.0);
-      } else {
-        // Get current speed
-        geometry_msgs::msg::Twist current_odom = odom_smoother_->getTwist();
-        current_linear_speed_ = hypot(current_odom.linear.x, current_odom.linear.y);
+      // Default value for time remaining
+      rclcpp::Duration estimated_time_remaining = rclcpp::Duration::from_seconds(0.0);
 
-        // Calculate estimated time taken to goal if speed is higher than 1cm/s 
-        // and at least 10cm to go
-        if ((std::abs(current_linear_speed_) > 0.01) && (distance_remaining > 0.1)) {
-          estimated_time_remaining_ =
-            rclcpp::Duration::from_seconds(distance_remaining / std::abs(current_linear_speed_));
-        }
+      // Get current speed
+      geometry_msgs::msg::Twist current_odom = odom_smoother_->getTwist();
+      double current_linear_speed = hypot(current_odom.linear.x, current_odom.linear.y);
+
+      // Calculate estimated time taken to goal if speed is higher than 1cm/s 
+      // and at least 10cm to go
+      if ((std::abs(current_linear_speed) > 0.01) && (distance_remaining > 0.1)) {
+        estimated_time_remaining =
+          rclcpp::Duration::from_seconds(distance_remaining / std::abs(current_linear_speed));
       }
 
       int recovery_count = 0;
       feedback_msg->current_pose = current_pose;
       blackboard_->get<int>("number_recoveries", recovery_count);
       feedback_msg->distance_remaining = distance_remaining;
-      feedback_msg->estimated_time_remaining = estimated_time_remaining_;
+      feedback_msg->estimated_time_remaining = estimated_time_remaining;
       feedback_msg->number_of_recoveries = recovery_count;
       feedback_msg->navigation_time = now() - start_time_;
       action_server_->publish_feedback(feedback_msg);

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -21,7 +21,6 @@
 #include <utility>
 #include <vector>
 #include <set>
-#include <cmath>
 
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
@@ -305,12 +304,6 @@ BtNavigator::navigateToPose()
         }
       }
 
-      std::cout << "=============== Current stats ================" << std::endl
-      << "Distance remaining: " << feedback_msg->distance_remaining << std::endl
-      << "Speed: " << current_linear_speed_ << std::endl
-      << "Time remaining: " << estimated_navigation_time_remaining_.seconds() << "." <<
-      estimated_navigation_time_remaining_.nanoseconds() << std::endl;
-
       int recovery_count = 0;
       blackboard_->get<int>("number_recoveries", recovery_count);
       feedback_msg->distance_remaining = distance_remaining;
@@ -368,6 +361,5 @@ BtNavigator::onGoalPoseReceived(const geometry_msgs::msg::PoseStamped::SharedPtr
   goal.pose = *pose;
   self_client_->async_send_goal(goal);
 }
-
 
 }  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 #include <set>
+#include <limits>
 
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
@@ -284,7 +285,7 @@ BtNavigator::navigateToPose()
       blackboard_->get("path", current_path);
 
       // Find the closest pose to current pose on global path
-      auto find_closest_pose_idx = 
+      auto find_closest_pose_idx =
         [&current_pose, &current_path]() {
           size_t closest_pose_idx = 0;
           double curr_min_dist = std::numeric_limits<double>::max();
@@ -310,7 +311,7 @@ BtNavigator::navigateToPose()
       geometry_msgs::msg::Twist current_odom = odom_smoother_->getTwist();
       double current_linear_speed = hypot(current_odom.linear.x, current_odom.linear.y);
 
-      // Calculate estimated time taken to goal if speed is higher than 1cm/s 
+      // Calculate estimated time taken to goal if speed is higher than 1cm/s
       // and at least 10cm to go
       if ((std::abs(current_linear_speed) > 0.01) && (distance_remaining > 0.1)) {
         estimated_time_remaining =

--- a/nav2_msgs/action/NavigateToPose.action
+++ b/nav2_msgs/action/NavigateToPose.action
@@ -7,6 +7,6 @@ std_msgs/Empty result
 ---
 geometry_msgs/PoseStamped current_pose
 builtin_interfaces/Duration navigation_time
-builtin_interfaces/Duration estimated_navigation_time_remaining
+builtin_interfaces/Duration estimated_time_remaining
 int16 number_of_recoveries
 float32 distance_remaining

--- a/nav2_msgs/action/NavigateToPose.action
+++ b/nav2_msgs/action/NavigateToPose.action
@@ -7,5 +7,6 @@ std_msgs/Empty result
 ---
 geometry_msgs/PoseStamped current_pose
 builtin_interfaces/Duration navigation_time
+builtin_interfaces/Duration estimated_navigation_time_remaining
 int16 number_of_recoveries
 float32 distance_remaining

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -63,7 +63,7 @@ inline double euclidean_distance(
   return euclidean_distance(pos1.pose, pos2.pose);
 }
 
-double calculate_distance_to_goal(const nav_msgs::msg::Path & path)
+inline double calculate_path_length(const nav_msgs::msg::Path & path)
 {
   double path_length = 0.0;
   for (size_t idx = 0; idx < path.poses.size() - 1; ++idx) {

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -63,11 +63,10 @@ inline double euclidean_distance(
   return euclidean_distance(pos1.pose, pos2.pose);
 }
 
-double calculate_distance_to_goal(const nav_msgs::msg::Path& path)
+double calculate_distance_to_goal(const nav_msgs::msg::Path & path)
 {
   double path_length = 0.0;
-  for (size_t idx = 0; idx < path.poses.size() - 1; ++idx)
-  {
+  for (size_t idx = 0; idx < path.poses.size() - 1; ++idx) {
     path_length += euclidean_distance(path.poses[idx].pose, path.poses[idx + 1].pose);
   }
   return path_length;

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -73,7 +73,6 @@ inline double calculate_distance_to_goal(const nav_msgs::msg::Path& path)
   return path_length;
 }
 
-
 }  // namespace geometry_utils
 }  // namespace nav2_util
 

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -63,7 +63,7 @@ inline double euclidean_distance(
   return euclidean_distance(pos1.pose, pos2.pose);
 }
 
-inline double calculate_distance_to_goal(const nav_msgs::msg::Path& path)
+double calculate_distance_to_goal(const nav_msgs::msg::Path& path)
 {
   double path_length = 0.0;
   for (size_t idx = 0; idx < path.poses.size() - 1; ++idx)

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -22,6 +22,7 @@
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "nav_msgs/msg/path.hpp"
 
 namespace nav2_util
 {
@@ -61,6 +62,17 @@ inline double euclidean_distance(
 {
   return euclidean_distance(pos1.pose, pos2.pose);
 }
+
+inline double calculate_distance_to_goal(const nav_msgs::msg::Path& path)
+{
+  double path_length = 0.0;
+  for (size_t idx = 0; idx < path.poses.size() - 1; ++idx)
+  {
+    path_length += euclidean_distance(path.poses[idx].pose, path.poses[idx + 1].pose);
+  }
+  return path_length;
+}
+
 
 }  // namespace geometry_utils
 }  // namespace nav2_util

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -63,10 +63,13 @@ inline double euclidean_distance(
   return euclidean_distance(pos1.pose, pos2.pose);
 }
 
-inline double calculate_path_length(const nav_msgs::msg::Path & path)
+inline double calculate_path_length(const nav_msgs::msg::Path & path, size_t start_index)
 {
+  if (start_index >= path.poses.size() - 1) {
+    return 0.0;
+  }
   double path_length = 0.0;
-  for (size_t idx = 0; idx < path.poses.size() - 1; ++idx) {
+  for (size_t idx = start_index; idx < path.poses.size() - 1; ++idx) {
     path_length += euclidean_distance(path.poses[idx].pose, path.poses[idx + 1].pose);
   }
   return path_length;

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -63,7 +63,7 @@ inline double euclidean_distance(
   return euclidean_distance(pos1.pose, pos2.pose);
 }
 
-inline double calculate_path_length(const nav_msgs::msg::Path & path, size_t start_index)
+inline double calculate_path_length(const nav_msgs::msg::Path & path, size_t start_index = 0)
 {
   if (start_index >= path.poses.size() - 1) {
     return 0.0;

--- a/nav2_util/test/test_geometry_utils.cpp
+++ b/nav2_util/test/test_geometry_utils.cpp
@@ -16,9 +16,11 @@
 #include "nav2_util/geometry_utils.hpp"
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/pose.hpp"
+#include "nav_msgs/msg/path.hpp"
 #include "gtest/gtest.h"
 
 using nav2_util::geometry_utils::euclidean_distance;
+using nav2_util::geometry_utils::calculate_distance_to_goal;
 
 TEST(GeometryUtils, euclidean_distance_point)
 {
@@ -48,4 +50,24 @@ TEST(GeometryUtils, euclidean_distance_pose)
   pose2.position.z = 2.0;
 
   ASSERT_NEAR(euclidean_distance(pose1, pose2), 10.24695, 1e-5);
+}
+
+TEST(GeometryUtils, calculate_distance_to_goal)
+{
+  nav_msgs::msg::Path straight_line_path;
+  size_t nb_path_points = 10;
+  float distance_between_poses = 2.0;
+  float current_x_loc = 0.0;
+
+  for (size_t i = 0; i < nb_path_points; ++i) {
+    geometry_msgs::msg::PoseStamped pose_stamped_msg;
+    pose_stamped_msg.pose.position.x = current_x_loc;
+
+    straight_line_path.poses.push_back(pose_stamped_msg);
+
+    current_x_loc += distance_between_poses;
+  }
+
+  ASSERT_NEAR(calculate_distance_to_goal(straight_line_path),
+    (nb_path_points - 1) * distance_between_poses, 1e-5);
 }

--- a/nav2_util/test/test_geometry_utils.cpp
+++ b/nav2_util/test/test_geometry_utils.cpp
@@ -69,7 +69,7 @@ TEST(GeometryUtils, calculate_path_length)
   }
 
   ASSERT_NEAR(
-    calculate_path_length(straight_line_path, 0),
+    calculate_path_length(straight_line_path),
     (nb_path_points - 1) * distance_between_poses, 1e-5);
 
   ASSERT_NEAR(
@@ -95,6 +95,6 @@ TEST(GeometryUtils, calculate_path_length)
   }
 
   ASSERT_NEAR(
-    calculate_path_length(circle_path, 0),
+    calculate_path_length(circle_path),
     2 * pi * polar_distance, 1e-1);
 }

--- a/nav2_util/test/test_geometry_utils.cpp
+++ b/nav2_util/test/test_geometry_utils.cpp
@@ -20,7 +20,7 @@
 #include "gtest/gtest.h"
 
 using nav2_util::geometry_utils::euclidean_distance;
-using nav2_util::geometry_utils::calculate_distance_to_goal;
+using nav2_util::geometry_utils::calculate_path_length;
 
 TEST(GeometryUtils, euclidean_distance_point)
 {
@@ -52,7 +52,7 @@ TEST(GeometryUtils, euclidean_distance_pose)
   ASSERT_NEAR(euclidean_distance(pose1, pose2), 10.24695, 1e-5);
 }
 
-TEST(GeometryUtils, calculate_distance_to_goal)
+TEST(GeometryUtils, calculate_path_length)
 {
   nav_msgs::msg::Path straight_line_path;
   size_t nb_path_points = 10;
@@ -68,6 +68,7 @@ TEST(GeometryUtils, calculate_distance_to_goal)
     current_x_loc += distance_between_poses;
   }
 
-  ASSERT_NEAR(calculate_distance_to_goal(straight_line_path),
+  ASSERT_NEAR(
+    calculate_path_length(straight_line_path),
     (nb_path_points - 1) * distance_between_poses, 1e-5);
 }

--- a/nav2_util/test/test_geometry_utils.cpp
+++ b/nav2_util/test/test_geometry_utils.cpp
@@ -71,4 +71,26 @@ TEST(GeometryUtils, calculate_path_length)
   ASSERT_NEAR(
     calculate_path_length(straight_line_path),
     (nb_path_points - 1) * distance_between_poses, 1e-5);
+
+  nav_msgs::msg::Path circle_path;
+  float polar_distance = 2.0;
+  uint32_t current_polar_angle_deg = 0;
+  constexpr float pi = 3.14159265358979;
+
+  while (current_polar_angle_deg != 360) {
+    float x_loc = polar_distance * std::cos(current_polar_angle_deg * (pi / 180.0));
+    float y_loc = polar_distance * std::sin(current_polar_angle_deg * (pi / 180.0));
+
+    geometry_msgs::msg::PoseStamped pose_stamped_msg;
+    pose_stamped_msg.pose.position.x = x_loc;
+    pose_stamped_msg.pose.position.y = y_loc;
+
+    circle_path.poses.push_back(pose_stamped_msg);
+
+    current_polar_angle_deg += 1;
+  }
+
+  ASSERT_NEAR(
+    calculate_path_length(circle_path),
+    2 * pi * polar_distance, 1e-1);
 }

--- a/nav2_util/test/test_geometry_utils.cpp
+++ b/nav2_util/test/test_geometry_utils.cpp
@@ -69,8 +69,12 @@ TEST(GeometryUtils, calculate_path_length)
   }
 
   ASSERT_NEAR(
-    calculate_path_length(straight_line_path),
+    calculate_path_length(straight_line_path, 0),
     (nb_path_points - 1) * distance_between_poses, 1e-5);
+
+  ASSERT_NEAR(
+    calculate_path_length(straight_line_path, straight_line_path.poses.size()),
+    0.0, 1e-5);
 
   nav_msgs::msg::Path circle_path;
   float polar_distance = 2.0;
@@ -91,6 +95,6 @@ TEST(GeometryUtils, calculate_path_length)
   }
 
   ASSERT_NEAR(
-    calculate_path_length(circle_path),
+    calculate_path_length(circle_path, 0),
     2 * pi * polar_distance, 1e-1);
 }


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |#2154 |
| Primary OS tested on |Ubuntu 20.04 |
| Robotic platform tested on | Gazebo Simulation of Turtlebot3 |

---

## Description of contribution in a few bullet points

* Improves feedback of the `NavigateToPose` action server by adding:
    - Better distance to goal estimate: by integrating distance between planned path poses.
    - Estimated time remaining: by dividing the distance remaining by current robot linear speed (using smoothed odometry).
* Updates the feedback in `.action` file for `NavigateToPose` action server. 
* Adds a utility to the `nav2_util::geometry_utils` to calculate path length.
* Adds simple unit testing for this function.

## Description of documentation updates required from your changes
* Documentation for `.action` needs to be updated.

---

## Future work that may be required in bullet points
* Currently the time remaining largely ignores the target yaw of the robot. It may be the case that the robot needs more time to rotate to the correct heading.

