### PR TITLE
Fix #2493 by removing the unused joint to camera_rgb_frame

### DIFF
--- a/nav2_bringup/bringup/worlds/waffle.model
+++ b/nav2_bringup/bringup/worlds/waffle.model
@@ -137,7 +137,6 @@
             </linear_acceleration>
           </imu>
           <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
-            <initial_orientation_as_reference>false</initial_orientation_as_reference>
             <ros>
               <!-- <namespace>/tb3</namespace> -->
               <remapping>~/out:=imu</remapping>

--- a/nav2_bringup/bringup/worlds/waffle.model
+++ b/nav2_bringup/bringup/worlds/waffle.model
@@ -137,6 +137,7 @@
             </linear_acceleration>
           </imu>
           <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
+            <initial_orientation_as_reference>false</initial_orientation_as_reference>
             <ros>
               <!-- <namespace>/tb3</namespace> -->
               <remapping>~/out:=imu</remapping>
@@ -498,15 +499,6 @@
         <parent>base_link</parent>
         <child>camera_link</child>
         <pose>0.064 -0.065 0.094 0 0 0</pose>
-        <axis>
-          <xyz>0 0 1</xyz>
-        </axis>
-      </joint>
-
-      <joint name="camera_rgb_joint" type="fixed">
-        <parent>camera_link</parent>
-        <child>camera_rgb_frame</child>
-        <pose>0.005 0.018 0.013 0 0 0</pose>
         <axis>
           <xyz>0 0 1</xyz>
         </axis>


### PR DESCRIPTION
It looks like `camera_rgb_link` is now `camera_link` e3ee2da2d5a274b52d32fcdf7e270567ca1093d0

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2493 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | none, Gazebo 11.5 |

## Description of contribution in a few bullet points
Fix the `waffle.model` file

## Description of documentation updates required from your changes
None

## Future work that may be required in bullet points
None

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
