### PR TITLE
Use incremental timeouts in spin_until_future_calls during BT execution to handle large server timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ __pycache__/
 *.py[cod]
 
 sphinx_doc/_build
+
+# CLion artifacts
+.idea
+cmake-build-debug/

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -52,7 +52,7 @@ public:
     bt_loop_timeout_ =
       config().blackboard->template get<std::chrono::milliseconds>("bt_loop_timeout");
     server_timeout_ =
-      config().blackboard->template get<std::chrono::milliseconds>("default_server_timeout");
+      config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
     getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
 
     // Set spin_until_future_complete timeout

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -271,7 +271,6 @@ public:
       }
     }
 
-    goal_handle_.reset();
     setStatus(BT::NodeStatus::IDLE);
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -55,9 +55,6 @@ public:
       config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
     getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
 
-    // Set spin_until_future_complete timeout
-    timeout_ = server_timeout_ < bt_loop_timeout_ ? server_timeout_ : bt_loop_timeout_;
-
     // Initialize the input and output messages
     goal_ = typename ActionT::Goal();
     result_ = typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult();
@@ -323,7 +320,7 @@ protected:
       return false;
     }
 
-    auto timeout = remaining > timeout_ ? timeout_ : remaining;
+    auto timeout = remaining > bt_loop_timeout_ ? bt_loop_timeout_ : remaining;
 
     auto result = rclcpp::spin_until_future_complete(node_, future_goal_handle_, timeout);
     if (result == rclcpp::FutureReturnCode::INTERRUPTED) {
@@ -372,9 +369,6 @@ protected:
 
   // The timeout value for BT loop execution
   std::chrono::milliseconds bt_loop_timeout_;
-
-  // spin_until_future_complete timeout value
-  std::chrono::milliseconds timeout_;
 
   // To track the action server response when a new goal is sent
   std::shared_future<typename rclcpp_action::ClientGoalHandle<ActionT>::SharedPtr>

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -225,6 +225,12 @@ protected:
   // To publish BT logs
   std::unique_ptr<RosTopicLogger> topic_logger_;
 
+  // Timeout value for each iteration of BT execution
+  std::chrono::milliseconds bt_loop_timeout_;
+
+  // Default timeout value while waiting for response from a server
+  std::chrono::milliseconds default_server_timeout_;
+
   // Parameters for Groot monitoring
   bool enable_groot_monitoring_;
   int groot_zmq_publisher_port_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -225,8 +225,8 @@ protected:
   // To publish BT logs
   std::unique_ptr<RosTopicLogger> topic_logger_;
 
-  // Timeout value for each iteration of BT execution
-  std::chrono::milliseconds bt_loop_timeout_;
+  // Duration for each iteration of BT execution
+  std::chrono::milliseconds bt_loop_duration_;
 
   // Default timeout value while waiting for response from a server
   std::chrono::milliseconds default_server_timeout_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -117,7 +117,7 @@ bool BtActionServer<ActionT>::on_configure()
 
   // Put items on the blackboard
   blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
-  blackboard_->set<std::chrono::milliseconds>("default_server_timeout", default_server_timeout_);  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);  // NOLINT
   blackboard_->set<std::chrono::milliseconds>("bt_loop_timeout", bt_loop_timeout_);  // NOLINT
 
   return true;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -57,7 +57,7 @@ BtActionServer<ActionT>::BtActionServer(
     node->declare_parameter("bt_loop_duration", 10);
   }
   if (!node->has_parameter("default_server_timeout")) {
-    node->declare_parameter("default_server_timeout", 10);
+    node->declare_parameter("default_server_timeout", 20);
   }
   if (!node->has_parameter("enable_groot_monitoring")) {
     node->declare_parameter("enable_groot_monitoring", true);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -53,8 +53,8 @@ BtActionServer<ActionT>::BtActionServer(
   clock_ = node->get_clock();
 
   // Declare this node's parameters
-  if (!node->has_parameter("bt_loop_timeout")) {
-    node->declare_parameter("bt_loop_timeout", 10);
+  if (!node->has_parameter("bt_loop_duration")) {
+    node->declare_parameter("bt_loop_duration", 10);
   }
   if (!node->has_parameter("default_server_timeout")) {
     node->declare_parameter("default_server_timeout", 10);
@@ -104,8 +104,8 @@ bool BtActionServer<ActionT>::on_configure()
 
   // Get parameters for BT timeouts
   int timeout;
-  node->get_parameter("bt_loop_timeout", timeout);
-  bt_loop_timeout_ = std::chrono::milliseconds(timeout);
+  node->get_parameter("bt_loop_duration", timeout);
+  bt_loop_duration_ = std::chrono::milliseconds(timeout);
   node->get_parameter("default_server_timeout", timeout);
   default_server_timeout_ = std::chrono::milliseconds(timeout);
 
@@ -118,7 +118,7 @@ bool BtActionServer<ActionT>::on_configure()
   // Put items on the blackboard
   blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
   blackboard_->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);  // NOLINT
-  blackboard_->set<std::chrono::milliseconds>("bt_loop_timeout", bt_loop_timeout_);  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>("bt_loop_duration", bt_loop_duration_);  // NOLINT
 
   return true;
 }
@@ -231,7 +231,7 @@ void BtActionServer<ActionT>::executeCallback()
     };
 
   // Execute the BT that was previously created in the configure step
-  nav2_behavior_tree::BtStatus rc = bt_->run(&tree_, on_loop, is_canceling, bt_loop_timeout_);
+  nav2_behavior_tree::BtStatus rc = bt_->run(&tree_, on_loop, is_canceling, bt_loop_duration_);
 
   // Make sure that the Bt is not in a running state from a previous execution
   // note: if all the ControlNodes are implemented correctly, this is not needed.

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -53,6 +53,12 @@ BtActionServer<ActionT>::BtActionServer(
   clock_ = node->get_clock();
 
   // Declare this node's parameters
+  if (!node->has_parameter("bt_loop_timeout")) {
+    node->declare_parameter("bt_loop_timeout", 10);
+  }
+  if (!node->has_parameter("default_server_timeout")) {
+    node->declare_parameter("default_server_timeout", 10);
+  }
   if (!node->has_parameter("enable_groot_monitoring")) {
     node->declare_parameter("enable_groot_monitoring", true);
   }
@@ -91,6 +97,18 @@ bool BtActionServer<ActionT>::on_configure()
     node->get_node_waitables_interface(),
     action_name_, std::bind(&BtActionServer<ActionT>::executeCallback, this));
 
+  // Get parameter for monitoring with Groot via ZMQ Publisher
+  node->get_parameter("enable_groot_monitoring", enable_groot_monitoring_);
+  node->get_parameter("groot_zmq_publisher_port", groot_zmq_publisher_port_);
+  node->get_parameter("groot_zmq_server_port", groot_zmq_server_port_);
+
+  // Get parameters for BT timeouts
+  int timeout;
+  node->get_parameter("bt_loop_timeout", timeout);
+  bt_loop_timeout_ = std::chrono::milliseconds(timeout);
+  node->get_parameter("default_server_timeout", timeout);
+  default_server_timeout_ = std::chrono::milliseconds(timeout);
+
   // Create the class that registers our custom nodes and executes the BT
   bt_ = std::make_unique<nav2_behavior_tree::BehaviorTreeEngine>(plugin_lib_names_);
 
@@ -99,12 +117,8 @@ bool BtActionServer<ActionT>::on_configure()
 
   // Put items on the blackboard
   blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
-  blackboard_->set<std::chrono::milliseconds>("server_timeout", std::chrono::milliseconds(10));  // NOLINT
-
-  // Get parameter for monitoring with Groot via ZMQ Publisher
-  node->get_parameter("enable_groot_monitoring", enable_groot_monitoring_);
-  node->get_parameter("groot_zmq_publisher_port", groot_zmq_publisher_port_);
-  node->get_parameter("groot_zmq_server_port", groot_zmq_server_port_);
+  blackboard_->set<std::chrono::milliseconds>("default_server_timeout", default_server_timeout_);  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>("bt_loop_timeout", bt_loop_timeout_);  // NOLINT
 
   return true;
 }
@@ -217,7 +231,7 @@ void BtActionServer<ActionT>::executeCallback()
     };
 
   // Execute the BT that was previously created in the configure step
-  nav2_behavior_tree::BtStatus rc = bt_->run(&tree_, on_loop, is_canceling);
+  nav2_behavior_tree::BtStatus rc = bt_->run(&tree_, on_loop, is_canceling, bt_loop_timeout_);
 
   // Make sure that the Bt is not in a running state from a previous execution
   // note: if all the ControlNodes are implemented correctly, this is not needed.

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -47,8 +47,8 @@ public:
     node_ = config().blackboard->template get<rclcpp::Node::SharedPtr>("node");
 
     // Get the required items from the blackboard
-    bt_loop_timeout_ =
-      config().blackboard->template get<std::chrono::milliseconds>("bt_loop_timeout");
+    bt_loop_duration_ =
+      config().blackboard->template get<std::chrono::milliseconds>("bt_loop_duration");
     server_timeout_ =
       config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
     getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
@@ -136,7 +136,7 @@ public:
     auto remaining = server_timeout_ - elapsed;
 
     if (remaining > std::chrono::milliseconds(0)) {
-      auto timeout = remaining > bt_loop_timeout_ ? bt_loop_timeout_ : remaining;
+      auto timeout = remaining > bt_loop_duration_ ? bt_loop_duration_ : remaining;
 
       auto rc = rclcpp::spin_until_future_complete(node_, future_result_, timeout);
       if (rc == rclcpp::FutureReturnCode::SUCCESS) {
@@ -192,7 +192,7 @@ protected:
   std::chrono::milliseconds server_timeout_;
 
   // The timeout value for BT loop execution
-  std::chrono::milliseconds bt_loop_timeout_;
+  std::chrono::milliseconds bt_loop_duration_;
 
   // To track the server response when a new request is sent
   std::shared_future<typename ServiceT::Response::SharedPtr> future_result_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -31,7 +31,7 @@ namespace nav2_behavior_tree
  * @tparam ServiceT Type of service
  */
 template<class ServiceT>
-class BtServiceNode : public BT::SyncActionNode
+class BtServiceNode : public BT::ActionNodeBase
 {
 public:
   /**
@@ -42,7 +42,7 @@ public:
   BtServiceNode(
     const std::string & service_node_name,
     const BT::NodeConfiguration & conf)
-  : BT::SyncActionNode(service_node_name, conf), service_node_name_(service_node_name)
+  : BT::ActionNodeBase(service_node_name, conf), service_node_name_(service_node_name)
   {
     node_ = config().blackboard->template get<rclcpp::Node::SharedPtr>("node");
 
@@ -116,6 +116,15 @@ public:
       request_sent_ = true;
     }
     return check_future();
+  }
+
+  /**
+   * @brief The other (optional) override required by a BT service.
+   */
+  void halt() override
+  {
+    request_sent_ = false;
+    setStatus(BT::NodeStatus::IDLE);
   }
 
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -156,7 +156,7 @@ public:
     RCLCPP_WARN(
       node_->get_logger(),
       "Node timed out while executing service call to %s.", service_name_.c_str());
-
+    request_sent_ = false;
     return BT::NodeStatus::FAILURE;
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -50,7 +50,7 @@ public:
     bt_loop_timeout_ =
       config().blackboard->template get<std::chrono::milliseconds>("bt_loop_timeout");
     server_timeout_ =
-      config().blackboard->template get<std::chrono::milliseconds>("default_server_timeout");
+      config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
     getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
 
     // Set spin_until_future_complete timeout

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -53,9 +53,6 @@ public:
       config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
     getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
 
-    // Set spin_until_future_complete timeout
-    timeout_ = server_timeout_ < bt_loop_timeout_ ? server_timeout_ : bt_loop_timeout_;
-
     // Now that we have node_ to use, create the service client for this BT service
     getInput("service_name", service_name_);
     service_client_ = node_->create_client<ServiceT>(service_name_);
@@ -139,7 +136,7 @@ public:
     auto remaining = server_timeout_ - elapsed;
 
     if (remaining > std::chrono::milliseconds(0)) {
-      auto timeout = remaining > timeout_ ? timeout_ : remaining;
+      auto timeout = remaining > bt_loop_timeout_ ? bt_loop_timeout_ : remaining;
 
       auto rc = rclcpp::spin_until_future_complete(node_, future_result_, timeout);
       if (rc == rclcpp::FutureReturnCode::SUCCESS) {
@@ -196,9 +193,6 @@ protected:
 
   // The timeout value for BT loop execution
   std::chrono::milliseconds bt_loop_timeout_;
-
-  // spin_until_future_complete timeout value
-  std::chrono::milliseconds timeout_;
 
   // To track the server response when a new request is sent
   std::shared_future<typename ServiceT::Response::SharedPtr> future_result_;

--- a/nav2_behavior_tree/test/plugins/action/CMakeLists.txt
+++ b/nav2_behavior_tree/test/plugins/action/CMakeLists.txt
@@ -1,3 +1,6 @@
+ament_add_gtest(test_bt_action_node test_bt_action_node.cpp)
+ament_target_dependencies(test_bt_action_node ${dependencies})
+
 ament_add_gtest(test_action_spin_action test_spin_action.cpp)
 target_link_libraries(test_action_spin_action nav2_spin_action_bt_node)
 ament_target_dependencies(test_action_spin_action ${dependencies})

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
@@ -65,6 +65,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
 

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
@@ -66,7 +66,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
@@ -64,7 +64,7 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
@@ -1,0 +1,317 @@
+// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2020 Sarthak Mittal
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <set>
+#include <vector>
+#include <string>
+#include <chrono>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+
+#include "behaviortree_cpp_v3/bt_factory.h"
+#include "nav2_behavior_tree/bt_action_node.hpp"
+
+#include "test_msgs/action/fibonacci.hpp"
+
+using namespace std::chrono_literals; // NOLINT
+using namespace std::placeholders;  // NOLINT
+
+class FibonacciActionServer : public rclcpp::Node
+{
+public:
+  FibonacciActionServer()
+  : rclcpp::Node("fibonacci_node", rclcpp::NodeOptions()),
+    sleep_duration_(0ms)
+  {
+    this->action_server_ = rclcpp_action::create_server<test_msgs::action::Fibonacci>(
+      this->get_node_base_interface(),
+      this->get_node_clock_interface(),
+      this->get_node_logging_interface(),
+      this->get_node_waitables_interface(),
+      "fibonacci",
+      std::bind(&FibonacciActionServer::handle_goal, this, _1, _2),
+      std::bind(&FibonacciActionServer::handle_cancel, this, _1),
+      std::bind(&FibonacciActionServer::handle_accepted, this, _1));
+  }
+
+  void setHandleGoalSleepDuration(std::chrono::milliseconds sleep_duration)
+  {
+    sleep_duration_ = sleep_duration;
+  }
+
+protected:
+  rclcpp_action::GoalResponse handle_goal(
+    const rclcpp_action::GoalUUID &,
+    std::shared_ptr<const test_msgs::action::Fibonacci::Goal>)
+  {
+    if (sleep_duration_ > 0ms) {
+      std::this_thread::sleep_for(sleep_duration_);
+    }
+    return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+  }
+
+  rclcpp_action::CancelResponse handle_cancel(
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<test_msgs::action::Fibonacci>>)
+  {
+    return rclcpp_action::CancelResponse::ACCEPT;
+  }
+
+  void handle_accepted(
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<test_msgs::action::Fibonacci>> handle)
+  {
+    // this needs to return quickly to avoid blocking the executor, so spin up a new thread
+    if (handle) {
+      const auto goal = handle->get_goal();
+      auto result = std::make_shared<test_msgs::action::Fibonacci::Result>();
+
+      if (goal->order < 0) {
+        handle->abort(result);
+        return;
+      }
+
+      auto & sequence = result->sequence;
+      sequence.push_back(0);
+      sequence.push_back(1);
+
+      for (int i = 1; (i < goal->order) && rclcpp::ok(); ++i) {
+        sequence.push_back(sequence[i] + sequence[i - 1]);
+      }
+
+      handle->succeed(result);
+    }
+  }
+
+protected:
+  rclcpp_action::Server<test_msgs::action::Fibonacci>::SharedPtr action_server_;
+  std::chrono::milliseconds sleep_duration_;
+};
+
+class FibonacciAction : public nav2_behavior_tree::BtActionNode<test_msgs::action::Fibonacci>
+{
+public:
+  FibonacciAction(
+    const std::string & xml_tag_name,
+    const BT::NodeConfiguration & conf)
+  : nav2_behavior_tree::BtActionNode<test_msgs::action::Fibonacci>(xml_tag_name, "fibonacci", conf)
+  {}
+
+  void on_tick() override
+  {
+    getInput("order", goal_.order);
+  }
+
+  BT::NodeStatus on_success() override
+  {
+    config().blackboard->set<std::vector<int>>("sequence", result_.result->sequence);
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return providedBasicPorts({BT::InputPort<int>("order", "Fibonacci order")});
+  }
+};
+
+class BTActionNodeTestFixture : public ::testing::Test
+{
+public:
+  static void SetUpTestCase()
+  {
+    node_ = std::make_shared<rclcpp::Node>("bt_action_node_test_fixture");
+    factory_ = std::make_shared<BT::BehaviorTreeFactory>();
+
+    config_ = new BT::NodeConfiguration();
+
+    // Create the blackboard that will be shared by all of the nodes in the tree
+    config_->blackboard = BT::Blackboard::create();
+    // Put items on the blackboard
+    config_->blackboard->set<rclcpp::Node::SharedPtr>("node", node_);
+    config_->blackboard->set<std::chrono::milliseconds>("server_timeout", 10ms);
+    config_->blackboard->set<std::chrono::milliseconds>("bt_loop_duration", 10ms);
+    config_->blackboard->set<bool>("initial_pose_received", false);
+
+    BT::NodeBuilder builder =
+      [](const std::string & name, const BT::NodeConfiguration & config)
+      {
+        return std::make_unique<FibonacciAction>(name, config);
+      };
+
+    factory_->registerBuilder<FibonacciAction>("Fibonacci", builder);
+  }
+
+  static void TearDownTestCase()
+  {
+    delete config_;
+    config_ = nullptr;
+    node_.reset();
+    action_server_.reset();
+    factory_.reset();
+  }
+
+  void SetUp() override
+  {
+    // initialize action server and spin on new thread
+    action_server_ = std::make_shared<FibonacciActionServer>();
+    server_thread_ = std::make_shared<std::thread>(
+      []() {
+        while (rclcpp::ok() && BTActionNodeTestFixture::action_server_ != nullptr) {
+          rclcpp::spin_some(BTActionNodeTestFixture::action_server_);
+          std::this_thread::sleep_for(100ns);
+        }
+      });
+  }
+
+  void TearDown() override
+  {
+    action_server_.reset();
+    tree_.reset();
+    server_thread_->join();
+    server_thread_.reset();
+  }
+
+  static std::shared_ptr<FibonacciActionServer> action_server_;
+
+protected:
+  static rclcpp::Node::SharedPtr node_;
+  static BT::NodeConfiguration * config_;
+  static std::shared_ptr<BT::BehaviorTreeFactory> factory_;
+  static std::shared_ptr<BT::Tree> tree_;
+  static std::shared_ptr<std::thread> server_thread_;
+};
+
+rclcpp::Node::SharedPtr BTActionNodeTestFixture::node_ = nullptr;
+std::shared_ptr<FibonacciActionServer> BTActionNodeTestFixture::action_server_ = nullptr;
+BT::NodeConfiguration * BTActionNodeTestFixture::config_ = nullptr;
+std::shared_ptr<BT::BehaviorTreeFactory> BTActionNodeTestFixture::factory_ = nullptr;
+std::shared_ptr<BT::Tree> BTActionNodeTestFixture::tree_ = nullptr;
+std::shared_ptr<std::thread> BTActionNodeTestFixture::server_thread_ = nullptr;
+
+TEST_F(BTActionNodeTestFixture, test_short_action)
+{
+  // create tree
+  std::string xml_txt =
+    R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+            <Fibonacci order="5" />
+        </BehaviorTree>
+      </root>)";
+
+  // the server timeout is larger than the goal handling duration
+  config_->blackboard->set<std::chrono::milliseconds>("server_timeout", 20ms);
+  config_->blackboard->set<std::chrono::milliseconds>("bt_loop_duration", 10ms);
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  // setting a small action server goal handling duration
+  action_server_->setHandleGoalSleepDuration(2ms);
+
+  // to keep track of the number of ticks it took to reach a terminal result
+  int ticks = 0;
+
+  BT::NodeStatus result = BT::NodeStatus::RUNNING;
+
+  // BT loop execution rate
+  rclcpp::WallRate loopRate(10ms);
+
+  // main BT execution loop
+  while (rclcpp::ok() && result == BT::NodeStatus::RUNNING) {
+    result = tree_->tickRoot();
+    ticks++;
+    loopRate.sleep();
+  }
+
+  // get calculated fibonacci sequence from blackboard
+  auto sequence = config_->blackboard->get<std::vector<int>>("sequence");
+
+  // expected fibonacci sequence for order 5
+  std::vector<int> expected = {0, 1, 1, 2, 3, 5};
+
+  // since the server timeout was larger than the action server goal handling duration
+  // the BT should have succeeded
+  EXPECT_EQ(result, BT::NodeStatus::SUCCESS);
+
+  // even though the goal is accepted in the first tick, due to some timing issues
+  // the goal result is available in the next tick
+  EXPECT_EQ(ticks, 2);
+
+  // checking the output fibonacci sequence
+  EXPECT_EQ(sequence.size(), expected.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(sequence[i], expected[i]);
+  }
+}
+
+TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)
+{
+  // create tree
+  std::string xml_txt =
+    R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+            <Fibonacci order="2" />
+        </BehaviorTree>
+      </root>)";
+
+  // setting a server timeout smaller than the time the action server will take to accept the goal
+  // to simulate a server timeout scenario
+  config_->blackboard->set<std::chrono::milliseconds>("server_timeout", 90ms);
+  config_->blackboard->set<std::chrono::milliseconds>("bt_loop_duration", 10ms);
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  // the action server will take 100ms before accepting the goal
+  action_server_->setHandleGoalSleepDuration(100ms);
+
+  // to keep track of the number of ticks it took to reach a terminal result
+  int ticks = 0;
+
+  BT::NodeStatus result = BT::NodeStatus::RUNNING;
+
+  // BT loop execution rate
+  rclcpp::WallRate loopRate(10ms);
+
+  // main BT execution loop
+  while (rclcpp::ok() && result == BT::NodeStatus::RUNNING) {
+    result = tree_->tickRoot();
+    ticks++;
+    loopRate.sleep();
+  }
+
+  // since the server timeout was smaller than the action server goal handling duration
+  // the BT should have failed
+  EXPECT_EQ(result, BT::NodeStatus::FAILURE);
+
+  // since the server timeout is 90ms and bt loop duration is 10ms, number of ticks should be 9
+  EXPECT_EQ(ticks, 9);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  int all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
@@ -141,7 +141,7 @@ public:
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
     config_->blackboard->set<rclcpp::Node::SharedPtr>("node", node_);
-    config_->blackboard->set<std::chrono::milliseconds>("server_timeout", 10ms);
+    config_->blackboard->set<std::chrono::milliseconds>("server_timeout", 20ms);
     config_->blackboard->set<std::chrono::milliseconds>("bt_loop_duration", 10ms);
     config_->blackboard->set<bool>("initial_pose_received", false);
 
@@ -246,10 +246,6 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_success)
   // the BT should have succeeded
   EXPECT_EQ(result, BT::NodeStatus::SUCCESS);
 
-  // even though the goal is accepted in the first tick, due to some timing issues
-  // the goal result is available in the next tick
-  EXPECT_EQ(ticks, 2);
-
   // checking the output fibonacci sequence
   EXPECT_EQ(sequence.size(), expected.size());
   for (size_t i = 0; i < expected.size(); ++i) {
@@ -350,9 +346,6 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)
   // since the server timeout was smaller than the action server goal handling duration
   // the BT should have failed
   EXPECT_EQ(result, BT::NodeStatus::SUCCESS);
-
-  // takes 3 ticks waiting for the action server acknowledgement and 3 more ticks to get goal result
-  EXPECT_EQ(ticks, 6);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
@@ -49,7 +49,7 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
@@ -51,7 +51,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
@@ -137,7 +137,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
@@ -229,7 +229,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);

--- a/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
@@ -50,6 +50,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
 
@@ -132,6 +135,9 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
+      std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
@@ -221,6 +227,9 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
+      std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
@@ -72,7 +72,7 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
@@ -73,6 +73,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     BT::NodeBuilder builder =

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
@@ -74,7 +74,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
@@ -70,7 +70,7 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
@@ -72,7 +72,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
@@ -71,6 +71,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     BT::NodeBuilder builder =

--- a/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
@@ -63,7 +63,7 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
@@ -65,7 +65,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 

--- a/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
@@ -64,6 +64,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     BT::NodeBuilder builder =

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
@@ -67,6 +67,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     std::vector<geometry_msgs::msg::PoseStamped> poses;
     config_->blackboard->set<std::vector<geometry_msgs::msg::PoseStamped>>(

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
@@ -66,7 +66,7 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
@@ -68,7 +68,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     std::vector<geometry_msgs::msg::PoseStamped> poses;

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
@@ -66,7 +66,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
@@ -65,6 +65,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     BT::NodeBuilder builder =

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
@@ -64,7 +64,7 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
@@ -50,6 +50,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     factory_->registerNodeType<nav2_behavior_tree::ReinitializeGlobalLocalizationService>(

--- a/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
@@ -49,7 +49,7 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
@@ -51,7 +51,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 

--- a/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
@@ -65,6 +65,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
 

--- a/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
@@ -66,7 +66,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);

--- a/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
@@ -64,7 +64,7 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
@@ -57,7 +57,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);

--- a/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
@@ -56,6 +56,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
     config_->blackboard->set<int>("number_recoveries", 0);
 

--- a/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
@@ -55,7 +55,7 @@ public:
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
@@ -46,7 +46,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
   }

--- a/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
@@ -45,6 +45,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
   }
 

--- a/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
@@ -44,7 +44,7 @@ public:
       transform_handler_->getBuffer());
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/test_behavior_tree_fixture.hpp
+++ b/nav2_behavior_tree/test/test_behavior_tree_fixture.hpp
@@ -52,6 +52,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));
+    config_->blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout",
+      std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 
     transform_handler_->activate();

--- a/nav2_behavior_tree/test/test_behavior_tree_fixture.hpp
+++ b/nav2_behavior_tree/test/test_behavior_tree_fixture.hpp
@@ -53,7 +53,7 @@ public:
       "server_timeout",
       std::chrono::milliseconds(10));
     config_->blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout",
+      "bt_loop_duration",
       std::chrono::milliseconds(10));
     config_->blackboard->set<bool>("initial_pose_received", false);
 

--- a/nav2_behavior_tree/test/test_behavior_tree_fixture.hpp
+++ b/nav2_behavior_tree/test/test_behavior_tree_fixture.hpp
@@ -51,7 +51,7 @@ public:
       transform_handler_->getBuffer());
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
-      std::chrono::milliseconds(10));
+      std::chrono::milliseconds(20));
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
@@ -53,6 +53,8 @@ bt_navigator:
     global_frame: map
     robot_base_frame: base_link
     odom_topic: /odom
+    bt_loop_timeout: 10
+    default_server_timeout: 10
     # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
     # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
     # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
@@ -53,7 +53,7 @@ bt_navigator:
     global_frame: map
     robot_base_frame: base_link
     odom_topic: /odom
-    bt_loop_timeout: 10
+    bt_loop_duration: 10
     default_server_timeout: 10
     # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
     # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
@@ -54,7 +54,7 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: /odom
     bt_loop_duration: 10
-    default_server_timeout: 10
+    default_server_timeout: 20
     # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
     # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
     # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
@@ -53,6 +53,8 @@ bt_navigator:
     global_frame: map
     robot_base_frame: base_link
     odom_topic: /odom
+    bt_loop_timeout: 10
+    default_server_timeout: 10
     # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
     # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
     # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
@@ -53,7 +53,7 @@ bt_navigator:
     global_frame: map
     robot_base_frame: base_link
     odom_topic: /odom
-    bt_loop_timeout: 10
+    bt_loop_duration: 10
     default_server_timeout: 10
     # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
     # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
@@ -54,7 +54,7 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: /odom
     bt_loop_duration: 10
-    default_server_timeout: 10
+    default_server_timeout: 20
     # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
     # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
     # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -53,6 +53,8 @@ bt_navigator:
     global_frame: map
     robot_base_frame: base_link
     odom_topic: /odom
+    bt_loop_timeout: 10
+    default_server_timeout: 10
     enable_groot_monitoring: True
     groot_zmq_publisher_port: 1666
     groot_zmq_server_port: 1667

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -54,7 +54,7 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: /odom
     bt_loop_duration: 10
-    default_server_timeout: 10
+    default_server_timeout: 20
     enable_groot_monitoring: True
     groot_zmq_publisher_port: 1666
     groot_zmq_server_port: 1667

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -53,7 +53,7 @@ bt_navigator:
     global_frame: map
     robot_base_frame: base_link
     odom_topic: /odom
-    bt_loop_timeout: 10
+    bt_loop_duration: 10
     default_server_timeout: 10
     enable_groot_monitoring: True
     groot_zmq_publisher_port: 1666

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -38,7 +38,7 @@ GoalPoseUpdater GoalUpdater;
 
 Nav2Panel::Nav2Panel(QWidget * parent)
 : Panel(parent),
-  server_timeout_(10),
+  server_timeout_(20),
   client_nav_("lifecycle_manager_navigation"),
   client_loc_("lifecycle_manager_localization")
 {

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -110,6 +110,8 @@ public:
     blackboard->set<rclcpp::Node::SharedPtr>("node", node_);  // NOLINT
     blackboard->set<std::chrono::milliseconds>(
       "server_timeout", std::chrono::milliseconds(10));  // NOLINT
+    blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_timeout", std::chrono::milliseconds(10));  // NOLINT
     blackboard->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", tf_);  // NOLINT
     blackboard->set<bool>("initial_pose_received", false);  // NOLINT
     blackboard->set<int>("number_recoveries", 0);  // NOLINT

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -111,7 +111,7 @@ public:
     blackboard->set<std::chrono::milliseconds>(
       "server_timeout", std::chrono::milliseconds(10));  // NOLINT
     blackboard->set<std::chrono::milliseconds>(
-      "bt_loop_timeout", std::chrono::milliseconds(10));  // NOLINT
+      "bt_loop_duration", std::chrono::milliseconds(10));  // NOLINT
     blackboard->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", tf_);  // NOLINT
     blackboard->set<bool>("initial_pose_received", false);  // NOLINT
     blackboard->set<int>("number_recoveries", 0);  // NOLINT

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -109,7 +109,7 @@ public:
     // Put items on the blackboard
     blackboard->set<rclcpp::Node::SharedPtr>("node", node_);  // NOLINT
     blackboard->set<std::chrono::milliseconds>(
-      "server_timeout", std::chrono::milliseconds(10));  // NOLINT
+      "server_timeout", std::chrono::milliseconds(20));  // NOLINT
     blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration", std::chrono::milliseconds(10));  // NOLINT
     blackboard->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", tf_);  // NOLINT


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2280 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | TurtleBot3 Gazebo simulation |

---

## Description of contribution in a few bullet points

* `BtServiceNode` and `BtActionNode` use incremental timeout values in all `rclcpp::spin_until_future_complete` calls while waiting for the server to response to a request when the specified server timeout exceeds the BT execution loop rate. This ensures that `rclcpp::spin_until_future_complete` don't slow down BT execution if the server timeout has to be increased for whatever reason.
* Expose `bt_loop_timeout` and `default_server_timeout` as node parameters.

## Description of documentation updates required from your changes

* Add `bt_loop_timeout` and `default_server_timeout` to navigation.ros.org

---

## Future work that may be required in bullet points


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
