### PR TITLE
Reduce amcl_node nodes

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -105,6 +105,12 @@ protected:
   // respond until we're in the active state
   std::atomic<bool> active_{false};
 
+  // Dedicated callback group and executor for services and subscriptions in AmclNode,
+  // in order to isolate TF timer used in message filter.
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
+  std::unique_ptr<nav2_util::NodeThread> executor_thread_;
+
   // Pose hypothesis
   typedef struct
   {
@@ -165,7 +171,8 @@ protected:
    * @brief Initialize incoming data message subscribers and filters
    */
   void initMessageFilters();
-  std::unique_ptr<message_filters::Subscriber<sensor_msgs::msg::LaserScan>> laser_scan_sub_;
+  std::unique_ptr<message_filters::Subscriber<sensor_msgs::msg::LaserScan,
+    rclcpp_lifecycle::LifecycleNode>> laser_scan_sub_;
   std::unique_ptr<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>> laser_scan_filter_;
   message_filters::Connection laser_scan_connection_;
 

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -59,7 +59,7 @@ namespace nav2_amcl
 using nav2_util::geometry_utils::orientationAroundZAxis;
 
 AmclNode::AmclNode(const rclcpp::NodeOptions & options)
-: nav2_util::LifecycleNode("amcl", "", true, options)
+: nav2_util::LifecycleNode("amcl", "", false, options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
@@ -236,7 +236,8 @@ nav2_util::CallbackReturn
 AmclNode::on_configure(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Configuring");
-
+  callback_group_ = create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive, false);
   initParameters();
   initTransforms();
   initParticleFilter();
@@ -245,7 +246,9 @@ AmclNode::on_configure(const rclcpp_lifecycle::State & /*state*/)
   initPubSub();
   initServices();
   initOdometry();
-
+  executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  executor_->add_callback_group(callback_group_, get_node_base_interface());
+  executor_thread_ = std::make_unique<nav2_util::NodeThread>(executor_);
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
@@ -316,6 +319,8 @@ nav2_util::CallbackReturn
 AmclNode::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Cleaning up");
+
+  executor_thread_.reset();
 
   // Get rid of the inputs first (services and message filter input), so we
   // don't continue to process incoming messages
@@ -1426,13 +1431,14 @@ AmclNode::initTransforms()
   RCLCPP_INFO(get_logger(), "initTransforms");
 
   // Initialize transform listener and broadcaster
-  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(rclcpp_node_->get_clock());
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
   auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    rclcpp_node_->get_node_base_interface(),
-    rclcpp_node_->get_node_timers_interface());
+    get_node_base_interface(),
+    get_node_timers_interface(),
+    callback_group_);
   tf_buffer_->setCreateTimerInterface(timer_interface);
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
-  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(rclcpp_node_);
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(shared_from_this(), true);
 
   sent_first_transform_ = false;
   latest_tf_valid_ = false;
@@ -1442,11 +1448,18 @@ AmclNode::initTransforms()
 void
 AmclNode::initMessageFilters()
 {
-  laser_scan_sub_ = std::make_unique<message_filters::Subscriber<sensor_msgs::msg::LaserScan>>(
-    rclcpp_node_.get(), scan_topic_, rmw_qos_profile_sensor_data);
+  auto sub_opt = rclcpp::SubscriptionOptions();
+  sub_opt.callback_group = callback_group_;
+  laser_scan_sub_ = std::make_unique<message_filters::Subscriber<sensor_msgs::msg::LaserScan,
+      rclcpp_lifecycle::LifecycleNode>>(
+    shared_from_this(), scan_topic_, rmw_qos_profile_sensor_data, sub_opt);
 
   laser_scan_filter_ = std::make_unique<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>>(
-    *laser_scan_sub_, *tf_buffer_, odom_frame_id_, 10, rclcpp_node_, transform_tolerance_);
+    *laser_scan_sub_, *tf_buffer_, odom_frame_id_, 10,
+    get_node_logging_interface(),
+    get_node_clock_interface(),
+    transform_tolerance_);
+
 
   laser_scan_connection_ = laser_scan_filter_->registerCallback(
     std::bind(


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info                       | Please fill out this column                                  |
| -------------------------- | ------------------------------------------------------------ |
| Ticket(s) this addresses   | (tickets:  [#816](https://github.com/ros-planning/navigation2/issues/816)) |
| Primary OS tested on       | (Ubuntu20.04, ROS 2 Galactic)                  |
| Robotic platform tested on | (gazebo simulation of turtlebot3)                            |

-------

## Description of contribution in a few bullet points

As described in [#816](https://github.com/ros-planning/navigation2/issues/816), `rclcpp_node_` in `class AmclNode` need be removed, you can find more details(other nodes which need be removed) in [#816 (comment)](https://github.com/ros-planning/navigation2/issues/816#issuecomment-876061677)

- After the PR (https://github.com/ros2/message_filters/pull/59) was merged, we can use `message_filters::Subscriber` in `LifecycleNode`. and update `tools/underlay.repos` to sync the feature.
- There is no blocked callback in `AmclNode`, so just use `shared_from_this()` instead of `rclcpp_node_` for `Transform` and `MessageFilter`

# Test

colcon test
```bash
colcon test --packages-select nav2_amcl

#result:0 errors, 0 failures, 0 skipped
```
navigation demo test (turtlebot3 in gazebo)

- success

---

## Future work that may be required in bullet points

- i notice that the constructor of `TransformListener` has a argument `spin_thread` with default value `true`, which create a internal node to subscribe tf topic and a dedicated thread to spin this node. 
- i think  the best way is to use new callback group and executor with dedicated thread  so that we could avoid creating internal node which is overhead. i will open a issue for `ros2/geometry` to discuss these.

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
