### PR TITLE
SMAC Planner: Treating "inscribed" costs not as collision anymore

### DIFF
--- a/nav2_costmap_2d/src/footprint_collision_checker.cpp
+++ b/nav2_costmap_2d/src/footprint_collision_checker.cpp
@@ -75,9 +75,7 @@ double FootprintCollisionChecker<CostmapT>::footprintCost(const Footprint footpr
     y0 = y1;
 
     // if in collision, no need to continue
-    if (footprint_cost == static_cast<double>(INSCRIBED_INFLATED_OBSTACLE) ||
-      footprint_cost == static_cast<double>(LETHAL_OBSTACLE))
-    {
+    if (footprint_cost == static_cast<double>(LETHAL_OBSTACLE)) {
       return footprint_cost;
     }
   }
@@ -101,9 +99,7 @@ double FootprintCollisionChecker<CostmapT>::lineCost(int x0, int x1, int y0, int
     }
 
     // if in collision, no need to continue
-    if (line_cost == static_cast<double>(INSCRIBED_INFLATED_OBSTACLE) ||
-      line_cost == static_cast<double>(LETHAL_OBSTACLE))
-    {
+    if (line_cost == static_cast<double>(LETHAL_OBSTACLE)) {
       return line_cost;
     }
   }

--- a/nav2_smac_planner/include/nav2_smac_planner/collision_checker.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/collision_checker.hpp
@@ -150,7 +150,7 @@ public:
       }
 
       // if occupied or unknown and not to traverse unknown space
-      return footprint_cost_ >= INSCRIBED;
+      return footprint_cost_ >= OCCUPIED;
     } else {
       // if radius, then we can check the center of the cost assuming inflation is used
       footprint_cost_ = costmap_->getCost(


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2457 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Physical & Simulated DiffDrive Robot |

---

## Description of contribution in a few bullet points

* The collision checker of the Smac planner does not count INSCRIBED as a collision (infeasible path) anymore, allowing the robot footprint edges to touch inscribed grid cells. 
* Some early stopping on the `nav2_costmap_2d::FootprintCollisionChecker::footprintCost` and `::lineCost` were reduced to OCCUPIED cells.

## Description of documentation updates required from your changes

* I would say none, as this is the expected behavior of the collision checker

---

## Future work that may be required in bullet points

None.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
