### PR TITLE
allow spawn non turtlebot urdf

### DIFF
--- a/nav2_bringup/nav2_gazebo_spawner/nav2_gazebo_spawner/nav2_gazebo_spawner.py
+++ b/nav2_bringup/nav2_gazebo_spawner/nav2_gazebo_spawner/nav2_gazebo_spawner.py
@@ -78,8 +78,7 @@ def main():
     tree = ET.parse(sdf_file_path)
     root = tree.getroot()
     for plugin in root.iter('plugin'):
-        # TODO(orduno) Handle case if an sdf file from non-turtlebot is provided
-        if 'turtlebot3_diff_drive' in plugin.attrib.values():
+        if 'ros_diff_drive' in plugin.get('filename'):
             # The only plugin we care for now is 'diff_drive' which is
             # broadcasting a transform between`odom` and `base_footprint`
             break


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | no ticket |
| Primary OS tested on | (Ubuntu 20.04) |
| Robotic platform tested on | Gazebo simulation,  turtlebot multi-robot simulation |

---

## Description of contribution in a few bullet points
Use gazebo diff_drive plugin filename instead of the customized plugin name to allow correct spawn of any type of robot.
I used the comparison with filename "libgazebo_ros_diff_drive.so" because AFAIK there is no other gazebo diff_drive plugin than this one.
Can be merged with both foxy and galactic
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
