### PR TITLE
Add argument node options

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -62,7 +62,7 @@ public:
    * @brief AMCL constructor
    * @param options Additional options to control creation of the node.
    */
-  AmclNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit AmclNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /*
    * @brief AMCL destructor
    */

--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -60,8 +60,9 @@ class AmclNode : public nav2_util::LifecycleNode
 public:
   /*
    * @brief AMCL constructor
+   * @param options Additional options to control creation of the node.
    */
-  AmclNode();
+  AmclNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /*
    * @brief AMCL destructor
    */

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -57,8 +57,8 @@ namespace nav2_amcl
 {
 using nav2_util::geometry_utils::orientationAroundZAxis;
 
-AmclNode::AmclNode()
-: nav2_util::LifecycleNode("amcl", "", true)
+AmclNode::AmclNode(const rclcpp::NodeOptions & options)
+: nav2_util::LifecycleNode("amcl", "", true, options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -42,7 +42,7 @@ public:
    * @brief A constructor for nav2_bt_navigator::BtNavigator class
    * @param options Additional options to control creation of the node.
    */
-  BtNavigator(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit BtNavigator(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /**
    * @brief A destructor for nav2_bt_navigator::BtNavigator class
    */

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -40,8 +40,9 @@ class BtNavigator : public nav2_util::LifecycleNode
 public:
   /**
    * @brief A constructor for nav2_bt_navigator::BtNavigator class
+   * @param options Additional options to control creation of the node.
    */
-  BtNavigator();
+  BtNavigator(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /**
    * @brief A destructor for nav2_bt_navigator::BtNavigator class
    */

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -28,8 +28,8 @@
 namespace nav2_bt_navigator
 {
 
-BtNavigator::BtNavigator()
-: nav2_util::LifecycleNode("bt_navigator", "", false)
+BtNavigator::BtNavigator(const rclcpp::NodeOptions & options)
+: nav2_util::LifecycleNode("bt_navigator", "", false, options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 

--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -54,7 +54,7 @@ public:
    * @brief Constructor for nav2_controller::ControllerServer
    * @param options Additional options to control creation of the node.
    */
-  ControllerServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit ControllerServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /**
    * @brief Destructor for nav2_controller::ControllerServer
    */

--- a/nav2_controller/include/nav2_controller/nav2_controller.hpp
+++ b/nav2_controller/include/nav2_controller/nav2_controller.hpp
@@ -52,8 +52,9 @@ public:
 
   /**
    * @brief Constructor for nav2_controller::ControllerServer
+   * @param options Additional options to control creation of the node.
    */
-  ControllerServer();
+  ControllerServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /**
    * @brief Destructor for nav2_controller::ControllerServer
    */

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -31,8 +31,8 @@ using namespace std::chrono_literals;
 namespace nav2_controller
 {
 
-ControllerServer::ControllerServer()
-: nav2_util::LifecycleNode("controller_server", ""),
+ControllerServer::ControllerServer(const rclcpp::NodeOptions & options)
+: nav2_util::LifecycleNode("controller_server", "", false, options),
   progress_checker_loader_("nav2_core", "nav2_core::ProgressChecker"),
   default_progress_checker_id_{"progress_checker"},
   default_progress_checker_type_{"nav2_controller::SimpleProgressChecker"},

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -47,7 +47,7 @@ public:
    * @brief A constructor for nav2_lifecycle_manager::LifecycleManager
    * @param options Additional options to control creation of the node.
    */
-  LifecycleManager(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit LifecycleManager(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /**
    * @brief A destructor for nav2_lifecycle_manager::LifecycleManager
    */

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -45,8 +45,9 @@ class LifecycleManager : public rclcpp::Node
 public:
   /**
    * @brief A constructor for nav2_lifecycle_manager::LifecycleManager
+   * @param options Additional options to control creation of the node.
    */
-  LifecycleManager();
+  LifecycleManager(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /**
    * @brief A destructor for nav2_lifecycle_manager::LifecycleManager
    */

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -31,8 +31,8 @@ using nav2_util::LifecycleServiceClient;
 namespace nav2_lifecycle_manager
 {
 
-LifecycleManager::LifecycleManager()
-: Node("lifecycle_manager")
+LifecycleManager::LifecycleManager(const rclcpp::NodeOptions & options)
+: Node("lifecycle_manager", options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 

--- a/nav2_map_server/include/nav2_map_server/map_saver.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_saver.hpp
@@ -39,7 +39,7 @@ public:
    * @brief Constructor for the nav2_map_server::MapSaver
    * @param options Additional options to control creation of the node.
    */
-  MapSaver(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit MapSaver(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   /**
    * @brief Destructor for the nav2_map_server::MapServer

--- a/nav2_map_server/include/nav2_map_server/map_saver.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_saver.hpp
@@ -37,8 +37,9 @@ class MapSaver : public nav2_util::LifecycleNode
 public:
   /**
    * @brief Constructor for the nav2_map_server::MapSaver
+   * @param options Additional options to control creation of the node.
    */
-  MapSaver();
+  MapSaver(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   /**
    * @brief Destructor for the nav2_map_server::MapServer

--- a/nav2_map_server/include/nav2_map_server/map_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_server.hpp
@@ -40,7 +40,7 @@ public:
    * @brief A constructor for nav2_map_server::MapServer
    * @param options Additional options to control creation of the node.
    */
-  MapServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit MapServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   /**
    * @brief A Destructor for nav2_map_server::MapServer

--- a/nav2_map_server/include/nav2_map_server/map_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_server.hpp
@@ -38,8 +38,9 @@ class MapServer : public nav2_util::LifecycleNode
 public:
   /**
    * @brief A constructor for nav2_map_server::MapServer
+   * @param options Additional options to control creation of the node.
    */
-  MapServer();
+  MapServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   /**
    * @brief A Destructor for nav2_map_server::MapServer

--- a/nav2_map_server/src/map_saver/map_saver.cpp
+++ b/nav2_map_server/src/map_saver/map_saver.cpp
@@ -41,8 +41,8 @@ using namespace std::placeholders;
 
 namespace nav2_map_server
 {
-MapSaver::MapSaver()
-: nav2_util::LifecycleNode("map_saver", "")
+MapSaver::MapSaver(const rclcpp::NodeOptions & options)
+: nav2_util::LifecycleNode("map_saver", "", false, options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 

--- a/nav2_map_server/src/map_server/map_server.cpp
+++ b/nav2_map_server/src/map_server/map_server.cpp
@@ -62,8 +62,8 @@ using namespace std::placeholders;
 namespace nav2_map_server
 {
 
-MapServer::MapServer()
-: nav2_util::LifecycleNode("map_server")
+MapServer::MapServer(const rclcpp::NodeOptions & options)
+: nav2_util::LifecycleNode("map_server", "", false, options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 

--- a/nav2_planner/include/nav2_planner/planner_server.hpp
+++ b/nav2_planner/include/nav2_planner/planner_server.hpp
@@ -50,8 +50,9 @@ class PlannerServer : public nav2_util::LifecycleNode
 public:
   /**
    * @brief A constructor for nav2_planner::PlannerServer
+   * @param options Additional options to control creation of the node.
    */
-  PlannerServer();
+  PlannerServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /**
    * @brief A destructor for nav2_planner::PlannerServer
    */

--- a/nav2_planner/include/nav2_planner/planner_server.hpp
+++ b/nav2_planner/include/nav2_planner/planner_server.hpp
@@ -52,7 +52,7 @@ public:
    * @brief A constructor for nav2_planner::PlannerServer
    * @param options Additional options to control creation of the node.
    */
-  PlannerServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit PlannerServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /**
    * @brief A destructor for nav2_planner::PlannerServer
    */

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -36,8 +36,8 @@ using namespace std::chrono_literals;
 namespace nav2_planner
 {
 
-PlannerServer::PlannerServer()
-: nav2_util::LifecycleNode("nav2_planner", ""),
+PlannerServer::PlannerServer(const rclcpp::NodeOptions & options)
+: nav2_util::LifecycleNode("nav2_planner", "", false, options),
   gp_loader_("nav2_core", "nav2_core::GlobalPlanner"),
   default_ids_{"GridBased"},
   default_types_{"nav2_navfn_planner/NavfnPlanner"},

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -37,7 +37,7 @@ namespace nav2_planner
 {
 
 PlannerServer::PlannerServer(const rclcpp::NodeOptions & options)
-: nav2_util::LifecycleNode("nav2_planner", "", false, options),
+: nav2_util::LifecycleNode("planner_server", "", false, options),
   gp_loader_("nav2_core", "nav2_core::GlobalPlanner"),
   default_ids_{"GridBased"},
   default_types_{"nav2_navfn_planner/NavfnPlanner"},

--- a/nav2_recoveries/include/nav2_recoveries/recovery_server.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery_server.hpp
@@ -40,8 +40,9 @@ class RecoveryServer : public nav2_util::LifecycleNode
 public:
   /**
    * @brief A constructor for recovery_server::RecoveryServer
+   * @param options Additional options to control creation of the node.
    */
-  RecoveryServer();
+  RecoveryServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   ~RecoveryServer();
 
   /**

--- a/nav2_recoveries/include/nav2_recoveries/recovery_server.hpp
+++ b/nav2_recoveries/include/nav2_recoveries/recovery_server.hpp
@@ -42,7 +42,7 @@ public:
    * @brief A constructor for recovery_server::RecoveryServer
    * @param options Additional options to control creation of the node.
    */
-  RecoveryServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit RecoveryServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   ~RecoveryServer();
 
   /**

--- a/nav2_recoveries/src/recovery_server.cpp
+++ b/nav2_recoveries/src/recovery_server.cpp
@@ -22,8 +22,8 @@
 namespace recovery_server
 {
 
-RecoveryServer::RecoveryServer()
-: LifecycleNode("recoveries_server", "", true),
+RecoveryServer::RecoveryServer(const rclcpp::NodeOptions & options)
+: LifecycleNode("recoveries_server", "", false, options),
   plugin_loader_("nav2_core", "nav2_core::Recovery"),
   default_ids_{"spin", "backup", "wait"},
   default_types_{"nav2_recoveries/Spin", "nav2_recoveries/BackUp", "nav2_recoveries/Wait"}

--- a/nav2_waypoint_follower/include/nav2_waypoint_follower/waypoint_follower.hpp
+++ b/nav2_waypoint_follower/include/nav2_waypoint_follower/waypoint_follower.hpp
@@ -59,7 +59,7 @@ public:
    * @brief A constructor for nav2_waypoint_follower::WaypointFollower class
    * @param options Additional options to control creation of the node.
    */
-  WaypointFollower(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit WaypointFollower(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /**
    * @brief A destructor for nav2_waypoint_follower::WaypointFollower class
    */

--- a/nav2_waypoint_follower/include/nav2_waypoint_follower/waypoint_follower.hpp
+++ b/nav2_waypoint_follower/include/nav2_waypoint_follower/waypoint_follower.hpp
@@ -57,8 +57,9 @@ public:
 
   /**
    * @brief A constructor for nav2_waypoint_follower::WaypointFollower class
+   * @param options Additional options to control creation of the node.
    */
-  WaypointFollower();
+  WaypointFollower(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   /**
    * @brief A destructor for nav2_waypoint_follower::WaypointFollower class
    */

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -25,7 +25,7 @@ namespace nav2_waypoint_follower
 {
 
 WaypointFollower::WaypointFollower(const rclcpp::NodeOptions & options)
-: nav2_util::LifecycleNode("WaypointFollower", "", false, options),
+: nav2_util::LifecycleNode("waypoint_follower", "", false, options),
   waypoint_task_executor_loader_("nav2_waypoint_follower",
     "nav2_core::WaypointTaskExecutor")
 {

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -24,8 +24,8 @@
 namespace nav2_waypoint_follower
 {
 
-WaypointFollower::WaypointFollower()
-: nav2_util::LifecycleNode("WaypointFollower", "", false),
+WaypointFollower::WaypointFollower(const rclcpp::NodeOptions & options)
+: nav2_util::LifecycleNode("WaypointFollower", "", false, options),
   waypoint_task_executor_loader_("nav2_waypoint_follower",
     "nav2_core::WaypointTaskExecutor")
 {


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2147 |
| Primary OS tested on | - |
| Robotic platform tested on | - |

---

## Description of contribution in a few bullet points

add argument `rclcpp::NodeOptions` for Nav2 Nodes, so that we can configure Node in `main()`.
* for example, use `rclcpp::NodeOptions().use_intra_process_comms(true)` for intra-process communication in `nav2_composition`

---


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
