### PR TITLE
Add missing comma in bt_navigator plugin list

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -61,7 +61,7 @@ BtNavigator::BtNavigator()
     "nav2_is_battery_low_condition_bt_node",
     "nav2_navigate_through_poses_action_bt_node",
     "nav2_navigate_to_pose_action_bt_node",
-    "nav2_remove_passed_goals_action_bt_node"
+    "nav2_remove_passed_goals_action_bt_node",
     "nav2_planner_selector_bt_node",
     "nav2_controller_selector_bt_node",
     "nav2_goal_checker_selector_bt_node"


### PR DESCRIPTION
Missing comma after bt node plugin name https://github.com/ros-planning/navigation2/blob/54911a701933f4613aef3f8f9cb62ac18975d907/nav2_bt_navigator/src/bt_navigator.cpp#L64