### PR TITLE
Forse ROS2 parameters to be static to meet RCLCPP API changes

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -49,7 +49,7 @@ BtActionServer<ActionT>::BtActionServer(
   clock_ = node->get_clock();
 
   // Declare this node's parameters
-  node->declare_parameter("default_bt_xml_filename");
+  node->declare_parameter("default_bt_xml_filename", rclcpp::PARAMETER_STRING);
   node->declare_parameter("enable_groot_monitoring", true);
   node->declare_parameter("groot_zmq_publisher_port", 1666);
   node->declare_parameter("groot_zmq_server_port", 1667);

--- a/nav2_costmap_2d/include/nav2_costmap_2d/layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layer.hpp
@@ -128,7 +128,8 @@ public:
     const std::string & param_name,
     const rclcpp::ParameterValue & value);
   void declareParameter(
-    const std::string & param_name);
+    const std::string & param_name,
+    const rclcpp::ParameterType & param_type);
   bool hasParameter(const std::string & param_name);
   std::string getFullName(const std::string & param_name);
 

--- a/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
@@ -60,22 +60,22 @@ void CostmapFilter::onInitialize()
     throw std::runtime_error{"Failed to lock node"};
   }
 
-  // Declare common for all costmap filters parameters
-  declareParameter("enabled", rclcpp::ParameterValue(true));
   try {
+    // Declare common for all costmap filters parameters
+    declareParameter("enabled", rclcpp::ParameterValue(true));
     declareParameter("filter_info_topic", rclcpp::PARAMETER_STRING);
-  } catch (rclcpp::exceptions::NoParameterOverrideProvided & ex) {
-    RCLCPP_ERROR(logger_, "filter_info_topic parameter is not set");
+    declareParameter("transform_tolerance", rclcpp::ParameterValue(0.1));
+
+    // Get parameters
+    node->get_parameter(name_ + "." + "enabled", enabled_);
+    filter_info_topic_ = node->get_parameter(name_ + "." + "filter_info_topic").as_string();
+    double transform_tolerance;
+    node->get_parameter(name_ + "." + "transform_tolerance", transform_tolerance);
+    transform_tolerance_ = tf2::durationFromSec(transform_tolerance);
+  } catch (const std::exception & ex) {
+    RCLCPP_ERROR(logger_, "Parameter problem: %s", ex.what());
     throw ex;
   }
-  declareParameter("transform_tolerance", rclcpp::ParameterValue(0.1));
-
-  // Get parameters
-  node->get_parameter(name_ + "." + "enabled", enabled_);
-  filter_info_topic_ = node->get_parameter(name_ + "." + "filter_info_topic").as_string();
-  double transform_tolerance;
-  node->get_parameter(name_ + "." + "transform_tolerance", transform_tolerance);
-  transform_tolerance_ = tf2::durationFromSec(transform_tolerance);
 }
 
 void CostmapFilter::activate()

--- a/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
@@ -62,17 +62,17 @@ void CostmapFilter::onInitialize()
 
   // Declare common for all costmap filters parameters
   declareParameter("enabled", rclcpp::ParameterValue(true));
-  declareParameter("filter_info_topic");
+  try {
+    declareParameter("filter_info_topic", rclcpp::PARAMETER_STRING);
+  } catch (rclcpp::exceptions::NoParameterOverrideProvided & ex) {
+    RCLCPP_ERROR(logger_, "filter_info_topic parameter is not set");
+    throw ex;
+  }
   declareParameter("transform_tolerance", rclcpp::ParameterValue(0.1));
 
   // Get parameters
   node->get_parameter(name_ + "." + "enabled", enabled_);
-  try {
-    filter_info_topic_ = node->get_parameter(name_ + "." + "filter_info_topic").as_string();
-  } catch (rclcpp::exceptions::ParameterNotDeclaredException & ex) {
-    RCLCPP_ERROR(logger_, "filter_info_topic parameter is not set");
-    throw ex;
-  }
+  filter_info_topic_ = node->get_parameter(name_ + "." + "filter_info_topic").as_string();
   double transform_tolerance;
   node->get_parameter(name_ + "." + "transform_tolerance", transform_tolerance);
   transform_tolerance_ = tf2::durationFromSec(transform_tolerance);

--- a/nav2_costmap_2d/src/layer.cpp
+++ b/nav2_costmap_2d/src/layer.cpp
@@ -91,7 +91,8 @@ Layer::declareParameter(
 
 void
 Layer::declareParameter(
-  const std::string & param_name)
+  const std::string & param_name,
+  const rclcpp::ParameterType & param_type)
 {
   auto node = node_.lock();
   if (!node) {
@@ -99,7 +100,7 @@ Layer::declareParameter(
   }
   local_params_.insert(param_name);
   nav2_util::declare_parameter_if_not_declared(
-    node, getFullName(param_name));
+    node, getFullName(param_name), param_type);
 }
 
 bool

--- a/nav2_costmap_2d/test/unit/declare_parameter_test.cpp
+++ b/nav2_costmap_2d/test/unit/declare_parameter_test.cpp
@@ -36,7 +36,7 @@ class LayerWrapper : public nav2_costmap_2d::Layer
   bool isClearable() {return false;}
 };
 
-TEST(DeclareParameter, useValidParameter2Args)
+TEST(DeclareParameter, useValidParameter)
 {
   LayerWrapper layer;
   nav2_util::LifecycleNode::SharedPtr node =
@@ -55,7 +55,7 @@ TEST(DeclareParameter, useValidParameter2Args)
   }
 }
 
-TEST(DeclareParameter, useValidParameter1Arg)
+TEST(DeclareParameter, useInvalidParameter)
 {
   LayerWrapper layer;
   nav2_util::LifecycleNode::SharedPtr node =
@@ -65,31 +65,10 @@ TEST(DeclareParameter, useValidParameter1Arg)
 
   layer.initialize(&layers, "test_layer", &tf, node, nullptr, nullptr);
 
-  layer.declareParameter("test2");
   try {
-    node->set_parameter(rclcpp::Parameter("test_layer.test2", "test_val2"));
-    std::string val = node->get_parameter("test_layer.test2").as_string();
-    EXPECT_EQ(val, "test_val2");
-  } catch (rclcpp::exceptions::ParameterNotDeclaredException & ex) {
-    FAIL() << "test_layer.test2 parameter is not set";
-  }
-}
-
-TEST(DeclareParameter, useInvalidParameter1Arg)
-{
-  LayerWrapper layer;
-  nav2_util::LifecycleNode::SharedPtr node =
-    std::make_shared<nav2_util::LifecycleNode>("test_node");
-  tf2_ros::Buffer tf(node->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
-
-  layer.initialize(&layers, "test_layer", &tf, node, nullptr, nullptr);
-
-  layer.declareParameter("test3");
-  try {
-    std::string val = node->get_parameter("test_layer.test3").as_string();
-    FAIL() << "Incorrectly handling test_layer.test3 parameters which was not set";
-  } catch (rclcpp::exceptions::ParameterNotDeclaredException & ex) {
+    layer.declareParameter("test2", rclcpp::PARAMETER_STRING);
+    FAIL() << "Incorrectly handling test_layer.test2 parameter which was not set";
+  } catch (rclcpp::exceptions::NoParameterOverrideProvided & ex) {
     SUCCEED();
   }
 }

--- a/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
+++ b/nav2_dwb_controller/dwb_core/src/dwb_local_planner.cpp
@@ -76,8 +76,12 @@ void DWBLocalPlanner::configure(
   costmap_ros_ = costmap_ros;
   tf_ = tf;
   dwb_plugin_name_ = name;
-  declare_parameter_if_not_declared(node, dwb_plugin_name_ + ".critics");
-  declare_parameter_if_not_declared(node, dwb_plugin_name_ + ".default_critic_namespaces");
+  declare_parameter_if_not_declared(
+    node, dwb_plugin_name_ + ".critics",
+    rclcpp::PARAMETER_STRING_ARRAY);
+  declare_parameter_if_not_declared(
+    node, dwb_plugin_name_ + ".default_critic_namespaces",
+    rclcpp::ParameterValue(std::vector<std::string>()));
   declare_parameter_if_not_declared(
     node, dwb_plugin_name_ + ".prune_plan",
     rclcpp::ParameterValue(true));

--- a/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -56,9 +56,9 @@ void LimitedAccelGenerator::initialize(
       nh, plugin_name + ".sim_period", rclcpp::PARAMETER_DOUBLE);
     if (!nh->get_parameter(plugin_name + ".sim_period", acceleration_time_)) {
       // This actually should never appear, since declare_parameter_if_not_declared()
-      // guarantee that static parameter will be initialized with some value.
-      // However for reliability we should also process the case
-      // when get_parameter() will return a failure value for some reasons.
+      // completed w/o exceptions guarantee that static parameter will be initialized
+      // with some value. However for reliability we should also process the case
+      // when get_parameter() will return a failure for some other reasons.
       throw std::runtime_error("Failed to get 'sim_period' value");
     }
   } catch (std::exception &) {

--- a/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/limited_accel_generator.cpp
@@ -51,10 +51,20 @@ void LimitedAccelGenerator::initialize(
   plugin_name_ = plugin_name;
   StandardTrajectoryGenerator::initialize(nh, plugin_name_);
 
-  nav2_util::declare_parameter_if_not_declared(nh, plugin_name + ".sim_period");
-
-  if (nh->get_parameter(plugin_name + ".sim_period", acceleration_time_)) {
-  } else {
+  try {
+    nav2_util::declare_parameter_if_not_declared(
+      nh, plugin_name + ".sim_period", rclcpp::PARAMETER_DOUBLE);
+    if (!nh->get_parameter(plugin_name + ".sim_period", acceleration_time_)) {
+      // This actually should never appear, since declare_parameter_if_not_declared()
+      // guarantee that static parameter will be initialized with some value.
+      // However for reliability we should also process the case
+      // when get_parameter() will return a failure value for some reasons.
+      throw std::runtime_error("Failed to get 'sim_period' value");
+    }
+  } catch (std::exception &) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("LimitedAccelGenerator"),
+      "'sim_period' parameter is not set for %s", plugin_name.c_str());
     double controller_frequency = nav_2d_utils::searchAndGetParam(
       nh, "controller_frequency", 20.0);
     if (controller_frequency > 0) {

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -38,7 +38,7 @@ LifecycleManager::LifecycleManager()
 
   // The list of names is parameterized, allowing this module to be used with a different set
   // of nodes
-  declare_parameter("node_names");
+  declare_parameter("node_names", rclcpp::PARAMETER_STRING_ARRAY);
   declare_parameter("autostart", rclcpp::ParameterValue(false));
   declare_parameter("bond_timeout", 4.0);
 

--- a/nav2_map_server/src/map_server/map_server.cpp
+++ b/nav2_map_server/src/map_server/map_server.cpp
@@ -68,7 +68,7 @@ MapServer::MapServer()
   RCLCPP_INFO(get_logger(), "Creating");
 
   // Declare the node parameters
-  declare_parameter("yaml_filename");
+  declare_parameter("yaml_filename", rclcpp::PARAMETER_STRING);
   declare_parameter("topic_name", "map");
   declare_parameter("frame_id", "map");
 }

--- a/nav2_util/test/test_dump_params/dump_params_md.txt
+++ b/nav2_util/test/test_dump_params/dump_params_md.txt
@@ -2,7 +2,6 @@
 |Parameter|Default Value|
 |---|---|
 |use_sim_time|False|
-|param_not_set|NOT_SET|
 |param_bool|True|
 |param_int|1234|
 |param_double|3.14|

--- a/nav2_util/test/test_dump_params/dump_params_md_verbose.txt
+++ b/nav2_util/test/test_dump_params/dump_params_md_verbose.txt
@@ -2,7 +2,6 @@
 |Parameter|Default Value|Range|Description|Additional Constraints|Read-Only|
 |---|---|---|---|---|---|
 |use_sim_time|False|N/A|||False|
-|param_not_set|NOT_SET|N/A|not set||False|
 |param_bool|True|N/A|boolean||True|
 |param_int|1234|-1000;10000;2||||False|
 |param_double|3.14|N/A|||False|

--- a/nav2_util/test/test_dump_params/dump_params_multiple.txt
+++ b/nav2_util/test/test_dump_params/dump_params_multiple.txt
@@ -1,7 +1,6 @@
 test_dump_params:
   ros__parameters:
     use_sim_time: False
-    param_not_set: NOT_SET
     param_bool: True
     param_int: 1234
     param_double: 3.14
@@ -15,7 +14,6 @@ test_dump_params:
 test_dump_params_copy:
   ros__parameters:
     use_sim_time: False
-    param_not_set: NOT_SET
     param_bool: True
     param_int: 1234
     param_double: 3.14

--- a/nav2_util/test/test_dump_params/dump_params_yaml.txt
+++ b/nav2_util/test/test_dump_params/dump_params_yaml.txt
@@ -1,7 +1,6 @@
 test_dump_params:
   ros__parameters:
     use_sim_time: False
-    param_not_set: NOT_SET
     param_bool: True
     param_int: 1234
     param_double: 3.14

--- a/nav2_util/test/test_dump_params/dump_params_yaml_verbose.txt
+++ b/nav2_util/test/test_dump_params/dump_params_yaml_verbose.txt
@@ -6,12 +6,6 @@ test_dump_params:
     # Additional constraints:       
     # Read-only:                    False
 
-    param_not_set:                  NOT_SET
-    # Range:                        N/A
-    # Description:                  not set
-    # Additional constraints:       
-    # Read-only:                    False
-
     param_bool:                     True
     # Range:                        N/A
     # Description:                  boolean

--- a/nav2_util/test/test_dump_params/test_dump_params_node.py
+++ b/nav2_util/test/test_dump_params/test_dump_params_node.py
@@ -24,8 +24,6 @@ class TestDumpParamsNode(Node):
 
     def __init__(self, name):
         Node.__init__(self, name)
-        self.declare_parameter('param_not_set',
-                               descriptor=ParameterDescriptor(description='not set'))
         self.declare_parameter('param_bool',
                                True,
                                ParameterDescriptor(description='boolean', read_only=True))


### PR DESCRIPTION
This commit fixes build failures with latest ROS2 releases appeared due to changed and deprecated RCLCPP API.
In RCLCPP API [update](https://discourse.ros.org/t/feedback-required-should-parameters-be-able-to-change-of-type/18319/2) all ROS2 parameters are treated to be a static by-default. This leaded an impossibility of using the `declare_parameters("with_one_argument")` method without knowing a type of parameter. Additionally, these changes forced all static parameters by their design intentionally to be initialized with some value.

This commit adopts Nav2 stack parameters for the changes from above and fixes related tests.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2220 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | TB3 simulation in Gazebo |

---

## Description of contribution in a few bullet points

* Adopted `declare_parameter()` direct calls for static parameters.
* Splitted `declare_parameter_if_not_declared()` routine into two implementations: first will be working with definite input parameter values, second - with defined type of parameters.
* Adopted dependent `declareParameter()` and `get_plugin_type_param()` routines.
* Switched to exception handling in some places which have a logic of processing not-defined parameter values.
* Added routines description in `nav2_util/include/nav2_util/node_utils.hpp`.
* Fixes testcases.