### PR TITLE
major smac planner collision checking speedups and improvements

### DIFF
--- a/nav2_costmap_2d/src/footprint_collision_checker.cpp
+++ b/nav2_costmap_2d/src/footprint_collision_checker.cpp
@@ -84,7 +84,7 @@ double FootprintCollisionChecker<CostmapT>::footprintCost(const Footprint footpr
 
   // we also need to connect the first point in the footprint to the last point
   // the last iteration's x1, y1 are the last footprint point's coordinates
-  return std::max(lineCost(xstart, x1, ystart, y1), footprint_cost);;
+  return std::max(lineCost(xstart, x1, ystart, y1), footprint_cost);
 }
 
 template<typename CostmapT>

--- a/nav2_costmap_2d/src/footprint_collision_checker.cpp
+++ b/nav2_costmap_2d/src/footprint_collision_checker.cpp
@@ -51,12 +51,17 @@ double FootprintCollisionChecker<CostmapT>::footprintCost(const Footprint footpr
   unsigned int x0, x1, y0, y1;
   double footprint_cost = 0.0;
 
+  // get the cell coord of the first point
+  if (!worldToMap(footprint[0].x, footprint[0].y, x0, y0)) {
+    return static_cast<double>(LETHAL_OBSTACLE);
+  }
+
+  // cache the start to eliminate a worldToMap call
+  unsigned int xstart = x0;
+  unsigned int ystart = y0;
+
   // we need to rasterize each line in the footprint
   for (unsigned int i = 0; i < footprint.size() - 1; ++i) {
-    // get the cell coord of the first point
-    if (!worldToMap(footprint[i].x, footprint[i].y, x0, y0)) {
-      return static_cast<double>(LETHAL_OBSTACLE);
-    }
 
     // get the cell coord of the second point
     if (!worldToMap(footprint[i + 1].x, footprint[i + 1].y, x1, y1)) {
@@ -64,23 +69,22 @@ double FootprintCollisionChecker<CostmapT>::footprintCost(const Footprint footpr
     }
 
     footprint_cost = std::max(lineCost(x0, x1, y0, y1), footprint_cost);
+
+    // the second point is next iteration's first point
+    x0 = x1;
+    y0 = y1;
+
+    // if in collision, no need to continue
+    if (footprint_cost == static_cast<double>(INSCRIBED_INFLATED_OBSTACLE) ||
+      footprint_cost == static_cast<double>(LETHAL_OBSTACLE))
+    {
+      return footprint_cost;
+    }
   }
 
   // we also need to connect the first point in the footprint to the last point
-  // get the cell coord of the last point
-  if (!worldToMap(footprint.back().x, footprint.back().y, x0, y0)) {
-    return static_cast<double>(LETHAL_OBSTACLE);
-  }
-
-  // get the cell coord of the first point
-  if (!worldToMap(footprint.front().x, footprint.front().y, x1, y1)) {
-    return static_cast<double>(LETHAL_OBSTACLE);
-  }
-
-  footprint_cost = std::max(lineCost(x0, x1, y0, y1), footprint_cost);
-
-  // if all line costs are legal... then we can return that the footprint is legal
-  return footprint_cost;
+  // the last iteration's x1, y1 are the last footprint point's coordinates
+  return std::max(lineCost(xstart, x1, ystart, y1), footprint_cost);;
 }
 
 template<typename CostmapT>
@@ -94,6 +98,13 @@ double FootprintCollisionChecker<CostmapT>::lineCost(int x0, int x1, int y0, int
 
     if (line_cost < point_cost) {
       line_cost = point_cost;
+    }
+
+    // if in collision, no need to continue
+    if (line_cost == static_cast<double>(INSCRIBED_INFLATED_OBSTACLE) ||
+      line_cost == static_cast<double>(LETHAL_OBSTACLE))
+    {
+      return line_cost;
     }
   }
 

--- a/nav2_smac_planner/CMakeLists.txt
+++ b/nav2_smac_planner/CMakeLists.txt
@@ -39,8 +39,13 @@ include_directories(
   ${OMPL_INCLUDE_DIRS}
   ${OpenMP_INCLUDE_DIRS}
 )
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+
+find_package(OpenMP)
+if (OPENMP_FOUND)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
 
 set(library_name nav2_smac_planner)
 

--- a/nav2_smac_planner/CMakeLists.txt
+++ b/nav2_smac_planner/CMakeLists.txt
@@ -41,10 +41,10 @@ include_directories(
 )
 
 find_package(OpenMP)
-if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+if(OPENMP_FOUND)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 endif()
 
 set(library_name nav2_smac_planner)

--- a/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
@@ -227,7 +227,7 @@ protected:
    * @param cost The cost to sort into the open set of the node
    * @param node Node pointer reference to add to open set
    */
-  inline void addNode(const float cost, NodePtr & node);
+  inline void addNode(const float & cost, NodePtr & node);
 
   /**
    * @brief Adds node to graph

--- a/nav2_smac_planner/include/nav2_smac_planner/collision_checker.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/collision_checker.hpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License. Reserved.
-
+#include <vector>
 #include "nav2_costmap_2d/footprint_collision_checker.hpp"
 #include "nav2_smac_planner/constants.hpp"
 

--- a/nav2_smac_planner/include/nav2_smac_planner/node_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_2d.hpp
@@ -96,7 +96,7 @@ public:
    * @brief Sets the accumulated cost at this node
    * @param reference to accumulated cost
    */
-  inline void setAccumulatedCost(const float cost_in)
+  inline void setAccumulatedCost(const float & cost_in)
   {
     _accumulated_cost = cost_in;
   }
@@ -160,7 +160,7 @@ public:
    * @param collision_checker Pointer to collision checker object
    * @return whether this node is valid and collision free
    */
-  bool isNodeValid(const bool & traverse_unknown, GridCollisionChecker collision_checker);
+  bool isNodeValid(const bool & traverse_unknown, GridCollisionChecker & collision_checker);
 
   /**
    * @brief get traversal cost from this node to child node
@@ -227,7 +227,7 @@ public:
   static void getNeighbors(
     NodePtr & node,
     std::function<bool(const unsigned int &, nav2_smac_planner::Node2D * &)> & validity_checker,
-    GridCollisionChecker collision_checker,
+    GridCollisionChecker & collision_checker,
     const bool & traverse_unknown,
     NodeVector & neighbors);
 

--- a/nav2_smac_planner/include/nav2_smac_planner/node_se2.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_se2.hpp
@@ -111,13 +111,6 @@ struct MotionTable
    */
   MotionPoses getProjections(const NodeSE2 * node);
 
-  /**
-   * @brief Get a projection of motion model
-   * @param node Ptr to SE2 node
-   * @return A motion pose
-   */
-  MotionPose getProjection(const NodeSE2 * node, const unsigned int & motion_index);
-
   MotionPoses projections;
   unsigned int size_x;
   unsigned int num_angle_quantization;
@@ -216,7 +209,7 @@ public:
    * @brief Sets the accumulated cost at this node
    * @param reference to accumulated cost
    */
-  inline void setAccumulatedCost(const float cost_in)
+  inline void setAccumulatedCost(const float & cost_in)
   {
     _accumulated_cost = cost_in;
   }
@@ -297,7 +290,7 @@ public:
    * @param traverse_unknown If we can explore unknown nodes on the graph
    * @return whether this node is valid and collision free
    */
-  bool isNodeValid(const bool & traverse_unknown, GridCollisionChecker collision_checker);
+  bool isNodeValid(const bool & traverse_unknown, GridCollisionChecker & collision_checker);
 
   /**
    * @brief Get traversal cost of parent node to child node
@@ -317,7 +310,7 @@ public:
    */
   static inline unsigned int getIndex(
     const unsigned int & x, const unsigned int & y, const unsigned int & angle,
-    const unsigned int & width, const unsigned int angle_quantization)
+    const unsigned int & width, const unsigned int & angle_quantization)
   {
     return angle + x * angle_quantization + y * width * angle_quantization;
   }
@@ -346,7 +339,7 @@ public:
    */
   static inline Coordinates getCoords(
     const unsigned int & index,
-    const unsigned int & width, const unsigned int angle_quantization)
+    const unsigned int & width, const unsigned int & angle_quantization)
   {
     return Coordinates(
       (index / angle_quantization) % width,    // x
@@ -401,7 +394,7 @@ public:
   static void getNeighbors(
     const NodePtr & node,
     std::function<bool(const unsigned int &, nav2_smac_planner::NodeSE2 * &)> & validity_checker,
-    GridCollisionChecker collision_checker,
+    GridCollisionChecker & collision_checker,
     const bool & traverse_unknown,
     NodeVector & neighbors);
 

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -109,6 +109,7 @@ void AStarAlgorithm<NodeSE2>::createGraph(
   if (getSizeX() != x_size || getSizeY() != y_size) {
     _x_size = x_size;
     _y_size = y_size;
+
     NodeSE2::initMotionModel(_motion_model, _x_size, _y_size, _dim3_size, _search_info);
   }
 }

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -49,7 +49,7 @@ AStarAlgorithm<NodeT>::AStarAlgorithm(
   _start(nullptr),
   _goal(nullptr),
   _motion_model(motion_model),
-  _collision_checker(nullptr)
+  _collision_checker(nullptr, 0)
 {
   _graph.reserve(100000);
 }
@@ -99,7 +99,7 @@ void AStarAlgorithm<NodeSE2>::createGraph(
   nav2_costmap_2d::Costmap2D * & costmap)
 {
   _costmap = costmap;
-  _collision_checker = GridCollisionChecker(costmap);
+  _collision_checker = GridCollisionChecker(costmap, dim_3_size);
   _collision_checker.setFootprint(_footprint, _is_radius_footprint);
 
   _dim3_size = dim_3_size;
@@ -506,7 +506,7 @@ typename AStarAlgorithm<NodeSE2>::NodePtr AStarAlgorithm<NodeSE2>::getNextNode()
 }
 
 template<typename NodeT>
-void AStarAlgorithm<NodeT>::addNode(const float cost, NodePtr & node)
+void AStarAlgorithm<NodeT>::addNode(const float & cost, NodePtr & node)
 {
   NodeBasic<NodeT> queued_node(node->getIndex());
   queued_node.graph_node_ptr = node;
@@ -514,7 +514,7 @@ void AStarAlgorithm<NodeT>::addNode(const float cost, NodePtr & node)
 }
 
 template<>
-void AStarAlgorithm<NodeSE2>::addNode(const float cost, NodePtr & node)
+void AStarAlgorithm<NodeSE2>::addNode(const float & cost, NodePtr & node)
 {
   NodeBasic<NodeSE2> queued_node(node->getIndex());
   queued_node.pose = node->pose;

--- a/nav2_smac_planner/src/node_2d.cpp
+++ b/nav2_smac_planner/src/node_2d.cpp
@@ -51,7 +51,7 @@ void Node2D::reset(const unsigned char & cost)
 
 bool Node2D::isNodeValid(
   const bool & traverse_unknown,
-  GridCollisionChecker /*collision_checker*/)
+  GridCollisionChecker & /*collision_checker*/)
 {
   // NOTE(stevemacenski): Right now, we do not check if the node has wrapped around
   // the regular grid (e.g. your node is on the edge of the costmap and i+1
@@ -119,7 +119,7 @@ void Node2D::initNeighborhood(
 void Node2D::getNeighbors(
   NodePtr & node,
   std::function<bool(const unsigned int &, nav2_smac_planner::Node2D * &)> & NeighborGetter,
-  GridCollisionChecker collision_checker,
+  GridCollisionChecker & collision_checker,
   const bool & traverse_unknown,
   NodeVector & neighbors)
 {

--- a/nav2_smac_planner/src/node_se2.cpp
+++ b/nav2_smac_planner/src/node_se2.cpp
@@ -188,7 +188,6 @@ MotionPoses MotionTable::getProjections(const NodeSE2 * node)
   projection_list.reserve(projections.size());
 
   for (unsigned int i = 0; i != projections.size(); i++) {
-
     const MotionPose & motion_model = projections[i];
 
     // normalize theta, I know its overkill, but I've been burned before...

--- a/nav2_smac_planner/test/test_collision_checker.cpp
+++ b/nav2_smac_planner/test/test_collision_checker.cpp
@@ -41,7 +41,7 @@ TEST(collision_footprint, test_basic)
 
   nav2_costmap_2d::Footprint footprint = {p1, p2, p3, p4};
 
-  nav2_smac_planner::GridCollisionChecker collision_checker(costmap_);
+  nav2_smac_planner::GridCollisionChecker collision_checker(costmap_, 72);
   collision_checker.setFootprint(footprint, false /*use footprint*/);
   collision_checker.inCollision(5.0, 5.0, 0.0, false);
   float cost = collision_checker.getCost();
@@ -53,7 +53,7 @@ TEST(collision_footprint, test_point_cost)
 {
   nav2_costmap_2d::Costmap2D * costmap_ = new nav2_costmap_2d::Costmap2D(100, 100, 0.1, 0, 0, 0);
 
-  nav2_smac_planner::GridCollisionChecker collision_checker(costmap_);
+  nav2_smac_planner::GridCollisionChecker collision_checker(costmap_, 72);
   nav2_costmap_2d::Footprint footprint;
   collision_checker.setFootprint(footprint, true /*radius / pointcose*/);
 
@@ -67,7 +67,7 @@ TEST(collision_footprint, test_world_to_map)
 {
   nav2_costmap_2d::Costmap2D * costmap_ = new nav2_costmap_2d::Costmap2D(100, 100, 0.1, 0, 0, 0);
 
-  nav2_smac_planner::GridCollisionChecker collision_checker(costmap_);
+  nav2_smac_planner::GridCollisionChecker collision_checker(costmap_, 72);
   nav2_costmap_2d::Footprint footprint;
   collision_checker.setFootprint(footprint, true /*radius / point cost*/);
 
@@ -113,7 +113,7 @@ TEST(collision_footprint, test_footprint_at_pose_with_movement)
 
   nav2_costmap_2d::Footprint footprint = {p1, p2, p3, p4};
 
-  nav2_smac_planner::GridCollisionChecker collision_checker(costmap_);
+  nav2_smac_planner::GridCollisionChecker collision_checker(costmap_, 72);
   collision_checker.setFootprint(footprint, false /*use footprint*/);
 
   collision_checker.inCollision(50, 50, 0.0, false);
@@ -153,7 +153,7 @@ TEST(collision_footprint, test_point_and_line_cost)
 
   nav2_costmap_2d::Footprint footprint = {p1, p2, p3, p4};
 
-  nav2_smac_planner::GridCollisionChecker collision_checker(costmap_);
+  nav2_smac_planner::GridCollisionChecker collision_checker(costmap_, 72);
   collision_checker.setFootprint(footprint, false /*use footprint*/);
 
   collision_checker.inCollision(50, 50, 0.0, false);

--- a/nav2_smac_planner/test/test_node2d.cpp
+++ b/nav2_smac_planner/test/test_node2d.cpp
@@ -35,7 +35,7 @@ RclCppFixture g_rclcppfixture;
 TEST(Node2DTest, test_node_2d)
 {
   nav2_costmap_2d::Costmap2D costmapA(10, 10, 0.05, 0.0, 0.0, 0);
-  nav2_smac_planner::GridCollisionChecker checker(&costmapA);
+  nav2_smac_planner::GridCollisionChecker checker(&costmapA, 72);
 
   // test construction
   unsigned char cost = static_cast<unsigned char>(1);
@@ -117,7 +117,7 @@ TEST(Node2DTest, test_node_2d_neighbors)
   EXPECT_EQ(nav2_smac_planner::Node2D::_neighbors_grid_offsets[7], 101);
 
   nav2_costmap_2d::Costmap2D costmapA(10, 10, 0.05, 0.0, 0.0, 0);
-  nav2_smac_planner::GridCollisionChecker checker(&costmapA);
+  nav2_smac_planner::GridCollisionChecker checker(&costmapA, 72);
   unsigned char cost = static_cast<unsigned int>(1);
   nav2_smac_planner::Node2D * node = new nav2_smac_planner::Node2D(cost, 1);
   std::function<bool(const unsigned int &, nav2_smac_planner::Node2D * &)> neighborGetter =

--- a/nav2_smac_planner/test/test_nodese2.cpp
+++ b/nav2_smac_planner/test/test_nodese2.cpp
@@ -49,7 +49,7 @@ TEST(NodeSE2Test, test_node_se2)
 
   nav2_costmap_2d::Costmap2D * costmapA = new nav2_costmap_2d::Costmap2D(
     10, 10, 0.05, 0.0, 0.0, 0);
-  nav2_smac_planner::GridCollisionChecker checker(costmapA);
+  nav2_smac_planner::GridCollisionChecker checker(costmapA, 72);
   checker.setFootprint(nav2_costmap_2d::Footprint(), true);
 
   // test construction
@@ -196,7 +196,7 @@ TEST(NodeSE2Test, test_node_2d_neighbors)
   EXPECT_NEAR(nav2_smac_planner::NodeSE2::motion_table.projections[5]._theta, 5, 0.01);
 
   nav2_costmap_2d::Costmap2D costmapA(100, 100, 0.05, 0.0, 0.0, 0);
-  nav2_smac_planner::GridCollisionChecker checker(&costmapA);
+  nav2_smac_planner::GridCollisionChecker checker(&costmapA, 72);
   nav2_smac_planner::NodeSE2 * node = new nav2_smac_planner::NodeSE2(49);
   std::function<bool(const unsigned int &, nav2_smac_planner::NodeSE2 * &)> neighborGetter =
     [&, this](const unsigned int & index, nav2_smac_planner::NodeSE2 * & neighbor_rtn) -> bool


### PR DESCRIPTION
@maxlein in my testing, this makes the full-footprint collision checking nearly immeasurably slower than the radius checking. I tested using the map and footprint you provided and found only a **2% slower** total planning this way. The radius-only planning does so at ~228 search iterations per milliscond and the full footprint checking is 222 search iterations per millisecond (up from ~140) improving performance by **around 40%**. 

Improvements include:
- Precomputing footprint orientations for collision checking
- Stopping collision checking early if already known to be in collision
- Optimizing collision checking code to minimize computations
- Inlining a simplified function from prior optimizations
- Only doing full collision checking if the robot is possibly inscribed (if we know its in free space for instance, there' no point in going through that trouble)  

@maxlein @naiveHobo  can you review?