### PR TITLE
Install test_updown to lib/

### DIFF
--- a/nav2_system_tests/src/updown/CMakeLists.txt
+++ b/nav2_system_tests/src/updown/CMakeLists.txt
@@ -6,6 +6,6 @@ ament_target_dependencies(test_updown
   ${dependencies}
 )
 
-install(TARGETS test_updown RUNTIME DESTINATION share/${PROJECT_NAME})
+install(TARGETS test_updown RUNTIME DESTINATION lib/${PROJECT_NAME})
 install(FILES test_updown_launch.py DESTINATION share/${PROJECT_NAME})
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |https://github.com/ros-planning/navigation2/issues/2200|
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Default test launch |

---

## Description of contribution in a few bullet points

* Fixed installation to `\lib`
