### PR TITLE
Add getTree() and  haltTree() to bt_action_server

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -140,6 +140,23 @@ public:
     action_server_->publish_feedback(feedback);
   }
 
+  /**
+   * @brief Getter function for the current BT tree
+   */
+  BT::Tree getTree() const
+  {
+    return tree_;
+  }
+
+  /**
+   * @brief Function to halt the current tree. It will interrupt the exectuion of RUNNING nodes
+   * by calling their halt() implementation (only for Async nodes that may return RUNNING)
+   */
+  void haltTree()
+  {
+    tree_.rootNode()->halt();
+  }
+
 protected:
   /**
    * @brief Action server callback


### PR DESCRIPTION
As discussed here: https://github.com/ros-planning/navigation2/issues/1971#issuecomment-795862059