### PR TITLE
Fix script error in codecov validation.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ _steps:
       working_directory: /opt/overlay_ws
       command: |
         curl -s https://codecov.io/bash > codecov
-        local codecov_version=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)
+        codecov_version=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)
         shasum -a 512 -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${codecov_version}/SHA512SUM" | grep -w "codecov")
         bash codecov \
           -f "lcov/project_coverage.info" \

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -88,7 +88,7 @@ lcov \
 
 if [ $COVERAGE_REPORT_VIEW = codecovio ]; then
   curl -s https://codecov.io/bash > codecov
-  local codecov_version=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)
+  codecov_version=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)
   shasum -a 512 -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${codecov_version}/SHA512SUM" | grep -w "codecov")
   bash codecov \
     -f ${LCOVDIR}/project_coverage.info \


### PR DESCRIPTION
`local` in bash can only be used within a function context.

Fixes the regression reported in https://github.com/ros-planning/navigation2/pull/2330#issuecomment-837032101