### PR TITLE
Add costmap_thread_.reset() on the destructor of ControllerServer class

### DIFF
--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -71,6 +71,7 @@ ControllerServer::~ControllerServer()
   progress_checker_.reset();
   goal_checkers_.clear();
   controllers_.clear();
+  costmap_thread_.reset();
 }
 
 nav2_util::CallbackReturn


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  |

---

## Description of contribution in a few bullet points


Add `costmap_thread_.reset()` on the destructor of ControllerServer class
I referred [this line](https://github.com/ros-planning/navigation2/blob/21a44bcb559682f67289ac72571206597c00855b/nav2_planner/src/planner_server.cpp#L70) of `nav2_planner` package.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
