### PR TITLE
Rolling ci with repos

### DIFF
--- a/.dockerhub/debug/hooks/build
+++ b/.dockerhub/debug/hooks/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-export FROM_IMAGE=osrf/ros2:nightly
+export FROM_IMAGE=ros:rolling
 export FAIL_ON_BUILD_FAILURE=""
 export UNDERLAY_MIXINS="release ccache"
 export OVERLAY_MIXINS="debug ccache coverage-gcc"

--- a/.dockerhub/distro.Dockerfile
+++ b/.dockerhub/distro.Dockerfile
@@ -6,14 +6,14 @@
 #
 # Example build command:
 # export DOCKER_BUILDKIT=1
-# export FROM_IMAGE="ros:foxy"
+# export FROM_IMAGE="ros:rolling"
 # export OVERLAY_MIXINS="release ccache"
-# docker build -t nav2:foxy \
+# docker build -t nav2:rolling \
 #   --build-arg FROM_IMAGE \
 #   --build-arg OVERLAY_MIXINS \
 #   -f distro.Dockerfile ../
 
-ARG FROM_IMAGE=ros:foxy
+ARG FROM_IMAGE=ros:rolling
 ARG OVERLAY_WS=/opt/overlay_ws
 
 # multi-stage for caching

--- a/.dockerhub/release/hooks/build
+++ b/.dockerhub/release/hooks/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-export FROM_IMAGE=osrf/ros2:nightly-rmw-nonfree
+export FROM_IMAGE=ros:rolling
 export FAIL_ON_BUILD_FAILURE=""
 export UNDERLAY_MIXINS="release ccache"
 export OVERLAY_MIXINS="release ccache"

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,13 @@ FROM $FROM_IMAGE AS builder
 ARG DEBIAN_FRONTEND=noninteractive
 
 # install CI dependencies
-RUN apt-get update && apt-get install -q -y \
+ARG RTI_NC_LICENSE_ACCEPTED=yes
+RUN apt-get update && apt-get install -y \
       ccache \
       lcov \
+      ros-$ROS_DISTRO-rmw-fastrtps-cpp \
+      ros-$ROS_DISTRO-rmw-connextdds \
+      ros-$ROS_DISTRO-rmw-cyclonedds-cpp \
     && rosdep update \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # docker build -t nav2:latest \
 #   --build-arg UNDERLAY_MIXINS \
 #   --build-arg OVERLAY_MIXINS ./
-ARG FROM_IMAGE=osrf/ros2:nightly
+ARG FROM_IMAGE=ros:rolling
 ARG UNDERLAY_WS=/opt/underlay_ws
 ARG OVERLAY_WS=/opt/overlay_ws
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/observation_buffer.hpp
@@ -44,7 +44,7 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 #include "rclcpp/time.hpp"
 #include "tf2_ros/buffer.h"
-#include "tf2_sensor_msgs/tf2_sensor_msgs.h"
+#include "tf2_sensor_msgs/tf2_sensor_msgs.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "nav2_costmap_2d/observation.hpp"
 #include "nav2_util/lifecycle_node.hpp"


### PR DESCRIPTION
https://github.com/ros-planning/navigation2/pull/2339 without removing unreleased packages from repos.
