### PR TITLE
Wait for goal result after cancelling BT action node

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -275,6 +275,22 @@ public:
       }
     }
 
+    auto start_time = node_->now();
+    while (rclcpp::ok()
+           && !goal_result_available_
+           && node_->now() - start_time < server_timeout_) {
+      RCLCPP_DEBUG(
+        node_->get_logger(),
+        "Waiting for goal result after cancelling, for action %s", action_name_.c_str());
+      callback_group_executor_.spin_some();
+      rclcpp::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (!goal_result_available_) {
+      RCLCPP_ERROR_STREAM(
+        node_->get_logger(),
+        "Failed to get result for action " << action_name_.c_str() << " after cancelling. BT might not finish cleanly. ");
+    }
+
     setStatus(BT::NodeStatus::IDLE);
   }
 


### PR DESCRIPTION
## Basic Info

The PR #2436 was previously opened.
This previous PR #2436 does not target the `main` branch (as it should have), but the `galactic` branch. 
This PR here is exactly the same than #2436, but for the `main` branch

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses | I didn't find any issue that is currently open, and that would be related to this PR. But I sure can open one if you want me to. The PR #2384 is related, as described below (see **Related PR** section). |
| Primary OS tested on | Ubuntu 20.04, ROS 2 Galactic from binaries |
| Robotic platform tested on | Gazebo simulation of Wyca's robot, and real Wyca's robot |

## Description of the problem fixed by this PR

Hello, 
I fixed a problematic behavior that happens quite often after cancelling a `bt_action_node` (approximately once every 5 cancel requests in our case). 

*What we do*:
- We start a nav2 `BtNavigator`, which controls the action "GoToPose" for instance.
- The BT has several `bt_action_node`s, in order to call sub-actions like `"/follow_path"` for instance.
- When cancelling the "GoToPose" action, all the `bt_action_node`s execute [`halt()` function](https://github.com/ros-planning/navigation2/blob/29c1af087afffb80ddc4ec172015fee2c8a37166/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp#L265-L279), hence they send a cancel request to their respective sub-actions.

*What should happen*:
- The `bt_action_node` should wait for the sub-action to properly end, before returning from the `halt()` function.

*What actually happen*:
- The `bt_action_node` only [waits for the cancel request to return](https://github.com/ros-planning/navigation2/blob/29c1af087afffb80ddc4ec172015fee2c8a37166/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp#L269-L275).
- Hence, when cancelling the `BtNavigator`'s action, the sub-actions' `result_callback`s are not always executed.

## Related PR

* Before #2384 was merged, the next action call after a cancel often results in an instant end of the BT, because the goal result of the previously canceled sub-action is received. Indeed, cancelling the `BtNavigator`'s action halts the `bt_action_node` without waiting for the sub-action goal result. 

* After #2384, if the goal result of the previously cancelled sub-action is received, it is [filtered out](https://github.com/ros-planning/navigation2/blob/29c1af087afffb80ddc4ec172015fee2c8a37166/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp#L315-L321) using the `future_goal_handle_`. So, the next action call does not return instantaneously. But this might not be the cleaner way to solve the problem, since the sub-actions' `result_callback`s are still not always executed. 

## This PR's description

* This PR allows to wait for the sub-actions results, by making the [`bt_action_node` spin](https://github.com/ros-planning/navigation2/blob/13e488392560cd746b94256822f9fe6afe261b25/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp#L285) until the sub-action goal result is available, after the cancel request is sent in the `halt()` function. This will force the `result_callback` to be executed after the sub-action is cancelled, allowing to get a clean `BtNavigator`'s action goal result.

* A [timeout](https://github.com/ros-planning/navigation2/blob/13e488392560cd746b94256822f9fe6afe261b25/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp#L281) is implemented to prevent from infinitely looping while halting the `bt_action_node`.

* If the sub-action goal result is not available within the timeout, there is an [error output in logs](https://github.com/ros-planning/navigation2/blob/13e488392560cd746b94256822f9fe6afe261b25/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp#L288-L292).

## Future work that may be required in bullet points

* Maybe the timeout can be handled differently
* The case "the goal result is not received after the timeout" may be handled (in a better way than just outputting an error in logs)


Thank you for reviewing this PR.


----


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
