### PR TITLE
removed name parameter from rviz_launch.py

### DIFF
--- a/nav2_bringup/bringup/launch/rviz_launch.py
+++ b/nav2_bringup/bringup/launch/rviz_launch.py
@@ -57,7 +57,6 @@ def generate_launch_description():
         condition=UnlessCondition(use_namespace),
         package='rviz2',
         executable='rviz2',
-        name='rviz2',
         arguments=['-d', rviz_config_file],
         output='screen')
 
@@ -69,7 +68,6 @@ def generate_launch_description():
         condition=IfCondition(use_namespace),
         package='rviz2',
         executable='rviz2',
-        name='rviz2',
         namespace=namespace,
         arguments=['-d', namespaced_rviz_config_file],
         output='screen',


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info
This should be a pretty trivial change to avoid warnings when launching `rviz_launch.py` included in the bringup directory (discussed a bit over in ros2/rviz#671). Setting the Node name parameter remaps the name of all 4 nodes launched by `rviz_launch.py` to be the same name. This results in warnings on launch and when listing ros2 nodes. As far as I can tell, removing the name parameter does not affect behavior of the launch script and avoids the node name clash. 


| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | () |

---

## Description of contribution in a few bullet points
- removed `name='rviz2'` from rviz_launch.py to eliminate duplicate node name warning

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points
- This could be extended to other branches that include `rviz_launch.py` (e.g. `foxy-devel`), but I figured I'd raise it for main first to make sure I  didn't overlook anything silly
<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
