### PR TITLE
fix: bug of passing string to printf

### DIFF
--- a/nav2_map_server/test/component/test_map_saver_publisher.cpp
+++ b/nav2_map_server/test/component/test_map_saver_publisher.cpp
@@ -36,7 +36,7 @@ public:
     std::string pub_map_file = path(TEST_DIR) / path(g_valid_yaml_file);
     LOAD_MAP_STATUS status = loadMapFromYaml(pub_map_file, msg_);
     if (status != LOAD_MAP_SUCCESS) {
-      RCLCPP_ERROR(get_logger(), "Can not load %s map file", pub_map_file);
+      RCLCPP_ERROR(get_logger(), "Can not load %s map file", pub_map_file.c_str());
       return;
     }
 


### PR DESCRIPTION
A trivial fix. It is a bug passing a string object to sprintf like variadic function.
I found it by building from source code with the tag (-Wnon-pod-varargs). 