### PR TITLE
navigation: Modify BackUp behavior to respect a demanded 'backup_dura…

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
@@ -54,7 +54,8 @@ public:
     return providedBasicPorts(
       {
         BT::InputPort<double>("backup_dist", 0.15, "Distance to backup"),
-        BT::InputPort<double>("backup_speed", 0.025, "Speed at which to backup")
+        BT::InputPort<double>("backup_speed", 0.025, "Speed at which to backup"),
+        BT::InputPort<double>("time_allowance", 10.0, "Allowed time for reversing")
       });
   }
 };

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -10,6 +10,7 @@
     <Action ID="BackUp">
       <input_port name="backup_dist">Distance to backup</input_port>
       <input_port name="backup_speed">Speed at which to backup</input_port>
+      <input_port name="time_allowance">Allowed time for reversing</input_port>
     </Action>
 
     <Action ID="ClearEntireCostmap">

--- a/nav2_behavior_tree/plugins/action/back_up_action.cpp
+++ b/nav2_behavior_tree/plugins/action/back_up_action.cpp
@@ -30,12 +30,15 @@ BackUpAction::BackUpAction(
   getInput("backup_dist", dist);
   double speed;
   getInput("backup_speed", speed);
+  double time_allowance;
+  getInput("time_allowance", time_allowance);
 
   // Populate the input message
   goal_.target.x = dist;
   goal_.target.y = 0.0;
   goal_.target.z = 0.0;
   goal_.speed = speed;
+  goal_.time_allowance = rclcpp::Duration::from_seconds(time_allowance);
 }
 
 void BackUpAction::on_tick()

--- a/nav2_bt_navigator/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml
@@ -36,7 +36,7 @@
           </Sequence>
           <Spin spin_dist="1.57"/>
           <Wait wait_duration="5"/>
-          <BackUp backup_dist="0.15" backup_speed="0.025"/>
+          <BackUp backup_dist="0.15" backup_speed="0.025" time_allowance="10.0"/>
         </RoundRobin>
       </ReactiveFallback>
     </RecoveryNode>

--- a/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml
@@ -34,7 +34,7 @@
           </Sequence>
           <Spin spin_dist="1.57"/>
           <Wait wait_duration="5"/>
-          <BackUp backup_dist="0.15" backup_speed="0.025"/>
+          <BackUp backup_dist="0.15" backup_speed="0.025" time_allowance="10.0"/>
         </RoundRobin>
       </ReactiveFallback>
     </RecoveryNode>

--- a/nav2_msgs/action/BackUp.action
+++ b/nav2_msgs/action/BackUp.action
@@ -1,8 +1,10 @@
 #goal definition
 geometry_msgs/Point target
 float32 speed
+builtin_interfaces/Duration time_allowance
 ---
 #result definition
 builtin_interfaces/Duration total_elapsed_time
 ---
 float32 distance_traveled
+builtin_interfaces/Duration time_left

--- a/nav2_recoveries/plugins/back_up.hpp
+++ b/nav2_recoveries/plugins/back_up.hpp
@@ -76,7 +76,9 @@ protected:
   geometry_msgs::msg::PoseStamped initial_pose_;
   double command_x_;
   double command_speed_;
+  rclcpp::Duration command_time_allowance_{0,0};
   double simulate_ahead_time_;
+  std::chrono::time_point<std::chrono::steady_clock> back_up_time_end_;
 
   BackUpAction::Feedback::SharedPtr feedback_;
 };


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/2453 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | custom differential drive robot |

---

## Description of contribution in a few bullet points

* The BackUp movement will be terminated as soon as the elapsed time exceeds the `time_allowance`, defined in the `time_allowance` input port of the `BackUp` behavior tree node.
* During the `onRun` call the `back_up_time_end_` time is calculated by adding the `time_allowance` to the current time
* If the `rem_time` (difference between `time_allowance` and the current time) becomes smaller or equal to zero during the cycle updates, the robot will be stopped and the `BackUp` behavior will be exited with `FAILURE`
* If the time_allowance is smaller than zero, this restriction will be ignored and the BackUp movement will continue until the robot reaches the desired goal position
* This commit changes all of the `BackUp` behavior tree node instances in the BT example xml's to make use of the newly added feature

## Description of documentation updates required from your changes

* Update [BackUp Doc](https://github.com/ros-planning/navigation.ros.org/blob/48b9615821bad5b2ffec3a507b0e43a8c92ffe14/configuration/packages/bt-plugins/actions/BackUp.rst)
* Update [nav_to_pose example](https://github.com/ros-planning/navigation.ros.org/blob/48b9615821bad5b2ffec3a507b0e43a8c92ffe14/behavior_trees/trees/nav_to_pose_recovery.rst)
* Update [nav_through_poses example](https://github.com/ros-planning/navigation.ros.org/blob/48b9615821bad5b2ffec3a507b0e43a8c92ffe14/behavior_trees/trees/nav_through_poses_recovery.rst)

---

## Future work that may be required in bullet points

* Make sure that the newly added feature is included in the test procedure
* Set the default value of the `time_allowance` to a negative value, preventing unintended behavior changes ??? (or select a more appropriate default value)

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists