### PR TITLE
Update invalid parameter exception handling

### DIFF
--- a/nav2_costmap_2d/test/unit/declare_parameter_test.cpp
+++ b/nav2_costmap_2d/test/unit/declare_parameter_test.cpp
@@ -65,8 +65,9 @@ TEST(DeclareParameter, useInvalidParameter)
 
   layer.initialize(&layers, "test_layer", &tf, node, nullptr, nullptr);
 
+  layer.declareParameter("test2", rclcpp::PARAMETER_STRING);
   try {
-    layer.declareParameter("test2", rclcpp::PARAMETER_STRING);
+    std::string val = node->get_parameter("test_layer.test2").as_string();
     FAIL() << "Incorrectly handling test_layer.test2 parameter which was not set";
   } catch (rclcpp::exceptions::ParameterUninitializedException & ex) {
     SUCCEED();

--- a/nav2_costmap_2d/test/unit/declare_parameter_test.cpp
+++ b/nav2_costmap_2d/test/unit/declare_parameter_test.cpp
@@ -68,7 +68,7 @@ TEST(DeclareParameter, useInvalidParameter)
   try {
     layer.declareParameter("test2", rclcpp::PARAMETER_STRING);
     FAIL() << "Incorrectly handling test_layer.test2 parameter which was not set";
-  } catch (rclcpp::exceptions::NoParameterOverrideProvided & ex) {
+  } catch (rclcpp::exceptions::ParameterUninitializedException & ex) {
     SUCCEED();
   }
 }

--- a/nav2_util/include/nav2_util/node_utils.hpp
+++ b/nav2_util/include/nav2_util/node_utils.hpp
@@ -104,9 +104,6 @@ void declare_parameter_if_not_declared(
 
 /// Declares static ROS2 parameter with given type if it was not already declared
 /* Declares static ROS2 parameter with given type if it was not already declared.
- * NOTE: The parameter should be set via input param-file
- * or throught a command-line. Otherwise according to the RCLCPP API,
- * ParameterUninitializedException exception will be thrown by declare_parameter().
  *
  * \param[in] node A node in which given parameter to be declared
  * \param[in] param_type The type of parameter
@@ -140,18 +137,19 @@ std::string get_plugin_type_param(
   NodeT node,
   const std::string & plugin_name)
 {
+  declare_parameter_if_not_declared(node, plugin_name + ".plugin", rclcpp::PARAMETER_STRING);
+  std::string plugin_type;
   try {
-    declare_parameter_if_not_declared(node, plugin_name + ".plugin", rclcpp::PARAMETER_STRING);
+    if (!node->get_parameter(plugin_name + ".plugin", plugin_type)) {
+      RCLCPP_FATAL(
+        node->get_logger(), "Can not get 'plugin' param value for %s", plugin_name.c_str());
+      exit(-1);
+    }
   } catch (rclcpp::exceptions::ParameterUninitialized & ex) {
     RCLCPP_FATAL(node->get_logger(), "'plugin' param not defined for %s", plugin_name.c_str());
     exit(-1);
   }
-  std::string plugin_type;
-  if (!node->get_parameter(plugin_name + ".plugin", plugin_type)) {
-    RCLCPP_FATAL(
-      node->get_logger(), "Can not get 'plugin' param value for %s", plugin_name.c_str());
-    exit(-1);
-  }
+
   return plugin_type;
 }
 

--- a/nav2_util/include/nav2_util/node_utils.hpp
+++ b/nav2_util/include/nav2_util/node_utils.hpp
@@ -145,7 +145,7 @@ std::string get_plugin_type_param(
         node->get_logger(), "Can not get 'plugin' param value for %s", plugin_name.c_str());
       exit(-1);
     }
-  } catch (rclcpp::exceptions::ParameterUninitialized & ex) {
+  } catch (rclcpp::exceptions::ParameterUninitializedException & ex) {
     RCLCPP_FATAL(node->get_logger(), "'plugin' param not defined for %s", plugin_name.c_str());
     exit(-1);
   }

--- a/nav2_util/include/nav2_util/node_utils.hpp
+++ b/nav2_util/include/nav2_util/node_utils.hpp
@@ -106,7 +106,7 @@ void declare_parameter_if_not_declared(
 /* Declares static ROS2 parameter with given type if it was not already declared.
  * NOTE: The parameter should be set via input param-file
  * or throught a command-line. Otherwise according to the RCLCPP API,
- * NoParameterOverrideProvided exception will be thrown by declare_parameter().
+ * ParameterUninitializedException exception will be thrown by declare_parameter().
  *
  * \param[in] node A node in which given parameter to be declared
  * \param[in] param_type The type of parameter
@@ -142,7 +142,7 @@ std::string get_plugin_type_param(
 {
   try {
     declare_parameter_if_not_declared(node, plugin_name + ".plugin", rclcpp::PARAMETER_STRING);
-  } catch (rclcpp::exceptions::NoParameterOverrideProvided & ex) {
+  } catch (rclcpp::exceptions::ParameterUninitialized & ex) {
     RCLCPP_FATAL(node->get_logger(), "'plugin' param not defined for %s", plugin_name.c_str());
     exit(-1);
   }


### PR DESCRIPTION
Since https://github.com/ros2/rclcpp/pull/1673, uninitialized parameters are allowed (ie. an exception is not thrown). Instead, if the parameter is not set by the time it is accessed, then an exception is thrown.

Note, this is a decision upstream to change this particular API for the upcoming Galactic release. Ultimately, we're hoping to avoid a deprecation cycle by landing this prior to the release date.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
