### PR TITLE
[Draft] [nav2_controller] Add controller_patience param

### DIFF
--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -93,6 +93,7 @@ controller_server:
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
+    failure_tolerance: 0.3
     progress_checker_plugin: "progress_checker"
     goal_checker_plugin: "goal_checker"
     controller_plugins: ["FollowPath"]

--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -229,8 +229,13 @@ protected:
   double min_y_velocity_threshold_;
   double min_theta_velocity_threshold_;
 
+  double controller_patience_;
+
   // Whether we've published the single controller warning yet
   geometry_msgs::msg::Pose end_pose_;
+
+  // Last time the controller generated a valid command
+  rclcpp::Time last_valid_cmd_time_;
 
 private:
   /**

--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -229,7 +229,7 @@ protected:
   double min_y_velocity_threshold_;
   double min_theta_velocity_threshold_;
 
-  double controller_patience_;
+  double failure_tolerance_;
 
   // Whether we've published the single controller warning yet
   geometry_msgs::msg::Pose end_pose_;

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -55,6 +55,8 @@ ControllerServer::ControllerServer()
 
   declare_parameter("speed_limit_topic", rclcpp::ParameterValue("speed_limit"));
 
+  declare_parameter("controller_patience", rclcpp::ParameterValue(0.0));
+
   // The costmap node is used in the implementation of the controller
   costmap_ros_ = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
     "local_costmap", std::string{get_namespace()}, "local_costmap");
@@ -297,6 +299,7 @@ void ControllerServer::computeControl()
     setPlannerPath(action_server_->get_current_goal()->path);
     progress_checker_->reset();
 
+    last_valid_cmd_time_ = now();
     rclcpp::WallRate loop_rate(controller_frequency_);
     while (rclcpp::ok()) {
       if (action_server_ == nullptr || !action_server_->is_server_active()) {
@@ -385,11 +388,34 @@ void ControllerServer::computeAndPublishVelocity()
 
   nav_2d_msgs::msg::Twist2D twist = getThresholdedTwist(odom_sub_->getTwist());
 
-  auto cmd_vel_2d =
-    controllers_[current_controller_]->computeVelocityCommands(
-    pose,
-    nav_2d_utils::twist2Dto3D(twist),
-    goal_checker_.get());
+  geometry_msgs::msg::TwistStamped cmd_vel_2d;
+
+  if (controller_patience_ > 0 || controller_patience_ == -1.0) {
+    try {
+      cmd_vel_2d =
+        controllers_[current_controller_]->computeVelocityCommands(
+        pose,
+        nav_2d_utils::twist2Dto3D(twist),
+        goal_checker_.get());
+      last_valid_cmd_time_ = now();
+    } catch (nav2_core::PlannerException & e) {
+      RCLCPP_WARN(this->get_logger(), e.what());
+      cmd_vel_2d.twist.angular.x = 0;
+      cmd_vel_2d.twist.angular.y = 0;
+      cmd_vel_2d.twist.angular.z = 0;
+      cmd_vel_2d.twist.linear.x = 0;
+      cmd_vel_2d.twist.linear.y = 0;
+      cmd_vel_2d.twist.linear.z = 0;
+      cmd_vel_2d.header.frame_id = costmap_ros_->getBaseFrameID();
+      cmd_vel_2d.header.stamp = now();
+    }
+  } else {
+    cmd_vel_2d =
+      controllers_[current_controller_]->computeVelocityCommands(
+      pose,
+      nav_2d_utils::twist2Dto3D(twist),
+      goal_checker_.get());
+  }
 
   std::shared_ptr<Action::Feedback> feedback = std::make_shared<Action::Feedback>();
   feedback->speed = std::hypot(cmd_vel_2d.twist.linear.x, cmd_vel_2d.twist.linear.y);
@@ -398,6 +424,9 @@ void ControllerServer::computeAndPublishVelocity()
 
   RCLCPP_DEBUG(get_logger(), "Publishing velocity at time %.2f", now().seconds());
   publishVelocity(cmd_vel_2d);
+  if (controller_patience_ > 0 && (now() - last_valid_cmd_time_).seconds() > 5) {
+    throw nav2_core::PlannerException("Controller patience exceeded");
+  }
 }
 
 void ControllerServer::updateGlobalPath()

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -409,8 +409,9 @@ void ControllerServer::computeAndPublishVelocity()
       cmd_vel_2d.twist.linear.z = 0;
       cmd_vel_2d.header.frame_id = costmap_ros_->getBaseFrameID();
       cmd_vel_2d.header.stamp = now();
-      publishVelocity(cmd_vel_2d);
-      if ((now() - last_valid_cmd_time_).seconds() > controller_patience_) {
+      if ((now() - last_valid_cmd_time_).seconds() > controller_patience_ &&
+        controller_patience_ != -1.0)
+      {
         throw nav2_core::PlannerException("Controller patience exceeded");
       }
     } else {

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -425,7 +425,6 @@ void ControllerServer::computeAndPublishVelocity()
 
   RCLCPP_DEBUG(get_logger(), "Publishing velocity at time %.2f", now().seconds());
   publishVelocity(cmd_vel_2d);
-
 }
 
 void ControllerServer::updateGlobalPath()


### PR DESCRIPTION
| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/2262 |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | Wyca Elodie Sim |

---

## Description of contribution in a few bullet points

This is a draft PR to support the discussion from here https://github.com/ros-planning/navigation2/issues/2262
Adds a `controller_patience` which makes the controller retry when for `computeVelocityCommands` throws an exception for the desired amount of second before failing. When equals to 0.0 the functionality is disabled. When equals to -1.0 the patience is infinite (the nav2_controller "FollowPath" action will likely fails thanks to the ProgressChecker though).

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists

Edit: I meant ProgressChecker instead of GoalChecker
