### PR TITLE
Remove second collision node from camera_link

### DIFF
--- a/nav2_bringup/bringup/worlds/waffle.model
+++ b/nav2_bringup/bringup/worlds/waffle.model
@@ -440,14 +440,6 @@
           </plugin>
         </sensor>
 
-        <collision name="collision">
-          <pose>0 0.047 -0.005 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>0.008 0.130 0.022</size>
-            </box>
-          </geometry>
-        </collision>
         <pose>0.069 -0.047 0.107 0 0 0</pose>
       </link>
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points
Remove the second `collision` node from `camera_link` in the `waffle.model`.

Fixes this Error:
```
[gzserver-1] [Msg] Loading world file [/opt/ros/foxy/share/nav2_bringup/worlds/waffle.model]
[gzserver-1] Error: Non-unique names detected in type collision in
[gzserver-1] <link name='camera_link'>
[gzserver-1]   <inertial>
[gzserver-1]     <pose>0.069 -0.047 0.107 0 -0 0</pose>
[gzserver-1]     <inertia>
[gzserver-1]       <ixx>0.001</ixx>
[gzserver-1]       <ixy>0</ixy>
[gzserver-1]       <ixz>0</ixz>
[gzserver-1]       <iyy>0.001</iyy>
[gzserver-1]       <iyz>0</iyz>
[gzserver-1]       <izz>0.001</izz>
[gzserver-1]     </inertia>
[gzserver-1]     <mass>0.035</mass>
[gzserver-1]   </inertial>
[gzserver-1]   <collision name='collision'>
[gzserver-1]     <pose>0 0.047 -0.005 0 -0 0</pose>
[gzserver-1]     <geometry>
[gzserver-1]       <box>
[gzserver-1]         <size>0.008 0.13 0.022</size>
[gzserver-1]       </box>
[gzserver-1]     </geometry>
[gzserver-1]   </collision>
[gzserver-1]   <pose>0.069 -0.047 0.107 0 -0 0</pose>
[gzserver-1]   <sensor name='intel_realsense_r200_depth' type='depth'>
[gzserver-1]     <always_on>1</always_on>
[gzserver-1]     <update_rate>5</update_rate>
[gzserver-1]     <pose>0.064 -0.047 0.107 0 -0 0</pose>
[gzserver-1]     <camera name='realsense_depth_camera'>
[gzserver-1]       <horizontal_fov>1.047</horizontal_fov>
[gzserver-1]       <image>
[gzserver-1]         <width>320</width>
[gzserver-1]         <height>240</height>
[gzserver-1]       </image>
[gzserver-1]       <clip>
[gzserver-1]         <near>0.1</near>
[gzserver-1]         <far>100</far>
[gzserver-1]       </clip>
[gzserver-1]     </camera>
[gzserver-1]     <plugin name='intel_realsense_r200_depth_driver' filename='libgazebo_ros_camera.so'>
[gzserver-1]       <ros/>
[gzserver-1]       <camera_name>intel_realsense_r200_depth</camera_name>
[gzserver-1]       <frame_name>camera_depth_frame</frame_name>
[gzserver-1]       <hack_baseline>0.07</hack_baseline>
[gzserver-1]       <min_depth>0.001</min_depth>
[gzserver-1]       <max_depth>5.0</max_depth>
[gzserver-1]     </plugin>
[gzserver-1]   </sensor>
[gzserver-1]   <collision name='collision'>
[gzserver-1]     <pose>0 0.047 -0.005 0 -0 0</pose>
[gzserver-1]     <geometry>
[gzserver-1]       <box>
[gzserver-1]         <size>0.008 0.13 0.022</size>
[gzserver-1]       </box>
[gzserver-1]     </geometry>
[gzserver-1]   </collision>
[gzserver-1]   <pose>0.069 -0.047 0.107 0 -0 0</pose>
[gzserver-1] </link>
[gzserver-1] 
[gzserver-1] [Err] [Server.cc:98] SDF is not valid, see errors above. This can lead to an unexpected behaviour.
```

---

## Description of documentation updates required from your changes
None

---

## Future work that may be required in bullet points
None

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
