### PR TITLE
Fix map_saver_cli arguments not parsed well

### DIFF
--- a/nav2_map_server/src/map_saver/main_cli.cpp
+++ b/nav2_map_server/src/map_saver/main_cli.cpp
@@ -108,10 +108,10 @@ ARGUMENTS_STATUS parse_arguments(
             save_parameters.map_file_name = *it;
             break;
           case COMMAND_FREE_THRESH:
-            save_parameters.free_thresh = atoi(it->c_str());
+            save_parameters.free_thresh = atof(it->c_str());
             break;
           case COMMAND_OCCUPIED_THRESH:
-            save_parameters.occupied_thresh = atoi(it->c_str());
+            save_parameters.occupied_thresh = atof(it->c_str());
             break;
           case COMMAND_IMAGE_FORMAT:
             save_parameters.image_format = *it;


### PR DESCRIPTION
Fixes #2358

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2358  |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points

* Fixes `map_saver_cli` when parsing `--free` and `--occ` arguments.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
