### PR TITLE
Reduce nodes for nav2_waypoint_follower 

### DIFF
--- a/nav2_waypoint_follower/include/nav2_waypoint_follower/waypoint_follower.hpp
+++ b/nav2_waypoint_follower/include/nav2_waypoint_follower/waypoint_follower.hpp
@@ -118,7 +118,8 @@ protected:
   // Our action server
   std::unique_ptr<ActionServer> action_server_;
   ActionClient::SharedPtr nav_to_pose_client_;
-  rclcpp::Node::SharedPtr client_node_;
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
+  rclcpp::executors::SingleThreadedExecutor callback_group_executor_;
   std::shared_future<rclcpp_action::ClientGoalHandle<ClientT>::SharedPtr> future_goal_handle_;
   bool stop_on_failure_;
   ActionStatus current_goal_status_;

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -57,8 +57,8 @@ WaypointFollower::on_configure(const rclcpp_lifecycle::State & /*state*/)
   waypoint_task_executor_id_ = get_parameter("waypoint_task_executor_plugin").as_string();
 
   callback_group_ = create_callback_group(
-      rclcpp::CallbackGroupType::MutuallyExclusive,
-      false);
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    false);
   callback_group_executor_.add_callback_group(callback_group_, get_node_base_interface());
 
   nav_to_pose_client_ = rclcpp_action::create_client<ClientT>(
@@ -66,7 +66,7 @@ WaypointFollower::on_configure(const rclcpp_lifecycle::State & /*state*/)
     get_node_graph_interface(),
     get_node_logging_interface(),
     get_node_waitables_interface(),
-    "navigate_to_pose",callback_group_);
+    "navigate_to_pose", callback_group_);
 
   action_server_ = std::make_unique<ActionServer>(
     get_node_base_interface(),


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #816) |
| Primary OS tested on |  (Ubuntu20.04, ROS 2 Galactic from binaries) |
| Robotic platform tested on | (gazebo simulation of  turtlebot3) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
This work is under project `Reduce ROS2 Nodes and Determinism` of OSPP2021.
As described in #816,  `client_node_` in `class WaypointFollower` need be removed, you can find more details(other nodes which need be removed) in https://github.com/ros-planning/navigation2/issues/816#issuecomment-876061677 

refer to https://github.com/ros-planning/navigation2/pull/2334, i remove `client_node_` by using callback groups / executors
* create new callback groups and executor 
* `nav_to_pose_client_` use  `callback_group_` install of `clinet_node_`
* replaced the `rclcpp::spin` of  `clinet_node_` by `executor.spin` 



---



#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
