### PR TITLE
Add action feedback information to nav2 rviz panel

### DIFF
--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -102,6 +102,12 @@ private:
   rclcpp_action::Client<nav2_msgs::action::NavigateThroughPoses>::SharedPtr
     nav_through_poses_action_client_;
 
+  // Navigation action feedback subscribers
+  rclcpp::Subscription<nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage>::SharedPtr
+    navigation_feedback_sub_;
+  rclcpp::Subscription<nav2_msgs::action::NavigateThroughPoses::Impl::FeedbackMessage>::SharedPtr
+    nav_through_poses_feedback_sub_;
+
   // Goal-related state
   nav2_msgs::action::NavigateToPose::Goal navigation_goal_;
   nav2_msgs::action::FollowWaypoints::Goal waypoint_follower_goal_;
@@ -120,6 +126,7 @@ private:
 
   QLabel * navigation_status_indicator_{nullptr};
   QLabel * localization_status_indicator_{nullptr};
+  QLabel * navigation_feedback_indicator_{nullptr};
 
   QStateMachine state_machine_;
   InitialThread * initial_thread_;
@@ -151,6 +158,19 @@ private:
   int getUniqueId();
 
   void resetUniqueId();
+
+  // callbacks for action feedback subscriptions
+  void onNavigateToPoseFeebackReceived(
+    const nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage::SharedPtr msg);
+  void onNavigateThroughPosesFeebackReceived(
+    const nav2_msgs::action::NavigateThroughPoses::Impl::FeedbackMessage::SharedPtr msg);
+
+  // create label string from feedback msg
+  template<typename T>
+  static inline std::string toLabel(T & msg);
+
+  // round off double to the specified precision and convert to string
+  static inline std::string toString(double val, int precision = 2);
 
   // Waypoint navigation visual markers publisher
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr wp_navigation_markers_pub_;

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -107,6 +107,10 @@ private:
     navigation_feedback_sub_;
   rclcpp::Subscription<nav2_msgs::action::NavigateThroughPoses::Impl::FeedbackMessage>::SharedPtr
     nav_through_poses_feedback_sub_;
+  rclcpp::Subscription<nav2_msgs::action::NavigateToPose::Impl::GoalStatusMessage>::SharedPtr
+    navigation_goal_status_sub_;
+  rclcpp::Subscription<nav2_msgs::action::NavigateThroughPoses::Impl::GoalStatusMessage>::SharedPtr
+    nav_through_poses_goal_status_sub_;
 
   // Goal-related state
   nav2_msgs::action::NavigateToPose::Goal navigation_goal_;
@@ -126,6 +130,7 @@ private:
 
   QLabel * navigation_status_indicator_{nullptr};
   QLabel * localization_status_indicator_{nullptr};
+  QLabel * navigation_goal_status_indicator_{nullptr};
   QLabel * navigation_feedback_indicator_{nullptr};
 
   QStateMachine state_machine_;
@@ -159,18 +164,22 @@ private:
 
   void resetUniqueId();
 
-  // callbacks for action feedback subscriptions
-  void onNavigateToPoseFeebackReceived(
-    const nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage::SharedPtr msg);
-  void onNavigateThroughPosesFeebackReceived(
-    const nav2_msgs::action::NavigateThroughPoses::Impl::FeedbackMessage::SharedPtr msg);
+  // create label string from goal status msg
+  static inline QString getGoalStatusLabel(
+    int8_t status = action_msgs::msg::GoalStatus::STATUS_UNKNOWN);
 
   // create label string from feedback msg
+  static inline QString getNavToPoseFeedbackLabel(
+    nav2_msgs::action::NavigateToPose::Feedback msg =
+    nav2_msgs::action::NavigateToPose::Feedback());
+  static inline QString getNavThroughPosesFeedbackLabel(
+    nav2_msgs::action::NavigateThroughPoses::Feedback =
+    nav2_msgs::action::NavigateThroughPoses::Feedback());
   template<typename T>
   static inline std::string toLabel(T & msg);
 
   // round off double to the specified precision and convert to string
-  static inline std::string toString(double val, int precision = 2);
+  static inline std::string toString(double val, int precision = 0);
 
   // Waypoint navigation visual markers publisher
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr wp_navigation_markers_pub_;

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -49,6 +49,7 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   navigation_mode_button_ = new QPushButton;
   navigation_status_indicator_ = new QLabel;
   localization_status_indicator_ = new QLabel;
+  navigation_goal_status_indicator_ = new QLabel;
   navigation_feedback_indicator_ = new QLabel;
 
   // Create the state machine used to present the proper control button states in the UI
@@ -75,16 +76,14 @@ Nav2Panel::Nav2Panel(QWidget * parent)
     "<td>inactive</td></tr></table>");
   const QString localization_unknown("<table><tr><td width=100><b>Localization:</b></td>"
     "<td>unknown</td></tr></table>");
-  const QString navigation_feedback_inactive("<table><tr><td width=100><b>Feedback:</b></td>"
-    "<td>inactive</td></tr></table>");
-  const QString navigation_feedback_unknown("<table><tr><td width=100><b>Feedback:</b></td>"
-    "<td>unknown</td></tr></table>");
 
   navigation_status_indicator_->setText(navigation_unknown);
   localization_status_indicator_->setText(localization_unknown);
-  navigation_feedback_indicator_->setText(navigation_feedback_unknown);
+  navigation_goal_status_indicator_->setText(getGoalStatusLabel());
+  navigation_feedback_indicator_->setText(getNavThroughPosesFeedbackLabel());
   navigation_status_indicator_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   localization_status_indicator_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  navigation_goal_status_indicator_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   navigation_feedback_indicator_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
   pre_initial_ = new QState();
@@ -299,9 +298,10 @@ Nav2Panel::Nav2Panel(QWidget * parent)
     });
   QObject::connect(
     initial_thread_, &InitialThread::navigationInactive,
-    [this, navigation_inactive, navigation_feedback_inactive] {
+    [this, navigation_inactive] {
       navigation_status_indicator_->setText(navigation_inactive);
-      navigation_feedback_indicator_->setText(navigation_feedback_inactive);
+      navigation_goal_status_indicator_->setText(getGoalStatusLabel());
+      navigation_feedback_indicator_->setText(getNavThroughPosesFeedbackLabel());
     });
   QObject::connect(
     initial_thread_, &InitialThread::localizationActive,
@@ -336,10 +336,11 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   QVBoxLayout * main_layout = new QVBoxLayout;
   main_layout->addWidget(navigation_status_indicator_);
   main_layout->addWidget(localization_status_indicator_);
+  main_layout->addWidget(navigation_goal_status_indicator_);
+  main_layout->addWidget(navigation_feedback_indicator_);
   main_layout->addWidget(pause_resume_button_);
   main_layout->addWidget(start_reset_button_);
   main_layout->addWidget(navigation_mode_button_);
-  main_layout->addWidget(navigation_feedback_indicator_);
 
   main_layout->setContentsMargins(10, 10, 10, 10);
   setLayout(main_layout);
@@ -388,12 +389,38 @@ Nav2Panel::onInitialize()
     node->create_subscription<nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage>(
     "navigate_to_pose/_action/feedback",
     rclcpp::SystemDefaultsQoS(),
-    std::bind(&Nav2Panel::onNavigateToPoseFeebackReceived, this, std::placeholders::_1));
+    [this](const nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage::SharedPtr msg) {
+      navigation_feedback_indicator_->setText(getNavToPoseFeedbackLabel(msg->feedback));
+    });
   nav_through_poses_feedback_sub_ =
     node->create_subscription<nav2_msgs::action::NavigateThroughPoses::Impl::FeedbackMessage>(
     "navigate_through_poses/_action/feedback",
     rclcpp::SystemDefaultsQoS(),
-    std::bind(&Nav2Panel::onNavigateThroughPosesFeebackReceived, this, std::placeholders::_1));
+    [this](const nav2_msgs::action::NavigateThroughPoses::Impl::FeedbackMessage::SharedPtr msg) {
+      navigation_feedback_indicator_->setText(getNavThroughPosesFeedbackLabel(msg->feedback));
+    });
+
+  // create action goal status subscribers
+  navigation_goal_status_sub_ = node->create_subscription<action_msgs::msg::GoalStatusArray>(
+    "navigate_to_pose/_action/status",
+    rclcpp::SystemDefaultsQoS(),
+    [this](const action_msgs::msg::GoalStatusArray::SharedPtr msg) {
+      navigation_goal_status_indicator_->setText(
+        getGoalStatusLabel(msg->status_list.back().status));
+      if (msg->status_list.back().status != action_msgs::msg::GoalStatus::STATUS_EXECUTING) {
+        navigation_feedback_indicator_->setText(getNavToPoseFeedbackLabel());
+      }
+    });
+  nav_through_poses_goal_status_sub_ = node->create_subscription<action_msgs::msg::GoalStatusArray>(
+    "navigate_through_poses/_action/status",
+    rclcpp::SystemDefaultsQoS(),
+    [this](const action_msgs::msg::GoalStatusArray::SharedPtr msg) {
+      navigation_goal_status_indicator_->setText(
+        getGoalStatusLabel(msg->status_list.back().status));
+      if (msg->status_list.back().status != action_msgs::msg::GoalStatus::STATUS_EXECUTING) {
+        navigation_feedback_indicator_->setText(getNavThroughPosesFeedbackLabel());
+      }
+    });
 }
 
 void
@@ -874,41 +901,68 @@ Nav2Panel::updateWpNavigationMarkers()
   wp_navigation_markers_pub_->publish(std::move(marker_array));
 }
 
-void
-Nav2Panel::onNavigateToPoseFeebackReceived(
-  const nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage::SharedPtr msg)
+inline QString
+Nav2Panel::getGoalStatusLabel(int8_t status)
 {
-  std::string feedback_str =
-    "<table><tr><td width=150><b>Feedback:</b></td>"
-    "<td><font color=green>active</color></td></tr>" +
-    toLabel(msg->feedback) + "</table>";
-  navigation_feedback_indicator_->setText(QString(feedback_str.c_str()));
+  std::string status_str;
+  switch (status) {
+    case action_msgs::msg::GoalStatus::STATUS_EXECUTING:
+      status_str = "<font color=green>active</color>";
+      break;
+
+    case action_msgs::msg::GoalStatus::STATUS_SUCCEEDED:
+      status_str = "<font color=green>reached</color>";
+      break;
+
+    case action_msgs::msg::GoalStatus::STATUS_CANCELED:
+      status_str = "<font color=orange>canceled</color>";
+      break;
+
+    case action_msgs::msg::GoalStatus::STATUS_ABORTED:
+      status_str = "<font color=red>aborted</color>";
+      break;
+
+    case action_msgs::msg::GoalStatus::STATUS_UNKNOWN:
+      status_str = "unknown";
+      break;
+
+    default:
+      status_str = "inactive";
+      break;
+  }
+  return QString(
+    std::string(
+      "<table><tr><td width=100><b>Feedback:</b></td><td>" +
+      status_str + "</td></tr></table>").c_str());
 }
 
-void
-Nav2Panel::onNavigateThroughPosesFeebackReceived(
-  const nav2_msgs::action::NavigateThroughPoses::Impl::FeedbackMessage::SharedPtr msg)
+inline QString
+Nav2Panel::getNavToPoseFeedbackLabel(nav2_msgs::action::NavigateToPose::Feedback msg)
 {
-  std::string feedback_str =
-    "<table><tr><td width=150><b>Feedback:</b></td>"
-    "<td><font color=green>active</color></td></tr>"
-    "<tr><td>Poses remaining:</td><td>" +
-    std::to_string(msg->feedback.number_of_poses_remaining) +
-    "</td></tr>" + toLabel(msg->feedback) + "</table>";
-  navigation_feedback_indicator_->setText(QString(feedback_str.c_str()));
+  return QString(std::string("<table>" + toLabel(msg) + "</table>").c_str());
+}
+
+inline QString
+Nav2Panel::getNavThroughPosesFeedbackLabel(nav2_msgs::action::NavigateThroughPoses::Feedback msg)
+{
+  return QString(
+    std::string(
+      "<table><tr><td width=150>Poses remaining:</td><td>" +
+      std::to_string(msg.number_of_poses_remaining) +
+      "</td></tr>" + toLabel(msg) + "</table>").c_str());
 }
 
 template<typename T>
 inline std::string Nav2Panel::toLabel(T & msg)
 {
   return std::string(
-    "<tr><td>ETA:</td><td>" +
-    toString(rclcpp::Duration(msg.estimated_time_remaining).seconds(), 2) + " s"
-    "</td></tr><tr><td>Distance remaining:</td><td>" +
+    "<tr><td width=150>ETA:</td><td>" +
+    toString(rclcpp::Duration(msg.estimated_time_remaining).seconds(), 0) + " s"
+    "</td></tr><tr><td width=150>Distance remaining:</td><td>" +
     toString(msg.distance_remaining, 2) + " m"
-    "</td></tr><tr><td>Time taken:</td><td>" +
-    toString(rclcpp::Duration(msg.navigation_time).seconds(), 2) + " s"
-    "</td></tr><tr><td>Recoveries:</td><td>" +
+    "</td></tr><tr><td width=150>Time taken:</td><td>" +
+    toString(rclcpp::Duration(msg.navigation_time).seconds(), 0) + " s"
+    "</td></tr><tr><td width=150>Recoveries:</td><td>" +
     std::to_string(msg.number_of_recoveries) +
     "</td></tr>");
 }

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -686,7 +686,9 @@ Nav2Panel::startWaypointFollowing(std::vector<geometry_msgs::msg::PoseStamped> p
   // Enable result awareness by providing an empty lambda function
   auto send_goal_options =
     rclcpp_action::Client<nav2_msgs::action::FollowWaypoints>::SendGoalOptions();
-  send_goal_options.result_callback = [](auto) {};
+  send_goal_options.result_callback = [this](auto) {
+    waypoint_follower_goal_handle_.reset();
+  };
 
   auto future_goal_handle =
     waypoint_follower_action_client_->async_send_goal(waypoint_follower_goal_, send_goal_options);
@@ -736,7 +738,9 @@ Nav2Panel::startNavThroughPoses(std::vector<geometry_msgs::msg::PoseStamped> pos
   // Enable result awareness by providing an empty lambda function
   auto send_goal_options =
     rclcpp_action::Client<nav2_msgs::action::NavigateThroughPoses>::SendGoalOptions();
-  send_goal_options.result_callback = [](auto) {};
+  send_goal_options.result_callback = [this](auto) {
+    nav_through_poses_goal_handle_.reset();
+  };
 
   auto future_goal_handle =
     nav_through_poses_action_client_->async_send_goal(nav_through_poses_goal_, send_goal_options);
@@ -780,7 +784,9 @@ Nav2Panel::startNavigation(geometry_msgs::msg::PoseStamped pose)
   // Enable result awareness by providing an empty lambda function
   auto send_goal_options =
     rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SendGoalOptions();
-  send_goal_options.result_callback = [](auto) {};
+  send_goal_options.result_callback = [this](auto) {
+    navigation_goal_handle_.reset();
+  };
 
   auto future_goal_handle =
     navigation_action_client_->async_send_goal(navigation_goal_, send_goal_options);

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -49,6 +49,7 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   navigation_mode_button_ = new QPushButton;
   navigation_status_indicator_ = new QLabel;
   localization_status_indicator_ = new QLabel;
+  navigation_feedback_indicator_ = new QLabel;
 
   // Create the state machine used to present the proper control button states in the UI
 
@@ -74,11 +75,17 @@ Nav2Panel::Nav2Panel(QWidget * parent)
     "<td>inactive</td></tr></table>");
   const QString localization_unknown("<table><tr><td width=100><b>Localization:</b></td>"
     "<td>unknown</td></tr></table>");
+  const QString navigation_feedback_inactive("<table><tr><td width=100><b>Feedback:</b></td>"
+    "<td>inactive</td></tr></table>");
+  const QString navigation_feedback_unknown("<table><tr><td width=100><b>Feedback:</b></td>"
+    "<td>unknown</td></tr></table>");
 
   navigation_status_indicator_->setText(navigation_unknown);
   localization_status_indicator_->setText(localization_unknown);
+  navigation_feedback_indicator_->setText(navigation_feedback_unknown);
   navigation_status_indicator_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   localization_status_indicator_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  navigation_feedback_indicator_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
   pre_initial_ = new QState();
   pre_initial_->setObjectName("pre_initial");
@@ -292,8 +299,9 @@ Nav2Panel::Nav2Panel(QWidget * parent)
     });
   QObject::connect(
     initial_thread_, &InitialThread::navigationInactive,
-    [this, navigation_inactive] {
+    [this, navigation_inactive, navigation_feedback_inactive] {
       navigation_status_indicator_->setText(navigation_inactive);
+      navigation_feedback_indicator_->setText(navigation_feedback_inactive);
     });
   QObject::connect(
     initial_thread_, &InitialThread::localizationActive,
@@ -331,6 +339,7 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   main_layout->addWidget(pause_resume_button_);
   main_layout->addWidget(start_reset_button_);
   main_layout->addWidget(navigation_mode_button_);
+  main_layout->addWidget(navigation_feedback_indicator_);
 
   main_layout->setContentsMargins(10, 10, 10, 10);
   setLayout(main_layout);
@@ -373,6 +382,18 @@ void
 Nav2Panel::onInitialize()
 {
   auto node = getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
+
+  // create action feedback subscribers
+  navigation_feedback_sub_ =
+    node->create_subscription<nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage>(
+    "navigate_to_pose/_action/feedback",
+    rclcpp::SystemDefaultsQoS(),
+    std::bind(&Nav2Panel::onNavigateToPoseFeebackReceived, this, std::placeholders::_1));
+  nav_through_poses_feedback_sub_ =
+    node->create_subscription<nav2_msgs::action::NavigateThroughPoses::Impl::FeedbackMessage>(
+    "navigate_through_poses/_action/feedback",
+    rclcpp::SystemDefaultsQoS(),
+    std::bind(&Nav2Panel::onNavigateThroughPosesFeebackReceived, this, std::placeholders::_1));
 }
 
 void
@@ -851,6 +872,54 @@ Nav2Panel::updateWpNavigationMarkers()
   }
 
   wp_navigation_markers_pub_->publish(std::move(marker_array));
+}
+
+void
+Nav2Panel::onNavigateToPoseFeebackReceived(
+  const nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage::SharedPtr msg)
+{
+  std::string feedback_str =
+    "<table><tr><td width=150><b>Feedback:</b></td>"
+    "<td><font color=green>active</color></td></tr>" +
+    toLabel(msg->feedback) + "</table>";
+  navigation_feedback_indicator_->setText(QString(feedback_str.c_str()));
+}
+
+void
+Nav2Panel::onNavigateThroughPosesFeebackReceived(
+  const nav2_msgs::action::NavigateThroughPoses::Impl::FeedbackMessage::SharedPtr msg)
+{
+  std::string feedback_str =
+    "<table><tr><td width=150><b>Feedback:</b></td>"
+    "<td><font color=green>active</color></td></tr>"
+    "<tr><td>Poses remaining:</td><td>" +
+    std::to_string(msg->feedback.number_of_poses_remaining) +
+    "</td></tr>" + toLabel(msg->feedback) + "</table>";
+  navigation_feedback_indicator_->setText(QString(feedback_str.c_str()));
+}
+
+template<typename T>
+inline std::string Nav2Panel::toLabel(T & msg)
+{
+  return std::string(
+    "<tr><td>ETA:</td><td>" +
+    toString(rclcpp::Duration(msg.estimated_time_remaining).seconds(), 2) + " s"
+    "</td></tr><tr><td>Distance remaining:</td><td>" +
+    toString(msg.distance_remaining, 2) + " m"
+    "</td></tr><tr><td>Time taken:</td><td>" +
+    toString(rclcpp::Duration(msg.navigation_time).seconds(), 2) + " s"
+    "</td></tr><tr><td>Recoveries:</td><td>" +
+    std::to_string(msg.number_of_recoveries) +
+    "</td></tr>");
+}
+
+inline std::string
+Nav2Panel::toString(double val, int precision)
+{
+  std::ostringstream out;
+  out.precision(precision);
+  out << std::fixed << val;
+  return out.str();
 }
 
 }  // namespace nav2_rviz_plugins


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2255 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Turtlebot3 gazebo simulation |

---

## Description of contribution in a few bullet points

* Added labels to display feedback information for `NavigateToPose` an `NavigateThroughPoses` actions to Nav2 Rviz panel.

![ezgif-2-eaf796b99a4b](https://user-images.githubusercontent.com/22402940/118307010-c0dc6580-b507-11eb-96dd-b84c333a5177.gif)

![ezgif-7-8beba71b678f](https://user-images.githubusercontent.com/22402940/118307698-ac4c9d00-b508-11eb-89ed-75cc42f82bc3.gif)


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
