### PR TITLE
Fix for the seg-fault that occurred when RPP was tested at high speed

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -232,6 +232,7 @@ protected:
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   nav2_costmap_2d::Costmap2D * costmap_;
   rclcpp::Logger logger_ {rclcpp::get_logger("RegulatedPurePursuitController")};
+  rclcpp::Clock::SharedPtr clock_;
 
   double desired_linear_vel_, base_desired_linear_vel_;
   double lookahead_dist_;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -461,7 +461,7 @@ double RegulatedPurePursuitController::costAtPose(const double & x, const double
   if (!costmap_->worldToMap(x, y, mx, my)) {
     RCLCPP_FATAL_ONCE(
       logger_,
-      "The dimensions of the costmap is smaller, the controller failed and so the robot cannot proceed further");
+      "The dimensions of the costmap is too small to fully include your robot's footprint, thusly the robot cannot proceed.");
     throw nav2_core::PlannerException(
             "RegulatedPurePursuitController detected poor configuration of local costmap!");
     return std::numeric_limits<double>::max();

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -436,8 +436,14 @@ bool RegulatedPurePursuitController::isCollisionImminent(
 bool RegulatedPurePursuitController::inCollision(const double & x, const double & y)
 {
   unsigned int mx, my;
-  costmap_->worldToMap(x, y, mx, my);
 
+  auto convertWorldToMap = costmap_->worldToMap(x, y, mx, my);
+  if (!convertWorldToMap) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *(clock_), 30000,
+      "The dimensions of the costmap is smaller, proceed at your own risk");
+    return false;
+  }
   unsigned char cost = costmap_->getCost(mx, my);
 
   if (costmap_ros_->getLayeredCostmap()->isTrackingUnknown()) {
@@ -450,7 +456,13 @@ bool RegulatedPurePursuitController::inCollision(const double & x, const double 
 double RegulatedPurePursuitController::costAtPose(const double & x, const double & y)
 {
   unsigned int mx, my;
-  costmap_->worldToMap(x, y, mx, my);
+  auto convertWorldToMap = costmap_->worldToMap(x, y, mx, my);
+  if (!convertWorldToMap) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *(clock_), 30000,
+      "The dimensions of the costmap is smaller, proceed at your own risk");
+    return 0.0;
+  }
 
   unsigned char cost = costmap_->getCost(mx, my);
   return static_cast<double>(cost);

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -441,7 +441,7 @@ bool RegulatedPurePursuitController::inCollision(const double & x, const double 
   if (!costmap_->worldToMap(x, y, mx, my)) {
     RCLCPP_WARN_THROTTLE(
       logger_, *(clock_), 30000,
-      "The dimensions of the costmap is smaller, proceed at your own risk");
+      "The dimensions of the costmap is too small to successfully check for collisions as far ahead as requested. Proceed at your own risk, slow the robot, or increase your costmap size.");
     return false;
   }
 

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -463,7 +463,7 @@ double RegulatedPurePursuitController::costAtPose(const double & x, const double
       logger_,
       "The dimensions of the costmap is too small to fully include your robot's footprint, thusly the robot cannot proceed.");
     throw nav2_core::PlannerException(
-            "RegulatedPurePursuitController detected poor configuration of local costmap!");
+            "RegulatedPurePursuitController: Dimensions of the costmap are too small to encapsulate the robot footprint at current speeds!");
     return std::numeric_limits<double>::max();
   }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2332  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | mp-400 from Neobotix |

---

## Description of contribution in a few bullet points

* Fixed the segfault issue that occurred when the robot was set to drive at high speed using RPP. 

## Description of documentation updates required from your changes

NA

---

## Future work that may be required in bullet points

NA

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
