### PR TITLE
If provided param file has no slam_toolbox params, don't forward it

### DIFF
--- a/nav2_bringup/bringup/launch/slam_launch.py
+++ b/nav2_bringup/bringup/launch/slam_launch.py
@@ -18,13 +18,13 @@ from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import (DeclareLaunchArgument, IncludeLaunchDescription,
-                            PushLaunchConfigurations, PopLaunchConfigurations,
+                            PopLaunchConfigurations, PushLaunchConfigurations,
                             UnsetLaunchConfiguration)
 from launch.conditions import UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from nav2_common.launch import RewrittenYaml, HasNodeParams
+from nav2_common.launch import HasNodeParams, RewrittenYaml
 
 
 def generate_launch_description():
@@ -75,7 +75,7 @@ def generate_launch_description():
     # Nodes launching commands
 
     # If the provided param file doesn't have slam_toolbox params, we must remove the 'params_file'
-    # LaunchConfiguration, or it will be passed automatically to slam_toolbox and will not load 
+    # LaunchConfiguration, or it will be passed automatically to slam_toolbox and will not load
     # the default file
     has_slam_toolbox_params = HasNodeParams(source_file=params_file,
                                             node_name='slam_toolbox')
@@ -84,7 +84,7 @@ def generate_launch_description():
             condition=UnlessCondition(has_slam_toolbox_params))
 
     remove_params_file = UnsetLaunchConfiguration(
-            "params_file", condition=UnlessCondition(has_slam_toolbox_params))
+            'params_file', condition=UnlessCondition(has_slam_toolbox_params))
 
     start_slam_toolbox_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(slam_launch_file),

--- a/nav2_common/nav2_common/launch/__init__.py
+++ b/nav2_common/nav2_common/launch/__init__.py
@@ -12,5 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .has_node_params import HasNodeParams
 from .rewritten_yaml import RewrittenYaml
 from .replace_string import ReplaceString

--- a/nav2_common/nav2_common/launch/has_node_params.py
+++ b/nav2_common/nav2_common/launch/has_node_params.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Intel Corporation
+# Copyright (c) 2021 PAL Robotics S.L.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/nav2_common/nav2_common/launch/has_node_params.py
+++ b/nav2_common/nav2_common/launch/has_node_params.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+from typing import Text
+
+import yaml
+import launch
+
+import sys # delete this
+
+class HasNodeParams(launch.Substitution):
+  """
+  Substitution that checks if a param file contains parameters for a node
+
+  Used in launch system
+  """
+
+  def __init__(self,
+    source_file: launch.SomeSubstitutionsType,
+    node_name: Text) -> None:
+    super().__init__()
+    """
+    Construct the substitution
+
+    :param: source_file the parameter YAML file
+    :param: node_name the name of the node to check
+    """
+
+    from launch.utilities import normalize_to_list_of_substitutions  # import here to avoid loop
+    self.__source_file = normalize_to_list_of_substitutions(source_file)
+    self.__node_name = node_name
+
+  @property
+  def name(self) -> List[launch.Substitution]:
+    """Getter for name."""
+    return self.__source_file
+
+  def describe(self) -> Text:
+    """Return a description of this substitution as a string."""
+    return ''
+
+  def perform(self, context: launch.LaunchContext) -> Text:
+    yaml_filename = launch.utilities.perform_substitutions(context, self.name)
+    data = yaml.safe_load(open(yaml_filename, 'r'))
+
+    if self.__node_name in data.keys():
+        return "True"
+    return "False"


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/2196|
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | simulated turtlebot |

---

## Description of contribution in a few bullet points

* After https://github.com/SteveMacenski/slam_toolbox/pull/347 params-file is automatically passed to slam_toolbox, these changes make sure that only happens if the params_file has `slam_toolbox` parameters.
