### PR TITLE
Naming BT client node after action name

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -85,10 +85,10 @@ bool BtActionServer<ActionT>::on_configure()
   // use suffix '_rclcpp_node' to keep parameter file consistency #1773
   auto options = rclcpp::NodeOptions().arguments(
     {"--ros-args",
-      "-r", std::string("__node:=") + std::string(node->get_name()) + action_name_ + "_rclcpp_node",
+      "-r", std::string("__node:=") + std::string(node->get_name()) + "_rclcpp_node",
       "--"});
   // Support for handling the topic-based goal pose from rviz
-  client_node_ = std::make_shared<rclcpp::Node>("_", options);
+  client_node_ = std::make_shared<rclcpp::Node>("_", action_name_, options);
 
   action_server_ = std::make_shared<ActionServer>(
     node->get_node_base_interface(),

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -88,8 +88,9 @@ bool BtActionServer<ActionT>::on_configure()
   // Use suffix '_rclcpp_node' to keep parameter file consistency #1773
   auto options = rclcpp::NodeOptions().arguments(
     {"--ros-args",
-      "-r", std::string("__node:=") + std::string(node->get_name()) + client_node_name + "_rclcpp_node",
-      "--"});
+      "-r",
+      std::string("__node:=") + std::string(node->get_name()) + client_node_name + "_rclcpp_node",
+     "--"});
 
   // Support for handling the topic-based goal pose from rviz
   client_node_ = std::make_shared<rclcpp::Node>("_", options);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -90,7 +90,7 @@ bool BtActionServer<ActionT>::on_configure()
     {"--ros-args",
       "-r",
       std::string("__node:=") + std::string(node->get_name()) + client_node_name + "_rclcpp_node",
-     "--"});
+      "--"});
 
   // Support for handling the topic-based goal pose from rviz
   client_node_ = std::make_shared<rclcpp::Node>("_", options);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -86,9 +86,11 @@ bool BtActionServer<ActionT>::on_configure()
   auto options = rclcpp::NodeOptions().arguments(
     {"--ros-args",
       "-r", std::string("__node:=") + std::string(node->get_name()) + "_rclcpp_node",
+      "-r", std::string("__ns:=") + action_name_,
       "--"});
+
   // Support for handling the topic-based goal pose from rviz
-  client_node_ = std::make_shared<rclcpp::Node>("_", action_name_, options);
+  client_node_ = std::make_shared<rclcpp::Node>("_", options);
 
   action_server_ = std::make_shared<ActionServer>(
     node->get_node_base_interface(),

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -82,11 +82,13 @@ bool BtActionServer<ActionT>::on_configure()
     throw std::runtime_error{"Failed to lock node"};
   }
 
-  // use suffix '_rclcpp_node' to keep parameter file consistency #1773
+  // Name client node after action name
+  std::string client_node_name = action_name_;
+  std::replace(client_node_name.begin(), client_node_name.end(), '/', '_');
+  // Use suffix '_rclcpp_node' to keep parameter file consistency #1773
   auto options = rclcpp::NodeOptions().arguments(
     {"--ros-args",
-      "-r", std::string("__node:=") + std::string(node->get_name()) + "_rclcpp_node",
-      "-r", std::string("__ns:=") + action_name_,
+      "-r", std::string("__node:=") + std::string(node->get_name()) + client_node_name + "_rclcpp_node",
       "--"});
 
   // Support for handling the topic-based goal pose from rviz


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Related to PR #2410, addresses the issue explained in [this comment](https://github.com/ros-planning/navigation2/pull/2410#issuecomment-884317758) |
| Primary OS tested on | Ubuntu 20.04 ROS2 Galactic |
| Robotic platform tested on | Wyca Elodie robot (simulation) |

---

## Description of contribution in a few bullet points

#### Issue description

The PR #2410 aimed at getting an unique name for each BT client nodes, by adding the action name into the BT client node name.

Action names often come with namespaces, and so with "/" characters.
Let's say my action is named "/my_api/navigation/go_to_pose". With the PR #2410, the BT client node's name will be remapped to "bt_navigator/my_api/navigation/go_to_pose_rclcpp_node". 
Nodes can be namespaced, but a node has a name and a namespace, that are two distinct entities.
Remapping the node name to "bt_navigator/my_api/navigation/go_to_pose_rclcpp_node" results into this error:
```c
[bt_navigator-57] [ERROR] []: Caught exception in callback for transition 10
[bt_navigator-57] [ERROR] []: Original error: failed to parse arguments: Couldn't parse remap rule: '-r __node:=bt_navigator/my_api/navigation/go_to_pose_rclcpp_node'. Error: Expected lexeme type 1, got 19 at index 20, at /tmp/binarydeb/ros-galactic-rcl-3.1.2/src/rcl/lexer_lookahead.c:238, at /tmp/binarydeb/ros-galactic-rcl-3.1.2/src/rcl/arguments.c:371
[bt_navigator-57] [FATAL] [bt_navigator]: Lifecycle node bt_navigator does not have error state implemented
[lifecycle_manager-54] [ERROR] [lifecycle_manager_navigation]: Failed to change state for node: bt_navigator
[lifecycle_manager-54] [ERROR]  [lifecycle_manager_navigation]: Failed to bring up all requested nodes. Aborting bringup.
```

#### Possible solutions

This PR aims at preventing the above error to happen, but still trying to keep the BT client node's name unique. So I see two easy solutions here:

1. Replacing all "/" within the action name by "_" before using for remapping the node name
In this case, the node name be named like "bt_navigator_my_api_navigation_go_to_pose_rclcpp_node"

2. Remapping only the node namespace after the action name
In this case, the node will be named like "/my_api/navigation/go_to_pose/bt_navigator_rclcpp_node" ("/my_api/navigation/go_to_pose/" being the namespace, "bt_navigator_rclcpp_node" being the name)

I rather go with solution 2, but we can discuss this. Plus, you may have better ideas that those two.

#### Contribution so far

- I removed the action name from the [node name remapping in `NodeOptions`](https://github.com/ros-planning/navigation2/blob/c417e2fd267e1dfa880b7ff9d37aaaa7b5eab9ca/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp#L88). This prevent the error given above to happen.

- I added a [remapping of the node namespace in `NodeOptions`](https://github.com/wyca-robotics/navigation2/blob/b3fbbd9c6ff24aad7658bf54d9b474aab0da8543/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp#L89). The namespace is the action name. This keeps the spirit of the PR #2410 by giving an unique namespace for each `bt_navigator_rclcpp_node` BT client node.


Thanks for considering this PR! 

---

## Future work that may be required in bullet points


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
