### PR TITLE
Export nav2_bt_navigator library and dependencies

### DIFF
--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -82,5 +82,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-
+ament_export_libraries(${library_name})
+ament_export_dependencies(${dependencies})
 ament_package()


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | |

---

## Description of contribution in a few bullet points
* Export the nav2_bt_navigator library to allow inheritance from it

## Description of documentation updates required from your changes

---

## Future work that may be required in bullet points

