### PR TITLE
Reduce map saver nodes

### DIFF
--- a/nav2_map_server/src/map_saver/map_saver.cpp
+++ b/nav2_map_server/src/map_saver/map_saver.cpp
@@ -42,7 +42,7 @@ using namespace std::placeholders;
 namespace nav2_map_server
 {
 MapSaver::MapSaver()
-: nav2_util::LifecycleNode("map_saver", "", true)
+: nav2_util::LifecycleNode("map_saver", "")
 {
   RCLCPP_INFO(get_logger(), "Creating");
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info                       | Please fill out this column                                  |
| -------------------------- | ------------------------------------------------------------ |
| Ticket(s) this addresses   | (tickets:  [#816](https://github.com/ros-planning/navigation2/issues/816)) |
| Primary OS tested on       | (Ubuntu20.04, ROS 2 Galactic from binaries)                  |
| Robotic platform tested on | (gazebo simulation of turtlebot3)                            |

-------

## Description of contribution in a few bullet points

As described in [#816](https://github.com/ros-planning/navigation2/issues/816), `rclcpp_node_` in `class MapSaver` need be removed, you can find more details(other nodes which need be removed) in [#816 (comment)](https://github.com/ros-planning/navigation2/issues/816#issuecomment-876061677)

refer to [#2334](https://github.com/ros-planning/navigation2/pull/2334),I use callback group/ executor combo instead of `rclcpp_node_` in `saveMapTopicToFile()`.

- create new `CallbackGroup` for `map_sub`
- create new `SingleThreadedExecutor` for new `CallbackGroup` 
- wait map subscription by using `executor.spin_some()` in `while()`

## Test

colcon test

```
colcon test --packages-select nav2_map_server

# Result: 0 errors, 0 failures, 0 skipped
```

turtlebot3 demo test

```
# Server node mode test
ros2 launch nav2_map_server map_saver_server.launch.py
ros2 service call /map_saver/save_map nav2_msgs/srv/SaveMap "{map_topic: map, map_url: my_map, image_format: pgm, map_mode: trinary, free_thresh: 0.25, occupied_thresh: 0.65}"
# CLI mode test
ros2 run nav2_map_server map_saver_cli -t map -f my_map2

# Result: my_map and my_map2(.yaml and .pgm) will be generated correctly.
```




#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
