### PR TITLE
Validate codecov script against checksums.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,10 @@ _steps:
       name: Upload Code Coverage
       working_directory: /opt/overlay_ws
       command: |
-        curl -s https://codecov.io/bash | bash -s -- \
+        curl -s https://codecov.io/bash > codecov
+        local codecov_version=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)
+        shasum -a 512 -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${codecov_version}/SHA512SUM" | grep -w "codecov")
+        bash codecov \
           -f "lcov/project_coverage.info" \
           -R "src/navigation2" \
           -t "${CODECOV_TOKEN}" \

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -87,7 +87,10 @@ lcov \
   --rc lcov_branch_coverage=0
 
 if [ $COVERAGE_REPORT_VIEW = codecovio ]; then
-  bash <(curl -s https://codecov.io/bash) \
+  curl -s https://codecov.io/bash > codecov
+  local codecov_version=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)
+  shasum -a 512 -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${codecov_version}/SHA512SUM" | grep -w "codecov")
+  bash codecov \
     -f ${LCOVDIR}/project_coverage.info \
     -R src/navigation2
 elif [ $COVERAGE_REPORT_VIEW = genhtml ]; then


### PR DESCRIPTION
After the recent Codecov security incident[1] I've been reviewing
codecov usage across ROS repositories.

This repository is fetching the codecov bash uploader without performing
the recommended validation step.

The validation step does not appear to have been widely explained or
publicised and even the official codecov GitHub action was not
validating the script until the recent security incident.

I have made an attempt to validate the bash uploader here.

[1]: https://about.codecov.io/security-update/
