### PR TITLE
Adjust CI to enable cache sharing with forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,32 +265,6 @@ _commands:
             path: << parameters.workspace >>/test_results
         - store_artifacts:
             path: << parameters.workspace >>/test_results
-    check_apt_updates:
-      description: "Check apt updates"
-      parameters:
-        sourcelist:
-          type: string
-      steps:
-        - run:
-            command: |
-              apt-get update \
-                -o Dir::Etc::sourcelist="<< parameters.sourcelist >>"
-              apt-get --simulate upgrade \
-                -o Dir::Etc::sourcelist="<< parameters.sourcelist >>" \
-                | grep "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded." \
-                && echo "No apt updates" || exit 1
-    trigger_dockerhub_url:
-      description: "Trigger Dockerhub URL"
-      parameters:
-        data:
-          type: string
-      steps:
-        - run:
-            when: on_fail
-            command: |
-              curl -H "Content-Type: application/json" \
-                --data '<< parameters.data >>' \
-                -X POST ${DOCKERHUB_TRIGGER_URL}
 
 _steps:
   pre_checkout: &pre_checkout
@@ -399,16 +373,6 @@ _steps:
           -F "project" \
           -Z || echo 'Codecov upload failed'
       when: always
-  check_ros2_updates: &check_ros2_updates
-    check_apt_updates:
-        sourcelist: sources.list.d/ros2.list
-  trigger_dockerhub_build: &trigger_dockerhub_build
-    trigger_dockerhub_url:
-        data: |
-          {
-            "source_type": "Branch",
-            "source_name": "main"
-          }
 
 commands:
   <<: *common_commands
@@ -454,11 +418,6 @@ commands:
     steps:
       - *collect_overlay_coverage
       - *upload_overlay_coverage
-  trigger_dockerhub:
-    description: "Trigger DockerHub"
-    steps:
-      - *check_ros2_updates
-      - *trigger_dockerhub_build
 
 _environments:
   common_environment: &common_environment
@@ -531,10 +490,6 @@ jobs:
       - restore_build
       - test_build:
           cache_test: << parameters.cache_test >>
-  rebuild_dockerhub:
-    executor: release_exec
-    steps:
-      - trigger_dockerhub
 
 workflows:
   version: 2
@@ -569,16 +524,6 @@ workflows:
     triggers:
       - schedule:
           cron: "0 13 * * *"
-          filters:
-            branches:
-              only:
-                - main
-  dockerhub:
-    jobs:
-      - rebuild_dockerhub
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,8 +396,6 @@ _steps:
         bash codecov \
           -f "lcov/project_coverage.info" \
           -R "src/navigation2" \
-          -t "${CODECOV_TOKEN}" \
-          -n "${CIRCLE_BUILD_NUM}" \
           -F "project" \
           -Z || echo 'Codecov upload failed'
       when: always

--- a/.github/workflows/trigger_dockerhub.yaml
+++ b/.github/workflows/trigger_dockerhub.yaml
@@ -1,0 +1,47 @@
+---
+name: Trigger Docker Hub
+
+on:
+  schedule:
+  # 7am UTC, 12am PDT
+  - cron:  '0 7 * * *'
+  push:
+    branches:
+    - main
+    paths:
+    - '**/package.xml'
+    - '**/*.repos'
+
+jobs:
+  rebuild_dockerhub:
+    name: Trigger Docker Hub
+    container:
+      image: rosplanning/navigation2:main.release
+    steps:
+    - name: "Check apt updates"
+       if: ${{ github.event_name == 'schedule' }}
+      env:
+        SOURCELIST: sources.list.d/ros2.list
+      run: |
+        apt-get update \
+          -o Dir::Etc::sourcelist="${SOURCELIST}"
+        apt-get --simulate upgrade \
+          -o Dir::Etc::sourcelist="${SOURCELIST}" \
+          | grep "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded." \
+          && echo "No apt updates" || exit 1
+    - name: "Check repo files"
+       if: ${{ github.event_name == 'push' }}
+      run: |
+        exit 1
+    - name: "Trigger Dockerhub URL"
+      if: ${{ failure() }}
+      env:
+        DATA: |
+          '{
+            "source_type": "Branch",
+            "source_name": "main"
+          }'
+      run: |
+        curl -H "Content-Type: application/json" \
+          --data ${DATA} \
+          -X POST ${{ secrets.DOCKERHUB_TRIGGER_URL }}

--- a/.github/workflows/trigger_dockerhub.yaml
+++ b/.github/workflows/trigger_dockerhub.yaml
@@ -18,30 +18,30 @@ jobs:
     container:
       image: rosplanning/navigation2:main.release
     steps:
-    - name: "Check apt updates"
-       if: ${{ github.event_name == 'schedule' }}
-      env:
-        SOURCELIST: sources.list.d/ros2.list
-      run: |
-        apt-get update \
-          -o Dir::Etc::sourcelist="${SOURCELIST}"
-        apt-get --simulate upgrade \
-          -o Dir::Etc::sourcelist="${SOURCELIST}" \
-          | grep "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded." \
-          && echo "No apt updates" || exit 1
-    - name: "Check repo files"
-       if: ${{ github.event_name == 'push' }}
-      run: |
-        exit 1
-    - name: "Trigger Dockerhub URL"
-      if: ${{ failure() }}
-      env:
-        DATA: |
-          '{
-            "source_type": "Branch",
-            "source_name": "main"
-          }'
-      run: |
-        curl -H "Content-Type: application/json" \
-          --data ${DATA} \
-          -X POST ${{ secrets.DOCKERHUB_TRIGGER_URL }}
+      - name: "Check apt updates"
+        if: ${{ github.event_name == 'schedule' }}
+        env:
+          SOURCELIST: sources.list.d/ros2.list
+        run: |
+          apt-get update \
+            -o Dir::Etc::sourcelist="${SOURCELIST}"
+          apt-get --simulate upgrade \
+            -o Dir::Etc::sourcelist="${SOURCELIST}" \
+            | grep "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded." \
+            && echo "No apt updates" || exit 1
+      - name: "Check repo files"
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          exit 1
+      - name: "Trigger Dockerhub URL"
+        if: ${{ failure() }}
+        env:
+          DATA: |
+            '{
+              "source_type": "Branch",
+              "source_name": "main"
+            }'
+        run: |
+          curl -H "Content-Type: application/json" \
+            --data ${DATA} \
+            -X POST ${{ secrets.DOCKERHUB_TRIGGER_URL }}


### PR DESCRIPTION
So for a recent PR https://github.com/ros-planning/navigation2/pull/2349 after merging https://github.com/ros-planning/navigation2/pull/2343 , I noticed that it's cache restore step was not finding the matching cache key provide by the main branch:

## Prior existing cache stored by main branch CI job

```
Creating cache archive...
Uploading cache archive...
Stored Cache to overlay_ws-v1-arch1-linux-amd64-6_85-main-<no value>-C8DP7DcUx71NZcYchPyQBH0ElDOZYfM4Uez8CyHmtNE=-1621429706
  * /opt/overlay_ws/build
  * /opt/overlay_ws/install
  * /opt/overlay_ws/log
https://app.circleci.com/pipelines/github/ros-planning/navigation2/5359/workflows/9c999dde-f6c0-4007-b8a3-87d6e091638f/jobs/19741/parallel-runs/0/steps/0-118
```

## Later failed cache restore from forked PR CI job
```
No cache is found for key: overlay_ws-v1-arch1-linux-amd64-6_85-pull/2349-2349-C8DP7DcUx71NZcYchPyQBH0ElDOZYfM4Uez8CyHmtNE=
No cache is found for key: overlay_ws-v1-arch1-linux-amd64-6_85-main-<no value>-C8DP7DcUx71NZcYchPyQBH0ElDOZYfM4Uez8CyHmtNE=
https://app.circleci.com/pipelines/github/ros-planning/navigation2/5354/workflows/97ef33a5-4b3d-4cce-bbf8-2598807fbf27/jobs/19728/parallel-runs/0/steps/0-116
```

This was because CircleCI does not share caches with forked repos, unless sharing of environment variables is enabled:

> enabling the sharing of environment variables will enable cache sharing between the original repo and all forked builds.
> https://circleci.com/docs/2.0/oss/#caching

We can simply enable sharing of environment variables in the repo's circleci settings, but we currently have two secret tokens stored in the repo's circleci environment. The codecov token and the DockerHub build trigger token. Turns out codecov token should be unnecessary for public repos when using major CI's like CircleCI or GH actions, so we could delete that variable from the current CircleCI environment.

> note that this is a public repo, so a token shouldn't be necessary
> https://github.com/codecov/codecov-circleci-orb/issues/12
> https://about.codecov.io/blog/tokenless-uploads-for-github-actions/

As for the DockerHub build trigger token, given GH actions has a slightly more nuance control for protecting repo secrets:

> Note: With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.
> https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow

I've ported the cron job config from https://github.com/ros-planning/navigation2/pull/2344 into a GH action workflow so we can move the DockerHub secret into GH actions. This also has the added benefit of allowing the use of GH action event triggers to rebuild the CI image if any of the `package.xml` or `.repos` files are changed, given they're subsequently used to pre-install depencies in the CI image.