### PR TITLE
Enable rmw_connextdds for nightly CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,7 +452,7 @@ workflows:
           matrix:
             parameters:
               rmw:
-                # - rmw_connext_cpp
+                - rmw_connextdds
                 - rmw_cyclonedds_cpp
                 - rmw_fastrtps_cpp
     triggers:


### PR DESCRIPTION
To again have a third RMW to triage CI failures

https://github.com/ros2/rmw_connextdds