### PR TITLE
Reduce planner server nodes

### DIFF
--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -37,7 +37,7 @@ namespace nav2_planner
 {
 
 PlannerServer::PlannerServer()
-: nav2_util::LifecycleNode("nav2_planner", "", true),
+: nav2_util::LifecycleNode("nav2_planner", ""),
   gp_loader_("nav2_core", "nav2_core::GlobalPlanner"),
   default_ids_{"GridBased"},
   default_types_{"nav2_navfn_planner/NavfnPlanner"},
@@ -132,14 +132,20 @@ PlannerServer::on_configure(const rclcpp_lifecycle::State & state)
 
   // Create the action servers for path planning to a pose and through poses
   action_server_pose_ = std::make_unique<ActionServerToPose>(
-    rclcpp_node_,
+    shared_from_this(),
     "compute_path_to_pose",
-    std::bind(&PlannerServer::computePlan, this));
+    std::bind(&PlannerServer::computePlan, this),
+    nullptr,
+    std::chrono::milliseconds(500),
+    true);
 
   action_server_poses_ = std::make_unique<ActionServerThroughPoses>(
-    rclcpp_node_,
+    shared_from_this(),
     "compute_path_through_poses",
-    std::bind(&PlannerServer::computePlanThroughPoses, this));
+    std::bind(&PlannerServer::computePlanThroughPoses, this),
+    nullptr,
+    std::chrono::milliseconds(500),
+    true);
 
   return nav2_util::CallbackReturn::SUCCESS;
 }


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info                       | Please fill out this column                                  |
| -------------------------- | ------------------------------------------------------------ |
| Ticket(s) this addresses   | (tickets:  [#816](https://github.com/ros-planning/navigation2/issues/816)) |
| Primary OS tested on       | (Ubuntu20.04, ROS 2 Galactic from binaries)                  |
| Robotic platform tested on | (gazebo simulation of turtlebot3)                            |

-------

## Description of contribution in a few bullet points

As described in [#816](https://github.com/ros-planning/navigation2/issues/816), `rclcpp_node_` in `class PlannerServer` need be removed, you can find more details(other nodes which need be removed) in [#816 (comment)](https://github.com/ros-planning/navigation2/issues/816#issuecomment-876061677)

after [PR#2459](https://github.com/ros-planning/navigation2/pull/2459) merged, we can create `SimpleActionServer` with argument `spin_thread` which could spin server with dedicated thread.

- set `spin_thread` true when create `action_server_pose_`  and `action_server_poses_`.

## Test
colcon test
```bash
colcon test --packages-select nav2_planner
#result:0 errors, 0 failures, 0 skipped
```
navigation demo test (turtlebot3 in gazebo)
* success
---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
