### PR TITLE
Change default timeout of BT navigator

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -133,7 +133,7 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   // Put items on the blackboard
   blackboard_->set<rclcpp::Node::SharedPtr>("node", client_node_);  // NOLINT
   blackboard_->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", tf_);  // NOLINT
-  blackboard_->set<std::chrono::milliseconds>("server_timeout", std::chrono::milliseconds(10));  // NOLINT
+  blackboard_->set<std::chrono::milliseconds>("server_timeout", std::chrono::milliseconds(500));  // NOLINT
   blackboard_->set<bool>("path_updated", false);  // NOLINT
   blackboard_->set<bool>("initial_pose_received", false);  // NOLINT
   blackboard_->set<int>("number_recoveries", 0);  // NOLINT


### PR DESCRIPTION
Changed the default timeout of BT navigator. The previous timeout of 10ms caused ROS to crash if there was some latency in the network - for example when setting a new goal, as seen in https://github.com/ros2/ros2/issues/1074.
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (https://github.com/ros2/ros2/issues/1074) |
| Primary OS tested on | (Ubuntu 20.04 Foxy) |
| Robotic platform tested on | (Custom robot) |

---

## Description of contribution in a few bullet points
Change default timeout of BT navigator
Timeout was 10ms. This was causing a crash if there was a tiny bit of latency in the network, or the CPU was overloaded by other tasks. Changed to 500ms to prevent crashing the whole robot.

## Description of documentation updates required from your changes

Might want to update the documentation to describe the parameter, and it's effect on the navigator.

---

## Future work that may be required in bullet points

None, as far as I can see

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
