### PR TITLE
Update CI to use colcon cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,17 @@ _commands:
       steps:
         - restore_cache:
             name: Restore Cache << parameters.key >>
-            key: "<< parameters.key >>-v1\
-              -{{ arch }}\
-              -{{ .Branch }}\
-              -{{ .Environment.CIRCLE_PR_NUMBER }}\
-              -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}"
+            keys:
+              - "<< parameters.key >>-v1\
+                -{{ arch }}\
+                -{{ .Branch }}\
+                -{{ .Environment.CIRCLE_PR_NUMBER }}\
+                -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}"
+              - "<< parameters.key >>-v1\
+                -{{ arch }}\
+                -main\
+                -<no value>\
+                -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}"
     save_to_cache:
       description: "Save To Cache"
       parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,7 +391,7 @@ _environments:
 executors:
   debug_exec:
     docker:
-      - image: rosplanning/navigation2:main.debug
+      - image: ruffsl/navigation2:main.debug
     working_directory: /opt/overlay_ws
     environment:
       <<: *common_environment
@@ -400,7 +400,7 @@ executors:
       UNDERLAY_MIXINS: "release ccache"
   release_exec:
     docker:
-      - image: rosplanning/navigation2:main.release
+      - image: ruffsl/navigation2:main.release
     working_directory: /opt/overlay_ws
     environment:
       <<: *common_environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ _commands:
             paths:
               - << parameters.path >>/build
               - << parameters.path >>/install
+              - << parameters.path >>/log
             when: << parameters.when >>
     install_dependencies:
       description: "Install Dependencies"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ _commands:
               sha256sum $PWD/checksum.txt >> checksum.txt
               apt-get update
               rosdep update
-              
+
               # workarround for OMPL and rosdep
               # https://github.com/ompl/ompl/issues/753
               # Prevent searching $ROS_WS/install given it's too big for rosdep
@@ -481,13 +481,13 @@ workflows:
             branches:
               only:
                 - main
-  dockerhub:
-    jobs:
-      - rebuild_dockerhub
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only:
-                - main
+  # dockerhub:
+  #   jobs:
+  #     - rebuild_dockerhub
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 7 * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,17 +128,22 @@ _commands:
                         --names-only \
                         --packages-skip-build-finished \
                       | xargs)
+                    echo BUILD_UNFINISHED: $BUILD_UNFINISHED
+
                     BUILD_FAILED=$(
                       colcon list \
                         --names-only \
                         --packages-select-build-failed \
                       | xargs)
+                    echo BUILD_FAILED: $BUILD_FAILED
+
                     BUILD_VOID=$(
                       colcon list \
                         --names-only \
                         --packages-select-cache-void \
                         --packages-respective-cache-verb build \
                       | xargs)
+                    echo BUILD_VOID: $BUILD_VOID
 
                     . << parameters.underlay >>/install/setup.sh
                     colcon build \
@@ -178,12 +183,15 @@ _commands:
                   --names-only \
                   --packages-select-test-failures \
                 | xargs)
+              echo TEST_FAILURES: $TEST_FAILURES
+
               TEST_VOID=$(
                 colcon list \
                   --names-only \
                   --packages-select-cache-void \
                   --packages-respective-cache-verb test \
                 | xargs)
+              echo TEST_VOID: $TEST_VOID
 
               . install/setup.sh
               TEST_PACKAGES=$(

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,8 +471,8 @@ workflows:
           matrix:
             parameters:
               rmw:
-                - rmw_connextdds
-                - rmw_cyclonedds_cpp
+                # - rmw_connextdds
+                # - rmw_cyclonedds_cpp
                 - rmw_fastrtps_cpp
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,16 @@ _commands:
                   command: |
                     colcon cache lock
 
-                    BUILD_UNFINISHED=$(colcon list --packages-skip-build-finished | xargs)
-                    BUILD_FAILED=$(colcon list --packages-select-build-failed | xargs)
+                    BUILD_UNFINISHED=$(
+                      colcon list \
+                        --names-only \
+                        --packages-skip-build-finished \
+                      | xargs)
+                    BUILD_FAILED=$(
+                      colcon list \
+                        --names-only \
+                        --packages-select-build-failed \
+                      | xargs)
 
                     . << parameters.underlay >>/install/setup.sh
                     rm -rf log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,8 +141,8 @@ _commands:
                     BUILD_VOID=$(
                       colcon list \
                         --names-only \
-                        --packages-select-cache-void \
-                        --packages-respective-cache-verb build \
+                        --packages-select-cache-invalid \
+                        --packages-select-cache-key build \
                       | xargs)
                     echo BUILD_VOID: $BUILD_VOID
 
@@ -196,8 +196,8 @@ _commands:
               TEST_VOID=$(
                 colcon list \
                   --names-only \
-                  --packages-select-cache-void \
-                  --packages-respective-cache-verb test \
+                  --packages-select-cache-invalid \
+                  --packages-select-cache-key test \
                 | xargs)
               echo TEST_VOID: $TEST_VOID
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,16 +150,23 @@ _commands:
                        [ -n "$BUILD_FAILED" ] || \
                        [ -n "$BUILD_INVALID" ]
                     then
-                      . << parameters.underlay >>/install/setup.sh
-                      colcon build \
-                        --packages-above \
-                          $BUILD_UNFINISHED \
-                          $BUILD_FAILED \
-                          $BUILD_INVALID \
-                        --mixin << parameters.mixins >>
+                      BUILD_PACKAGES=$(
+                        colcon list \
+                          --names-only \
+                          --packages-above \
+                            $BUILD_UNFINISHED \
+                            $BUILD_FAILED \
+                            $BUILD_INVALID \
+                        | xargs)
                     else
-                      echo "Skipping Build"
+                      BUILD_PACKAGES=""
                     fi
+                    echo BUILD_PACKAGES: $BUILD_PACKAGES
+                    
+                    . << parameters.underlay >>/install/setup.sh
+                    colcon build \
+                      --packages-select ${BUILD_PACKAGES} \
+                      --mixin << parameters.mixins >>
               - save_to_cache:
                   key: << parameters.key >>
                   path: << parameters.workspace >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,8 +157,12 @@ _commands:
     test_workspace:
       description: "Test Workspace"
       parameters:
+        key:
+          type: string
         workspace:
           type: string
+        cache_test:
+          type: boolean
       steps:
         - run:
             name: Test Workspace | << parameters.workspace >>
@@ -181,6 +185,14 @@ _commands:
                 --ctest-args --test-regex "test_.*"
               colcon test-result \
                 --verbose
+        - when:
+            condition: << parameters.cache_test >>
+            steps:
+              - save_to_cache:
+                  key: << parameters.key >>
+                  path: << parameters.workspace >>
+                  workspace: << parameters.workspace >>
+                  when: always
         - run:
             name: Copy Test Logs
             working_directory: << parameters.workspace >>
@@ -312,7 +324,9 @@ _steps:
       when: always
   test_overlay_workspace: &test_overlay_workspace
     test_workspace:
+      key: overlay_ws
       workspace: /opt/overlay_ws
+      cache_test: << parameters.cache_test >>
   collect_overlay_coverage: &collect_overlay_coverage
     run:
       name: Collect Code Coverage
@@ -380,6 +394,9 @@ commands:
       - *restore_overlay_workspace
   test_build:
     description: "Test Build"
+    parameters:
+      cache_test:
+        type: boolean
     steps:
       - *test_overlay_workspace
   report_coverage:
@@ -431,6 +448,9 @@ executors:
 _jobs:
   job_test: &job_test
     parameters:
+      cache_test:
+        type: boolean
+        default: false
       rmw:
         default: "rmw_cyclonedds_cpp"
         type: string
@@ -453,14 +473,16 @@ jobs:
     executor: debug_exec
     steps:
       - restore_build
-      - test_build
+      - test_build:
+          cache_test: << parameters.cache_test >>
       - report_coverage
   release_test:
     <<: *job_test
     executor: release_exec
     steps:
       - restore_build
-      - test_build
+      - test_build:
+          cache_test: << parameters.cache_test >>
   rebuild_dockerhub:
     executor: release_exec
     steps:
@@ -474,10 +496,13 @@ workflows:
       # - debug_test:
       #     requires:
       #       - debug_build
+      #     parameters:
+      #       cache_test: true
       - release_build
-      # - release_test:
-      #     requires:
-      #       - release_build
+      - release_test:
+          requires:
+            - release_build
+          cache_test: true
   nightly:
     jobs:
       # - debug_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,9 +236,7 @@ _commands:
               . install/setup.sh
               set -o xtrace
               colcon test \
-                --packages-select ${TEST_PACKAGES} \
-                --retest-until-pass ${RETEST_UNTIL_PASS} \
-                --ctest-args --test-regex "test_.*"
+                --packages-select ${TEST_PACKAGES}
               colcon test-result \
                 --verbose
         - when:
@@ -477,7 +475,6 @@ _environments:
     COLCON_DEFAULTS_FILE: "/tmp/defaults.yaml"
     RCUTILS_LOGGING_BUFFERED_STREAM: "0"
     RCUTILS_LOGGING_USE_STDOUT: "0"
-    RETEST_UNTIL_PASS: "2"
     DEBIAN_FRONTEND: "noninteractive"
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,13 +145,20 @@ _commands:
                       | xargs)
                     echo BUILD_VOID: $BUILD_VOID
 
-                    . << parameters.underlay >>/install/setup.sh
-                    colcon build \
-                      --packages-above \
-                        $BUILD_UNFINISHED \
-                        $BUILD_FAILED \
-                        $BUILD_VOID \
-                      --mixin << parameters.mixins >>
+                    if [ -n "$BUILD_UNFINISHED" ] || \
+                       [ -n "$BUILD_FAILED" ] || \
+                       [ -n "$BUILD_VOID" ]
+                    then
+                      . << parameters.underlay >>/install/setup.sh
+                      colcon build \
+                        --packages-above \
+                          $BUILD_UNFINISHED \
+                          $BUILD_FAILED \
+                          $BUILD_VOID \
+                        --mixin << parameters.mixins >>
+                    else
+                      echo "Skipping Build"
+                    fi
               - save_to_cache:
                   key: << parameters.key >>
                   path: << parameters.workspace >>
@@ -193,25 +200,31 @@ _commands:
                 | xargs)
               echo TEST_VOID: $TEST_VOID
 
-              . install/setup.sh
-              TEST_PACKAGES=$(
-                colcon list \
-                  --names-only \
-                  --packages-above \
-                    $TEST_FAILURES \
-                    $TEST_VOID \
-                | circleci tests split \
-                  --split-by=timings \
-                  --timings-type=classname \
-                  --show-counts \
-                | xargs)
-              set -o xtrace
-              colcon test \
-                --packages-select ${TEST_PACKAGES} \
-                --retest-until-pass ${RETEST_UNTIL_PASS} \
-                --ctest-args --test-regex "test_.*"
-              colcon test-result \
-                --verbose
+              if [ -n "$TEST_FAILURES" ] || \
+                 [ -n "$TEST_VOID" ]
+              then
+                . install/setup.sh
+                TEST_PACKAGES=$(
+                  colcon list \
+                    --names-only \
+                    --packages-above \
+                      $TEST_FAILURES \
+                      $TEST_VOID \
+                  | circleci tests split \
+                    --split-by=timings \
+                    --timings-type=classname \
+                    --show-counts \
+                  | xargs)
+                set -o xtrace
+                colcon test \
+                  --packages-select ${TEST_PACKAGES} \
+                  --retest-until-pass ${RETEST_UNTIL_PASS} \
+                  --ctest-args --test-regex "test_.*"
+                colcon test-result \
+                  --verbose
+              else
+                echo "Skipping Test"
+              fi
         - when:
             condition: << parameters.cache_test >>
             steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,12 +540,11 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      # - debug_build
-      # - debug_test:
-      #     requires:
-      #       - debug_build
-      #     parameters:
-      #       cache_test: true
+      - debug_build
+      - debug_test:
+          requires:
+            - debug_build
+          cache_test: true
       - release_build
       - release_test:
           requires:
@@ -553,20 +552,20 @@ workflows:
           cache_test: true
   nightly:
     jobs:
-      # - debug_build
-      # - debug_test:
-      #     requires:
-      #       - debug_build
+      - debug_build
+      - debug_test:
+          requires:
+            - debug_build
       - release_build
-      # - release_test:
-      #     requires:
-      #       - release_build
-      #     matrix:
-      #       parameters:
-      #         rmw:
-      #           # - rmw_connextdds
-      #           # - rmw_cyclonedds_cpp
-      #           - rmw_fastrtps_cpp
+      - release_test:
+          requires:
+            - release_build
+          matrix:
+            parameters:
+              rmw:
+                - rmw_connextdds
+                - rmw_cyclonedds_cpp
+                - rmw_fastrtps_cpp
     triggers:
       - schedule:
           cron: "0 13 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,24 +138,24 @@ _commands:
                       | xargs)
                     echo BUILD_FAILED: $BUILD_FAILED
 
-                    BUILD_VOID=$(
+                    BUILD_INVALID=$(
                       colcon list \
                         --names-only \
                         --packages-select-cache-invalid \
                         --packages-select-cache-key build \
                       | xargs)
-                    echo BUILD_VOID: $BUILD_VOID
+                    echo BUILD_INVALID: $BUILD_INVALID
 
                     if [ -n "$BUILD_UNFINISHED" ] || \
                        [ -n "$BUILD_FAILED" ] || \
-                       [ -n "$BUILD_VOID" ]
+                       [ -n "$BUILD_INVALID" ]
                     then
                       . << parameters.underlay >>/install/setup.sh
                       colcon build \
                         --packages-above \
                           $BUILD_UNFINISHED \
                           $BUILD_FAILED \
-                          $BUILD_VOID \
+                          $BUILD_INVALID \
                         --mixin << parameters.mixins >>
                     else
                       echo "Skipping Build"
@@ -193,23 +193,23 @@ _commands:
                 | xargs)
               echo TEST_FAILURES: $TEST_FAILURES
 
-              TEST_VOID=$(
+              TEST_INVALID=$(
                 colcon list \
                   --names-only \
                   --packages-select-cache-invalid \
                   --packages-select-cache-key test \
                 | xargs)
-              echo TEST_VOID: $TEST_VOID
+              echo TEST_INVALID: $TEST_INVALID
 
               if [ -n "$TEST_FAILURES" ] || \
-                 [ -n "$TEST_VOID" ]
+                 [ -n "$TEST_INVALID" ]
               then
                 TEST_PACKAGES=$(
                   colcon list \
                     --names-only \
                     --packages-above \
                       $TEST_FAILURES \
-                      $TEST_VOID \
+                      $TEST_INVALID \
                   | circleci tests split \
                     --split-by=timings \
                     --timings-type=classname \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,17 +120,19 @@ _commands:
                   name: Build Workspace | << parameters.workspace >>
                   working_directory: << parameters.workspace >>
                   command: |
-                    BUILD_UNFINISHED=$(colcon list --packages-skip-build-finished)
-                    BUILD_FAILED=$(colcon list --packages-select-build-failed)
-                    if [ -n "$BUILD_UNFINISHED" ] || [ -n "$BUILD_FAILED" ]
-                    then
-                      . << parameters.underlay >>/install/setup.sh
-                      rm -rf build install log
-                      colcon build \
-                        --mixin << parameters.mixins >>
-                    else
-                      echo "Skipping Build"
-                    fi
+                    colcon cache lock
+
+                    BUILD_UNFINISHED=$(colcon list --packages-skip-build-finished | xarg)
+                    BUILD_FAILED=$(colcon list --packages-select-build-failed | xarg)
+
+                    . << parameters.underlay >>/install/setup.sh
+                    rm -rf log
+                    colcon build \
+                      --packages-above \
+                        $BUILD_UNFINISHED \
+                        $BUILD_FAILED \
+                      --packages-skip-cache-hit \
+                      --mixin << parameters.mixins >>
               - save_to_cache:
                   key: << parameters.key >>
                   path: << parameters.workspace >>
@@ -154,12 +156,14 @@ _commands:
             command: |
               . install/setup.sh
               TEST_PACKAGES=$(
-                colcon list --names-only | \
-                  circleci tests split \
-                    --split-by=timings \
-                    --timings-type=classname \
-                    --show-counts | \
-                  xargs)
+                colcon list \
+                  --names-only \
+                  --packages-skip-cache-hit \
+                | circleci tests split \
+                  --split-by=timings \
+                  --timings-type=classname \
+                  --show-counts \
+                | xargs)
               set -o xtrace
               colcon test \
                 --packages-select ${TEST_PACKAGES} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,20 +450,20 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - debug_build
-      - debug_test:
-          requires:
-            - debug_build
+      # - debug_build
+      # - debug_test:
+      #     requires:
+      #       - debug_build
       - release_build
       - release_test:
           requires:
             - release_build
   nightly:
     jobs:
-      - debug_build
-      - debug_test:
-          requires:
-            - debug_build
+      # - debug_build
+      # - debug_test:
+      #     requires:
+      #       - debug_build
       - release_build
       - release_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,7 @@ _commands:
                       | xargs)
                     echo BUILD_INVALID: $BUILD_INVALID
 
+                    BUILD_PACKAGES=""
                     if [ -n "$BUILD_UNFINISHED" ] || \
                        [ -n "$BUILD_FAILED" ] || \
                        [ -n "$BUILD_INVALID" ]
@@ -158,11 +159,9 @@ _commands:
                             $BUILD_FAILED \
                             $BUILD_INVALID \
                         | xargs)
-                    else
-                      BUILD_PACKAGES=""
                     fi
                     echo BUILD_PACKAGES: $BUILD_PACKAGES
-                    
+
                     . << parameters.underlay >>/install/setup.sh
                     colcon build \
                       --packages-select ${BUILD_PACKAGES} \
@@ -208,6 +207,7 @@ _commands:
                 | xargs)
               echo TEST_INVALID: $TEST_INVALID
 
+              TEST_PACKAGES=""
               if [ -n "$TEST_FAILURES" ] || \
                  [ -n "$TEST_INVALID" ]
               then
@@ -216,15 +216,21 @@ _commands:
                     --names-only \
                     --packages-above \
                       $TEST_FAILURES \
-                      $TEST_INVALID \
-                  | circleci tests split \
-                    --split-by=timings \
-                    --timings-type=classname \
-                    --show-counts \
-                  | xargs)
-              else
-                TEST_PACKAGES=""
+                      $TEST_INVALID)
               fi
+              if ( ! << parameters.cache_test >> )
+              then
+                TEST_PACKAGES=$(
+                  colcon list \
+                    --names-only)
+              fi
+              TEST_PACKAGES=$(
+                echo $TEST_PACKAGES \
+                | circleci tests split \
+                  --split-by=timings \
+                  --timings-type=classname \
+                  --show-counts \
+                | xargs)
               echo TEST_PACKAGES: $TEST_PACKAGES
 
               . install/setup.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,9 +477,9 @@ workflows:
       #     requires:
       #       - debug_build
       - release_build
-      - release_test:
-          requires:
-            - release_build
+      # - release_test:
+      #     requires:
+      #       - release_build
   nightly:
     jobs:
       # - debug_build
@@ -487,15 +487,15 @@ workflows:
       #     requires:
       #       - debug_build
       - release_build
-      - release_test:
-          requires:
-            - release_build
-          matrix:
-            parameters:
-              rmw:
-                # - rmw_connextdds
-                # - rmw_cyclonedds_cpp
-                - rmw_fastrtps_cpp
+      # - release_test:
+      #     requires:
+      #       - release_build
+      #     matrix:
+      #       parameters:
+      #         rmw:
+      #           # - rmw_connextdds
+      #           # - rmw_cyclonedds_cpp
+      #           - rmw_fastrtps_cpp
     triggers:
       - schedule:
           cron: "0 13 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,12 @@ _commands:
                         --names-only \
                         --packages-select-build-failed \
                       | xargs)
+                    BUILD_VOID=$(
+                      colcon list \
+                        --names-only \
+                        --packages-select-cache-void \
+                        --packages-respective-cache-verb build \
+                      | xargs)
 
                     . << parameters.underlay >>/install/setup.sh
                     rm -rf log
@@ -140,7 +146,7 @@ _commands:
                       --packages-above \
                         $BUILD_UNFINISHED \
                         $BUILD_FAILED \
-                      --packages-skip-cache-hit \
+                        $BUILD_VOID \
                       --mixin << parameters.mixins >>
               - save_to_cache:
                   key: << parameters.key >>
@@ -168,11 +174,25 @@ _commands:
             name: Test Workspace | << parameters.workspace >>
             working_directory: << parameters.workspace >>
             command: |
+              TEST_FAILURES=$(
+                colcon list \
+                  --names-only \
+                  --packages-select-test-failures \
+                | xargs)
+              TEST_VOID=$(
+                colcon list \
+                  --names-only \
+                  --packages-select-cache-void \
+                  --packages-respective-cache-verb test \
+                | xargs)
+
               . install/setup.sh
               TEST_PACKAGES=$(
                 colcon list \
                   --names-only \
-                  --packages-skip-cache-hit \
+                  --packages-above \
+                    $TEST_FAILURES \
+                    $TEST_VOID \
                 | circleci tests split \
                   --split-by=timings \
                   --timings-type=classname \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,8 @@ _commands:
                   command: |
                     colcon cache lock
 
-                    BUILD_UNFINISHED=$(colcon list --packages-skip-build-finished | xarg)
-                    BUILD_FAILED=$(colcon list --packages-select-build-failed | xarg)
+                    BUILD_UNFINISHED=$(colcon list --packages-skip-build-finished | xargs)
+                    BUILD_FAILED=$(colcon list --packages-select-build-failed | xargs)
 
                     . << parameters.underlay >>/install/setup.sh
                     rm -rf log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,6 @@ _steps:
         TZ=utc stat -c '%y' /ros_entrypoint.sh | \
           (echo ros_entrypoint && cat) >> checksum.txt
         sha256sum $PWD/checksum.txt >> checksum.txt
-        rm -rf $OVERLAY_WS/*
         mv ~/.ccache $CCACHE_DIR
   on_checkout: &on_checkout
     checkout:
@@ -284,11 +283,9 @@ _steps:
           $OVERLAY_WS/src/navigation2/tools/underlay.repos \
           $UNDERLAY_WS/underlay.repos >/dev/null 2>&1
         then
-          echo "Cleaning Underlay"
-          rm -rf $UNDERLAY_WS/*
+          echo "Importing Underlay"
           cp $OVERLAY_WS/src/navigation2/tools/underlay.repos \
             $UNDERLAY_WS/underlay.repos
-          mkdir -p $UNDERLAY_WS/src
           vcs import $UNDERLAY_WS/src \
             < $UNDERLAY_WS/underlay.repos
         fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,7 +482,7 @@ _environments:
 executors:
   debug_exec:
     docker:
-      - image: ruffsl/navigation2:main.debug
+      - image: rosplanning/navigation2:main.debug
     working_directory: /opt/overlay_ws
     environment:
       <<: *common_environment
@@ -491,7 +491,7 @@ executors:
       UNDERLAY_MIXINS: "release ccache"
   release_exec:
     docker:
-      - image: ruffsl/navigation2:main.release
+      - image: rosplanning/navigation2:main.release
     working_directory: /opt/overlay_ws
     environment:
       <<: *common_environment
@@ -579,13 +579,13 @@ workflows:
             branches:
               only:
                 - main
-  # dockerhub:
-  #   jobs:
-  #     - rebuild_dockerhub
-  #   triggers:
-  #     - schedule:
-  #         cron: "0 7 * * *"
-  #         filters:
-  #           branches:
-  #             only:
-  #               - main
+  dockerhub:
+    jobs:
+      - rebuild_dockerhub
+    triggers:
+      - schedule:
+          cron: "0 7 * * *"
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,7 @@ _commands:
                   key: << parameters.key >>
                   path: << parameters.workspace >>
                   workspace: << parameters.workspace >>
+                  when: always
               - run:
                   name: Copy Build Logs
                   working_directory: << parameters.workspace >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ _commands:
             command: |
               . << parameters.underlay >>/install/setup.sh
               cat << parameters.underlay >>/checksum.txt > checksum.txt
+              vcs export --exact << parameters.underlay >>/src | \
+                (echo vcs_export && cat) >> checksum.txt
+              sha256sum $PWD/checksum.txt >> checksum.txt
               apt-get update
               rosdep update
 
@@ -142,13 +145,6 @@ _commands:
                   key: << parameters.key >>
                   path: << parameters.workspace >>
                   workspace: << parameters.workspace >>
-              - run:
-                  name: Append Checksum | << parameters.workspace >>
-                  working_directory: << parameters.workspace >>
-                  command: |
-                    vcs export --exact src | \
-                      (echo vcs_export && cat) >> checksum.txt
-                    sha256sum $PWD/checksum.txt >> checksum.txt
               - run:
                   name: Copy Build Logs
                   working_directory: << parameters.workspace >>
@@ -233,7 +229,7 @@ _steps:
     run:
       name: Pre Checkout
       command: |
-        mkdir -p $ROS_WS && cd $ROS_WS
+        mkdir -p $ROS_WS/src && cd $ROS_WS
         ln -s /opt/ros/$ROS_DISTRO install
         echo $CACHE_NONCE | \
           (echo cache_nonce && cat) >> checksum.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,12 @@ _commands:
                 -{{ arch }}\
                 -{{ .Branch }}\
                 -{{ .Environment.CIRCLE_PR_NUMBER }}\
-                -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}"
+                -{{ checksum  \"<< parameters.workspace >>/lockfile.txt\" }}"
               - "<< parameters.key >>-v1\
                 -{{ arch }}\
                 -main\
                 -<no value>\
-                -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}"
+                -{{ checksum  \"<< parameters.workspace >>/lockfile.txt\" }}"
     save_to_cache:
       description: "Save To Cache"
       parameters:
@@ -42,7 +42,7 @@ _commands:
               -{{ arch }}\
               -{{ .Branch }}\
               -{{ .Environment.CIRCLE_PR_NUMBER }}\
-              -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}\
+              -{{ checksum  \"<< parameters.workspace >>/lockfile.txt\" }}\
               -{{ epoch }}"
             paths:
               - << parameters.path >>/build
@@ -62,10 +62,10 @@ _commands:
             working_directory: << parameters.workspace >>
             command: |
               . << parameters.underlay >>/install/setup.sh
-              cat << parameters.underlay >>/checksum.txt > checksum.txt
+              cat << parameters.underlay >>/lockfile.txt > lockfile.txt
               vcs export --exact << parameters.underlay >>/src | \
-                (echo vcs_export && cat) >> checksum.txt
-              sha256sum $PWD/checksum.txt >> checksum.txt
+                (echo vcs_export && cat) >> lockfile.txt
+              sha256sum $PWD/lockfile.txt >> lockfile.txt
               apt-get update
               rosdep update
 
@@ -93,8 +93,8 @@ _commands:
                 awk -F'[][]' '{print $2}' | \
                 tr -d \, | xargs -n1 | sort -u | xargs)
               dpkg -s $dependencies | \
-                (echo workspace_dependencies && cat) >> checksum.txt
-              sha256sum $PWD/checksum.txt >> checksum.txt
+                (echo workspace_dependencies && cat) >> lockfile.txt
+              sha256sum $PWD/lockfile.txt >> lockfile.txt
     setup_workspace:
       description: "Setup Workspace"
       parameters:
@@ -111,7 +111,7 @@ _commands:
           type: boolean
       steps:
         - store_artifacts:
-            path: << parameters.workspace >>/checksum.txt
+            path: << parameters.workspace >>/lockfile.txt
         - restore_from_cache:
             key: << parameters.key >>
             workspace: << parameters.workspace >>
@@ -302,11 +302,11 @@ _steps:
         mkdir -p $ROS_WS/src && cd $ROS_WS
         ln -s /opt/ros/$ROS_DISTRO install
         echo $CACHE_NONCE | \
-          (echo cache_nonce && cat) >> checksum.txt
-        sha256sum $PWD/checksum.txt >> checksum.txt
+          (echo cache_nonce && cat) >> lockfile.txt
+        sha256sum $PWD/lockfile.txt >> lockfile.txt
         TZ=utc stat -c '%y' /ros_entrypoint.sh | \
-          (echo ros_entrypoint && cat) >> checksum.txt
-        sha256sum $PWD/checksum.txt >> checksum.txt
+          (echo ros_entrypoint && cat) >> lockfile.txt
+        sha256sum $PWD/lockfile.txt >> lockfile.txt
         mv ~/.ccache $CCACHE_DIR
         rm -rf $OVERLAY_WS/src
   on_checkout: &on_checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,6 @@ _commands:
                       | xargs)
 
                     . << parameters.underlay >>/install/setup.sh
-                    rm -rf log
                     colcon build \
                       --packages-above \
                         $BUILD_UNFINISHED \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,6 +469,7 @@ _environments:
     ROS_WS: "/opt/ros_ws"
     UNDERLAY_WS: "/opt/underlay_ws"
     OVERLAY_WS: "/opt/overlay_ws"
+    UNDERLAY_MIXINS: "release ccache"
     CCACHE_DIR: "/tmp/.ccache"
     CCACHE_LOGFILE: "/tmp/ccache.log"
     CCACHE_MAXSIZE: "200M"
@@ -488,7 +489,6 @@ executors:
       <<: *common_environment
       CACHE_NONCE: "Debug"
       OVERLAY_MIXINS: "debug ccache coverage-gcc"
-      UNDERLAY_MIXINS: "release ccache"
   release_exec:
     docker:
       - image: rosplanning/navigation2:main.release
@@ -497,7 +497,6 @@ executors:
       <<: *common_environment
       CACHE_NONCE: "Release"
       OVERLAY_MIXINS: "release ccache"
-      UNDERLAY_MIXINS: "release ccache"
 
 _jobs:
   job_test: &job_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,6 @@ _commands:
               if [ -n "$TEST_FAILURES" ] || \
                  [ -n "$TEST_VOID" ]
               then
-                . install/setup.sh
                 TEST_PACKAGES=$(
                   colcon list \
                     --names-only \
@@ -216,16 +215,19 @@ _commands:
                     --timings-type=classname \
                     --show-counts \
                   | xargs)
-                set -o xtrace
-                colcon test \
-                  --packages-select ${TEST_PACKAGES} \
-                  --retest-until-pass ${RETEST_UNTIL_PASS} \
-                  --ctest-args --test-regex "test_.*"
-                colcon test-result \
-                  --verbose
               else
-                echo "Skipping Test"
+                TEST_PACKAGES=""
               fi
+              echo TEST_PACKAGES: $TEST_PACKAGES
+
+              . install/setup.sh
+              set -o xtrace
+              colcon test \
+                --packages-select ${TEST_PACKAGES} \
+                --retest-until-pass ${RETEST_UNTIL_PASS} \
+                --ctest-args --test-regex "test_.*"
+              colcon test-result \
+                --verbose
         - when:
             condition: << parameters.cache_test >>
             steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,6 @@ _commands:
             command: |
               . << parameters.underlay >>/install/setup.sh
               cat << parameters.underlay >>/checksum.txt > checksum.txt
-              vcs export --exact src | \
-                (echo vcs_export && cat) >> checksum.txt
-              sha256sum $PWD/checksum.txt >> checksum.txt
               apt-get update
               rosdep update
 
@@ -145,6 +142,13 @@ _commands:
                   key: << parameters.key >>
                   path: << parameters.workspace >>
                   workspace: << parameters.workspace >>
+              - run:
+                  name: Append Checksum | << parameters.workspace >>
+                  working_directory: << parameters.workspace >>
+                  command: |
+                    vcs export --exact src | \
+                      (echo vcs_export && cat) >> checksum.txt
+                    sha256sum $PWD/checksum.txt >> checksum.txt
               - run:
                   name: Copy Build Logs
                   working_directory: << parameters.workspace >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ _steps:
           (echo ros_entrypoint && cat) >> checksum.txt
         sha256sum $PWD/checksum.txt >> checksum.txt
         mv ~/.ccache $CCACHE_DIR
+        rm -rf $OVERLAY_WS/src
   on_checkout: &on_checkout
     checkout:
       path: src/navigation2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,8 @@ _commands:
               -{{ checksum  \"<< parameters.workspace >>/checksum.txt\" }}\
               -{{ epoch }}"
             paths:
-              - << parameters.path >>
+              - << parameters.path >>/build
+              - << parameters.path >>/install
             when: << parameters.when >>
     install_dependencies:
       description: "Install Dependencies"

--- a/.dockerhub/debug/hooks/build
+++ b/.dockerhub/debug/hooks/build
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ex
+rm -rf ../../.dockerignore
 
 export FROM_IMAGE=ros:rolling
 export FAIL_ON_BUILD_FAILURE=""

--- a/.dockerhub/release/hooks/build
+++ b/.dockerhub/release/hooks/build
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ex
+rm -rf ../../.dockerignore
 
 export FROM_IMAGE=ros:rolling
 export FAIL_ON_BUILD_FAILURE=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ FROM $FROM_IMAGE AS cacher
 ARG UNDERLAY_WS
 WORKDIR $UNDERLAY_WS/src
 COPY ./tools/underlay.repos ../
-RUN vcs import ./ < ../underlay.repos && \
-    find ./ -name ".git" | xargs rm -rf
+RUN vcs import ./ < ../underlay.repos
 
 # copy overlay source
 ARG OVERLAY_WS

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && \
     apt-get install -y \
       ccache \
       lcov \
+      python3-pip \
       ros-$ROS_DISTRO-rmw-fastrtps-cpp \
       ros-$ROS_DISTRO-rmw-connextdds \
       ros-$ROS_DISTRO-rmw-cyclonedds-cpp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && \
       ros-$ROS_DISTRO-rmw-connextdds \
       ros-$ROS_DISTRO-rmw-cyclonedds-cpp \
     && pip3 install \
-      git+https://github.com/ruffsl/colcon-cache.git@c8d4b3b84c67e8897731906aa11cd9e8911f5674 \
+      git+https://github.com/ruffsl/colcon-cache.git@13c424c3a455ae04d1a4176a54c49a9d20c9dca0 \
     && rosdep update \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,10 @@ RUN . $UNDERLAY_WS/install/setup.sh && \
       --mixin $OVERLAY_MIXINS \
     || ([ -z "$FAIL_ON_BUILD_FAILURE" ] || exit 1)
 
+# install CI dependencies
+RUN pip3 install \
+      git+https://github.com/ruffsl/colcon-cache.git
+
 # source overlay from entrypoint
 ENV UNDERLAY_WS $UNDERLAY_WS
 ENV OVERLAY_WS $OVERLAY_WS

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN . $UNDERLAY_WS/install/setup.sh && \
 
 # install CI dependencies
 RUN pip3 install \
-      git+https://github.com/ruffsl/colcon-cache.git
+      git+https://github.com/ruffsl/colcon-cache.git@c8d4b3b84c67e8897731906aa11cd9e8911f5674
 
 # source overlay from entrypoint
 ENV UNDERLAY_WS $UNDERLAY_WS


### PR DESCRIPTION
This updates the CI to make use of colcon cache, a colcon extension that enables the caching of an entire workspace by tracking the state of package source files. This essentially allows the CI to focus on building and testing only packages that have been modified. For more info on colcon cache: https://github.com/ruffsl/colcon-cache/pull/12 . 

Changes in this PR to incorporate colcon cache include:

* Add cache key from main branch as a fallback cache to restore from
  * now that invalid packages can be detected and rebuilt on demand with colcon cache 
* Cache only the build, install, log folders, not the entire workspace directory
  * as not to include or restore the deterministic checksum files
* Hash underlay repos into checksum, rather than active workspace
  * so that source file changes don't result in missed active workspace cache restore
  * so that source file changes can still bust overlay workspace cache restore
* clean up built and test logic in bash using env
  * to clarify which and how packages are being selected
* Add `cache_test` parameter
  * to bypass caching of tests for nightly jobs
  * so nighy jobs always retest every package
* Don't clean or ignore .git folders from cloned or copied source repos
  * so colcon cache can use revision control in package to track source changes



Pending on: https://github.com/ros-planning/navigation2/pull/2339