### PR TITLE
Adding launch_testing_ros dep on nav2 utils to install to fix dump tests

### DIFF
--- a/nav2_util/package.xml
+++ b/nav2_util/package.xml
@@ -39,6 +39,7 @@
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>std_srvs</test_depend>
   <test_depend>action_msgs</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
 
   <export>


### PR DESCRIPTION
https://github.com/ros-planning/navigation2/issues/2433