### PR TITLE
[SimpleGoalChecker] Make parameters changeable at runtime

### DIFF
--- a/nav2_controller/include/nav2_controller/plugins/simple_goal_checker.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/simple_goal_checker.hpp
@@ -70,6 +70,16 @@ protected:
   bool stateful_, check_xy_;
   // Cached squared xy_goal_tolerance_
   double xy_goal_tolerance_sq_;
+  // Subscription for parameter change
+  rclcpp::AsyncParametersClient::SharedPtr parameters_client_;
+  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr parameter_event_sub_;
+  std::string plugin_name_;
+
+  /**
+   * @brief Callback executed when a paramter change is detected
+   * @param event ParameterEvent message
+   */
+  void on_parameter_event_callback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
 };
 
 }  // namespace nav2_controller

--- a/nav2_controller/plugins/simple_goal_checker.cpp
+++ b/nav2_controller/plugins/simple_goal_checker.cpp
@@ -131,6 +131,7 @@ SimpleGoalChecker::on_parameter_event_callback(
     if (type == ParameterType::PARAMETER_DOUBLE) {
       if (name == plugin_name_ + ".xy_goal_tolerance") {
         xy_goal_tolerance_ = value.double_value;
+        xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
       } else if (name == plugin_name_ + ".yaw_goal_tolerance") {
         yaw_goal_tolerance_ = value.double_value;
       }


### PR DESCRIPTION
I need to change the **SimpleGoalChecker** params at runtime, so here is a PR activating this feature in a similar fashion as https://github.com/ros-planning/navigation2/pull/2181
Working and tested on my simulation.
If there is an interest I can add to this PR changeable parameters for the 2 others `nav2_controller` plugins: **SimpleProgressChecker** and **StoppedGoalChecker**