### PR TITLE
[Smac2d] Accept path of length 1

### DIFF
--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -329,7 +329,7 @@ bool AStarAlgorithm<Node2D>::backtracePath(NodePtr node, CoordinateVector & path
     current_node = current_node->parent;
   }
 
-  return path.size() > 1;
+  return path.size() > 0;
 }
 
 template<typename NodeT>
@@ -346,7 +346,7 @@ bool AStarAlgorithm<NodeT>::backtracePath(NodePtr node, CoordinateVector & path)
     current_node = current_node->parent;
   }
 
-  return path.size() > 1;
+  return path.size() > 0;
 }
 
 template<typename NodeT>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/2494 |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | Wyca Elodie |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
Solves https://github.com/ros-planning/navigation2/issues/2494 . 
Fully tested with smac2d planner. However as a_star is used for the hybrid version, it may have implications that I don't foresee (I did a basic sanity check with the hybrid though)

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
