### PR TITLE
Increase timeout for nav2 rviz panel clients to 100ms

### DIFF
--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -38,7 +38,7 @@ GoalPoseUpdater GoalUpdater;
 
 Nav2Panel::Nav2Panel(QWidget * parent)
 : Panel(parent),
-  server_timeout_(20),
+  server_timeout_(100),
   client_nav_("lifecycle_manager_navigation"),
   client_loc_("lifecycle_manager_localization")
 {


### PR DESCRIPTION
Resolves https://github.com/ros-planning/navigation2/issues/2383 to increase the base timeout for nav2 panel. If it reoccurs as an issue, we can add a parameterization. Ideally the nav2 panel is just a demo panel for people getting started or during basic testing. If we find that people want to use in a more real use-case, many more things should be parameterized. 