### PR TITLE
reset all goal checkers on cleanup state

### DIFF
--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -256,6 +256,8 @@ ControllerServer::on_cleanup(const rclcpp_lifecycle::State & state)
     it->second->cleanup();
   }
   controllers_.clear();
+
+  goal_checkers_.clear();
   costmap_ros_->on_cleanup(state);
 
   // Release any allocated resources
@@ -264,7 +266,6 @@ ControllerServer::on_cleanup(const rclcpp_lifecycle::State & state)
   vel_publisher_.reset();
   speed_limit_sub_.reset();
   action_server_.reset();
-  goal_checkers_[current_goal_checker_]->reset();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/2351 |
| Primary OS tested on | CI |
| Robotic platform tested on | N/A |

---

## Description of contribution in a few bullet points

* Cleanup state resets map of goal checkers, not just resetting the current one

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
