### PR TITLE
Modify the BtServiceNode to include an on_success call.

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -144,10 +144,10 @@ public:
 
   /**
    * @brief Function to perform some user-defined operation upon successful
-   * completion of the action. Could put a value on the blackboard.
-   * @return BT::NodeStatus Returns SUCCESS by default, user may override return another value
+   * completion of the service. Could put a value on the blackboard.
+   * @return BT::NodeStatus Returns SUCCESS by default, user may override to return another value
    */
-  virtual BT::NodeStatus on_success()
+  virtual BT::NodeStatus on_completion()
   {
     return BT::NodeStatus::SUCCESS;
   }
@@ -168,7 +168,7 @@ public:
       rc = callback_group_executor_.spin_until_future_complete(future_result_, server_timeout_);
       if (rc == rclcpp::FutureReturnCode::SUCCESS) {
         request_sent_ = false;
-        BT::NodeStatus status = on_success();
+        BT::NodeStatus status = on_completion();
         return status;
       }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -168,7 +168,7 @@ public:
       rc = callback_group_executor_.spin_until_future_complete(future_result_, server_timeout_);
       if (rc == rclcpp::FutureReturnCode::SUCCESS) {
         request_sent_ = false;
-        BT::NodeStatus status = on_success();   
+        BT::NodeStatus status = on_success();
         return status;
       }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -143,6 +143,16 @@ public:
   }
 
   /**
+   * @brief Function to perform some user-defined operation upon successful
+   * completion of the action. Could put a value on the blackboard.
+   * @return BT::NodeStatus Returns SUCCESS by default, user may override return another value
+   */
+  virtual BT::NodeStatus on_success()
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  /**
    * @brief Check the future and decide the status of BT
    * @return BT::NodeStatus SUCCESS if future complete before timeout, FAILURE otherwise
    */
@@ -158,7 +168,8 @@ public:
       rc = callback_group_executor_.spin_until_future_complete(future_result_, server_timeout_);
       if (rc == rclcpp::FutureReturnCode::SUCCESS) {
         request_sent_ = false;
-        return BT::NodeStatus::SUCCESS;
+        BT::NodeStatus status = on_success();   
+        return status;
       }
 
       if (rc == rclcpp::FutureReturnCode::TIMEOUT) {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2467 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | custom differential drive robot |

---

## Description of contribution in a few bullet points

* Modified the `bt_service_node` to include an `on_success()` function, to process the service answer. 
* The additional `on_success()` function can be used to process the results send from the service server, to, for example, set the BT::NodeStatus of the behavior tree leave node

## Description of documentation updates required from your changes

* The `on_success()` function was added. However, I am not sure if this needs to be documented somewhere. 

---

## Future work that may be required in bullet points

* So far I can't think of an additional on-function, which could be useful and which is not yet implemented.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
