### PR TITLE
Add modern cmake export for missing definitions

### DIFF
--- a/nav2_controller/CMakeLists.txt
+++ b/nav2_controller/CMakeLists.txt
@@ -17,7 +17,6 @@ find_package(pluginlib REQUIRED)
 nav2_package()
 
 include_directories(
-  include
 )
 
 set(executable_name controller_server)
@@ -30,6 +29,11 @@ set(library_name ${executable_name}_core)
 
 add_library(${library_name}
   src/nav2_controller.cpp
+)
+
+target_include_directories(${library_name} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
@@ -52,16 +56,31 @@ ament_target_dependencies(simple_progress_checker ${dependencies})
 # prevent pluginlib from using boost
 target_compile_definitions(simple_progress_checker PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
+target_include_directories(simple_progress_checker PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 add_library(simple_goal_checker SHARED plugins/simple_goal_checker.cpp)
 ament_target_dependencies(simple_goal_checker ${dependencies})
 # prevent pluginlib from using boost
 target_compile_definitions(simple_goal_checker PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
+target_include_directories(simple_goal_checker PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 add_library(stopped_goal_checker SHARED plugins/stopped_goal_checker.cpp)
 target_link_libraries(stopped_goal_checker simple_goal_checker)
 ament_target_dependencies(stopped_goal_checker ${dependencies})
 # prevent pluginlib from using boost
 target_compile_definitions(stopped_goal_checker PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
+target_include_directories(stopped_goal_checker PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 ament_target_dependencies(${library_name}
   ${dependencies}
@@ -87,6 +106,7 @@ ament_target_dependencies(${executable_name}
 target_link_libraries(${executable_name} ${library_name})
 
 install(TARGETS simple_progress_checker simple_goal_checker stopped_goal_checker ${library_name}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -110,6 +130,7 @@ ament_export_libraries(simple_progress_checker
   simple_goal_checker
   stopped_goal_checker
   ${library_name})
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 pluginlib_export_plugin_description_file(nav2_core plugins.xml)
 
 ament_package()

--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -30,7 +30,6 @@ find_package(Eigen3 REQUIRED)
 nav2_package()
 
 include_directories(
-  include
   ${EIGEN3_INCLUDE_DIRS}
 )
 
@@ -54,6 +53,11 @@ add_library(nav2_costmap_2d_core SHARED
 
 # prevent pluginlib from using boost
 target_compile_definitions(nav2_costmap_2d_core PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
+target_include_directories(nav2_costmap_2d_core PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 set(dependencies
   geometry_msgs
@@ -95,6 +99,10 @@ ament_target_dependencies(layers
 target_link_libraries(layers
   nav2_costmap_2d_core
 )
+target_include_directories(layers PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 add_library(filters SHARED
   plugins/costmap_filters/keepout_filter.cpp
@@ -105,6 +113,10 @@ ament_target_dependencies(filters
 )
 target_link_libraries(filters
   nav2_costmap_2d_core
+)
+target_include_directories(filters PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 add_library(nav2_costmap_2d_client SHARED
@@ -119,6 +131,10 @@ ament_target_dependencies(nav2_costmap_2d_client
 
 target_link_libraries(nav2_costmap_2d_client
   nav2_costmap_2d_core
+)
+target_include_directories(nav2_costmap_2d_client PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 add_executable(nav2_costmap_2d_markers src/costmap_2d_markers.cpp)
@@ -151,6 +167,7 @@ install(TARGETS
   layers
   filters
   nav2_costmap_2d_client
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -185,5 +202,6 @@ endif()
 ament_export_include_directories(include)
 ament_export_libraries(layers filters nav2_costmap_2d_core nav2_costmap_2d_client)
 ament_export_dependencies(${dependencies})
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 pluginlib_export_plugin_description_file(nav2_costmap_2d costmap_plugins.xml)
 ament_package()

--- a/nav2_dwb_controller/dwb_core/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_core/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(nav2_core REQUIRED)
 nav2_package()
 
 include_directories(
-  include
 )
 
 set(dependencies
@@ -51,11 +50,17 @@ add_library(dwb_core SHARED
 # prevent pluginlib from using boost
 target_compile_definitions(dwb_core PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
+target_include_directories(dwb_core PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 ament_target_dependencies(dwb_core
   ${dependencies}
 )
 
 install(TARGETS dwb_core
+  EXPORT export_dwb_core
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -78,6 +83,7 @@ endif()
 ament_export_include_directories(include)
 ament_export_libraries(dwb_core)
 ament_export_dependencies(${dependencies})
+ament_export_targets(export_dwb_core HAS_LIBRARY_TARGET)
 
 pluginlib_export_plugin_description_file(nav2_core local_planner_plugin.xml)
 

--- a/nav2_dwb_controller/dwb_critics/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_critics/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(nav2_util REQUIRED)
 nav2_package()
 
 include_directories(
-  include
 )
 
 add_library(${PROJECT_NAME} SHARED
@@ -39,6 +38,11 @@ add_library(${PROJECT_NAME} SHARED
 # prevent pluginlib from using boost
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 set(dependencies
   angles
   nav2_costmap_2d
@@ -58,6 +62,7 @@ ament_target_dependencies(${PROJECT_NAME}
 )
 
 install(TARGETS ${PROJECT_NAME}
+        EXPORT export_${PROJECT_NAME}
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -84,6 +89,7 @@ ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(
   ${dependencies}
 )
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 pluginlib_export_plugin_description_file(dwb_core default_critics.xml)
 

--- a/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
@@ -24,7 +24,6 @@ set(dependencies
 )
 
 include_directories(
-  include
 )
 
 add_library(standard_traj_generator SHARED
@@ -36,6 +35,10 @@ ament_target_dependencies(standard_traj_generator ${dependencies})
 # prevent pluginlib from using boost
 target_compile_definitions(standard_traj_generator PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
+target_include_directories(standard_traj_generator PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -48,6 +51,7 @@ if(BUILD_TESTING)
 endif()
 
 install(TARGETS standard_traj_generator
+        EXPORT export_standard_traj_generator
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -61,6 +65,8 @@ install(FILES plugins.xml
 
 ament_export_include_directories(include)
 ament_export_libraries(standard_traj_generator)
+ament_export_targets(export_standard_traj_generator HAS_LIBRARY_TARGET)
+
 pluginlib_export_plugin_description_file(dwb_core plugins.xml)
 
 ament_package()

--- a/nav2_dwb_controller/dwb_plugins/test/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 ament_add_gtest(vtest velocity_iterator_test.cpp)
+target_include_directories(vtest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 ament_add_gtest(twist_gen_test twist_gen.cpp)
 target_link_libraries(twist_gen_test standard_traj_generator)

--- a/nav2_navfn_planner/CMakeLists.txt
+++ b/nav2_navfn_planner/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(pluginlib REQUIRED)
 nav2_package()
 
 include_directories(
-  include
 )
 
 set(library_name nav2_navfn_planner)
@@ -55,9 +54,15 @@ ament_target_dependencies(${library_name}
 # prevent pluginlib from using boost
 target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
+target_include_directories(${library_name} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 pluginlib_export_plugin_description_file(nav2_core global_planner_plugin.xml)
 
 install(TARGETS ${library_name}
+  EXPORT export_${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -78,5 +83,6 @@ endif()
 
 ament_export_include_directories(include)
 ament_export_libraries(${library_name})
+ament_export_targets(export_${library_name} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dependencies})
 ament_package()

--- a/nav2_planner/CMakeLists.txt
+++ b/nav2_planner/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(nav2_core REQUIRED)
 nav2_package()
 
 include_directories(
-  include
 )
 
 set(executable_name planner_server)
@@ -54,6 +53,11 @@ ament_target_dependencies(${library_name}
 
 target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
+target_include_directories(${library_name} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 add_executable(${executable_name}
   src/main.cpp
 )
@@ -68,6 +72,7 @@ ament_target_dependencies(${executable_name}
 target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 install(TARGETS ${library_name}
+  EXPORT export_${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -89,4 +94,5 @@ endif()
 ament_export_include_directories(include)
 ament_export_libraries(${library_name})
 ament_export_dependencies(${dependencies})
+ament_export_targets(export_${library_name} HAS_LIBRARY_TARGET)
 ament_package()

--- a/nav2_recoveries/CMakeLists.txt
+++ b/nav2_recoveries/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(pluginlib REQUIRED)
 nav2_package()
 
 include_directories(
-  include
 )
 
 set(library_name recoveries_server_core)
@@ -56,6 +55,11 @@ ament_target_dependencies(nav2_spin_recovery
 # prevent pluginlib from using boost
 target_compile_definitions(nav2_spin_recovery PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
+target_include_directories(nav2_spin_recovery PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 add_library(nav2_backup_recovery SHARED
   plugins/back_up.cpp
 )
@@ -67,6 +71,11 @@ ament_target_dependencies(nav2_backup_recovery
 # prevent pluginlib from using boost
 target_compile_definitions(nav2_backup_recovery PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
+target_include_directories(nav2_backup_recovery PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 add_library(nav2_wait_recovery SHARED
   plugins/wait.cpp
 )
@@ -77,6 +86,11 @@ ament_target_dependencies(nav2_wait_recovery
 
 # prevent pluginlib from using boost
 target_compile_definitions(nav2_wait_recovery PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
+target_include_directories(nav2_wait_recovery PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 pluginlib_export_plugin_description_file(nav2_core recovery_plugin.xml)
 
@@ -91,6 +105,11 @@ ament_target_dependencies(${library_name}
 
 # prevent pluginlib from using boost
 target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
+target_include_directories(${library_name} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 # Executable
 add_executable(${executable_name}
@@ -108,6 +127,7 @@ install(TARGETS ${library_name}
                 nav2_backup_recovery
                 nav2_spin_recovery
                 nav2_wait_recovery
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -138,5 +158,6 @@ ament_export_libraries(${library_name}
   nav2_spin_recovery
   nav2_wait_recovery
 )
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 ament_package()

--- a/nav2_recoveries/test/CMakeLists.txt
+++ b/nav2_recoveries/test/CMakeLists.txt
@@ -2,6 +2,8 @@ ament_add_gtest(test_recoveries
   test_recoveries.cpp
 )
 
+target_include_directories(test_recoveries PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
 ament_target_dependencies(test_recoveries
   ${dependencies}
 )

--- a/nav2_regulated_pure_pursuit_controller/CMakeLists.txt
+++ b/nav2_regulated_pure_pursuit_controller/CMakeLists.txt
@@ -16,7 +16,6 @@ nav2_package()
 set(CMAKE_CXX_STANDARD 17)
 
 include_directories(
-  include
 )
 
 set(dependencies
@@ -38,11 +37,17 @@ add_library(${library_name} SHARED
 # prevent pluginlib from using boost
 target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
+target_include_directories(${library_name} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
 install(TARGETS ${library_name}
+  EXPORT export_${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -63,6 +68,7 @@ endif()
 ament_export_include_directories(include)
 ament_export_libraries(${library_name})
 ament_export_dependencies(${dependencies})
+ament_export_targets(export_${library_name} HAS_LIBRARY_TARGET)
 
 pluginlib_export_plugin_description_file(nav2_core nav2_regulated_pure_pursuit_controller.xml)
 

--- a/nav2_rviz_plugins/CMakeLists.txt
+++ b/nav2_rviz_plugins/CMakeLists.txt
@@ -42,7 +42,6 @@ set(nav2_rviz_plugins_headers_to_moc
 )
 
 include_directories(
-  include
 )
 
 set(library_name ${PROJECT_NAME})
@@ -78,6 +77,8 @@ ament_target_dependencies(${library_name}
 )
 
 target_include_directories(${library_name} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
   ${Qt5Widgets_INCLUDE_DIRS}
   ${OGRE_INCLUDE_DIRS}
 )
@@ -98,7 +99,7 @@ pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
 
 install(
   TARGETS ${library_name}
-  EXPORT ${library_name}
+  EXPORT export_${library_name}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -116,7 +117,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_targets(${library_name} HAS_LIBRARY_TARGET)
+ament_export_targets(export_${library_name} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   Qt5
   rviz_common

--- a/nav2_smac_planner/CMakeLists.txt
+++ b/nav2_smac_planner/CMakeLists.txt
@@ -33,7 +33,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 add_compile_options(-O3 -Wextra -Wdeprecated -fPIC)
 
 include_directories(
-  include
   ${OMPL_INCLUDE_DIRS}
   ${OpenMP_INCLUDE_DIRS}
 )
@@ -75,7 +74,11 @@ add_library(${library_name} SHARED
 )
 
 target_link_libraries(${library_name} ${OMPL_LIBRARIES} ${OpenMP_LIBRARIES}  OpenMP::OpenMP_CXX)
-target_include_directories(${library_name} PUBLIC ${Eigen3_INCLUDE_DIRS})
+target_include_directories(${library_name} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  ${Eigen3_INCLUDE_DIRS}
+)
 
 ament_target_dependencies(${library_name}
   ${dependencies}
@@ -91,7 +94,11 @@ add_library(${library_name}_2d SHARED
 )
 
 target_link_libraries(${library_name}_2d ${OMPL_LIBRARIES})
-target_include_directories(${library_name}_2d PUBLIC ${Eigen3_INCLUDE_DIRS})
+target_include_directories(${library_name}_2d PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  ${Eigen3_INCLUDE_DIRS}
+)
 
 ament_target_dependencies(${library_name}_2d
   ${dependencies}
@@ -104,6 +111,7 @@ pluginlib_export_plugin_description_file(nav2_core smac_plugin.xml)
 pluginlib_export_plugin_description_file(nav2_core smac_plugin_2d.xml)
 
 install(TARGETS ${library_name} ${library_name}_2d
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
@@ -122,5 +130,6 @@ endif()
 
 ament_export_include_directories(include)
 ament_export_libraries(${library_name} ${library_name}_2d)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dependencies})
 ament_package()

--- a/nav2_waypoint_follower/CMakeLists.txt
+++ b/nav2_waypoint_follower/CMakeLists.txt
@@ -27,7 +27,6 @@ nav2_package()
 link_libraries(stdc++fs)
 
 include_directories(
-  include
 )
 
 set(executable_name waypoint_follower)
@@ -40,6 +39,11 @@ set(library_name ${executable_name}_core)
 
 add_library(${library_name} SHARED
   src/waypoint_follower.cpp
+)
+
+target_include_directories(${library_name} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 set(dependencies
@@ -71,18 +75,31 @@ add_library(wait_at_waypoint SHARED plugins/wait_at_waypoint.cpp)
 ament_target_dependencies(wait_at_waypoint ${dependencies})
 #prevent pluginlib from using boost
 target_compile_definitions(wait_at_waypoint PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_include_directories(wait_at_waypoint PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 add_library(photo_at_waypoint SHARED plugins/photo_at_waypoint.cpp)
 ament_target_dependencies(photo_at_waypoint ${dependencies})
 #prevent pluginlib from using boost
 target_compile_definitions(photo_at_waypoint PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_include_directories(photo_at_waypoint PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 add_library(input_at_waypoint SHARED plugins/input_at_waypoint.cpp)
 ament_target_dependencies(input_at_waypoint ${dependencies})
 #prevent pluginlib from using boost
 target_compile_definitions(input_at_waypoint PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_include_directories(input_at_waypoint PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 install(TARGETS ${library_name} wait_at_waypoint photo_at_waypoint input_at_waypoint
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -105,6 +122,7 @@ endif()
 
 ament_export_include_directories(include)
 ament_export_libraries(wait_at_waypoint photo_at_waypoint input_at_waypoint)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 pluginlib_export_plugin_description_file(nav2_waypoint_follower plugins.xml)
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2429 |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | none|

---

## Description of contribution in a few bullet points
* Switch to modern cmake export for packages using the `PLUGINLIB__DISABLE_BOOST_FUNCTIONS`
* Used export_${PROJECT_NAME} or export_${library_name} as by [foxy documentation/convention](https://docs.ros.org/en/foxy/Guides/Ament-CMake-Documentation.html#building-a-library)
* Updated rviz plugin to this convention
* Removed include_directories for directory `include`
* Instead use `target_include_directories pubic build/install_interface` as this is the only way the dir will get exported

## Description of documentation updates required from your changes

Nothing should be required to change

---

## Future work that may be required in bullet points

* Thorough porting of all packages to modern cmake
* Consistently using cmake vars or names
* Consistently using public and private in all cmake functions for targets

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
