### PR TITLE
Reduce lifecycle manager nodes

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -54,7 +54,7 @@ public:
 protected:
   // Callback group used by services and timers
   rclcpp::CallbackGroup::SharedPtr callback_group_;
-  rclcpp::SingleThreadedExecutor callback_group_executor_;
+  rclcpp::executors::SingleThreadedExecutor callback_group_executor_;
   std::thread callback_group_executor_thread_;
 
   // The services provided by this node

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -52,7 +52,7 @@ public:
   ~LifecycleManager();
 
 protected:
-  // Callback group used by services and timers 
+  // Callback group used by services and timers
   rclcpp::CallbackGroup::SharedPtr callback_group_;
 
   // The services provided by this node

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -52,9 +52,7 @@ public:
   ~LifecycleManager();
 
 protected:
-  // The ROS node to create bond
-  rclcpp::Node::SharedPtr bond_client_node_;
-  std::unique_ptr<nav2_util::NodeThread> bond_node_thread_;
+  // Callback group used by services and timers 
   rclcpp::CallbackGroup::SharedPtr callback_group_;
 
   // The services provided by this node

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "nav2_util/lifecycle_service_client.hpp"
+#include "nav2_util/node_thread.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/empty.hpp"
 #include "nav2_msgs/srv/manage_lifecycle_nodes.hpp"
@@ -54,8 +55,7 @@ public:
 protected:
   // Callback group used by services and timers
   rclcpp::CallbackGroup::SharedPtr callback_group_;
-  rclcpp::executors::SingleThreadedExecutor callback_group_executor_;
-  std::thread callback_group_executor_thread_;
+  std::unique_ptr<nav2_util::NodeThread> service_thread_;
 
   // The services provided by this node
   rclcpp::Service<ManageLifecycleNodes>::SharedPtr manager_srv_;

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -55,6 +55,7 @@ protected:
   // The ROS node to create bond
   rclcpp::Node::SharedPtr bond_client_node_;
   std::unique_ptr<nav2_util::NodeThread> bond_node_thread_;
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
 
   // The services provided by this node
   rclcpp::Service<ManageLifecycleNodes>::SharedPtr manager_srv_;

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -49,18 +49,18 @@ LifecycleManager::LifecycleManager()
   bond_timeout_ = std::chrono::duration_cast<std::chrono::milliseconds>(
     std::chrono::duration<double>(bond_timeout_s));
 
+  callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   manager_srv_ = create_service<ManageLifecycleNodes>(
     get_name() + std::string("/manage_nodes"),
-    std::bind(&LifecycleManager::managerCallback, this, _1, _2, _3));
+    std::bind(&LifecycleManager::managerCallback, this, _1, _2, _3),
+    rmw_qos_profile_services_default,
+    callback_group_);
 
   is_active_srv_ = create_service<std_srvs::srv::Trigger>(
     get_name() + std::string("/is_active"),
-    std::bind(&LifecycleManager::isActiveCallback, this, _1, _2, _3));
-
-  auto bond_options = rclcpp::NodeOptions().arguments(
-    {"--ros-args", "-r", std::string("__node:=") + get_name() + "_bond_client", "--"});
-  bond_client_node_ = std::make_shared<rclcpp::Node>("_", bond_options);
-  bond_node_thread_ = std::make_unique<nav2_util::NodeThread>(bond_client_node_);
+    std::bind(&LifecycleManager::isActiveCallback, this, _1, _2, _3),
+    rmw_qos_profile_services_default,
+    callback_group_);
 
   transition_state_map_[Transition::TRANSITION_CONFIGURE] = State::PRIMARY_STATE_INACTIVE;
   transition_state_map_[Transition::TRANSITION_CLEANUP] = State::PRIMARY_STATE_UNCONFIGURED;
@@ -84,7 +84,8 @@ LifecycleManager::LifecycleManager()
       if (autostart_) {
         startup();
       }
-    });
+    },
+    callback_group_);
 }
 
 LifecycleManager::~LifecycleManager()
@@ -154,7 +155,7 @@ LifecycleManager::createBondConnection(const std::string & node_name)
 
   if (bond_map_.find(node_name) == bond_map_.end() && bond_timeout_.count() > 0.0) {
     bond_map_[node_name] =
-      std::make_shared<bond::Bond>("bond", node_name, bond_client_node_);
+      std::make_shared<bond::Bond>("bond", node_name, shared_from_this());
     bond_map_[node_name]->setHeartbeatTimeout(timeout_s);
     bond_map_[node_name]->setHeartbeatPeriod(0.10);
     bond_map_[node_name]->start();
@@ -317,7 +318,8 @@ LifecycleManager::createBondTimer()
 
   bond_timer_ = this->create_wall_timer(
     200ms,
-    std::bind(&LifecycleManager::checkBondConnections, this));
+    std::bind(&LifecycleManager::checkBondConnections, this),
+    callback_group_);
 }
 
 void

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -86,18 +86,15 @@ LifecycleManager::LifecycleManager()
       }
     },
     callback_group_);
-
-  callback_group_executor_thread_ = std::thread([this]() {
-    callback_group_executor_.add_callback_group(callback_group_, this->get_node_base_interface());
-    callback_group_executor_.spin();
-  });
+  auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  executor->add_callback_group(callback_group_, get_node_base_interface());
+  service_thread_ = std::make_unique<nav2_util::NodeThread>(executor);
 }
 
 LifecycleManager::~LifecycleManager()
 {
   RCLCPP_INFO(get_logger(), "Destroying %s", get_name());
-  callback_group_executor_.cancel();
-  callback_group_executor_thread_.join();
+  service_thread_.reset();
 }
 
 void

--- a/nav2_lifecycle_manager/src/main.cpp
+++ b/nav2_lifecycle_manager/src/main.cpp
@@ -21,7 +21,9 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<nav2_lifecycle_manager::LifecycleManager>();
-  rclcpp::spin(node->get_node_base_interface());
+  rclcpp::executors::MultiThreadedExecutor executor(rclcpp::ExecutorOptions(), 2);
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
   rclcpp::shutdown();
 
   return 0;

--- a/nav2_util/include/nav2_util/node_thread.hpp
+++ b/nav2_util/include/nav2_util/node_thread.hpp
@@ -23,7 +23,7 @@ namespace nav2_util
 {
 /**
  * @class nav2_util::NodeThread
- * @brief A background thread to process node callbacks
+ * @brief A background thread to process node/executor callbacks
  */
 class NodeThread
 {
@@ -33,6 +33,12 @@ public:
    * @param node_base Interface to Node to spin in thread
    */
   explicit NodeThread(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base);
+
+  /**
+   * @brief A background thread to process executor's callbacks constructor
+   * @param executor Interface to executor to spin in thread
+   */
+  explicit NodeThread(rclcpp::Executor::SharedPtr executor);
 
   /**
    * @brief A background thread to process node callbacks constructor
@@ -51,7 +57,7 @@ public:
 protected:
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_;
   std::unique_ptr<std::thread> thread_;
-  rclcpp::executors::SingleThreadedExecutor executor_;
+  rclcpp::Executor::SharedPtr executor_;
 };
 
 }  // namespace nav2_util

--- a/nav2_util/include/nav2_util/node_thread.hpp
+++ b/nav2_util/include/nav2_util/node_thread.hpp
@@ -38,7 +38,7 @@ public:
    * @brief A background thread to process executor's callbacks constructor
    * @param executor Interface to executor to spin in thread
    */
-  explicit NodeThread(rclcpp::Executor::SharedPtr executor);
+  explicit NodeThread(rclcpp::executors::SingleThreadedExecutor::SharedPtr executor);
 
   /**
    * @brief A background thread to process node callbacks constructor

--- a/nav2_util/src/node_thread.cpp
+++ b/nav2_util/src/node_thread.cpp
@@ -22,19 +22,25 @@ namespace nav2_util
 NodeThread::NodeThread(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base)
 : node_(node_base)
 {
+  executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
   thread_ = std::make_unique<std::thread>(
     [&]()
     {
-      executor_.add_node(node_);
-      executor_.spin();
-      executor_.remove_node(node_);
+      executor_->add_node(node_);
+      executor_->spin();
+      executor_->remove_node(node_);
     });
 }
 
+NodeThread::NodeThread(rclcpp::Executor::SharedPtr executor)
+: executor_(executor)
+{
+  thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});
+}
 
 NodeThread::~NodeThread()
 {
-  executor_.cancel();
+  executor_->cancel();
   thread_->join();
 }
 

--- a/nav2_util/src/node_thread.cpp
+++ b/nav2_util/src/node_thread.cpp
@@ -32,7 +32,7 @@ NodeThread::NodeThread(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr nod
     });
 }
 
-NodeThread::NodeThread(rclcpp::Executor::SharedPtr executor)
+NodeThread::NodeThread(rclcpp::executors::SingleThreadedExecutor::SharedPtr executor)
 : executor_(executor)
 {
   thread_ = std::make_unique<std::thread>([&]() {executor_->spin();});


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info                       | Please fill out this column                                  |
| -------------------------- | ------------------------------------------------------------ |
| Ticket(s) this addresses   | (tickets:  [#816](https://github.com/ros-planning/navigation2/issues/816)) |
| Primary OS tested on       | (Ubuntu20.04, ROS 2 Galactic)                  |
| Robotic platform tested on | (gazebo simulation of turtlebot3)                            |

-------

## Description of contribution in a few bullet points

As described in [#816](https://github.com/ros-planning/navigation2/issues/816), `bond_client_node_` in `class LifecycleManager` need be removed, you can find more details(other nodes which need be removed) in [#816 (comment)](https://github.com/ros-planning/navigation2/issues/816#issuecomment-876061677)

I use `CallbackGroup` + `MultiThreadedExecutor` instead of `bond_client_node_`.
- because `Bond` doesn't support new callback group, so let `Bond` use `default_callback_group`, and create new callback group for services and timers in `LifecycleManager`.
- then use `MultiThreadedExecutor` with 2 threads to spin 2  `CallbackGroup` in `main()`

## Test
```
#colcon test
colcon test --packages-select nav2_lifecycle_manager

#result:0 errors, 0 failures, 0 skipped
```

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
