### PR TITLE
[nav2_bringup] Update waffle.model

### DIFF
--- a/nav2_bringup/bringup/worlds/waffle.model
+++ b/nav2_bringup/bringup/worlds/waffle.model
@@ -266,7 +266,7 @@
           <pose>0.0 0.144 0.023 0 0 0</pose>
           <geometry>
             <mesh>
-              <uri>model://turtlebot3_waffle/meshes/left_tire.dae</uri>
+              <uri>model://turtlebot3_waffle/meshes/tire.dae</uri>
               <scale>0.001 0.001 0.001</scale>
             </mesh>
           </geometry>
@@ -324,7 +324,7 @@
           <pose>0.0 -0.144 0.023 0 0 0</pose>
           <geometry>
             <mesh>
-              <uri>model://turtlebot3_waffle/meshes/right_tire.dae</uri>
+              <uri>model://turtlebot3_waffle/meshes/tire.dae</uri>
               <scale>0.001 0.001 0.001</scale>
             </mesh>
           </geometry>


### PR DESCRIPTION
Changed to the latest tire mesh file names for waffle as per the latest `turtlebot3_gazebo` package.

This results in faster loading and resolves the errors that come in `gazebo --verbose`

