### PR TITLE
Fix code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 fixes:
-  - "src/navigation2/::"
+  - "**/src/navigation2/::"
+  - "**/install/::"
 
 ignore:
   - "*/**/test/*"  # ignore package test directories, e.g. nav2_dwb_controller/costmap_queue/tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 fixes:
-  - "**/src/navigation2/::"
-  - "**/install/::"
+  - "src/navigation2/::"
+  - "install/::"
 
 ignore:
   - "*/**/test/*"  # ignore package test directories, e.g. nav2_dwb_controller/costmap_queue/tests

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -62,7 +62,6 @@ fastcov --lcov \
   -d build \
   --exclude test/ $EXCLUDE_PACKAGES \
   --include $INCLUDE_PACKAGES \
-  --branch-coverage \
   --process-gcno \
   --validate-sources \
   --dump-statistic \

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -44,7 +44,7 @@ mkdir -p ${LCOVDIR}
 # - rviz plugins, which are not used for real navigation
 INCLUDE_PACKAGES=$(
   colcon list \
-    --paths-only \
+    --names-only \
     --packages-ignore-regex \
       ".*_msgs" \
       ".*_tests" \

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -52,11 +52,11 @@ INCLUDE_PACKAGES=$(
   | xargs)
 
 # Capture executed code data.
-fastcov \
+fastcov --lcov \
   -d build \
   --exclude test/ \
   --include $INCLUDE_PACKAGES \
-  --output ${LCOVDIR}/total_coverage.info --lcov
+  --output ${LCOVDIR}/total_coverage.info
 
 if [ $COVERAGE_REPORT_VIEW = codecovio ]; then
   curl -s https://codecov.io/bash > codecov

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -56,6 +56,7 @@ fastcov --lcov \
   -d build \
   --exclude test/ \
   --include $INCLUDE_PACKAGES \
+  --branch-coverage \
   --process-gcno \
   --validate-sources \
   --dump-statistic \

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -58,6 +58,7 @@ fastcov --lcov \
   --include $INCLUDE_PACKAGES \
   --process-gcno \
   --validate-sources \
+  --dump-statistic \
   --output ${LCOVDIR}/total_coverage.info
 
 if [ $COVERAGE_REPORT_VIEW = codecovio ]; then

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -42,19 +42,25 @@ mkdir -p ${LCOVDIR}
 # - messages, which are auto generated files
 # - system tests, which are themselves all test artifacts
 # - rviz plugins, which are not used for real navigation
-INCLUDE_PACKAGES=$(
+EXCLUDE_PACKAGES=$(
   colcon list \
     --names-only \
-    --packages-ignore-regex \
+    --packages-select-regex \
       ".*_msgs" \
       ".*_tests" \
       ".*_rviz.*" \
+  | xargs)
+INCLUDE_PACKAGES=$(
+  colcon list \
+    --names-only \
+    --packages-ignore \
+      $EXCLUDE_PACKAGES \
   | xargs)
 
 # Capture executed code data.
 fastcov --lcov \
   -d build \
-  --exclude test/ \
+  --exclude test/ $EXCLUDE_PACKAGES \
   --include $INCLUDE_PACKAGES \
   --branch-coverage \
   --process-gcno \

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -56,6 +56,7 @@ fastcov --lcov \
   -d build \
   --exclude test/ \
   --include $INCLUDE_PACKAGES \
+  --process-gcno \
   --output ${LCOVDIR}/total_coverage.info
 
 if [ $COVERAGE_REPORT_VIEW = codecovio ]; then

--- a/tools/code_coverage_report.bash
+++ b/tools/code_coverage_report.bash
@@ -57,6 +57,7 @@ fastcov --lcov \
   --exclude test/ \
   --include $INCLUDE_PACKAGES \
   --process-gcno \
+  --validate-sources \
   --output ${LCOVDIR}/total_coverage.info
 
 if [ $COVERAGE_REPORT_VIEW = codecovio ]; then


### PR DESCRIPTION
This mainly fixes the include filter to only look for the package name in the paths reported, as using package source paths can exclude coverage for files from other packages, such as header files reported using under workspace's install path.