### PR TITLE
Fix export dependency and library

### DIFF
--- a/nav2_controller/CMakeLists.txt
+++ b/nav2_controller/CMakeLists.txt
@@ -99,6 +99,7 @@ ament_export_libraries(simple_progress_checker
   simple_goal_checker
   stopped_goal_checker
   ${library_name})
+ament_export_dependencies(${dependencies})
 pluginlib_export_plugin_description_file(nav2_core plugins.xml)
 
 ament_package()

--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -154,4 +154,5 @@ ament_export_libraries(
   ${library_name}
   ${map_io_library_name}
 )
+ament_export_dependencies(${map_io_dependencies} ${map_server_dependencies})
 ament_package()

--- a/nav2_recoveries/CMakeLists.txt
+++ b/nav2_recoveries/CMakeLists.txt
@@ -126,5 +126,5 @@ ament_export_libraries(${library_name}
   nav2_spin_recovery
   nav2_wait_recovery
 )
-
+ament_export_dependencies(${dependencies})
 ament_package()

--- a/nav2_waypoint_follower/CMakeLists.txt
+++ b/nav2_waypoint_follower/CMakeLists.txt
@@ -98,8 +98,8 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(wait_at_waypoint photo_at_waypoint input_at_waypoint)
-
+ament_export_libraries(wait_at_waypoint photo_at_waypoint input_at_waypoint ${library_name})
+ament_export_dependencies(${dependencies})
 pluginlib_export_plugin_description_file(nav2_waypoint_follower plugins.xml)
 
 ament_package()


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2147 |
| Primary OS tested on | - |
| Robotic platform tested on | - |

---

## Description of contribution in a few bullet points

fix export dependency and library so that we can use nav2 packages correctly (for exmaple, used in `nav2_composition`).


---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
