### PR TITLE
[WIP] Fix for wings artifacts: adding new filters entity to separately update costmaps

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d.hpp
@@ -115,6 +115,22 @@ public:
     double win_size_y);
 
   /**
+   * @brief Copies the (x0,y0)..(xn,yn) window from source costmap into a current costmap
+     @param source Source costmap where the window will be copied from
+     @param sx0 Lower x-boundary of the source window to copy, in cells
+     @param sy0 Lower y-boundary of the source window to copy, in cells
+     @param sxn Upper x-boundary of the source window to copy, in cells
+     @param syn Upper y-boundary of the source window to copy, in cells
+     @param dx0 Lower x-boundary of the destination window to copy, in cells
+     @param dx0 Lower y-boundary of the destination window to copy, in cells
+     @returns true if copy was succeeded or false in negative case
+   */
+  bool copyWindow(
+    const Costmap2D & source,
+    unsigned int sx0, unsigned int sy0, unsigned int sxn, unsigned int syn,
+    unsigned int dx0, unsigned int dy0);
+
+  /**
    * @brief  Default constructor
    */
   Costmap2D();

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -344,6 +344,8 @@ protected:
   std::vector<std::string> default_types_;
   std::vector<std::string> plugin_names_;
   std::vector<std::string> plugin_types_;
+  std::vector<std::string> filter_names_;
+  std::vector<std::string> filter_types_;
   double resolution_{0};
   std::string robot_base_frame_;   ///< The frame_id of the robot base
   double robot_radius_;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
@@ -136,11 +136,27 @@ public:
   }
 
   /**
+   * @brief Get the vector of pointers to the costmap filters
+   */
+  std::vector<std::shared_ptr<Layer>> * getFilters()
+  {
+    return &filters_;
+  }
+
+  /**
    * @brief Add a new plugin to the plugins vector to process
    */
   void addPlugin(std::shared_ptr<Layer> plugin)
   {
     plugins_.push_back(plugin);
+  }
+
+  /**
+   * @brief Add a new costmap filter plugin to the filters vector to process
+   */
+  void addFilter(std::shared_ptr<Layer> filter)
+  {
+    filters_.push_back(filter);
   }
 
   /**
@@ -197,7 +213,7 @@ public:
   bool isOutofBounds(double robot_x, double robot_y);
 
 private:
-  Costmap2D costmap_;
+  Costmap2D plugins_costmap_, costmap_;
   std::string global_frame_;
 
   bool rolling_window_;  /// < @brief Whether or not the costmap should roll with the robot
@@ -207,6 +223,7 @@ private:
   unsigned int bx0_, bxn_, by0_, byn_;
 
   std::vector<std::shared_ptr<Layer>> plugins_;
+  std::vector<std::shared_ptr<Layer>> filters_;
 
   bool initialized_;
   bool size_locked_;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
@@ -108,7 +108,7 @@ public:
    */
   Costmap2D * getCostmap()
   {
-    return &costmap_;
+    return &combined_costmap_;
   }
 
   /**
@@ -124,7 +124,7 @@ public:
    */
   bool isTrackingUnknown()
   {
-    return costmap_.getDefaultValue() == nav2_costmap_2d::NO_INFORMATION;
+    return combined_costmap_.getDefaultValue() == nav2_costmap_2d::NO_INFORMATION;
   }
 
   /**
@@ -213,7 +213,12 @@ public:
   bool isOutofBounds(double robot_x, double robot_y);
 
 private:
-  Costmap2D plugins_costmap_, costmap_;
+  // primary_costmap_ is a bottom costmap used by plugins when costmap filters were enabled.
+  // combined_costmap_ is a final costmap where all results produced by plugins and filters (if any)
+  // to be merged.
+  // The separation is aimed to avoid interferences of work between plugins and filters.
+  // primay_costmap_ and combined_costmap_ have the same sizes, origins and default values.
+  Costmap2D primary_costmap_, combined_costmap_;
   std::string global_frame_;
 
   bool rolling_window_;  /// < @brief Whether or not the costmap should roll with the robot

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -112,6 +112,15 @@ void ClearCostmapService::clearRegion(const double reset_distance, bool invert)
       clearLayerRegion(costmap_layer, x, y, reset_distance, invert);
     }
   }
+
+  layers = costmap_.getLayeredCostmap()->getFilters();
+
+  for (auto & layer : *layers) {
+    if (layer->isClearable()) {
+      auto costmap_layer = std::static_pointer_cast<CostmapLayer>(layer);
+      clearLayerRegion(costmap_layer, x, y, reset_distance, invert);
+    }
+  }
 }
 
 void ClearCostmapService::clearLayerRegion(

--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -113,14 +113,8 @@ void ClearCostmapService::clearRegion(const double reset_distance, bool invert)
     }
   }
 
-  layers = costmap_.getLayeredCostmap()->getFilters();
-
-  for (auto & layer : *layers) {
-    if (layer->isClearable()) {
-      auto costmap_layer = std::static_pointer_cast<CostmapLayer>(layer);
-      clearLayerRegion(costmap_layer, x, y, reset_distance, invert);
-    }
-  }
+  // AlexeyMerzlyakov: No need to clear layer region for costmap filters
+  // as they are always supposed to be not clearable.
 }
 
 void ClearCostmapService::clearLayerRegion(

--- a/nav2_costmap_2d/src/costmap_2d.cpp
+++ b/nav2_costmap_2d/src/costmap_2d.cpp
@@ -192,6 +192,10 @@ bool Costmap2D::copyWindow(
   const unsigned int sz_x = sxn - sx0;
   const unsigned int sz_y = syn - sy0;
 
+  if (sxn > source.getSizeInCellsX() || syn > source.getSizeInCellsY()) {
+    return false;
+  }
+
   if (dx0 + sz_x > size_x_ || dy0 + sz_y > size_y_) {
     return false;
   }

--- a/nav2_costmap_2d/src/costmap_2d.cpp
+++ b/nav2_costmap_2d/src/costmap_2d.cpp
@@ -184,6 +184,25 @@ bool Costmap2D::copyCostmapWindow(
   return true;
 }
 
+bool Costmap2D::copyWindow(
+  const Costmap2D & source,
+  unsigned int sx0, unsigned int sy0, unsigned int sxn, unsigned int syn,
+  unsigned int dx0, unsigned int dy0)
+{
+  const unsigned int sz_x = sxn - sx0;
+  const unsigned int sz_y = syn - sy0;
+
+  if (dx0 + sz_x > size_x_ || dy0 + sz_y > size_y_) {
+    return false;
+  }
+
+  copyMapRegion(
+    source.costmap_, sx0, sy0, source.size_x_,
+    costmap_, dx0, dy0, size_x_,
+    sz_x, sz_y);
+  return true;
+}
+
 Costmap2D & Costmap2D::operator=(const Costmap2D & map)
 {
   // check for self assignement

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -101,6 +101,7 @@ Costmap2DROS::Costmap2DROS(
   declare_parameter("origin_x", rclcpp::ParameterValue(0.0));
   declare_parameter("origin_y", rclcpp::ParameterValue(0.0));
   declare_parameter("plugins", rclcpp::ParameterValue(default_plugins_));
+  declare_parameter("filters", rclcpp::ParameterValue(std::vector<std::string>()));
   declare_parameter("publish_frequency", rclcpp::ParameterValue(1.0));
   declare_parameter("resolution", rclcpp::ParameterValue(0.1));
   declare_parameter("robot_base_frame", rclcpp::ParameterValue(std::string("base_link")));
@@ -156,6 +157,20 @@ Costmap2DROS::on_configure(const rclcpp_lifecycle::State & /*state*/)
       shared_from_this(), client_node_, rclcpp_node_);
 
     RCLCPP_INFO(get_logger(), "Initialized plugin \"%s\"", plugin_names_[i].c_str());
+  }
+  // and costmap filters as well
+  for (unsigned int i = 0; i < filter_names_.size(); ++i) {
+    RCLCPP_INFO(get_logger(), "Using costmap filter \"%s\"", filter_names_[i].c_str());
+
+    std::shared_ptr<Layer> filter = plugin_loader_.createSharedInstance(filter_types_[i]);
+    layered_costmap_->addFilter(filter);
+
+    // TODO(mjeronimo): instead of get(), use a shared ptr
+    filter->initialize(
+      layered_costmap_.get(), filter_names_[i], tf_buffer_.get(),
+      shared_from_this(), client_node_, rclcpp_node_);
+
+    RCLCPP_INFO(get_logger(), "Initialized costmap filter \"%s\"", filter_names_[i].c_str());
   }
 
   // Create the publishers and subscribers
@@ -300,6 +315,7 @@ Costmap2DROS::getParameters()
   get_parameter("update_frequency", map_update_frequency_);
   get_parameter("width", map_width_meters_);
   get_parameter("plugins", plugin_names_);
+  get_parameter("filters", filter_names_);
 
   auto node = shared_from_this();
 
@@ -310,10 +326,14 @@ Costmap2DROS::getParameters()
     }
   }
   plugin_types_.resize(plugin_names_.size());
+  filter_types_.resize(filter_names_.size());
 
   // 1. All plugins must have 'plugin' param defined in their namespace to define the plugin type
   for (size_t i = 0; i < plugin_names_.size(); ++i) {
     plugin_types_[i] = nav2_util::get_plugin_type_param(node, plugin_names_[i]);
+  }
+  for (size_t i = 0; i < filter_names_.size(); ++i) {
+    filter_types_[i] = nav2_util::get_plugin_type_param(node, filter_names_[i]);
   }
 
   // 2. The map publish frequency cannot be 0 (to avoid a divde-by-zero)
@@ -455,6 +475,7 @@ Costmap2DROS::start()
 {
   RCLCPP_INFO(get_logger(), "start");
   std::vector<std::shared_ptr<Layer>> * plugins = layered_costmap_->getPlugins();
+  std::vector<std::shared_ptr<Layer>> * filters = layered_costmap_->getFilters();
 
   // check if we're stopped or just paused
   if (stopped_) {
@@ -464,6 +485,12 @@ Costmap2DROS::start()
       ++plugin)
     {
       (*plugin)->activate();
+    }
+    for (std::vector<std::shared_ptr<Layer>>::iterator filter = filters->begin();
+      filter != filters->end();
+      ++filter)
+    {
+      (*filter)->activate();
     }
     stopped_ = false;
   }
@@ -482,11 +509,17 @@ Costmap2DROS::stop()
 {
   stop_updates_ = true;
   std::vector<std::shared_ptr<Layer>> * plugins = layered_costmap_->getPlugins();
+  std::vector<std::shared_ptr<Layer>> * filters = layered_costmap_->getFilters();
   // unsubscribe from topics
   for (std::vector<std::shared_ptr<Layer>>::iterator plugin = plugins->begin();
     plugin != plugins->end(); ++plugin)
   {
     (*plugin)->deactivate();
+  }
+  for (std::vector<std::shared_ptr<Layer>>::iterator filter = filters->begin();
+    filter != filters->end(); ++filter)
+  {
+    (*filter)->deactivate();
   }
   initialized_ = false;
   stopped_ = true;
@@ -519,10 +552,16 @@ Costmap2DROS::resetLayers()
 
   // Reset each of the plugins
   std::vector<std::shared_ptr<Layer>> * plugins = layered_costmap_->getPlugins();
+  std::vector<std::shared_ptr<Layer>> * filters = layered_costmap_->getFilters();
   for (std::vector<std::shared_ptr<Layer>>::iterator plugin = plugins->begin();
     plugin != plugins->end(); ++plugin)
   {
     (*plugin)->reset();
+  }
+  for (std::vector<std::shared_ptr<Layer>>::iterator filter = filters->begin();
+    filter != filters->end(); ++filter)
+  {
+    (*filter)->reset();
   }
 }
 

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -165,7 +165,6 @@ Costmap2DROS::on_configure(const rclcpp_lifecycle::State & /*state*/)
     std::shared_ptr<Layer> filter = plugin_loader_.createSharedInstance(filter_types_[i]);
     layered_costmap_->addFilter(filter);
 
-    // TODO(mjeronimo): instead of get(), use a shared ptr
     filter->initialize(
       layered_costmap_.get(), filter_names_[i], tf_buffer_.get(),
       shared_from_this(), client_node_, rclcpp_node_);

--- a/nav2_costmap_2d/src/layered_costmap.cpp
+++ b/nav2_costmap_2d/src/layered_costmap.cpp
@@ -175,7 +175,7 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
       RCLCPP_WARN(
         rclcpp::get_logger(
           "nav2_costmap_2d"), "Illegal bounds change, was [tl: (%f, %f), br: (%f, %f)], but "
-        "is now [tl: (%f, %f), br: (%f, %f)]. The offending layer is %s",
+        "is now [tl: (%f, %f), br: (%f, %f)]. The offending filter is %s",
         prev_minx, prev_miny, prev_maxx, prev_maxy,
         minx_, miny_, maxx_, maxy_,
         (*filter)->getName().c_str());

--- a/nav2_costmap_2d/test/unit/CMakeLists.txt
+++ b/nav2_costmap_2d/test/unit/CMakeLists.txt
@@ -29,3 +29,8 @@ target_link_libraries(speed_filter_test
   nav2_costmap_2d_core
   filters
 )
+
+ament_add_gtest(copy_window_test copy_window_test.cpp)
+target_link_libraries(copy_window_test
+  nav2_costmap_2d_core
+)

--- a/nav2_costmap_2d/test/unit/copy_window_test.cpp
+++ b/nav2_costmap_2d/test/unit/copy_window_test.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 Samsung Research Russia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include <gtest/gtest.h>
+
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+RclCppFixture g_rclcppfixture;
+
+TEST(CopyWindow, copyValidWindow)
+{
+  nav2_costmap_2d::Costmap2D src(10, 10, 0.1, 0.0, 0.0);
+  nav2_costmap_2d::Costmap2D dst(5, 5, 0.2, 100.0, 100.0);
+  // Adding 2 marked cells to source costmap
+  src.setCost(2, 2, 100);
+  src.setCost(5, 5, 200);
+
+  ASSERT_TRUE(dst.copyWindow(src, 2, 2, 6, 6, 0, 0));
+  // Check that both marked cells were copied to destination costmap
+  ASSERT_TRUE(dst.getCost(0, 0) == 100);
+  ASSERT_TRUE(dst.getCost(3, 3) == 200);
+}
+
+TEST(CopyWindow, copyInvalidWindow)
+{
+  nav2_costmap_2d::Costmap2D src(10, 10, 0.1, 0.0, 0.0);
+  nav2_costmap_2d::Costmap2D dst(5, 5, 0.2, 100.0, 100.0);
+
+  // Case1: incorrect source bounds
+  ASSERT_FALSE(dst.copyWindow(src, 9, 9, 11, 11, 0, 0));
+  // Case2: incorrect destination bounds
+  ASSERT_FALSE(dst.copyWindow(src, 0, 0, 1, 1, 5, 5));
+  ASSERT_FALSE(dst.copyWindow(src, 0, 0, 6, 6, 0, 0));
+}

--- a/nav2_system_tests/src/costmap_filters/keepout_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/keepout_params.yaml
@@ -175,7 +175,8 @@ local_costmap:
       height: 3
       resolution: 0.05
       robot_radius: 0.22
-      plugins: ["voxel_layer", "inflation_layer", "keepout_filter"]
+      plugins: ["voxel_layer", "inflation_layer"]
+      filters: ["keepout_filter"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 3.0
@@ -225,7 +226,8 @@ global_costmap:
       robot_radius: 0.22
       resolution: 0.05
       track_unknown_space: true
-      plugins: ["static_layer", "obstacle_layer", "inflation_layer", "keepout_filter"]
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+      filters: ["keepout_filter"]
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True

--- a/nav2_system_tests/src/costmap_filters/speed_global_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/speed_global_params.yaml
@@ -197,11 +197,6 @@ local_costmap:
           data_type: "LaserScan"
       static_layer:
         map_subscribe_transient_local: True
-      speed_filter:
-        plugin: "nav2_costmap_2d::SpeedFilter"
-        enabled: True
-        filter_info_topic: "/costmap_filter_info"
-        speed_limit_topic: "/speed_limit"
       always_send_full_costmap: True
   local_costmap_client:
     ros__parameters:
@@ -221,7 +216,8 @@ global_costmap:
       robot_radius: 0.22
       resolution: 0.05
       track_unknown_space: true
-      plugins: ["static_layer", "obstacle_layer", "inflation_layer", "speed_filter"]
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+      filters: ["speed_filter"]
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True

--- a/nav2_system_tests/src/costmap_filters/speed_local_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/speed_local_params.yaml
@@ -174,7 +174,8 @@ local_costmap:
       height: 3
       resolution: 0.05
       robot_radius: 0.22
-      plugins: ["voxel_layer", "inflation_layer", "speed_filter"]
+      plugins: ["voxel_layer", "inflation_layer"]
+      filters: ["speed_filter"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 3.0


### PR DESCRIPTION
This fixes remaining "wings" artifacts from #2051 issue.
Wings artifacts appeared on the boundary window edges when costmap filters (e.g. `keepout_filter`) are being applied _after_ `inflation_layer`. The result of filter work at the `LayeredCostmap::updateMap()` stage is being merged into resulting costmap and on next `updateMap()` iterations treated as normal obstacles and finally being inflated inside boundary window which is causing "wings".
This can lead to such effects as shown in the picture below:
![no_fix_2d](https://user-images.githubusercontent.com/60094858/114550652-1b657600-9c6b-11eb-94a4-4b68e7011a12.png)

The proposed fix separates plugins and filters, applying plugins on `plugins_costmap_` and filters over the plugins, to usual `costmap_`. After fix applied, the resulting costmap looks like expected:
![fixd](https://user-images.githubusercontent.com/60094858/114550888-6089a800-9c6b-11eb-9fbd-ce31acd8c32f.png)


---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2051 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Gazebo simulation of TB3 in a [AWS](https://github.com/aws-robotics/aws-robomaker-small-warehouse-world) world |

---

## Description of contribution in a few bullet points

* Added new `filters` entity, the same as `plugins` but separated from them.
* Separeted costmaps updating mechanism for plugins and filters in order to allow filters to be applied over the plugins.
* Remain costmaps updating mechanism to be untouched when there are no filters enabled.
* Added auxilary `Costmap2D::copyWindow()` method.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
