### PR TITLE
Fix SEGV caused by goal_handle_ which is nullptr while result_callback called

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -312,19 +312,12 @@ protected:
     auto send_goal_options = typename rclcpp_action::Client<ActionT>::SendGoalOptions();
     send_goal_options.result_callback =
       [this](const typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult & result) {
-        if (!this->goal_handle_) {
-          if (!future_goal_handle_) {
-            // Shouldn't run into this block scope
-            RCLCPP_WARN(
-              node_->get_logger(),
-              "Goal result for %s available, but it can not get a valid goal_handle_. "
-              "Normally, this message shouldn't be printed.",
-              action_name_.c_str());
-            return;
-          }
-
-          // If the future_goal_handle_ is not nullptr, try to get goal_handle_
-          this->goal_handle_ = future_goal_handle_->get();
+        if (future_goal_handle_) {
+          RCLCPP_DEBUG(
+            node_->get_logger(),
+            "Goal result for %s available, but it hasn't received the goal response yet. "
+            "It's probably a goal result for the last goal request", action_name_.c_str());
+          return;
         }
 
         // TODO(#1652): a work around until rcl_action interface is updated

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -312,6 +312,21 @@ protected:
     auto send_goal_options = typename rclcpp_action::Client<ActionT>::SendGoalOptions();
     send_goal_options.result_callback =
       [this](const typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult & result) {
+        if (!this->goal_handle_) {
+          if (!future_goal_handle_) {
+            // Shouldn't run into this block scope
+            RCLCPP_WARN(
+              node_->get_logger(),
+              "Goal result for %s available, but it can not get a valid goal_handle_. "
+              "Normally, this message shouldn't be printed.",
+              action_name_.c_str());
+            return;
+          }
+
+          // If the future_goal_handle_ is not nullptr, try to get goal_handle_
+          this->goal_handle_ = future_goal_handle_->get();
+        }
+
         // TODO(#1652): a work around until rcl_action interface is updated
         // if goal ids are not matched, the older goal call this callback so ignore the result
         // if matched, it must be processed (including aborted)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2303, #2305 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation|

---

## Description of contribution in a few bullet points

- Checking `goal_handle_` if it is `nullptr`.
- If the `future_goal_handle_` is not `nullptr`, try to get `goal_handle_` in `result_callback`.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
