### PR TITLE
adjusting new files for tb3 model (ros2 of 2296)

### DIFF
--- a/nav2_bringup/bringup/worlds/waffle.model
+++ b/nav2_bringup/bringup/worlds/waffle.model
@@ -267,7 +267,7 @@
           <pose>0.0 0.144 0.023 0 0 0</pose>
           <geometry>
             <mesh>
-              <uri>model://turtlebot3_waffle/meshes/left_tire.dae</uri>
+              <uri>model://turtlebot3_waffle/meshes/tire.dae</uri>
               <scale>0.001 0.001 0.001</scale>
             </mesh>
           </geometry>
@@ -325,7 +325,7 @@
           <pose>0.0 -0.144 0.023 0 0 0</pose>
           <geometry>
             <mesh>
-              <uri>model://turtlebot3_waffle/meshes/right_tire.dae</uri>
+              <uri>model://turtlebot3_waffle/meshes/tire.dae</uri>
               <scale>0.001 0.001 0.001</scale>
             </mesh>
           </geometry>


### PR DESCRIPTION
See https://github.com/ros-planning/navigation2/pull/2296 for details

TB3 model has changed the file paths for the tires, requiring people to pull in the new changes `turtlebot3_simulation` repository if building locally. 

@ruffsl for CI, I don't see where it pulls `turtlebot3_simulation` to get these files, can you clarify for me? The underlay workspace doesn't include it and nor does `ros2 master`. We don't base on foxy so it can't be getting those binaries. 

Foxy users we tell to get the binaries in the build instructions. ROS2 main developers have a local copy. Its not clear to me where its coming from for CI. **Should we be including turtlebot3_simulation in the underlay?** 