### PR TITLE
Remove deprecated pluginlib boost feature disable

### DIFF
--- a/nav2_controller/CMakeLists.txt
+++ b/nav2_controller/CMakeLists.txt
@@ -32,8 +32,6 @@ add_library(${library_name}
   src/nav2_controller.cpp
 )
 
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 set(dependencies
   angles
   rclcpp
@@ -49,26 +47,17 @@ set(dependencies
 
 add_library(simple_progress_checker SHARED plugins/simple_progress_checker.cpp)
 ament_target_dependencies(simple_progress_checker ${dependencies})
-# prevent pluginlib from using boost
-target_compile_definitions(simple_progress_checker PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 add_library(simple_goal_checker SHARED plugins/simple_goal_checker.cpp)
 ament_target_dependencies(simple_goal_checker ${dependencies})
-# prevent pluginlib from using boost
-target_compile_definitions(simple_goal_checker PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 add_library(stopped_goal_checker SHARED plugins/stopped_goal_checker.cpp)
 target_link_libraries(stopped_goal_checker simple_goal_checker)
 ament_target_dependencies(stopped_goal_checker ${dependencies})
-# prevent pluginlib from using boost
-target_compile_definitions(stopped_goal_checker PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 ament_target_dependencies(${library_name}
   ${dependencies}
 )
-
-# prevent pluginlib from using boost
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -52,9 +52,6 @@ add_library(nav2_costmap_2d_core SHARED
   plugins/costmap_filters/costmap_filter.cpp
 )
 
-# prevent pluginlib from using boost
-target_compile_definitions(nav2_costmap_2d_core PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 set(dependencies
   geometry_msgs
   laser_geometry

--- a/nav2_dwb_controller/dwb_core/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_core/CMakeLists.txt
@@ -48,9 +48,6 @@ add_library(dwb_core SHARED
   src/trajectory_utils.cpp
 )
 
-# prevent pluginlib from using boost
-target_compile_definitions(dwb_core PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 ament_target_dependencies(dwb_core
   ${dependencies}
 )

--- a/nav2_dwb_controller/dwb_critics/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_critics/CMakeLists.txt
@@ -36,9 +36,6 @@ add_library(${PROJECT_NAME} SHARED
     src/twirling.cpp
 )
 
-# prevent pluginlib from using boost
-target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 set(dependencies
   angles
   nav2_costmap_2d

--- a/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
+++ b/nav2_dwb_controller/dwb_plugins/CMakeLists.txt
@@ -33,8 +33,6 @@ add_library(standard_traj_generator SHARED
             src/kinematic_parameters.cpp
             src/xy_theta_iterator.cpp)
 ament_target_dependencies(standard_traj_generator ${dependencies})
-# prevent pluginlib from using boost
-target_compile_definitions(standard_traj_generator PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 
 if(BUILD_TESTING)

--- a/nav2_navfn_planner/CMakeLists.txt
+++ b/nav2_navfn_planner/CMakeLists.txt
@@ -52,9 +52,6 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
-# prevent pluginlib from using boost
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 pluginlib_export_plugin_description_file(nav2_core global_planner_plugin.xml)
 
 install(TARGETS ${library_name}

--- a/nav2_planner/CMakeLists.txt
+++ b/nav2_planner/CMakeLists.txt
@@ -52,8 +52,6 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 add_executable(${executable_name}
   src/main.cpp
 )
@@ -63,9 +61,6 @@ target_link_libraries(${executable_name} ${library_name})
 ament_target_dependencies(${executable_name}
   ${dependencies}
 )
-
-# prevent pluginlib from using boost
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 install(TARGETS ${library_name}
   ARCHIVE DESTINATION lib

--- a/nav2_recoveries/CMakeLists.txt
+++ b/nav2_recoveries/CMakeLists.txt
@@ -53,9 +53,6 @@ ament_target_dependencies(nav2_spin_recovery
   ${dependencies}
 )
 
-# prevent pluginlib from using boost
-target_compile_definitions(nav2_spin_recovery PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 add_library(nav2_backup_recovery SHARED
   plugins/back_up.cpp
 )
@@ -64,9 +61,6 @@ ament_target_dependencies(nav2_backup_recovery
   ${dependencies}
 )
 
-# prevent pluginlib from using boost
-target_compile_definitions(nav2_backup_recovery PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 add_library(nav2_wait_recovery SHARED
   plugins/wait.cpp
 )
@@ -74,9 +68,6 @@ add_library(nav2_wait_recovery SHARED
 ament_target_dependencies(nav2_wait_recovery
   ${dependencies}
 )
-
-# prevent pluginlib from using boost
-target_compile_definitions(nav2_wait_recovery PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 pluginlib_export_plugin_description_file(nav2_core recovery_plugin.xml)
 
@@ -88,9 +79,6 @@ add_library(${library_name}
 ament_target_dependencies(${library_name}
   ${dependencies}
 )
-
-# prevent pluginlib from using boost
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 # Executable
 add_executable(${executable_name}

--- a/nav2_regulated_pure_pursuit_controller/CMakeLists.txt
+++ b/nav2_regulated_pure_pursuit_controller/CMakeLists.txt
@@ -35,9 +35,6 @@ set(library_name nav2_regulated_pure_pursuit_controller)
 add_library(${library_name} SHARED
         src/regulated_pure_pursuit_controller.cpp)
 
-# prevent pluginlib from using boost
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 ament_target_dependencies(${library_name}
   ${dependencies}
 )

--- a/nav2_rviz_plugins/CMakeLists.txt
+++ b/nav2_rviz_plugins/CMakeLists.txt
@@ -91,9 +91,6 @@ target_link_libraries(${library_name}
 # TODO: Make this specific to this project (not rviz default plugins)
 target_compile_definitions(${library_name} PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
 
-# prevent pluginlib from using boost
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
 
 install(

--- a/nav2_smac_planner/CMakeLists.txt
+++ b/nav2_smac_planner/CMakeLists.txt
@@ -97,9 +97,6 @@ ament_target_dependencies(${library_name}_2d
   ${dependencies}
 )
 
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-target_compile_definitions(${library_name}_2d PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 pluginlib_export_plugin_description_file(nav2_core smac_plugin.xml)
 pluginlib_export_plugin_description_file(nav2_core smac_plugin_2d.xml)
 

--- a/nav2_waypoint_follower/CMakeLists.txt
+++ b/nav2_waypoint_follower/CMakeLists.txt
@@ -69,18 +69,12 @@ ament_target_dependencies(${library_name}
 
 add_library(wait_at_waypoint SHARED plugins/wait_at_waypoint.cpp)
 ament_target_dependencies(wait_at_waypoint ${dependencies})
-#prevent pluginlib from using boost
-target_compile_definitions(wait_at_waypoint PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 add_library(photo_at_waypoint SHARED plugins/photo_at_waypoint.cpp)
 ament_target_dependencies(photo_at_waypoint ${dependencies})
-#prevent pluginlib from using boost
-target_compile_definitions(photo_at_waypoint PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 add_library(input_at_waypoint SHARED plugins/input_at_waypoint.cpp)
 ament_target_dependencies(input_at_waypoint ${dependencies})
-#prevent pluginlib from using boost
-target_compile_definitions(input_at_waypoint PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 install(TARGETS ${library_name} wait_at_waypoint photo_at_waypoint input_at_waypoint
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
Boost features have been deprecated and removed
in pluginlib for rolling

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |#2429|
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | none |

---

## Description of contribution in a few bullet points

* Removed compile definition `PLUGINLIB__DISABLE_BOOST_FUNCTIONS` as it has been deprecated for rolling (and galactic)

## Description of documentation updates required from your changes

None required. Should be transparent to users.

---

## Future work that may be required in bullet points

None required.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
