### PR TITLE
Fix #2186

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -146,7 +146,8 @@ public:
    * @param transformed_pose pose transformed
    * @return True if the pose was transformed successfully, false otherwise
    */
-  bool transformPoseToGlobalFrame(const geometry_msgs::msg::PoseStamped & input_pose,
+  bool transformPoseToGlobalFrame(
+    const geometry_msgs::msg::PoseStamped & input_pose,
     geometry_msgs::msg::PoseStamped & transformed_pose);
 
   /** @brief Returns costmap name */

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -140,6 +140,14 @@ public:
    */
   bool getRobotPose(geometry_msgs::msg::PoseStamped & global_pose);
 
+  /**
+   * @brief Transform the pose in the global frame of the costmap
+   * @param pose will be set to the pose of the robot in the global frame of the costmap
+   * @return True if the pose was transformed successfully, false otherwise
+   */
+
+  bool getPoseInGlobalFrame(geometry_msgs::msg::PoseStamped & pose);
+
   /** @brief Returns costmap name */
   std::string getName() const
   {

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -141,12 +141,13 @@ public:
   bool getRobotPose(geometry_msgs::msg::PoseStamped & global_pose);
 
   /**
-   * @brief Transform the pose in the global frame of the costmap
-   * @param pose will be set to the pose of the robot in the global frame of the costmap
+   * @brief Transform the input_pose in the global frame of the costmap
+   * @param input_pose pose to be transformed
+   * @param transformed_pose pose transformed
    * @return True if the pose was transformed successfully, false otherwise
    */
-
-  bool getPoseInGlobalFrame(geometry_msgs::msg::PoseStamped & pose);
+  bool transformPoseToGlobalFrame(const geometry_msgs::msg::PoseStamped & input_pose,
+    geometry_msgs::msg::PoseStamped & transformed_pose);
 
   /** @brief Returns costmap name */
   std::string getName() const

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -534,4 +534,16 @@ Costmap2DROS::getRobotPose(geometry_msgs::msg::PoseStamped & global_pose)
     global_frame_, robot_base_frame_, transform_tolerance_);
 }
 
+bool
+Costmap2DROS::getPoseInGlobalFrame(geometry_msgs::msg::PoseStamped & pose)
+{
+  if (pose.header.frame_id == global_frame_) {
+    return true;
+  } else {
+    return nav2_util::getPoseInTargetFrame(
+      pose, *tf_buffer_,
+      global_frame_, transform_tolerance_);
+  }
+}
+
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -535,13 +535,15 @@ Costmap2DROS::getRobotPose(geometry_msgs::msg::PoseStamped & global_pose)
 }
 
 bool
-Costmap2DROS::getPoseInGlobalFrame(geometry_msgs::msg::PoseStamped & pose)
+Costmap2DROS::transformPoseToGlobalFrame(const geometry_msgs::msg::PoseStamped & input_pose,
+  geometry_msgs::msg::PoseStamped & transformed_pose)
 {
-  if (pose.header.frame_id == global_frame_) {
+  if (input_pose.header.frame_id == global_frame_) {
+    transformed_pose = input_pose;
     return true;
   } else {
-    return nav2_util::getPoseInTargetFrame(
-      pose, *tf_buffer_,
+    return nav2_util::transformPoseInTargetFrame(
+      input_pose, transformed_pose, *tf_buffer_,
       global_frame_, transform_tolerance_);
   }
 }

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -535,7 +535,8 @@ Costmap2DROS::getRobotPose(geometry_msgs::msg::PoseStamped & global_pose)
 }
 
 bool
-Costmap2DROS::transformPoseToGlobalFrame(const geometry_msgs::msg::PoseStamped & input_pose,
+Costmap2DROS::transformPoseToGlobalFrame(
+  const geometry_msgs::msg::PoseStamped & input_pose,
   geometry_msgs::msg::PoseStamped & transformed_pose)
 {
   if (input_pose.header.frame_id == global_frame_) {

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -244,7 +244,8 @@ PlannerServer::computePlan()
     // Changing the start and goal pose frame to the global_frame_ of costmap_ros_ if needed
     geometry_msgs::msg::PoseStamped goal_pose = goal->goal;
     if (!costmap_ros_->transformPoseToGlobalFrame(start, start) ||
-        !costmap_ros_->transformPoseToGlobalFrame(goal->goal, goal_pose)) {
+      !costmap_ros_->transformPoseToGlobalFrame(goal->goal, goal_pose))
+    {
       RCLCPP_WARN(
         get_logger(), "Could not transform the start or goal pose in the costmap frame");
       action_server_->terminate_current();

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -241,11 +241,21 @@ PlannerServer::computePlan()
       return;
     }
 
+    // Copy needed as goal is const
+    geometry_msgs::msg::PoseStamped goal_pose = goal->goal;
+    if (!costmap_ros_->getPoseInGlobalFrame(start) ||
+        !costmap_ros_->getPoseInGlobalFrame(goal_pose)) {
+      RCLCPP_WARN(
+        get_logger(), "Could not transform the start or goal pose in the costmap frame");
+      action_server_->terminate_current();
+      return;
+    }
+
     if (action_server_->is_preempt_requested()) {
       goal = action_server_->accept_pending_goal();
     }
 
-    result->path = getPlan(start, goal->goal, goal->planner_id);
+    result->path = getPlan(start, goal_pose, goal->planner_id);
 
     if (result->path.poses.size() == 0) {
       RCLCPP_WARN(

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -241,7 +241,7 @@ PlannerServer::computePlan()
       return;
     }
 
-    // Copy needed as goal is const
+    // Changing the start and goal pose frame to the global_frame_ of costmap_ros_ if needed
     geometry_msgs::msg::PoseStamped goal_pose = goal->goal;
     if (!costmap_ros_->getPoseInGlobalFrame(start) ||
         !costmap_ros_->getPoseInGlobalFrame(goal_pose)) {
@@ -261,7 +261,7 @@ PlannerServer::computePlan()
       RCLCPP_WARN(
         get_logger(), "Planning algorithm %s failed to generate a valid"
         " path to (%.2f, %.2f)", goal->planner_id.c_str(),
-        goal->goal.pose.position.x, goal->goal.pose.position.y);
+        goal_pose.pose.position.x, goal_pose.pose.position.y);
       action_server_->terminate_current();
       return;
     }
@@ -269,8 +269,8 @@ PlannerServer::computePlan()
     RCLCPP_DEBUG(
       get_logger(),
       "Found valid path of size %lu to (%.2f, %.2f)",
-      result->path.poses.size(), goal->goal.pose.position.x,
-      goal->goal.pose.position.y);
+      result->path.poses.size(), goal_pose.pose.position.x,
+      goal_pose.pose.position.y);
 
     // Publish the plan for visualization purposes
     publishPlan(result->path);

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -243,8 +243,8 @@ PlannerServer::computePlan()
 
     // Changing the start and goal pose frame to the global_frame_ of costmap_ros_ if needed
     geometry_msgs::msg::PoseStamped goal_pose = goal->goal;
-    if (!costmap_ros_->getPoseInGlobalFrame(start) ||
-        !costmap_ros_->getPoseInGlobalFrame(goal_pose)) {
+    if (!costmap_ros_->transformPoseToGlobalFrame(start, start) ||
+        !costmap_ros_->transformPoseToGlobalFrame(goal->goal, goal_pose)) {
       RCLCPP_WARN(
         get_logger(), "Could not transform the start or goal pose in the costmap frame");
       action_server_->terminate_current();

--- a/nav2_util/include/nav2_util/robot_utils.hpp
+++ b/nav2_util/include/nav2_util/robot_utils.hpp
@@ -36,6 +36,11 @@ bool getCurrentPose(
   tf2_ros::Buffer & tf_buffer, const std::string global_frame = "map",
   const std::string robot_frame = "base_link", const double transform_timeout = 0.1);
 
+bool getPoseInTargetFrame(
+  geometry_msgs::msg::PoseStamped & pose,
+  tf2_ros::Buffer & tf_buffer, const std::string target_frame,
+    const double transform_timeout = 0.1);
+
 }  // end namespace nav2_util
 
 #endif  // NAV2_UTIL__ROBOT_UTILS_HPP_

--- a/nav2_util/include/nav2_util/robot_utils.hpp
+++ b/nav2_util/include/nav2_util/robot_utils.hpp
@@ -36,10 +36,11 @@ bool getCurrentPose(
   tf2_ros::Buffer & tf_buffer, const std::string global_frame = "map",
   const std::string robot_frame = "base_link", const double transform_timeout = 0.1);
 
-bool getPoseInTargetFrame(
-  geometry_msgs::msg::PoseStamped & pose,
+bool transformPoseInTargetFrame(
+  const geometry_msgs::msg::PoseStamped & input_pose,
+  geometry_msgs::msg::PoseStamped & transformed_pose,
   tf2_ros::Buffer & tf_buffer, const std::string target_frame,
-    const double transform_timeout = 0.1);
+  const double transform_timeout = 0.1);
 
 }  // end namespace nav2_util
 

--- a/nav2_util/src/robot_utils.cpp
+++ b/nav2_util/src/robot_utils.cpp
@@ -33,14 +33,14 @@ bool getCurrentPose(
   global_pose.header.stamp = rclcpp::Time();
 
   return transformPoseInTargetFrame(
-        global_pose, global_pose, tf_buffer, global_frame, transform_timeout);
+    global_pose, global_pose, tf_buffer, global_frame, transform_timeout);
 }
 
 bool transformPoseInTargetFrame(
   const geometry_msgs::msg::PoseStamped & input_pose,
   geometry_msgs::msg::PoseStamped & transformed_pose,
   tf2_ros::Buffer & tf_buffer, const std::string target_frame,
-    const double transform_timeout)
+  const double transform_timeout)
 {
   static rclcpp::Logger logger = rclcpp::get_logger("transformPoseInTargetFrame");
 

--- a/nav2_util/src/robot_utils.cpp
+++ b/nav2_util/src/robot_utils.cpp
@@ -32,19 +32,21 @@ bool getCurrentPose(
   global_pose.header.frame_id = robot_frame;
   global_pose.header.stamp = rclcpp::Time();
 
-  return getPoseInTargetFrame(global_pose, tf_buffer, global_frame, transform_timeout);
+  return transformPoseInTargetFrame(
+        global_pose, global_pose, tf_buffer, global_frame, transform_timeout);
 }
 
-bool getPoseInTargetFrame(
-  geometry_msgs::msg::PoseStamped & pose,
+bool transformPoseInTargetFrame(
+  const geometry_msgs::msg::PoseStamped & input_pose,
+  geometry_msgs::msg::PoseStamped & transformed_pose,
   tf2_ros::Buffer & tf_buffer, const std::string target_frame,
     const double transform_timeout)
 {
-  static rclcpp::Logger logger = rclcpp::get_logger("getPoseInTargetFrame");
+  static rclcpp::Logger logger = rclcpp::get_logger("transformPoseInTargetFrame");
 
   try {
-    pose = tf_buffer.transform(
-      pose, target_frame,
+    transformed_pose = tf_buffer.transform(
+      input_pose, target_frame,
       tf2::durationFromSec(transform_timeout));
     return true;
   } catch (tf2::LookupException & ex) {
@@ -66,7 +68,7 @@ bool getPoseInTargetFrame(
   } catch (tf2::TransformException & ex) {
     RCLCPP_ERROR(
       logger, "Failed to transform from %s to %s",
-      pose.header.frame_id.c_str(), target_frame.c_str());
+      input_pose.header.frame_id.c_str(), target_frame.c_str());
   }
 
   return false;

--- a/nav2_util/src/robot_utils.cpp
+++ b/nav2_util/src/robot_utils.cpp
@@ -66,4 +66,41 @@ bool getCurrentPose(
   return false;
 }
 
+bool getPoseInTargetFrame(
+  geometry_msgs::msg::PoseStamped & pose,
+  tf2_ros::Buffer & tf_buffer, const std::string target_frame,
+    const double transform_timeout)
+{
+  static rclcpp::Logger logger = rclcpp::get_logger("getPoseInTargetFrame");
+
+  try {
+    pose = tf_buffer.transform(
+      pose, target_frame,
+      tf2::durationFromSec(transform_timeout));
+    return true;
+  } catch (tf2::LookupException & ex) {
+    RCLCPP_ERROR(
+      logger,
+      "No Transform available Error looking up target frame: %s\n", ex.what());
+  } catch (tf2::ConnectivityException & ex) {
+    RCLCPP_ERROR(
+      logger,
+      "Connectivity Error looking up target frame: %s\n", ex.what());
+  } catch (tf2::ExtrapolationException & ex) {
+    RCLCPP_ERROR(
+      logger,
+      "Extrapolation Error looking up target frame: %s\n", ex.what());
+  } catch (tf2::TimeoutException & ex) {
+    RCLCPP_ERROR(
+      logger,
+      "Transform timeout with tolerance: %.4f", transform_timeout);
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_ERROR(
+      logger, "Failed to transform from %s to %s",
+      pose.header.frame_id.c_str(), target_frame.c_str());
+  }
+
+  return false;
+}
+
 }  // end namespace nav2_util

--- a/nav2_util/src/robot_utils.cpp
+++ b/nav2_util/src/robot_utils.cpp
@@ -28,42 +28,11 @@ bool getCurrentPose(
   tf2_ros::Buffer & tf_buffer, const std::string global_frame,
   const std::string robot_frame, const double transform_timeout)
 {
-  static rclcpp::Logger logger = rclcpp::get_logger("getCurrentPose");
-  geometry_msgs::msg::PoseStamped robot_pose;
-
   tf2::toMsg(tf2::Transform::getIdentity(), global_pose.pose);
-  tf2::toMsg(tf2::Transform::getIdentity(), robot_pose.pose);
-  robot_pose.header.frame_id = robot_frame;
-  robot_pose.header.stamp = rclcpp::Time();
+  global_pose.header.frame_id = robot_frame;
+  global_pose.header.stamp = rclcpp::Time();
 
-  try {
-    global_pose = tf_buffer.transform(
-      robot_pose, global_frame,
-      tf2::durationFromSec(transform_timeout));
-    return true;
-  } catch (tf2::LookupException & ex) {
-    RCLCPP_ERROR(
-      logger,
-      "No Transform available Error looking up robot pose: %s\n", ex.what());
-  } catch (tf2::ConnectivityException & ex) {
-    RCLCPP_ERROR(
-      logger,
-      "Connectivity Error looking up robot pose: %s\n", ex.what());
-  } catch (tf2::ExtrapolationException & ex) {
-    RCLCPP_ERROR(
-      logger,
-      "Extrapolation Error looking up robot pose: %s\n", ex.what());
-  } catch (tf2::TimeoutException & ex) {
-    RCLCPP_ERROR(
-      logger,
-      "Transform timeout with tolerance: %.4f", transform_timeout);
-  } catch (tf2::TransformException & ex) {
-    RCLCPP_ERROR(
-      logger, "Failed to transform from %s to %s",
-      global_frame.c_str(), robot_frame.c_str());
-  }
-
-  return false;
+  return getPoseInTargetFrame(global_pose, tf_buffer, global_frame, transform_timeout);
 }
 
 bool getPoseInTargetFrame(

--- a/nav2_util/test/test_robot_utils.cpp
+++ b/nav2_util/test/test_robot_utils.cpp
@@ -30,5 +30,5 @@ TEST(RobotUtils, LookupExceptionError)
   tf2_ros::Buffer tf(node->get_clock());
   ASSERT_FALSE(nav2_util::getCurrentPose(global_pose, tf, "map", "base_link", 0.1));
   global_pose.header.frame_id = "base_link";
-  ASSERT_FALSE(nav2_util::getPoseInTargetFrame(global_pose, tf, "map", 0.1));
+  ASSERT_FALSE(nav2_util::transformPoseInTargetFrame(global_pose, global_pose, tf, "map", 0.1));
 }

--- a/nav2_util/test/test_robot_utils.cpp
+++ b/nav2_util/test/test_robot_utils.cpp
@@ -29,4 +29,6 @@ TEST(RobotUtils, LookupExceptionError)
   geometry_msgs::msg::PoseStamped global_pose;
   tf2_ros::Buffer tf(node->get_clock());
   ASSERT_FALSE(nav2_util::getCurrentPose(global_pose, tf, "map", "base_link", 0.1));
+  global_pose.header.frame_id = "base_link";
+  ASSERT_FALSE(nav2_util::getPoseInTargetFrame(global_pose, tf, "map", 0.1));
 }


### PR DESCRIPTION
Fix https://github.com/ros-planning/navigation2/issues/2186
Proper PR for a commit that was proposed as part of https://github.com/ros-planning/navigation2/pull/2179
Implementation can be discussed, but I PRed it as the work as been done and for it not to be forgotten and lost.

There is already a `getCurrentPose` fonction in `nav2_utils` that is using tf to transform the `robot_frame` to a target frame (`global_frame`) and convert this transform into a PoseStamped (`global_pose`) with the proper try/catch of `tf2::*Exception`. This function is used for the `getRobotPose` of `costamp_2d_ros` (which provides the tf_buffer). And this `getRobotPose` of `costamp_2d_ros` is already called in the `planner_server` (which owns a `nav2_costmap_2d::Costmap2DROS`).

All I did was to mimick this architecture. I added a `getPoseInTargetFrame` fonction in `nav2_utils` that is using tf to transform the passed PoseStamped `pose` to the `target_frame` in the same way as the `getCurrentPose` fonction. Then I added `getPoseInGlobalFrame` in `costamp_2d_ros` which is using it (and provides the tf_buffer and the target_frame). And finally `getPoseInGlobalFrame` can be called in the `planner_server` to ensure that the pose received from the goal is transformed in the global_frame (aka, most of the time, `map`). 

No unnecessary transform is done if the pose is already in the correct frame.
Tested on a real robot. TBD: proper unit tests (I believe the ones for robot_utils needs to be augmented, none are fully testing `nav2_util::getCurrentPose`)