### PR TITLE
[SmacPlanner2D] make tolerance parameter dynamic

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
@@ -88,6 +88,12 @@ public:
     const geometry_msgs::msg::PoseStamped & goal) override;
 
 protected:
+  /**
+   * @brief Callback executed when a paramter change is detected
+   * @param event ParameterEvent message
+   */
+  void on_parameter_event_callback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
+
   std::unique_ptr<AStarAlgorithm<Node2D>> _a_star;
   GridCollisionChecker _collision_checker;
   std::unique_ptr<Smoother> _smoother;
@@ -113,12 +119,6 @@ protected:
   // Subscription for parameter change
   rclcpp::AsyncParametersClient::SharedPtr _parameters_client;
   rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr _parameter_event_sub;
-
-  /**
-   * @brief Callback executed when a paramter change is detected
-   * @param event ParameterEvent message
-   */
-  void on_parameter_event_callback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
 };
 
 }  // namespace nav2_smac_planner

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
@@ -100,6 +100,16 @@ protected:
   bool _downsample_costmap;
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _raw_plan_publisher;
   double _max_planning_time;
+
+  // Subscription for parameter change
+  rclcpp::AsyncParametersClient::SharedPtr parameters_client_;
+  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr parameter_event_sub_;
+
+  /**
+   * @brief Callback executed when a paramter change is detected
+   * @param event ParameterEvent message
+   */
+  void on_parameter_event_callback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
 };
 
 }  // namespace nav2_smac_planner

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <mutex>
 
 #include "nav2_smac_planner/a_star.hpp"
 #include "nav2_smac_planner/smoother.hpp"
@@ -100,10 +101,18 @@ protected:
   bool _downsample_costmap;
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _raw_plan_publisher;
   double _max_planning_time;
+  bool _allow_unknown;
+  int _max_iterations;
+  int _max_on_approach_iterations;
+  SearchInfo _search_info;
+  std::string _motion_model_for_search;
+  MotionModel _motion_model;
+  std::mutex _mutex;
+  rclcpp_lifecycle::LifecycleNode::WeakPtr _node;
 
   // Subscription for parameter change
-  rclcpp::AsyncParametersClient::SharedPtr parameters_client_;
-  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr parameter_event_sub_;
+  rclcpp::AsyncParametersClient::SharedPtr _parameters_client;
+  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr _parameter_event_sub;
 
   /**
    * @brief Callback executed when a paramter change is detected

--- a/nav2_smac_planner/src/smac_planner_2d.cpp
+++ b/nav2_smac_planner/src/smac_planner_2d.cpp
@@ -375,7 +375,7 @@ void SmacPlanner2D::on_parameter_event_callback(
     }
 
     // Re-Initialize costmap downsampler
-    if (reinit_a_star) {
+    if (reinit_downsampler) {
       if (_downsample_costmap && _downsampling_factor > 1) {
         auto node = _node.lock();
         std::string topic_name = "downsampled_costmap";

--- a/nav2_smac_planner/src/smac_planner_2d.cpp
+++ b/nav2_smac_planner/src/smac_planner_2d.cpp
@@ -296,6 +296,8 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
 void SmacPlanner2D::on_parameter_event_callback(
   const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
 {
+  std::lock_guard<std::mutex> lock_reinit(_mutex);
+
   bool reinit_a_star = false;
   bool reinit_downsampler = false;
 
@@ -361,8 +363,6 @@ void SmacPlanner2D::on_parameter_event_callback(
 
   // Re-init if needed with mutex lock (to avoid re-init while creating a plan)
   if (reinit_a_star || reinit_downsampler) {
-    std::lock_guard<std::mutex> lock_reinit(_mutex);
-
     // Re-Initialize A* template
     if (reinit_a_star) {
       _a_star = std::make_unique<AStarAlgorithm<Node2D>>(_motion_model, _search_info);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/956|
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Wyca sim) |

---

## Description of contribution in a few bullet points
I am starting to experiment with **SmacPlanner2D** and in order to work in our workflow, I need the tolerance parameter to be dynamic, which is what this PR is about.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

Should we make other paremeters dynamic in **SmacPlanner2D** ? Though most of them would require re-initialization of several objects

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
