### PR TITLE
Feature addition: capability for the RRP to drive the robot backwards

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -198,7 +198,7 @@ protected:
   void applyConstraints(
     const double & dist_error, const double & lookahead_dist,
     const double & curvature, const geometry_msgs::msg::Twist & speed,
-    const double & pose_cost, double & linear_vel);
+    const double & pose_cost, double & linear_vel, double & sign);
 
   /**
    * @brief Get lookahead point
@@ -208,9 +208,20 @@ protected:
    */
   geometry_msgs::msg::PoseStamped getLookAheadPoint(const double &, const nav_msgs::msg::Path &);
 
-  double checkOrientation(const geometry_msgs::msg::PoseStamped & pose);
+  /**
+   * @brief checks for the cusp position
+   * @param pose Pose input to determine the cusp position
+   * @return robot distance from the cusp
+   */
+  double detectPathOrientation(const geometry_msgs::msg::PoseStamped & pose);
 
-  double dot(double q1[], double q2[]);
+  /**
+   * @brief determines the dot product
+   * @param u_x, u_y, represents the vector u
+   * @param v_x, v_y, represents the vector v 
+   * @return robot distance from the cusp
+   */
+  inline double dot(double u_x, double u_y, double v_x, double v_y);
 
   std::shared_ptr<tf2_ros::Buffer> tf_;
   std::string plugin_name_;
@@ -243,7 +254,7 @@ protected:
   double max_angular_accel_;
   double rotate_to_heading_min_angle_;
   double goal_dist_tol_;
-  bool reverse_driving_;
+  bool allow_reversing_;
 
   nav_msgs::msg::Path global_plan_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> global_path_pub_;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -208,6 +208,10 @@ protected:
    */
   geometry_msgs::msg::PoseStamped getLookAheadPoint(const double &, const nav_msgs::msg::Path &);
 
+  double checkOrientation(const geometry_msgs::msg::PoseStamped & pose);
+
+  double dot(double q1[], double q2[]);
+
   std::shared_ptr<tf2_ros::Buffer> tf_;
   std::string plugin_name_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
@@ -239,6 +243,7 @@ protected:
   double max_angular_accel_;
   double rotate_to_heading_min_angle_;
   double goal_dist_tol_;
+  bool reverse_driving_;
 
   nav_msgs::msg::Path global_plan_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> global_path_pub_;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -213,15 +213,7 @@ protected:
    * @param pose Pose input to determine the cusp position
    * @return robot distance from the cusp
    */
-  double detectPathOrientation(const geometry_msgs::msg::PoseStamped & pose);
-
-  /**
-   * @brief determines the dot product
-   * @param u_x, u_y, represents the vector u
-   * @param v_x, v_y, represents the vector v 
-   * @return robot distance from the cusp
-   */
-  inline double dot(double u_x, double u_y, double v_x, double v_y);
+  double findDirectionChange(const geometry_msgs::msg::PoseStamped & pose);
 
   std::shared_ptr<tf2_ros::Buffer> tf_;
   std::string plugin_name_;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -480,7 +480,7 @@ void RegulatedPurePursuitController::applyConstraints(
     if (unbounded_vel < min_approach_linear_velocity_) {
       approach_vel = min_approach_linear_velocity_;
     } else {
-      approach_vel = approach_vel * velocity_scaling;
+      approach_vel *= velocity_scaling;
     }
     // Use the lowest velocity between approach and other constraints, if all overlapping
     linear_vel = std::min(linear_vel, approach_vel);

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -376,7 +376,7 @@ bool RegulatedPurePursuitController::isCollisionImminent(
   pose_msg.header.frame_id = arc_pts_msg.header.frame_id;
   pose_msg.header.stamp = arc_pts_msg.header.stamp;
 
-  const double projection_time = costmap_->getResolution() / fabs(linear_vel);
+  const double projection_time = costmap_->getResolution() / linear_vel;
 
   geometry_msgs::msg::Pose2D curr_pose;
   curr_pose.x = robot_pose.pose.position.x;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -581,8 +581,9 @@ double RegulatedPurePursuitController::findDirectionChange(
       global_plan_.poses[pose_id].pose.position.y;
 
     /* Checking for the existance of cusp, in the path, using the dot product
-    and determine it's distance from the robot */
-    if ( (oa_x * ab_x) + (oa_y * ab_y) <= 0) {
+    and determine it's distance from the robot. If there is no cusp in the path,
+    then just determine the distance to the goal location. */
+    if ( (oa_x * ab_x) + (oa_y * ab_y) < 0.0 || pose_id == global_plan_.poses.size() ) {
       auto x = global_plan_.poses[pose_id].pose.position.x - pose.pose.position.x;
       auto y = global_plan_.poses[pose_id].pose.position.y - pose.pose.position.y;
       return hypot(x, y); // returning the distance if there is a cusp

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -569,7 +569,7 @@ double RegulatedPurePursuitController::findDirectionChange(
   const geometry_msgs::msg::PoseStamped & pose )
 {
   // Iterating through the global path to determine the position of the cusp
-   for (auto pose_id = 1; pose_id <= (int)global_plan_.poses.size(); ++pose_id)  {
+   for (unsigned int pose_id = 1; pose_id <= global_plan_.poses.size(); ++pose_id)  {
     // We have two vectors for the dot product OA and AB. Determining the vectors.
     double oa_x = global_plan_.poses[pose_id].pose.position.x -
       global_plan_.poses[pose_id - 1].pose.position.x;

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -82,9 +82,10 @@ public:
   void applyConstraintsWrapper(
   const double & dist_error, const double & lookahead_dist,
   const double & curvature, const geometry_msgs::msg::Twist & curr_speed,
-  const double & pose_cost, double & linear_vel)
+  const double & pose_cost, double & linear_vel, double & sign)
   {
-    return applyConstraints(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel);
+    return applyConstraints(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+      linear_vel, sign);
   }
 
 };
@@ -270,25 +271,29 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   geometry_msgs::msg::Twist curr_speed;
   double pose_cost = 0.0;
   double linear_vel = 0.0;
+  double sign = 1.0;
 
   // since costmaps here are bogus, we can't access them
   ctrl->resetVelocityApproachScaling();
 
   // test curvature regulation (default)
   curr_speed.linear.x = 0.25;
-  ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel);
+  ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+    linear_vel, sign);
   EXPECT_EQ(linear_vel, 0.25);  // min set speed
 
   linear_vel = 1.0;
   curvature = 0.7407;
   curr_speed.linear.x = 0.5;
-  ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel);
+  ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+    linear_vel, sign);
   EXPECT_NEAR(linear_vel, 0.5, 0.01);  // lower by curvature
 
   linear_vel = 1.0;
   curvature = 1000.0;
   curr_speed.linear.x = 0.25;
-  ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel);
+  ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+    linear_vel, sign);
   EXPECT_NEAR(linear_vel, 0.25, 0.01);  // min out by curvature
 
 
@@ -301,24 +306,24 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   // pose_cost = 1;
   // linear_vel = 0.5;
   // curr_speed.linear.x = 0.5;
-  // ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel);
+  // ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel, sign);
   // EXPECT_NEAR(linear_vel, 0.498, 0.01);
 
   // max changing cost
   // pose_cost = 127;
   // curr_speed.linear.x = 0.255;
-  // ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel);
+  // ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel, sign);
   // EXPECT_NEAR(linear_vel, 0.255, 0.01);
 
   // over max cost thresh
   // pose_cost = 200;
   // curr_speed.linear.x = 0.25;
-  // ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel);
+  // ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel, sign);
   // EXPECT_NEAR(linear_vel, 0.25, 0.01);
 
   // test kinematic clamping
   // pose_cost = 200;
   // curr_speed.linear.x = 1.0;
-  // ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel);
+  // ctrl->applyConstraintsWrapper(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, linear_vel, sign);
   // EXPECT_NEAR(linear_vel, 0.5, 0.01);
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2327  |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | gazebo simulation of neobotix mp-400 |

---

## Description of contribution in a few bullet points


* I added this neat new feature for driving the robot using the RRP planner backwards. This enables car-like robots to efficiently perform the maneuvers using the SMAC planner. 



## Description of documentation updates required from your changes


* Added new parameter "reverse_driving", so need to add that to default configs and documentation page


---

## Future work that may be required in bullet points


* I tested on a differential drive robot, but it will be great if someone can test it on an Ackermann drive! 


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
