### PR TITLE
fix data race: addPlugin() and resizeMap() can be executed concurrently

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
@@ -146,10 +146,8 @@ public:
   /**
    * @brief Add a new plugin to the plugins vector to process
    */
-  void addPlugin(std::shared_ptr<Layer> plugin)
-  {
-    plugins_.push_back(plugin);
-  }
+  void addPlugin(std::shared_ptr<Layer> plugin);
+
 
   /**
    * @brief Add a new costmap filter plugin to the filters vector to process

--- a/nav2_costmap_2d/src/layered_costmap.cpp
+++ b/nav2_costmap_2d/src/layered_costmap.cpp
@@ -89,6 +89,12 @@ LayeredCostmap::~LayeredCostmap()
   }
 }
 
+void LayeredCostmap::addPlugin(std::shared_ptr<Layer> plugin)
+{
+  std::unique_lock<Costmap2D::mutex_t> lock(*(combined_costmap_.getMutex()));
+  plugins_.push_back(plugin);
+}
+
 void LayeredCostmap::resizeMap(
   unsigned int size_x, unsigned int size_y, double resolution,
   double origin_x,


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2508|
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of turtlebot3 |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
addPlugin() and resizeMap() can be executed concurrently.
std::vector is unsafe in multithreading.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
