### PR TITLE
Revert CI image to build from osrf/ros2:testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ _steps:
         TZ=utc stat -c '%y' /ros_entrypoint.sh | \
           (echo ros_entrypoint && cat) >> lockfile.txt
         sha256sum $PWD/lockfile.txt >> lockfile.txt
-        mv ~/.ccache $CCACHE_DIR
+        mv ~/.ccache $CCACHE_DIR || true
         rm -rf $OVERLAY_WS/*
   on_checkout: &on_checkout
     checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,21 +69,9 @@ _commands:
               apt-get update
               rosdep update
 
-              # workarround for OMPL and rosdep
-              # https://github.com/ompl/ompl/issues/753
-              # Prevent searching $ROS_WS/install given it's too big for rosdep
-
-              if [ "$ROS_WS" == "<< parameters.underlay >>" ]; then
-                underlay_ws=""
-              else
-                underlay_ws=<< parameters.underlay >>/src
-              fi
-              echo underlay_ws = $underlay_ws
-
               dependencies=$(
                 rosdep install -q -y \
                   --from-paths src \
-                    $underlay_ws \
                   --ignore-src \
                   --skip-keys " \
                     slam_toolbox \

--- a/.dockerhub/builder/hooks/build
+++ b/.dockerhub/builder/hooks/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-export FROM_IMAGE=osrf/ros2:nightly-rmw-nonfree
+export FROM_IMAGE=osrf/ros2:testing
 export FAIL_ON_BUILD_FAILURE=""
 export UNDERLAY_MIXINS="release ccache"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # docker build -t nav2:latest \
 #   --build-arg UNDERLAY_MIXINS \
 #   --build-arg OVERLAY_MIXINS ./
-ARG FROM_IMAGE=osrf/ros2:nightly
+ARG FROM_IMAGE=osrf/ros2:testing
 ARG UNDERLAY_WS=/opt/underlay_ws
 ARG OVERLAY_WS=/opt/overlay_ws
 
@@ -43,12 +43,16 @@ APT::Install-Suggests "0";\n\
 ' > /etc/apt/apt.conf.d/01norecommend
 
 # install CI dependencies
+ARG RTI_NC_LICENSE_ACCEPTED=yes
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
       ccache \
       lcov \
       python3-pip \
+      ros-$ROS_DISTRO-rmw-fastrtps-cpp \
+      ros-$ROS_DISTRO-rmw-connextdds \
+      ros-$ROS_DISTRO-rmw-cyclonedds-cpp \
     && pip3 install \
       fastcov \
       git+https://github.com/ruffsl/colcon-cache.git@c1cedadc1ac6131fe825d075526ed4ae8e1b473c \

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,6 @@ COPY --from=cacher /tmp/$OVERLAY_WS ./
 RUN . $UNDERLAY_WS/install/setup.sh && \
     apt-get update && rosdep install -q -y \
       --from-paths src \
-        $UNDERLAY_WS/src \
       --skip-keys " \
         slam_toolbox \
         "\

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,13 @@ COPY ./ ./navigation2
 # copy manifests for caching
 WORKDIR /opt
 RUN mkdir -p /tmp/opt && \
-    find ./ -name "package.xml" | \
-      xargs cp --parents -t /tmp/opt && \
-    find ./ -name "COLCON_IGNORE" | \
-      xargs cp --parents -t /tmp/opt || true
+    find . -name "package.xml" \
+      | xargs cp --parents -t /tmp/opt && \
+    find . -name "COLCON_IGNORE" \
+      | xargs cp --parents -t /tmp/opt || true && \
+    find . -name "src" -type d \
+      -mindepth 1 -maxdepth 2 -printf '%P\n' \
+      | xargs -I % mkdir -p /tmp/opt/%
 
 # multi-stage for building
 FROM $FROM_IMAGE AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,14 +26,13 @@ COPY ./ ./navigation2
 
 # copy manifests for caching
 WORKDIR /opt
-RUN mkdir -p /tmp/opt && \
+RUN find . -name "src" -type d \
+      -mindepth 1 -maxdepth 2 -printf '%P\n' \
+      | xargs -I % mkdir -p /tmp/opt/% && \
     find . -name "package.xml" \
       | xargs cp --parents -t /tmp/opt && \
     find . -name "COLCON_IGNORE" \
-      | xargs cp --parents -t /tmp/opt || true && \
-    find . -name "src" -type d \
-      -mindepth 1 -maxdepth 2 -printf '%P\n' \
-      | xargs -I % mkdir -p /tmp/opt/%
+      | xargs cp --parents -t /tmp/opt || true
 
 # multi-stage for building
 FROM $FROM_IMAGE AS builder

--- a/tools/underlay.repos
+++ b/tools/underlay.repos
@@ -1,24 +1,24 @@
 repositories:
-  BehaviorTree/BehaviorTree.CPP:
-    type: git
-    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: master
-  ros/angles:
-    type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
-  ros-simulation/gazebo_ros_pkgs:
-    type: git
-    url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-    version: ros2
-  ros-perception/vision_opencv:
-    type: git
-    url: https://github.com/ros-perception/vision_opencv.git
-    version: ros2
-  ros/bond_core:
-    type: git
-    url: https://github.com/ros/bond_core.git
-    version: ros2
+  # BehaviorTree/BehaviorTree.CPP:
+  #   type: git
+  #   url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+  #   version: master
+  # ros/angles:
+  #   type: git
+  #   url: https://github.com/ros/angles.git
+  #   version: ros2
+  # ros-simulation/gazebo_ros_pkgs:
+  #   type: git
+  #   url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+  #   version: ros2
+  # ros-perception/vision_opencv:
+  #   type: git
+  #   url: https://github.com/ros-perception/vision_opencv.git
+  #   version: ros2
+  # ros/bond_core:
+  #   type: git
+  #   url: https://github.com/ros/bond_core.git
+  #   version: ros2
   ompl/ompl:
     type: git
     url: https://github.com/ompl/ompl.git

--- a/tools/underlay.repos
+++ b/tools/underlay.repos
@@ -22,4 +22,4 @@ repositories:
   # ompl/ompl:
   #   type: git
   #   url: https://github.com/ompl/ompl.git
-  #   version: 1.5.0
+  #   version: main

--- a/tools/underlay.repos
+++ b/tools/underlay.repos
@@ -19,7 +19,7 @@ repositories:
   #   type: git
   #   url: https://github.com/ros/bond_core.git
   #   version: ros2
-  ompl/ompl:
-    type: git
-    url: https://github.com/ompl/ompl.git
-    version: 1.5.0
+  # ompl/ompl:
+  #   type: git
+  #   url: https://github.com/ompl/ompl.git
+  #   version: 1.5.0


### PR DESCRIPTION
Reverts parts of: https://github.com/ros-planning/navigation2/pull/2348
Depends on: https://github.com/osrf/docker_images/pull/542