### PR TITLE
fix possible use-after-free: unsafe shared_ptr in multithread

### DIFF
--- a/nav2_costmap_2d/src/costmap_subscriber.cpp
+++ b/nav2_costmap_2d/src/costmap_subscriber.cpp
@@ -55,30 +55,33 @@ std::shared_ptr<Costmap2D> CostmapSubscriber::getCostmap()
 
 void CostmapSubscriber::toCostmap2D()
 {
+
+  auto current_costmap_msg = std::atomic_load(&costmap_msg_);
+
   if (costmap_ == nullptr) {
     costmap_ = std::make_shared<Costmap2D>(
-      costmap_msg_->metadata.size_x, costmap_msg_->metadata.size_y,
-      costmap_msg_->metadata.resolution, costmap_msg_->metadata.origin.position.x,
-      costmap_msg_->metadata.origin.position.y);
-  } else if (costmap_->getSizeInCellsX() != costmap_msg_->metadata.size_x ||  // NOLINT
-    costmap_->getSizeInCellsY() != costmap_msg_->metadata.size_y ||
-    costmap_->getResolution() != costmap_msg_->metadata.resolution ||
-    costmap_->getOriginX() != costmap_msg_->metadata.origin.position.x ||
-    costmap_->getOriginY() != costmap_msg_->metadata.origin.position.y)
+      current_costmap_msg->metadata.size_x, current_costmap_msg->metadata.size_y,
+      current_costmap_msg->metadata.resolution, current_costmap_msg->metadata.origin.position.x,
+      current_costmap_msg->metadata.origin.position.y);
+  } else if (costmap_->getSizeInCellsX() != current_costmap_msg->metadata.size_x ||  // NOLINT
+    costmap_->getSizeInCellsY() != current_costmap_msg->metadata.size_y ||
+    costmap_->getResolution() != current_costmap_msg->metadata.resolution ||
+    costmap_->getOriginX() != current_costmap_msg->metadata.origin.position.x ||
+    costmap_->getOriginY() != current_costmap_msg->metadata.origin.position.y)
   {
     // Update the size of the costmap
     costmap_->resizeMap(
-      costmap_msg_->metadata.size_x, costmap_msg_->metadata.size_y,
-      costmap_msg_->metadata.resolution,
-      costmap_msg_->metadata.origin.position.x,
-      costmap_msg_->metadata.origin.position.y);
+      current_costmap_msg->metadata.size_x, current_costmap_msg->metadata.size_y,
+      current_costmap_msg->metadata.resolution,
+      current_costmap_msg->metadata.origin.position.x,
+      current_costmap_msg->metadata.origin.position.y);
   }
 
   unsigned char * master_array = costmap_->getCharMap();
   unsigned int index = 0;
-  for (unsigned int i = 0; i < costmap_msg_->metadata.size_x; ++i) {
-    for (unsigned int j = 0; j < costmap_msg_->metadata.size_y; ++j) {
-      master_array[index] = costmap_msg_->data[index];
+  for (unsigned int i = 0; i < current_costmap_msg->metadata.size_x; ++i) {
+    for (unsigned int j = 0; j < current_costmap_msg->metadata.size_y; ++j) {
+      master_array[index] = current_costmap_msg->data[index];
       ++index;
     }
   }
@@ -86,7 +89,7 @@ void CostmapSubscriber::toCostmap2D()
 
 void CostmapSubscriber::costmapCallback(const nav2_msgs::msg::Costmap::SharedPtr msg)
 {
-  costmap_msg_ = msg;
+  std::atomic_store(&costmap_msg_, msg);
   if (!costmap_received_) {
     costmap_received_ = true;
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2529 , #2510   |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | gazebo simulation of turtlebot3 |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
fix potential use-after-free bug. The cause is much the same as #2510.

## Description of documentation updates required from your changes

std::atomic_load() and std::atomic_store() require C++11.
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
