### PR TITLE
 Feature addition: capability for the RRP to drive the robot backwards 

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -210,7 +210,7 @@ protected:
   void applyConstraints(
     const double & dist_error, const double & lookahead_dist,
     const double & curvature, const geometry_msgs::msg::Twist & speed,
-    const double & pose_cost, double & linear_vel);
+    const double & pose_cost, double & linear_vel, double & sign);
 
   /**
    * @brief Get lookahead point
@@ -219,6 +219,13 @@ protected:
    * @return Lookahead point
    */
   geometry_msgs::msg::PoseStamped getLookAheadPoint(const double &, const nav_msgs::msg::Path &);
+
+  /**
+   * @brief checks for the cusp position
+   * @param pose Pose input to determine the cusp position
+   * @return robot distance from the cusp
+   */
+  double findDirectionChange(const geometry_msgs::msg::PoseStamped & pose);
 
   std::shared_ptr<tf2_ros::Buffer> tf_;
   std::string plugin_name_;
@@ -251,6 +258,7 @@ protected:
   double max_angular_accel_;
   double rotate_to_heading_min_angle_;
   double goal_dist_tol_;
+  bool allow_reversing_;
 
   nav_msgs::msg::Path global_plan_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> global_path_pub_;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -620,7 +620,7 @@ double RegulatedPurePursuitController::findDirectionChange(
     /* Checking for the existance of cusp, in the path, using the dot product
     and determine it's distance from the robot. If there is no cusp in the path,
     then just determine the distance to the goal location. */
-    if ( (oa_x * ab_x) + (oa_y * ab_y) < 0.0 ) {
+    if ( (oa_x * ab_x) + (oa_y * ab_y) < 0.0) {
       auto x = global_plan_.poses[pose_id].pose.position.x - pose.pose.position.x;
       auto y = global_plan_.poses[pose_id].pose.position.y - pose.pose.position.y;
       return hypot(x, y);  // returning the distance if there is a cusp

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -103,6 +103,8 @@ void RegulatedPurePursuitController::configure(
     node, plugin_name_ + ".rotate_to_heading_min_angle", rclcpp::ParameterValue(0.785));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".max_angular_accel", rclcpp::ParameterValue(3.2));
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".allow_reversing", rclcpp::ParameterValue(false));
 
   node->get_parameter(plugin_name_ + ".desired_linear_vel", desired_linear_vel_);
   base_desired_linear_vel_ = desired_linear_vel_;
@@ -148,6 +150,7 @@ void RegulatedPurePursuitController::configure(
   node->get_parameter(plugin_name_ + ".use_rotate_to_heading", use_rotate_to_heading_);
   node->get_parameter(plugin_name_ + ".rotate_to_heading_min_angle", rotate_to_heading_min_angle_);
   node->get_parameter(plugin_name_ + ".max_angular_accel", max_angular_accel_);
+  node->get_parameter(plugin_name_ + ".allow_reversing", allow_reversing_);
   node->get_parameter("controller_frequency", control_frequency);
 
   transform_tolerance_ = tf2::durationFromSec(transform_tolerance);
@@ -158,6 +161,15 @@ void RegulatedPurePursuitController::configure(
       logger_, "The value inflation_cost_scaling_factor is incorrectly set, "
       "it should be >0. Disabling cost regulated linear velocity scaling.");
     use_cost_regulated_linear_velocity_scaling_ = false;
+  }
+
+  /** Possible to drive in reverse direction if and only if 
+   "use_rotate_to_heading" parameter is set to false **/
+
+  if (use_rotate_to_heading_ && allow_reversing_) {
+    RCLCPP_WARN(logger_, "Disabling reversing. Both use_rotate_to_heading and allow_reversing "
+      "parameter cannot be set to true. By default setting use_rotate_to_heading true");
+    allow_reversing_ = false;
   }
 
   global_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("received_global_plan", 1);
@@ -243,7 +255,19 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
   auto transformed_plan = transformGlobalPlan(pose);
 
   // Find look ahead distance and point on path and publish
-  const double lookahead_dist = getLookAheadDistance(speed);
+  double lookahead_dist = getLookAheadDistance(speed);
+
+  // Check for reverse driving
+  if (allow_reversing_) {
+    // Cusp check
+    double dist_to_direction_change = findDirectionChange(pose);
+
+    // if the lookahead distance is further than the cusp, use the cusp distance instead
+    if (dist_to_direction_change < lookahead_dist) {
+      lookahead_dist = dist_to_direction_change;
+    }
+  }
+
   auto carrot_pose = getLookAheadPoint(lookahead_dist, transformed_plan);
   carrot_pub_->publish(createCarrotMsg(carrot_pose));
 
@@ -261,6 +285,12 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
     curvature = 2.0 * carrot_pose.pose.position.y / carrot_dist2;
   }
 
+  // Setting the velocity direction
+  double sign = 1.0;
+  if (allow_reversing_) {
+    sign = carrot_pose.pose.position.x >= 0.0 ? 1.0 : -1.0;
+  }
+
   linear_vel = desired_linear_vel_;
 
   // Make sure we're in compliance with basic constraints
@@ -274,7 +304,7 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
     applyConstraints(
       fabs(lookahead_dist - sqrt(carrot_dist2)),
       lookahead_dist, curvature, speed,
-      costAtPose(pose.pose.position.x, pose.pose.position.y), linear_vel);
+      costAtPose(pose.pose.position.x, pose.pose.position.y), linear_vel, sign);
 
     // Apply curvature to angular velocity after constraining linear velocity
     angular_vel = linear_vel * curvature;
@@ -427,7 +457,7 @@ double RegulatedPurePursuitController::costAtPose(const double & x, const double
 void RegulatedPurePursuitController::applyConstraints(
   const double & dist_error, const double & lookahead_dist,
   const double & curvature, const geometry_msgs::msg::Twist & curr_speed,
-  const double & pose_cost, double & linear_vel)
+  const double & pose_cost, double & linear_vel, double & sign)
 {
   double curvature_vel = linear_vel;
   double cost_vel = linear_vel;
@@ -474,11 +504,13 @@ void RegulatedPurePursuitController::applyConstraints(
   }
 
   // Limit linear velocities to be valid and kinematically feasible, v = v0 + a * dt
+  linear_vel = sign * linear_vel;
   double & dt = control_duration_;
   const double max_feasible_linear_speed = curr_speed.linear.x + max_linear_accel_ * dt;
   const double min_feasible_linear_speed = curr_speed.linear.x - max_linear_decel_ * dt;
   linear_vel = std::clamp(linear_vel, min_feasible_linear_speed, max_feasible_linear_speed);
-  linear_vel = std::clamp(linear_vel, 0.0, desired_linear_vel_);
+  linear_vel = std::clamp(fabs(linear_vel), 0.0, desired_linear_vel_);
+  linear_vel = sign * linear_vel;
 }
 
 void RegulatedPurePursuitController::setPlan(const nav_msgs::msg::Path & path)
@@ -566,6 +598,34 @@ nav_msgs::msg::Path RegulatedPurePursuitController::transformGlobalPlan(
   }
 
   return transformed_plan;
+}
+
+double RegulatedPurePursuitController::findDirectionChange(
+  const geometry_msgs::msg::PoseStamped & pose )
+{
+  // Iterating through the global path to determine the position of the cusp
+   for (unsigned int pose_id = 1; pose_id <= global_plan_.poses.size(); ++pose_id)  {
+    // We have two vectors for the dot product OA and AB. Determining the vectors.
+    double oa_x = global_plan_.poses[pose_id].pose.position.x -
+      global_plan_.poses[pose_id - 1].pose.position.x;
+    double oa_y = global_plan_.poses[pose_id].pose.position.y -
+      global_plan_.poses[pose_id - 1].pose.position.y;
+    double ab_x = global_plan_.poses[pose_id + 1].pose.position.x -
+      global_plan_.poses[pose_id].pose.position.x;
+    double ab_y = global_plan_.poses[pose_id + 1].pose.position.y -
+      global_plan_.poses[pose_id].pose.position.y;
+
+    /* Checking for the existance of cusp, in the path, using the dot product
+    and determine it's distance from the robot. If there is no cusp in the path,
+    then just determine the distance to the goal location. */
+    if ( (oa_x * ab_x) + (oa_y * ab_y) < 0.0 || pose_id == global_plan_.poses.size() ) {
+      auto x = global_plan_.poses[pose_id].pose.position.x - pose.pose.position.x;
+      auto y = global_plan_.poses[pose_id].pose.position.y - pose.pose.position.y;
+      return hypot(x, y); // returning the distance if there is a cusp
+    }
+  }
+
+  return 0.0;
 }
 
 bool RegulatedPurePursuitController::transformPose(

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -604,7 +604,7 @@ double RegulatedPurePursuitController::findDirectionChange(
   const geometry_msgs::msg::PoseStamped & pose )
 {
   // Iterating through the global path to determine the position of the cusp
-   for (unsigned int pose_id = 1; pose_id <= global_plan_.poses.size(); ++pose_id)  {
+   for (unsigned int pose_id = 1; pose_id < global_plan_.poses.size(); ++pose_id)  {
     // We have two vectors for the dot product OA and AB. Determining the vectors.
     double oa_x = global_plan_.poses[pose_id].pose.position.x -
       global_plan_.poses[pose_id - 1].pose.position.x;
@@ -625,7 +625,7 @@ double RegulatedPurePursuitController::findDirectionChange(
     }
   }
 
-  return 0.0;
+  return std::numeric_limits<double>::max();
 }
 
 bool RegulatedPurePursuitController::transformPose(

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <string>
+#include <limits>
 #include <memory>
 #include <utility>
 
@@ -163,11 +164,12 @@ void RegulatedPurePursuitController::configure(
     use_cost_regulated_linear_velocity_scaling_ = false;
   }
 
-  /** Possible to drive in reverse direction if and only if 
+  /** Possible to drive in reverse direction if and only if
    "use_rotate_to_heading" parameter is set to false **/
 
   if (use_rotate_to_heading_ && allow_reversing_) {
-    RCLCPP_WARN(logger_, "Disabling reversing. Both use_rotate_to_heading and allow_reversing "
+    RCLCPP_WARN(
+      logger_, "Disabling reversing. Both use_rotate_to_heading and allow_reversing "
       "parameter cannot be set to true. By default setting use_rotate_to_heading true");
     allow_reversing_ = false;
   }
@@ -601,10 +603,10 @@ nav_msgs::msg::Path RegulatedPurePursuitController::transformGlobalPlan(
 }
 
 double RegulatedPurePursuitController::findDirectionChange(
-  const geometry_msgs::msg::PoseStamped & pose )
+  const geometry_msgs::msg::PoseStamped & pose)
 {
   // Iterating through the global path to determine the position of the cusp
-   for (unsigned int pose_id = 1; pose_id < global_plan_.poses.size(); ++pose_id)  {
+  for (unsigned int pose_id = 1; pose_id < global_plan_.poses.size(); ++pose_id) {
     // We have two vectors for the dot product OA and AB. Determining the vectors.
     double oa_x = global_plan_.poses[pose_id].pose.position.x -
       global_plan_.poses[pose_id - 1].pose.position.x;
@@ -621,7 +623,7 @@ double RegulatedPurePursuitController::findDirectionChange(
     if ( (oa_x * ab_x) + (oa_y * ab_y) < 0.0 || pose_id == global_plan_.poses.size() ) {
       auto x = global_plan_.poses[pose_id].pose.position.x - pose.pose.position.x;
       auto y = global_plan_.poses[pose_id].pose.position.y - pose.pose.position.y;
-      return hypot(x, y); // returning the distance if there is a cusp
+      return hypot(x, y);  // returning the distance if there is a cusp
     }
   }
 

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -620,7 +620,7 @@ double RegulatedPurePursuitController::findDirectionChange(
     /* Checking for the existance of cusp, in the path, using the dot product
     and determine it's distance from the robot. If there is no cusp in the path,
     then just determine the distance to the goal location. */
-    if ( (oa_x * ab_x) + (oa_y * ab_y) < 0.0 || pose_id == global_plan_.poses.size() ) {
+    if ( (oa_x * ab_x) + (oa_y * ab_y) < 0.0 ) {
       auto x = global_plan_.poses[pose_id].pose.position.x - pose.pose.position.x;
       auto y = global_plan_.poses[pose_id].pose.position.y - pose.pose.position.y;
       return hypot(x, y);  // returning the distance if there is a cusp

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -87,7 +87,8 @@ public:
     const double & curvature, const geometry_msgs::msg::Twist & curr_speed,
     const double & pose_cost, double & linear_vel, double & sign)
   {
-    return applyConstraints(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+    return applyConstraints(
+      dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
       linear_vel, sign);
   }
 };
@@ -293,7 +294,7 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   // test curvature regulation (default)
   curr_speed.linear.x = 0.25;
   ctrl->applyConstraintsWrapper(
-    dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+    dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
     linear_vel, sign);
   EXPECT_EQ(linear_vel, 0.25);  // min set speed
 
@@ -301,7 +302,7 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   curvature = 0.7407;
   curr_speed.linear.x = 0.5;
   ctrl->applyConstraintsWrapper(
-    dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+    dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
     linear_vel, sign);
   EXPECT_NEAR(linear_vel, 0.5, 0.01);  // lower by curvature
 
@@ -309,7 +310,7 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   curvature = 1000.0;
   curr_speed.linear.x = 0.25;
   ctrl->applyConstraintsWrapper(
-    dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+    dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
     linear_vel, sign);
   EXPECT_NEAR(linear_vel, 0.25, 0.01);  // min out by curvature
 

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -85,11 +85,10 @@ public:
   void applyConstraintsWrapper(
     const double & dist_error, const double & lookahead_dist,
     const double & curvature, const geometry_msgs::msg::Twist & curr_speed,
-    const double & pose_cost, double & linear_vel)
+    const double & pose_cost, double & linear_vel, double & sign)
   {
-    return applyConstraints(
-      dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
-      linear_vel);
+    return applyConstraints(dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+      linear_vel, sign);
   }
 };
 
@@ -286,6 +285,7 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   geometry_msgs::msg::Twist curr_speed;
   double pose_cost = 0.0;
   double linear_vel = 0.0;
+  double sign = 1.0;
 
   // since costmaps here are bogus, we can't access them
   ctrl->resetVelocityApproachScaling();
@@ -293,26 +293,25 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   // test curvature regulation (default)
   curr_speed.linear.x = 0.25;
   ctrl->applyConstraintsWrapper(
-    dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
-    linear_vel);
+    dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+    linear_vel, sign);
   EXPECT_EQ(linear_vel, 0.25);  // min set speed
 
   linear_vel = 1.0;
   curvature = 0.7407;
   curr_speed.linear.x = 0.5;
   ctrl->applyConstraintsWrapper(
-    dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
-    linear_vel);
+    dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+    linear_vel, sign);
   EXPECT_NEAR(linear_vel, 0.5, 0.01);  // lower by curvature
 
   linear_vel = 1.0;
   curvature = 1000.0;
   curr_speed.linear.x = 0.25;
   ctrl->applyConstraintsWrapper(
-    dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
-    linear_vel);
+    dist_error, lookahead_dist, curvature, curr_speed, pose_cost, 
+    linear_vel, sign);
   EXPECT_NEAR(linear_vel, 0.25, 0.01);  // min out by curvature
-
 
   // now try with cost regulation (turn off velocity and only cost)
   // ctrl->setCostRegulationScaling();

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -313,6 +313,7 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
     linear_vel, sign);
   EXPECT_NEAR(linear_vel, 0.25, 0.01);  // min out by curvature
 
+
   // now try with cost regulation (turn off velocity and only cost)
   // ctrl->setCostRegulationScaling();
   // ctrl->resetVelocityRegulationScaling();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2327 #2427 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | gazebo simulation of [Neobotix mp-400](https://github.com/neobotix/neo_simulation2.git) |

---

## Description of contribution in a few bullet points


* I added this neat new feature for driving the robot using the RRP planner backwards. This enables car-like robots to efficiently perform the maneuvers using the SMAC planner. 



## Description of documentation updates required from your changes


* Added new parameter "allow_reversing", so need to add that to default configs and documentation page


---

## Future work that may be required in bullet points


* I tested on a differential drive robot, but it will be great if someone can test it on an Ackermann drive! 


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
