### PR TITLE
catch runtime_error if the message from laser is malformed

### DIFF
--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -291,12 +291,13 @@ ObstacleLayer::laserScanCallback(
       global_frame_.c_str(),
       ex.what());
     projector_.projectLaser(*message, cloud);
-  } catch (std::runtime_error &ex) {
+  } catch (std::runtime_error & ex) {
     RCLCPP_WARN(
       logger_,
-      "transformLaserScanToPointCloud error, it seems the message from laser is malformed. Ignore this message. what(): %s",
+      "transformLaserScanToPointCloud error, it seems the message from laser is malformed."
+      " Ignore this message. what(): %s",
       ex.what());
-    return; //ignore this message
+    return;
   }
 
   // buffer the point cloud
@@ -333,12 +334,13 @@ ObstacleLayer::laserScanValidInfCallback(
       "High fidelity enabled, but TF returned a transform exception to frame %s: %s",
       global_frame_.c_str(), ex.what());
     projector_.projectLaser(message, cloud);
-  } catch (std::runtime_error &ex) {
+  } catch (std::runtime_error & ex) {
     RCLCPP_WARN(
       logger_,
-      "transformLaserScanToPointCloud error, it seems the message from laser is malformed. Ignore this message. what(): %s",
+      "transformLaserScanToPointCloud error, it seems the message from laser is malformed."
+      " Ignore this message. what(): %s",
       ex.what());
-    return; //ignore this message
+    return;
   }
 
   // buffer the point cloud

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -291,6 +291,12 @@ ObstacleLayer::laserScanCallback(
       global_frame_.c_str(),
       ex.what());
     projector_.projectLaser(*message, cloud);
+  } catch (std::runtime_error &ex) {
+    RCLCPP_WARN(
+      logger_,
+      "transformLaserScanToPointCloud error, it seems the message from laser is malformed. Ignore this message. what(): %s",
+      ex.what());
+    return; //ignore this message
   }
 
   // buffer the point cloud
@@ -327,6 +333,12 @@ ObstacleLayer::laserScanValidInfCallback(
       "High fidelity enabled, but TF returned a transform exception to frame %s: %s",
       global_frame_.c_str(), ex.what());
     projector_.projectLaser(message, cloud);
+  } catch (std::runtime_error &ex) {
+    RCLCPP_WARN(
+      logger_,
+      "transformLaserScanToPointCloud error, it seems the message from laser is malformed. Ignore this message. what(): %s",
+      ex.what());
+    return; //ignore this message
   }
 
   // buffer the point cloud


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2506 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |  gazebo simulation turtlebot3) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
catch runtime_error from rclcpp if the message from laser is malformed.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
