### PR TITLE
Initialize environment for when no trigger is tripped

### DIFF
--- a/.github/workflows/trigger_dockerhub.yaml
+++ b/.github/workflows/trigger_dockerhub.yaml
@@ -19,6 +19,9 @@ jobs:
     container:
       image: rosplanning/navigation2:main.release
     steps:
+      - name: "Initialize environment"
+        run: |
+          echo "TRIGGER=false" >> $GITHUB_ENV
       - name: "Check apt updates"
         if: ${{ github.event_name == 'schedule' }}
         env:


### PR DESCRIPTION
To avoid this:
https://github.com/ros-planning/navigation2/runs/2682686099