### PR TITLE
corrected backup plugin name for multirobot params

### DIFF
--- a/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
@@ -226,7 +226,7 @@ recoveries_server:
     costmap_topic: local_costmap/costmap_raw
     footprint_topic: local_costmap/published_footprint
     cycle_frequency: 10.0
-    recovery_plugins: ["spin", "back_up", "wait"]
+    recovery_plugins: ["spin", "backup", "wait"]
     spin:
       plugin: "nav2_recoveries/Spin"
     backup:

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
@@ -226,7 +226,7 @@ recoveries_server:
     costmap_topic: local_costmap/costmap_raw
     footprint_topic: local_costmap/published_footprint
     cycle_frequency: 10.0
-    recovery_plugins: ["spin", "back_up", "wait"]
+    recovery_plugins: ["spin", "backup", "wait"]
     spin:
       plugin: "nav2_recoveries/Spin"
     backup:


### PR DESCRIPTION
Same as ros-planning/navigation2#2287, but for foxy branch. 

Fairly trivial change - the multi-robot param files included in nav2_bringup used an invalid plugin name for nav2_recoveries/BackUp. 

The .yaml file used "back_up" where "backup" should have been used. This resulted in a Fatal Error when a multi-robot simulation is run with the recoveries_server. Removing the underscore fixes the issue. 