### PR TITLE
Rebuild CI images when there are dependency updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,17 +179,20 @@ _commands:
             path: << parameters.workspace >>/test_results
         - store_artifacts:
             path: << parameters.workspace >>/test_results
-    check_image_updates:
-      description: "Check image updates"
+    check_apt_updates:
+      description: "Check apt updates"
+      parameters:
+        sourcelist:
+          type: string
       steps:
         - run:
             command: |
               apt-get update \
-                -o Dir::Etc::sourcelist="sources.list.d/ros2.list"
+                -o Dir::Etc::sourcelist="<< parameters.sourcelist >>"
               apt-get --simulate upgrade \
-                -o Dir::Etc::sourcelist="sources.list.d/ros2.list" \
+                -o Dir::Etc::sourcelist="<< parameters.sourcelist >>" \
                 | grep "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded." \
-                && echo "No image updates" || exit 1
+                && echo "No apt updates" || exit 1
     trigger_dockerhub_url:
       description: "Trigger Dockerhub URL"
       parameters:
@@ -312,6 +315,9 @@ _steps:
           -F "project" \
           -Z || echo 'Codecov upload failed'
       when: always
+  check_ros2_updates: &check_ros2_updates
+    check_apt_updates:
+        sourcelist: sources.list.d/ros2.list
   trigger_dockerhub_build: &trigger_dockerhub_build
     trigger_dockerhub_url:
         data: |
@@ -364,7 +370,7 @@ commands:
   trigger_dockerhub:
     description: "Trigger DockerHub"
     steps:
-      - *check_image_updates
+      - *check_ros2_updates
       - *trigger_dockerhub_build
 
 _environments:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,17 @@ _commands:
             path: << parameters.workspace >>/test_results
         - store_artifacts:
             path: << parameters.workspace >>/test_results
+    check_image_updates:
+      description: "Check image updates"
+      steps:
+        - run:
+            command: |
+              apt-get update \
+                -o Dir::Etc::sourcelist="sources.list.d/ros2.list"
+              apt-get --simulate upgrade \
+                -o Dir::Etc::sourcelist="sources.list.d/ros2.list" \
+                | grep "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded." \
+                && echo "No image updates" || exit 1
     trigger_dockerhub_url:
       description: "Trigger Dockerhub URL"
       parameters:
@@ -186,6 +197,7 @@ _commands:
           type: string
       steps:
         - run:
+            when: on_fail
             command: |
               curl -H "Content-Type: application/json" \
                 --data '<< parameters.data >>' \
@@ -352,6 +364,7 @@ commands:
   trigger_dockerhub:
     description: "Trigger DockerHub"
     steps:
+      - *check_image_updates
       - *trigger_dockerhub_build
 
 _environments:
@@ -388,9 +401,6 @@ executors:
       CACHE_NONCE: "Release"
       OVERLAY_MIXINS: "release ccache"
       UNDERLAY_MIXINS: "release ccache"
-  python_exec:
-    docker:
-      - image: circleci/python
 
 _jobs:
   job_test: &job_test
@@ -426,7 +436,7 @@ jobs:
       - restore_build
       - test_build
   rebuild_dockerhub:
-    executor: python_exec
+    executor: release_exec
     steps:
       - trigger_dockerhub
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # install CI dependencies
 ARG RTI_NC_LICENSE_ACCEPTED=yes
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
       ccache \
       lcov \
       ros-$ROS_DISTRO-rmw-fastrtps-cpp \


### PR DESCRIPTION
Change daily job for CI so it only triggers Docker Hub to rebuild CI image tags when there are dependencies to upgrade, specifically apt upgrades for installed ros2 packages. This helps preserve CI caches for longer, while ensuring the CI image remains up-to-date.

This is because an image timestamp is used in computing the cache key

https://github.com/ros-planning/navigation2/blob/1ab08ce555bea9304e291682ce6b6d141dc2fb14/.circleci/config.yml#L204-L206

The timestamp of this file is modified when building the image here:

https://github.com/ros-planning/navigation2/blob/1ab08ce555bea9304e291682ce6b6d141dc2fb14/Dockerfile#L101-L103

The above is done so CI caches are invalidated when CI images are updated, as new images could include API/ABI breaks from updated dependencies.