### PR TITLE
Update lockfile formating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,10 @@ _commands:
               . << parameters.underlay >>/install/setup.sh
               AMENT_PREFIX_PATH=$(echo "$AMENT_PREFIX_PATH" | \
                 sed -e 's|:/opt/ros/'$ROS_DISTRO'$||')
-              AMENT_PREFIX_PATH=$(echo "$AMENT_PREFIX_PATH" | \
-                sed -e 's|/opt/ros/'$ROS_DISTRO'$||')
+              if [ "$AMENT_PREFIX_PATH" == "/opt/ros/$ROS_DISTRO" ]
+              then
+                unset AMENT_PREFIX_PATH
+              fi
 
               cat << parameters.underlay >>/lockfile.txt > lockfile.txt
               vcs export --exact << parameters.underlay >>/src | \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,8 @@ _commands:
               . << parameters.underlay >>/install/setup.sh
               AMENT_PREFIX_PATH=$(echo "$AMENT_PREFIX_PATH" | \
                 sed -e 's|:/opt/ros/'$ROS_DISTRO'$||')
+              AMENT_PREFIX_PATH=$(echo "$AMENT_PREFIX_PATH" | \
+                sed -e 's|/opt/ros/'$ROS_DISTRO'$||')
 
               cat << parameters.underlay >>/lockfile.txt > lockfile.txt
               vcs export --exact << parameters.underlay >>/src | \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ _commands:
                 awk '$1 ~ /^resolution\:/' | \
                 awk -F'[][]' '{print $2}' | \
                 tr -d \, | xargs -n1 | sort -u | xargs)
-              dpkg --list $dependencies | \
+              dpkg --list dpkg $dependencies | \
                 (echo workspace_dependencies && cat) >> lockfile.txt
               sha256sum $PWD/lockfile.txt >> lockfile.txt
     setup_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ _commands:
                 awk '$1 ~ /^resolution\:/' | \
                 awk -F'[][]' '{print $2}' | \
                 tr -d \, | xargs -n1 | sort -u | xargs)
-              dpkg -s $dependencies | \
+              dpkg --list $dependencies | \
                 (echo workspace_dependencies && cat) >> lockfile.txt
               sha256sum $PWD/lockfile.txt >> lockfile.txt
     setup_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,12 +82,13 @@ _commands:
             command: |
               . << parameters.underlay >>/install/setup.sh
               cat << parameters.underlay >>/lockfile.txt > lockfile.txt
+              
               vcs export --exact << parameters.underlay >>/src | \
                 (echo vcs_export && cat) >> lockfile.txt
               sha256sum $PWD/lockfile.txt >> lockfile.txt
+
               apt-get update
               rosdep update
-
               dependencies=$(
                 rosdep install -q -y \
                   --from-paths src \
@@ -287,12 +288,15 @@ _steps:
       command: |
         mkdir -p $ROS_WS/src && cd $ROS_WS
         ln -s /opt/ros/$ROS_DISTRO install
+
         echo $CACHE_NONCE | \
           (echo cache_nonce && cat) >> lockfile.txt
         sha256sum $PWD/lockfile.txt >> lockfile.txt
+        
         TZ=utc stat -c '%y' /ros_entrypoint.sh | \
           (echo ros_entrypoint && cat) >> lockfile.txt
         sha256sum $PWD/lockfile.txt >> lockfile.txt
+
         rm -rf $OVERLAY_WS/*
   on_checkout: &on_checkout
     checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,13 +82,13 @@ _commands:
             command: |
               . << parameters.underlay >>/install/setup.sh
               cat << parameters.underlay >>/lockfile.txt > lockfile.txt
-              
+
               vcs export --exact << parameters.underlay >>/src | \
                 (echo vcs_export && cat) >> lockfile.txt
               sha256sum $PWD/lockfile.txt >> lockfile.txt
 
               apt-get update
-              rosdep update
+              rosdep update --rosdistro $ROS_DISTRO
               dependencies=$(
                 rosdep install -q -y \
                   --from-paths src \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,10 @@ _commands:
             working_directory: << parameters.workspace >>
             command: |
               . << parameters.underlay >>/install/setup.sh
-              cat << parameters.underlay >>/lockfile.txt > lockfile.txt
+              AMENT_PREFIX_PATH=$(echo "$AMENT_PREFIX_PATH" | \
+                sed -e 's|:/opt/ros/'$ROS_DISTRO'$||')
 
+              cat << parameters.underlay >>/lockfile.txt > lockfile.txt
               vcs export --exact << parameters.underlay >>/src | \
                 (echo vcs_export && cat) >> lockfile.txt
               sha256sum $PWD/lockfile.txt >> lockfile.txt


### PR DESCRIPTION
Update lockfile format to cleanly list versioned package dependencies for each workspace in a readable table format, and fix up environment so that rosdep correctly resolves apt installed dependencies.