### PR TITLE
checking if handle is active in handle_cancel

### DIFF
--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -133,9 +133,17 @@ public:
    * @return CancelResponse response of the goal cancelled
    */
   rclcpp_action::CancelResponse handle_cancel(
-    const std::shared_ptr<rclcpp_action::ServerGoalHandle<ActionT>>/*handle*/)
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<ActionT>> handle)
   {
     std::lock_guard<std::recursive_mutex> lock(update_mutex_);
+
+    if (!handle->is_active()) {
+      warn_msg(
+        "Received request for goal cancellation,"
+        "but the handle is inactive, so reject the request");
+      return rclcpp_action::CancelResponse::REJECT;
+    }
+
     debug_msg("Received request for goal cancellation");
     return rclcpp_action::CancelResponse::ACCEPT;
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |#2273 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on |Turtlebot3 Simulation |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
I added `is_publishing_succeeded_state_` and `is_handling_cancel_request_` to mark down current handling state. Make sure that `succeeded_current` and` cancel_handle` can not be handled simultaneously. And I also added `handle_state_mutex_` to protect the two variables.

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
1. I think all invailed state transformations should be avoided, such as `SUCCEEDED` to `CANCELING`, `ABORTED` to `CANCELING`, and so on. But It seems to be a little complicated to SimpleActionServer. 

2. I'm not sure if action server only run in one thread could be better. It seems that these problems are all caused by multithreading.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
