### PR TITLE
[nav2_behavior_tree] Add OnBtExitedCallback 

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -40,6 +40,7 @@ public:
   typedef std::function<bool (typename ActionT::Goal::ConstSharedPtr)> OnGoalReceivedCallback;
   typedef std::function<void ()> OnLoopCallback;
   typedef std::function<void ()> OnPreemptCallback;
+  typedef std::function<void (typename ActionT::Result::SharedPtr)> OnBtExitedCallback;
 
   /**
    * @brief A constructor for nav2_behavior_tree::BtActionServer class
@@ -50,7 +51,8 @@ public:
     const std::vector<std::string> & plugin_lib_names,
     OnGoalReceivedCallback on_goal_received_callback,
     OnLoopCallback on_loop_callback,
-    OnPreemptCallback on_preempt_callback = nullptr);
+    OnPreemptCallback on_preempt_callback = nullptr,
+    OnBtExitedCallback on_bt_exited_callback = nullptr);
 
   /**
    * @brief A destructor for nav2_behavior_tree::BtActionServer class
@@ -211,6 +213,7 @@ protected:
   OnGoalReceivedCallback on_goal_received_callback_;
   OnLoopCallback on_loop_callback_;
   OnPreemptCallback on_preempt_callback_;
+  OnBtExitedCallback on_bt_exited_callback_;
 };
 
 }  // namespace nav2_behavior_tree


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Wyca Elodie Sim |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

Added an optional `OnBtExitedCallback` to `nav2_behavior_tree::BtActionServer`. This allows getting data from the blackboard and filling the result of the action before it returns (and just after the BT is done).
This would be a prerequisite to use and extent the result fields of the `NavigateToPose` action for instance.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
