### PR TITLE
Clean install and test result bases for stale packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,10 @@ _commands:
                     fi
                     echo BUILD_PACKAGES: $BUILD_PACKAGES
 
+                    colcon clean packages --yes \
+                      --packages-select ${BUILD_PACKAGES} \
+                      --base-select install
+
                     . << parameters.underlay >>/install/setup.sh
                     colcon build \
                       --packages-select ${BUILD_PACKAGES} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,13 @@ _commands:
             when: always
         - store_artifacts:
             path: << parameters.workspace >>/log/test
+        - run:
+            name: Copy Test Results
+            working_directory: << parameters.workspace >>
+            command: |
+              mkdir test_results/
+              cp -rH test_result/*/test_results/* test_results
+            when: always
         - store_test_results:
             path: << parameters.workspace >>/test_results
         - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,10 @@ _commands:
                 | xargs)
               echo TEST_PACKAGES: $TEST_PACKAGES
 
+              colcon clean packages --yes \
+                --packages-select ${TEST_PACKAGES} \
+                --base-select test_result 
+
               . install/setup.sh
               set -o xtrace
               colcon test \
@@ -246,13 +250,6 @@ _commands:
             when: always
         - store_artifacts:
             path: << parameters.workspace >>/log/test
-        - run:
-            name: Copy Test Results
-            working_directory: << parameters.workspace >>
-            command: |
-              mkdir test_results/
-              cp -rH build/*/test_results/* test_results
-            when: always
         - store_test_results:
             path: << parameters.workspace >>/test_results
         - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,13 +250,6 @@ _commands:
             when: always
         - store_artifacts:
             path: << parameters.workspace >>/log/test
-        - run:
-            name: Copy Test Results
-            working_directory: << parameters.workspace >>
-            command: |
-              mkdir test_results/
-              cp -rH test_result/*/test_results/* test_results
-            when: always
         - store_test_results:
             path: << parameters.workspace >>/test_results
         - store_artifacts:

--- a/.circleci/defaults.yaml
+++ b/.circleci/defaults.yaml
@@ -1,3 +1,5 @@
+"clean.packages":
+  "test-result-base": "test_results"
 "build":
   "executor": "parallel"
   "parallel-workers": 2

--- a/.circleci/defaults.yaml
+++ b/.circleci/defaults.yaml
@@ -10,6 +10,7 @@ _common: &common
   "symlink-install": true
 "test":
   <<: *common
-  "executor": "sequential"
+  "executor": "parallel"
+  "parallel-workers": 1
 "test-result":
   <<: *common

--- a/.circleci/defaults.yaml
+++ b/.circleci/defaults.yaml
@@ -2,3 +2,7 @@
   "executor": "parallel"
   "parallel-workers": 2
   "symlink-install": true
+"test":
+  "test-result-base": "test_results"
+"test-result":
+  "test-result-base": "test_results"

--- a/.circleci/defaults.yaml
+++ b/.circleci/defaults.yaml
@@ -1,10 +1,15 @@
+_common: &common
+  "test-result-base": "test_results"
+
 "clean.packages":
-  "test-result-base": "test_result"
+  <<: *common
 "build":
+  <<: *common
   "executor": "parallel"
   "parallel-workers": 2
   "symlink-install": true
 "test":
-  "test-result-base": "test_result"
+  <<: *common
+  "executor": "sequential"
 "test-result":
-  "test-result-base": "test_result"
+  <<: *common

--- a/.circleci/defaults.yaml
+++ b/.circleci/defaults.yaml
@@ -1,10 +1,10 @@
 "clean.packages":
-  "test-result-base": "test_results"
+  "test-result-base": "test_result"
 "build":
   "executor": "parallel"
   "parallel-workers": 2
   "symlink-install": true
 "test":
-  "test-result-base": "test_results"
+  "test-result-base": "test_result"
 "test-result":
-  "test-result-base": "test_results"
+  "test-result-base": "test_result"

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update && \
     && pip3 install \
       fastcov \
       git+https://github.com/ruffsl/colcon-cache.git@c1cedadc1ac6131fe825d075526ed4ae8e1b473c \
+      git+https://github.com/ruffsl/colcon-clean.git@87dee2dd1e47c2b97ac6d8300f76e3f607d19ef6 \
     && rosdep update \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,11 +102,6 @@ RUN . $UNDERLAY_WS/install/setup.sh && \
       --ignore-src \
     && rm -rf /var/lib/apt/lists/*
 
-# source underlay from entrypoint
-RUN sed --in-place \
-      's|^source .*|source "$UNDERLAY_WS/install/setup.bash"|' \
-      /ros_entrypoint.sh
-
 # multi-stage for testing
 FROM builder AS tester
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,11 @@ RUN . $UNDERLAY_WS/install/setup.sh && \
       --ignore-src \
     && rm -rf /var/lib/apt/lists/*
 
+# source underlay from entrypoint
+RUN sed --in-place \
+      's|^source .*|source "$UNDERLAY_WS/install/setup.bash"|' \
+      /ros_entrypoint.sh
+
 # multi-stage for testing
 FROM builder AS tester
 


### PR DESCRIPTION
Use the colcon clean extension to clean out stale build artifacts or test results for packages that are to be rebuilt or retested, preventing them from persisting in the cache cycle and accounting for when source files or tests are deleted or renamed.