### PR TITLE
[nav2_lifecycle_manager] Reduce lifecycle manager client verbose

### DIFF
--- a/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
@@ -74,7 +74,7 @@ LifecycleManagerClient::is_active(const std::chrono::nanoseconds timeout)
 {
   auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
 
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     node_->get_logger(), "Waiting for the %s service...",
     active_service_name_.c_str());
 
@@ -82,7 +82,7 @@ LifecycleManagerClient::is_active(const std::chrono::nanoseconds timeout)
     return SystemStatus::TIMEOUT;
   }
 
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     node_->get_logger(), "Sending %s request",
     active_service_name_.c_str());
   auto future_result = is_active_client_->async_send_request(request);
@@ -106,7 +106,7 @@ LifecycleManagerClient::callService(uint8_t command, const std::chrono::nanoseco
   auto request = std::make_shared<ManageLifecycleNodes::Request>();
   request->command = command;
 
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     node_->get_logger(), "Waiting for the %s service...",
     manage_service_name_.c_str());
 
@@ -115,10 +115,10 @@ LifecycleManagerClient::callService(uint8_t command, const std::chrono::nanoseco
       RCLCPP_ERROR(node_->get_logger(), "Client interrupted while waiting for service to appear");
       return false;
     }
-    RCLCPP_INFO(node_->get_logger(), "Waiting for service to appear...");
+    RCLCPP_DEBUG(node_->get_logger(), "Waiting for service to appear...");
   }
 
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     node_->get_logger(), "Sending %s request",
     manage_service_name_.c_str());
   auto future_result = manager_client_->async_send_request(request);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  |

---

## Description of contribution in a few bullet points
Switched RCLCPP_INFO to RCLCPP_DEBUG in `lifecycle_manager_client`. They are only messages about waiting and sending services to the lifecycle manager.
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
