### PR TITLE
Reduce lifecycle service client nodes

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager_client.hpp
@@ -46,15 +46,6 @@ public:
   /**
    * @brief A constructor for LifeCycleMangerClient
    * @param name Managed node name
-   * @param ns Service node namespace
-   */
-  explicit LifecycleManagerClient(
-    const std::string & name,
-    const std::string & ns = "");
-
-  /**
-   * @brief A constructor for LifeCycleMangerClient
-   * @param name Managed node name
    * @param parent_node Node that execute the service calls
    */
   explicit LifecycleManagerClient(

--- a/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager_client.cpp
@@ -28,23 +28,6 @@ using nav2_util::geometry_utils::orientationAroundZAxis;
 
 LifecycleManagerClient::LifecycleManagerClient(
   const std::string & name,
-  const std::string & ns)
-{
-  manage_service_name_ = name + std::string("/manage_nodes");
-  active_service_name_ = name + std::string("/is_active");
-
-  // Create the node to use for all of the service clients
-  node_ = std::make_shared<rclcpp::Node>(name + "_service_client", ns);
-
-  // Create the service clients
-  manager_client_ = std::make_shared<nav2_util::ServiceClient<ManageLifecycleNodes>>(
-    manage_service_name_, node_);
-  is_active_client_ = std::make_shared<nav2_util::ServiceClient<std_srvs::srv::Trigger>>(
-    active_service_name_, node_);
-}
-
-LifecycleManagerClient::LifecycleManagerClient(
-  const std::string & name,
   std::shared_ptr<rclcpp::Node> parent_node)
 {
   manage_service_name_ = name + std::string("/manage_nodes");

--- a/nav2_lifecycle_manager/test/test_bond.cpp
+++ b/nav2_lifecycle_manager/test/test_bond.cpp
@@ -130,7 +130,8 @@ TEST(LifecycleBondTest, POSITIVE)
   // let the lifecycle server come up
   rclcpp::Rate(1).sleep();
 
-  nav2_lifecycle_manager::LifecycleManagerClient client("lifecycle_manager_test");
+  auto node = std::make_shared<rclcpp::Node>("lifecycle_manager_test_service_client");
+  nav2_lifecycle_manager::LifecycleManagerClient client("lifecycle_manager_test", node);
 
   // create node, should be up now
   auto fixture = TestFixture(true, "bond_tester");
@@ -169,7 +170,8 @@ TEST(LifecycleBondTest, POSITIVE)
 
 TEST(LifecycleBondTest, NEGATIVE)
 {
-  nav2_lifecycle_manager::LifecycleManagerClient client("lifecycle_manager_test");
+  auto node = std::make_shared<rclcpp::Node>("lifecycle_manager_test_service_client");
+  nav2_lifecycle_manager::LifecycleManagerClient client("lifecycle_manager_test", node);
 
   // create node, now without bond setup to connect to. Should fail because no bond
   auto fixture = TestFixture(false, "bond_tester");

--- a/nav2_lifecycle_manager/test/test_lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/test/test_lifecycle_manager.cpp
@@ -82,7 +82,8 @@ private:
 TEST(LifecycleClientTest, BasicTest)
 {
   LifecycleClientTestFixture fix;
-  nav2_lifecycle_manager::LifecycleManagerClient client("lifecycle_manager_test");
+  auto node = std::make_shared<rclcpp::Node>("lifecycle_manager_test_service_client");
+  nav2_lifecycle_manager::LifecycleManagerClient client("lifecycle_manager_test", node);
   EXPECT_EQ(
     nav2_lifecycle_manager::SystemStatus::TIMEOUT,
     client.is_active(std::chrono::nanoseconds(1000)));
@@ -104,7 +105,8 @@ TEST(LifecycleClientTest, BasicTest)
 
 TEST(LifecycleClientTest, WithoutFixture)
 {
-  nav2_lifecycle_manager::LifecycleManagerClient client("lifecycle_manager_test");
+  auto node = std::make_shared<rclcpp::Node>("lifecycle_manager_test_service_client");
+  nav2_lifecycle_manager::LifecycleManagerClient client("lifecycle_manager_test", node);
   EXPECT_EQ(
     nav2_lifecycle_manager::SystemStatus::TIMEOUT,
     client.is_active(std::chrono::nanoseconds(1000)));

--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -121,8 +121,8 @@ private:
   NavThroughPosesGoalHandle::SharedPtr nav_through_poses_goal_handle_;
 
   // The client used to control the nav2 stack
-  nav2_lifecycle_manager::LifecycleManagerClient client_nav_;
-  nav2_lifecycle_manager::LifecycleManagerClient client_loc_;
+  std::shared_ptr<nav2_lifecycle_manager::LifecycleManagerClient> client_nav_;
+  std::shared_ptr<nav2_lifecycle_manager::LifecycleManagerClient> client_loc_;
 
   QPushButton * start_reset_button_{nullptr};
   QPushButton * pause_resume_button_{nullptr};
@@ -193,8 +193,8 @@ public:
   using SystemStatus = nav2_lifecycle_manager::SystemStatus;
 
   explicit InitialThread(
-    nav2_lifecycle_manager::LifecycleManagerClient & client_nav,
-    nav2_lifecycle_manager::LifecycleManagerClient & client_loc)
+    std::shared_ptr<nav2_lifecycle_manager::LifecycleManagerClient> & client_nav,
+    std::shared_ptr<nav2_lifecycle_manager::LifecycleManagerClient> & client_loc)
   : client_nav_(client_nav), client_loc_(client_loc)
   {}
 
@@ -205,14 +205,14 @@ public:
 
     while (status_nav == SystemStatus::TIMEOUT) {
       if (status_nav == SystemStatus::TIMEOUT) {
-        status_nav = client_nav_.is_active(std::chrono::seconds(1));
+        status_nav = client_nav_->is_active(std::chrono::seconds(1));
       }
     }
 
     // try to communicate twice, might not actually be up if in SLAM mode
     bool tried_loc_bringup_once = false;
     while (status_loc == SystemStatus::TIMEOUT) {
-      status_loc = client_loc_.is_active(std::chrono::seconds(1));
+      status_loc = client_loc_->is_active(std::chrono::seconds(1));
       if (tried_loc_bringup_once) {
         break;
       }
@@ -239,8 +239,8 @@ signals:
   void localizationInactive();
 
 private:
-  nav2_lifecycle_manager::LifecycleManagerClient client_nav_;
-  nav2_lifecycle_manager::LifecycleManagerClient client_loc_;
+  std::shared_ptr<nav2_lifecycle_manager::LifecycleManagerClient> client_nav_;
+  std::shared_ptr<nav2_lifecycle_manager::LifecycleManagerClient> client_loc_;
 };
 
 }  // namespace nav2_rviz_plugins

--- a/nav2_system_tests/src/updown/test_updown.cpp
+++ b/nav2_system_tests/src/updown/test_updown.cpp
@@ -15,6 +15,7 @@
 #include <random>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_lifecycle_manager/lifecycle_manager_client.hpp"

--- a/nav2_system_tests/src/updown/test_updown.cpp
+++ b/nav2_system_tests/src/updown/test_updown.cpp
@@ -26,8 +26,9 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   RCLCPP_INFO(rclcpp::get_logger("test_updown"), "Initializing test");
-  nav2_lifecycle_manager::LifecycleManagerClient client_nav("lifecycle_manager_navigation");
-  nav2_lifecycle_manager::LifecycleManagerClient client_loc("lifecycle_manager_localization");
+  auto node = std::make_shared<rclcpp::Node>("lifecycle_manager_service_client");
+  nav2_lifecycle_manager::LifecycleManagerClient client_nav("lifecycle_manager_navigation", node);
+  nav2_lifecycle_manager::LifecycleManagerClient client_loc("lifecycle_manager_localization", node);
   bool test_passed = true;
 
   // Wait for a few seconds to let all of the nodes come up


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info                       | Please fill out this column                                  |
| -------------------------- | ------------------------------------------------------------ |
| Ticket(s) this addresses   | (tickets:  [#816](https://github.com/ros-planning/navigation2/issues/816)) |
| Primary OS tested on       | (Ubuntu20.04, ROS 2 Galactic from binaries)                  |
| Robotic platform tested on | (gazebo simulation of turtlebot3)                            |

-------

## Description of contribution in a few bullet points

As described in [#816](https://github.com/ros-planning/navigation2/issues/816), `node_ ` in `class LifecycleManagerClient` need be removed, you can find more details(other nodes which need be removed) in [#816 (comment)](https://github.com/ros-planning/navigation2/issues/816#issuecomment-876061677)

`LifecycleManagerClient` has 2 constructors, simply remove the constructor which create internal node. 

* update instantiation of `LifecycleManagerClient` used in test files
* update `Nav2Panel` , use `client_node_` to create `client_nav_` and `client_loc_`.

## Test
colcon test
```
colcon test --packages-select nav2_lifecycle_manager nav2_rviz_plugins 

#result:0 errors, 0 failures, 0 skipped
```

turtlebot3 navigation demo 

* success

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
