### PR TITLE
ServiceClient wait_for_service not infinite

### DIFF
--- a/nav2_util/include/nav2_util/service_client.hpp
+++ b/nav2_util/include/nav2_util/service_client.hpp
@@ -123,19 +123,13 @@ public:
   }
 
   /**
-  * @brief Block until a service is available
+  * @brief Block until a service is available or timeout
   * @param timeout Maximum timeout to wait for, default infinite
+  * @return bool true if service is available
   */
-  void wait_for_service(const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::max())
+  bool wait_for_service(const std::chrono::nanoseconds timeout = std::chrono::nanoseconds::max())
   {
-    auto sleep_dur = std::chrono::milliseconds(10);
-    while (!client_->wait_for_service(timeout)) {
-      if (!rclcpp::ok()) {
-        throw std::runtime_error(
-                service_name_ + " service client: interrupted while waiting for service");
-      }
-      rclcpp::sleep_for(sleep_dur);
-    }
+    return client_->wait_for_service(timeout);
   }
 
 protected:

--- a/nav2_util/test/test_service_client.cpp
+++ b/nav2_util/test/test_service_client.cpp
@@ -86,3 +86,14 @@ TEST(ServiceClient, can_ServiceClient_invoke_in_callback)
   pub_thread.join();
   ASSERT_EQ(a, 1);
 }
+
+TEST(ServiceClient, can_ServiceClient_timeout)
+{
+  rclcpp::init(0, nullptr);
+  auto node = rclcpp::Node::make_shared("test_node");
+  TestServiceClient t("bar", node);
+  rclcpp::spin_some(node);
+  bool ready = t.wait_for_service(std::chrono::milliseconds(10));
+  rclcpp::shutdown();
+  ASSERT_EQ(ready, false);
+}


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [comment](https://github.com/ros-planning/navigation2/pull/2267#issuecomment-809671090) |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | Wyca (simulation)|

---

## Description of contribution in a few bullet points

* I changed the behavior of wait_for_service to be not blocked forever if the service doesn't exist
* The method returns the result of `client.wait_for_service()`
* I added a unit test to check this behavior

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
