### PR TITLE
Reduce controller server nodes

### DIFF
--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -32,7 +32,7 @@ namespace nav2_controller
 {
 
 ControllerServer::ControllerServer()
-: LifecycleNode("controller_server", "", true),
+: nav2_util::LifecycleNode("controller_server", ""),
   progress_checker_loader_("nav2_core", "nav2_core::ProgressChecker"),
   default_progress_checker_id_{"progress_checker"},
   default_progress_checker_type_{"nav2_controller::SimpleProgressChecker"},
@@ -195,8 +195,12 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & state)
 
   // Create the action server that we implement with our followPath method
   action_server_ = std::make_unique<ActionServer>(
-    rclcpp_node_, "follow_path",
-    std::bind(&ControllerServer::computeControl, this));
+    shared_from_this(),
+    "follow_path",
+    std::bind(&ControllerServer::computeControl, this),
+    nullptr,
+    std::chrono::milliseconds(500),
+    true);
 
   // Set subscribtion to the speed limiting topic
   speed_limit_sub_ = create_subscription<nav2_msgs::msg::SpeedLimit>(

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -270,7 +270,6 @@ ControllerServer::on_cleanup(const rclcpp_lifecycle::State & state)
   odom_sub_.reset();
   vel_publisher_.reset();
   speed_limit_sub_.reset();
-  action_server_.reset();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info                       | Please fill out this column                                  |
| -------------------------- | ------------------------------------------------------------ |
| Ticket(s) this addresses   | (tickets:  [#816](https://github.com/ros-planning/navigation2/issues/816)) |
| Primary OS tested on       | (Ubuntu20.04, ROS 2 Galactic from binaries)                  |
| Robotic platform tested on | (gazebo simulation of turtlebot3)                            |

-------

## Description of contribution in a few bullet points

As described in [#816](https://github.com/ros-planning/navigation2/issues/816), `rclcpp_node_` in `class ControllerServer ` need be removed, you can find more details(other nodes which need be removed) in [#816 (comment)](https://github.com/ros-planning/navigation2/issues/816#issuecomment-876061677)

after [PR#2459](https://github.com/ros-planning/navigation2/pull/2459) merged, we can create `SimpleActionServer` with argument `spin_thread` which could spin server with dedicated thread.

- set `spin_thread` true when create `action_server_` .

## Test
colcon test
```bash
colcon test --packages-select nav2_controller
#result:0 errors, 0 failures, 0 skipped
```
navigation demo test (turtlebot3 in gazebo)
* success
---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
