### PR TITLE
Optional transient map saver

### DIFF
--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -243,6 +243,7 @@ map_saver:
     save_map_timeout: 5000
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65
+    map_subscribe_transient_local: True
 
 planner_server:
   ros__parameters:

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -243,7 +243,7 @@ map_saver:
     save_map_timeout: 5000
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65
-    map_subscribe_transient_local: True
+    map_subscribe_transient_local: False
 
 planner_server:
   ros__parameters:

--- a/nav2_map_server/include/nav2_map_server/map_saver.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_saver.hpp
@@ -103,6 +103,8 @@ protected:
   // Default values for map thresholds
   double free_thresh_default_;
   double occupied_thresh_default_;
+  // param for handling QoS configuration
+  bool map_subscribe_transient_local_;
 
   // The name of the service for saving a map from topic
   const std::string save_map_service_name_{"save_map"};

--- a/nav2_map_server/src/map_saver/map_saver.cpp
+++ b/nav2_map_server/src/map_saver/map_saver.cpp
@@ -50,6 +50,7 @@ MapSaver::MapSaver()
 
   free_thresh_default_ = declare_parameter("free_thresh_default", 0.25),
   occupied_thresh_default_ = declare_parameter("occupied_thresh_default", 0.65);
+  map_subscribe_transient_local_ = declare_parameter("map_subscribe_transient_local", true);
 }
 
 MapSaver::~MapSaver()
@@ -173,8 +174,14 @@ bool MapSaver::saveMapTopicToFile(
     // Add new subscription for incoming map topic.
     // Utilizing local rclcpp::Node (rclcpp_node_) from nav2_util::LifecycleNode
     // as a map listener.
+    rclcpp::QoS map_qos(10);  // initialize to default
+    if (map_subscribe_transient_local_) {
+      map_qos.transient_local();
+      map_qos.reliable();
+      map_qos.keep_last(1);
+    }
     auto map_sub = rclcpp_node_->create_subscription<nav_msgs::msg::OccupancyGrid>(
-      map_topic_loc, rclcpp::SystemDefaultsQoS(), mapCallback);
+      map_topic_loc, map_qos, mapCallback);
 
     rclcpp::Time start_time = now();
     while (rclcpp::ok()) {

--- a/nav2_map_server/src/map_saver/map_saver.cpp
+++ b/nav2_map_server/src/map_saver/map_saver.cpp
@@ -50,7 +50,8 @@ MapSaver::MapSaver()
 
   free_thresh_default_ = declare_parameter("free_thresh_default", 0.25),
   occupied_thresh_default_ = declare_parameter("occupied_thresh_default", 0.65);
-  map_subscribe_transient_local_ = declare_parameter("map_subscribe_transient_local", true);
+  // false only of foxy for backwards compatibility
+  map_subscribe_transient_local_ = declare_parameter("map_subscribe_transient_local", false);
 }
 
 MapSaver::~MapSaver()
@@ -174,8 +175,9 @@ bool MapSaver::saveMapTopicToFile(
     // Add new subscription for incoming map topic.
     // Utilizing local rclcpp::Node (rclcpp_node_) from nav2_util::LifecycleNode
     // as a map listener.
-    rclcpp::QoS map_qos(10);  // initialize to default
+    rclcpp::QoS map_qos = rclcpp::SystemDefaultsQoS();  // initialize to default
     if (map_subscribe_transient_local_) {
+      map_qos = rclcpp::QoS(10);
       map_qos.transient_local();
       map_qos.reliable();
       map_qos.keep_last(1);


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/pull/1871|
| Primary OS tested on | Ubuntu 20.04 |

---

## Description of contribution in a few bullet points

* Same changes as https://github.com/ros-planning/navigation2/pull/1871 but keeping default foxy behavior unless `map_subscribe_transient_local` is set to `true`
* To save the map you have to set the parameter to True via `ros2 run nav2_map_server map_saver_cli -f ~/map --ros-args -p map_subscribe_transient_local:=True`