### PR TITLE
Enabled runtime configuration of parameters for Hybrid A*

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
@@ -89,7 +89,7 @@ public:
 
 protected:
   /**
-   * @brief Callback executed when a paramter change is detected
+   * @brief Callback executed when a parameter change is detected
    * @param event ParameterEvent message
    */
   void on_parameter_event_callback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_hybrid.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_hybrid.hpp
@@ -107,7 +107,7 @@ protected:
   bool _downsample_costmap;
   int _downsampling_factor;
   double _angle_bin_size;
-  int _angle_quantizations;
+  unsigned int _angle_quantizations;
   bool _allow_unknown;
   int _max_iterations;
   SearchInfo _search_info;

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_hybrid.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_hybrid.hpp
@@ -87,21 +87,41 @@ public:
     const geometry_msgs::msg::PoseStamped & goal) override;
 
 protected:
+  /**
+   * @brief Callback executed when a parameter change is detected
+   * @param event ParameterEvent message
+   */
+  void on_parameter_event_callback(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
+
   std::unique_ptr<AStarAlgorithm<NodeHybrid>> _a_star;
   GridCollisionChecker _collision_checker;
   std::unique_ptr<Smoother> _smoother;
   rclcpp::Clock::SharedPtr _clock;
   rclcpp::Logger _logger{rclcpp::get_logger("SmacPlannerHybrid")};
   nav2_costmap_2d::Costmap2D * _costmap;
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> _costmap_ros;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
   std::string _global_frame, _name;
+  float _lookup_table_dim;
   float _tolerance;
-  int _downsampling_factor;
-  unsigned int _angle_quantizations;
-  double _angle_bin_size;
   bool _downsample_costmap;
-  rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _raw_plan_publisher;
+  int _downsampling_factor;
+  double _angle_bin_size;
+  int _angle_quantizations;
+  bool _allow_unknown;
+  int _max_iterations;
+  SearchInfo _search_info;
   double _max_planning_time;
+  double _lookup_table_size;
+  std::string _motion_model_for_search;
+  MotionModel _motion_model;
+  rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _raw_plan_publisher;
+  std::mutex _mutex;
+  rclcpp_lifecycle::LifecycleNode::WeakPtr _node;
+
+  // Subscription for parameter change
+  rclcpp::AsyncParametersClient::SharedPtr _parameters_client;
+  rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr _parameter_event_sub;
 };
 
 }  // namespace nav2_smac_planner

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -60,6 +60,8 @@ void SmacPlannerHybrid::configure(
   _name = name;
   _global_frame = costmap_ros->getGlobalFrameID();
 
+  int angle_quantizations;
+
   // General planner params
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".downsample_costmap", rclcpp::ParameterValue(false));
@@ -70,9 +72,9 @@ void SmacPlannerHybrid::configure(
 
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".angle_quantization_bins", rclcpp::ParameterValue(72));
-  node->get_parameter(name + ".angle_quantization_bins", _angle_quantizations);
-  _angle_bin_size = 2.0 * M_PI / _angle_quantizations;
-  _angle_quantizations = static_cast<unsigned int>(_angle_quantizations);
+  node->get_parameter(name + ".angle_quantization_bins", angle_quantizations);
+  _angle_bin_size = 2.0 * M_PI / angle_quantizations;
+  _angle_quantizations = static_cast<unsigned int>(angle_quantizations);
 
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".allow_unknown", rclcpp::ParameterValue(true));
@@ -417,9 +419,9 @@ void SmacPlannerHybrid::on_parameter_event_callback(
       } else if (name == _name + ".angle_quantization_bins") {
         reinit_collision_checker = true;
         reinit_a_star = true;
-        _angle_quantizations = value.integer_value;
-        _angle_bin_size = 2.0 * M_PI / _angle_quantizations;
-        _angle_quantizations = static_cast<unsigned int>(_angle_quantizations);
+        int angle_quantizations = value.integer_value;
+        _angle_bin_size = 2.0 * M_PI / angle_quantizations;
+        _angle_quantizations = static_cast<unsigned int>(angle_quantizations);
       }
     } else if (type == ParameterType::PARAMETER_STRING) {
       if (name == _name + ".motion_model_for_search") {

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -414,14 +414,13 @@ void SmacPlannerHybrid::on_parameter_event_callback(
             "disabling maximum iterations.");
           _max_iterations = std::numeric_limits<int>::max();
         }
-      } else if (name == _name + ".angle_quantizations_bins") {
+      } else if (name == _name + ".angle_quantization_bins") {
         reinit_collision_checker = true;
         reinit_a_star = true;
         _angle_quantizations = value.integer_value;
         _angle_bin_size = 2.0 * M_PI / _angle_quantizations;
         _angle_quantizations = static_cast<unsigned int>(_angle_quantizations);
       }
-
     } else if (type == ParameterType::PARAMETER_STRING) {
       if (name == _name + ".motion_model_for_search") {
         reinit_a_star = true;

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -27,6 +27,8 @@ namespace nav2_smac_planner
 {
 
 using namespace std::chrono;  // NOLINT
+using rcl_interfaces::msg::ParameterType;
+using std::placeholders::_1;
 
 SmacPlannerHybrid::SmacPlannerHybrid()
 : _a_star(nullptr),
@@ -49,19 +51,14 @@ void SmacPlannerHybrid::configure(
   std::string name, std::shared_ptr<tf2_ros::Buffer>/*tf*/,
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros)
 {
+  _node = parent;
   auto node = parent.lock();
   _logger = node->get_logger();
   _clock = node->get_clock();
   _costmap = costmap_ros->getCostmap();
+  _costmap_ros = costmap_ros;
   _name = name;
   _global_frame = costmap_ros->getGlobalFrameID();
-
-  bool allow_unknown;
-  int max_iterations;
-  int angle_quantizations;
-  double lookup_table_size;
-  SearchInfo search_info;
-  std::string motion_model_for_search;
 
   // General planner params
   nav2_util::declare_parameter_if_not_declared(
@@ -73,99 +70,99 @@ void SmacPlannerHybrid::configure(
 
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".angle_quantization_bins", rclcpp::ParameterValue(72));
-  node->get_parameter(name + ".angle_quantization_bins", angle_quantizations);
-  _angle_bin_size = 2.0 * M_PI / angle_quantizations;
-  _angle_quantizations = static_cast<unsigned int>(angle_quantizations);
+  node->get_parameter(name + ".angle_quantization_bins", _angle_quantizations);
+  _angle_bin_size = 2.0 * M_PI / _angle_quantizations;
+  _angle_quantizations = static_cast<unsigned int>(_angle_quantizations);
 
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".allow_unknown", rclcpp::ParameterValue(true));
-  node->get_parameter(name + ".allow_unknown", allow_unknown);
+  node->get_parameter(name + ".allow_unknown", _allow_unknown);
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".max_iterations", rclcpp::ParameterValue(1000000));
-  node->get_parameter(name + ".max_iterations", max_iterations);
+  node->get_parameter(name + ".max_iterations", _max_iterations);
 
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".minimum_turning_radius", rclcpp::ParameterValue(0.4));
-  node->get_parameter(name + ".minimum_turning_radius", search_info.minimum_turning_radius);
+  node->get_parameter(name + ".minimum_turning_radius", _search_info.minimum_turning_radius);
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".cache_obstacle_heuristic", rclcpp::ParameterValue(false));
-  node->get_parameter(name + ".cache_obstacle_heuristic", search_info.cache_obstacle_heuristic);
+  node->get_parameter(name + ".cache_obstacle_heuristic", _search_info.cache_obstacle_heuristic);
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".reverse_penalty", rclcpp::ParameterValue(2.0));
-  node->get_parameter(name + ".reverse_penalty", search_info.reverse_penalty);
+  node->get_parameter(name + ".reverse_penalty", _search_info.reverse_penalty);
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".change_penalty", rclcpp::ParameterValue(0.15));
-  node->get_parameter(name + ".change_penalty", search_info.change_penalty);
+  node->get_parameter(name + ".change_penalty", _search_info.change_penalty);
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".non_straight_penalty", rclcpp::ParameterValue(1.50));
-  node->get_parameter(name + ".non_straight_penalty", search_info.non_straight_penalty);
+  node->get_parameter(name + ".non_straight_penalty", _search_info.non_straight_penalty);
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".cost_penalty", rclcpp::ParameterValue(1.7));
-  node->get_parameter(name + ".cost_penalty", search_info.cost_penalty);
+  node->get_parameter(name + ".cost_penalty", _search_info.cost_penalty);
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".analytic_expansion_ratio", rclcpp::ParameterValue(3.5));
-  node->get_parameter(name + ".analytic_expansion_ratio", search_info.analytic_expansion_ratio);
+  node->get_parameter(name + ".analytic_expansion_ratio", _search_info.analytic_expansion_ratio);
 
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".max_planning_time", rclcpp::ParameterValue(5.0));
   node->get_parameter(name + ".max_planning_time", _max_planning_time);
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".lookup_table_size", rclcpp::ParameterValue(20.0));
-  node->get_parameter(name + ".lookup_table_size", lookup_table_size);
+  node->get_parameter(name + ".lookup_table_size", _lookup_table_size);
 
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".motion_model_for_search", rclcpp::ParameterValue(std::string("DUBIN")));
-  node->get_parameter(name + ".motion_model_for_search", motion_model_for_search);
-  MotionModel motion_model = fromString(motion_model_for_search);
-  if (motion_model == MotionModel::UNKNOWN) {
+  node->get_parameter(name + ".motion_model_for_search", _motion_model_for_search);
+  _motion_model = fromString(_motion_model_for_search);
+  if (_motion_model == MotionModel::UNKNOWN) {
     RCLCPP_WARN(
       _logger,
       "Unable to get MotionModel search type. Given '%s', "
       "valid options are MOORE, VON_NEUMANN, DUBIN, REEDS_SHEPP, STATE_LATTICE.",
-      motion_model_for_search.c_str());
+      _motion_model_for_search.c_str());
   }
 
-  if (max_iterations <= 0) {
+  if (_max_iterations <= 0) {
     RCLCPP_INFO(
       _logger, "maximum iteration selected as <= 0, "
       "disabling maximum iterations.");
-    max_iterations = std::numeric_limits<int>::max();
+    _max_iterations = std::numeric_limits<int>::max();
   }
 
   // convert to grid coordinates
-  const double minimum_turning_radius_global_coords = search_info.minimum_turning_radius;
-  search_info.minimum_turning_radius =
-    search_info.minimum_turning_radius / (_costmap->getResolution() * _downsampling_factor);
-  float lookup_table_dim =
-    static_cast<float>(lookup_table_size) /
+  const double minimum_turning_radius_global_coords = _search_info.minimum_turning_radius;
+  _search_info.minimum_turning_radius =
+    _search_info.minimum_turning_radius / (_costmap->getResolution() * _downsampling_factor);
+  _lookup_table_dim =
+    static_cast<float>(_lookup_table_size) /
     static_cast<float>(_costmap->getResolution() * _downsampling_factor);
 
   // Make sure its a whole number
-  lookup_table_dim = static_cast<float>(static_cast<int>(lookup_table_dim));
+  _lookup_table_dim = static_cast<float>(static_cast<int>(_lookup_table_dim));
 
   // Make sure its an odd number
-  if (static_cast<int>(lookup_table_dim) % 2 == 0) {
+  if (static_cast<int>(_lookup_table_dim) % 2 == 0) {
     RCLCPP_INFO(
       _logger,
       "Even sized heuristic lookup table size set %f, increasing size by 1 to make odd",
-      lookup_table_dim);
-    lookup_table_dim += 1.0;
+      _lookup_table_dim);
+    _lookup_table_dim += 1.0;
   }
 
   // Initialize collision checker
   _collision_checker = GridCollisionChecker(_costmap, _angle_quantizations);
   _collision_checker.setFootprint(
-    costmap_ros->getRobotFootprint(),
-    costmap_ros->getUseRadius(),
-    findCircumscribedCost(costmap_ros));
+    _costmap_ros->getRobotFootprint(),
+    _costmap_ros->getUseRadius(),
+    findCircumscribedCost(_costmap_ros));
 
   // Initialize A* template
-  _a_star = std::make_unique<AStarAlgorithm<NodeHybrid>>(motion_model, search_info);
+  _a_star = std::make_unique<AStarAlgorithm<NodeHybrid>>(_motion_model, _search_info);
   _a_star->initialize(
-    allow_unknown,
-    max_iterations,
+    _allow_unknown,
+    _max_iterations,
     std::numeric_limits<int>::max(),
-    lookup_table_dim,
+    _lookup_table_dim,
     _angle_quantizations);
 
   // Initialize path smoother
@@ -176,20 +173,30 @@ void SmacPlannerHybrid::configure(
 
   // Initialize costmap downsampler
   if (_downsample_costmap && _downsampling_factor > 1) {
-    std::string topic_name = "downsampled_costmap";
     _costmap_downsampler = std::make_unique<CostmapDownsampler>();
+    std::string topic_name = "downsampled_costmap";
     _costmap_downsampler->on_configure(
       node, _global_frame, topic_name, _costmap, _downsampling_factor);
   }
 
   _raw_plan_publisher = node->create_publisher<nav_msgs::msg::Path>("unsmoothed_plan", 1);
 
+  // Setup callback for changes to parameters.
+  _parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(
+    node->get_node_base_interface(),
+    node->get_node_topics_interface(),
+    node->get_node_graph_interface(),
+    node->get_node_services_interface());
+
+  _parameter_event_sub = _parameters_client->on_parameter_event(
+    std::bind(&SmacPlannerHybrid::on_parameter_event_callback, this, _1));
+
   RCLCPP_INFO(
     _logger, "Configured plugin %s of type SmacPlannerHybrid with "
     "maximum iterations %i, and %s. Using motion model: %s.",
-    _name.c_str(), max_iterations,
-    allow_unknown ? "allowing unknown traversal" : "not allowing unknown traversal",
-    toString(motion_model).c_str());
+    _name.c_str(), _max_iterations,
+    _allow_unknown ? "allowing unknown traversal" : "not allowing unknown traversal",
+    toString(_motion_model).c_str());
 }
 
 void SmacPlannerHybrid::activate()
@@ -232,6 +239,7 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
   const geometry_msgs::msg::PoseStamped & start,
   const geometry_msgs::msg::PoseStamped & goal)
 {
+  std::lock_guard<std::mutex> lock_reinit(_mutex);
   steady_clock::time_point a = steady_clock::now();
 
   std::unique_lock<nav2_costmap_2d::Costmap2D::mutex_t> lock(*(_costmap->getMutex()));
@@ -338,6 +346,159 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
 #endif
 
   return plan;
+}
+
+void SmacPlannerHybrid::on_parameter_event_callback(
+  const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
+{
+  std::lock_guard<std::mutex> lock_reinit(_mutex);
+
+  bool reinit_collision_checker = false;
+  bool reinit_a_star = false;
+  bool reinit_downsampler = false;
+  bool reinit_smoother = false;
+
+  for (auto & changed_parameter : event->changed_parameters) {
+    const auto & type = changed_parameter.value.type;
+    const auto & name = changed_parameter.name;
+    const auto & value = changed_parameter.value;
+
+    if (type == ParameterType::PARAMETER_DOUBLE) {
+      if (name == _name + ".max_planning_time") {
+        _max_planning_time = value.double_value;
+      } else if (name == _name + ".lookup_table_size") {
+        reinit_a_star = true;
+        _lookup_table_size = value.double_value;
+      } else if (name == _name + ".minimum_turning_radius") {
+        reinit_a_star = true;
+        reinit_smoother = true;
+        _search_info.minimum_turning_radius = static_cast<float>(value.double_value);
+      } else if (name == _name + ".reverse_penalty") {
+        reinit_a_star = true;
+        _search_info.reverse_penalty = static_cast<float>(value.double_value);
+      } else if (name == _name + ".change_penalty") {
+        reinit_a_star = true;
+        _search_info.change_penalty = static_cast<float>(value.double_value);
+      } else if (name == _name + ".non_straight_penalty") {
+        reinit_a_star = true;
+        _search_info.non_straight_penalty = static_cast<float>(value.double_value);
+      } else if (name == _name + ".cost_penalty") {
+        reinit_a_star = true;
+        _search_info.cost_penalty = static_cast<float>(value.double_value);
+      } else if (name == _name + ".analytic_expansion_ratio") {
+        reinit_a_star = true;
+        _search_info.analytic_expansion_ratio = static_cast<float>(value.double_value);
+      }
+    } else if (type == ParameterType::PARAMETER_BOOL) {
+      if (name == _name + ".downsample_costmap") {
+        reinit_downsampler = true;
+        _downsample_costmap = value.bool_value;
+      } else if (name == _name + ".allow_unknown") {
+        reinit_a_star = true;
+        _allow_unknown = value.bool_value;
+      } else if (name == _name + ".cache_obstacle_heuristic") {
+        reinit_a_star = true;
+        _search_info.cache_obstacle_heuristic = value.bool_value;
+      }
+    } else if (type == ParameterType::PARAMETER_INTEGER) {
+      if (name == _name + ".downsampling_factor") {
+        reinit_a_star = true;
+        reinit_downsampler = true;
+        _downsampling_factor = value.integer_value;
+      } else if (name == _name + ".max_iterations") {
+        reinit_a_star = true;
+        _max_iterations = value.integer_value;
+        if (_max_iterations <= 0) {
+          RCLCPP_INFO(
+            _logger, "maximum iteration selected as <= 0, "
+            "disabling maximum iterations.");
+          _max_iterations = std::numeric_limits<int>::max();
+        }
+      } else if (name == _name + ".angle_quantizations_bins") {
+        reinit_collision_checker = true;
+        reinit_a_star = true;
+        _angle_quantizations = value.integer_value;
+        _angle_bin_size = 2.0 * M_PI / _angle_quantizations;
+        _angle_quantizations = static_cast<unsigned int>(_angle_quantizations);
+      }
+
+    } else if (type == ParameterType::PARAMETER_STRING) {
+      if (name == _name + ".motion_model_for_search") {
+        reinit_a_star = true;
+        _motion_model = fromString(value.string_value);
+        if (_motion_model == MotionModel::UNKNOWN) {
+          RCLCPP_WARN(
+            _logger,
+            "Unable to get MotionModel search type. Given '%s', "
+            "valid options are MOORE, VON_NEUMANN, DUBIN, REEDS_SHEPP.",
+            _motion_model_for_search.c_str());
+        }
+      }
+    }
+  }
+
+  // Re-init if needed with mutex lock (to avoid re-init while creating a plan)
+  if (reinit_a_star || reinit_downsampler || reinit_collision_checker || reinit_smoother) {
+    // convert to grid coordinates
+    const double minimum_turning_radius_global_coords = _search_info.minimum_turning_radius;
+    _search_info.minimum_turning_radius =
+      _search_info.minimum_turning_radius / (_costmap->getResolution() * _downsampling_factor);
+    _lookup_table_dim =
+      static_cast<float>(_lookup_table_size) /
+      static_cast<float>(_costmap->getResolution() * _downsampling_factor);
+
+    // Make sure its a whole number
+    _lookup_table_dim = static_cast<float>(static_cast<int>(_lookup_table_dim));
+
+    // Make sure its an odd number
+    if (static_cast<int>(_lookup_table_dim) % 2 == 0) {
+      RCLCPP_INFO(
+        _logger,
+        "Even sized heuristic lookup table size set %f, increasing size by 1 to make odd",
+        _lookup_table_dim);
+      _lookup_table_dim += 1.0;
+    }
+
+    // Re-Initialize A* template
+    if (reinit_a_star) {
+      _a_star = std::make_unique<AStarAlgorithm<NodeHybrid>>(_motion_model, _search_info);
+      _a_star->initialize(
+        _allow_unknown,
+        _max_iterations,
+        std::numeric_limits<int>::max(),
+        _lookup_table_dim,
+        _angle_quantizations);
+    }
+
+    // Re-Initialize costmap downsampler
+    if (reinit_downsampler) {
+      if (_downsample_costmap && _downsampling_factor > 1) {
+        auto node = _node.lock();
+        std::string topic_name = "downsampled_costmap";
+        _costmap_downsampler = std::make_unique<CostmapDownsampler>();
+        _costmap_downsampler->on_configure(
+          node, _global_frame, topic_name, _costmap, _downsampling_factor);
+      }
+    }
+
+    // Re-Initialize collision checker
+    if (reinit_collision_checker) {
+      _collision_checker = GridCollisionChecker(_costmap, _angle_quantizations);
+      _collision_checker.setFootprint(
+        _costmap_ros->getRobotFootprint(),
+        _costmap_ros->getUseRadius(),
+        findCircumscribedCost(_costmap_ros));
+    }
+
+    // Re-Initialize smoother
+    if (reinit_smoother) {
+      auto node = _node.lock();
+      SmootherParams params;
+      params.get(node, _name);
+      _smoother = std::make_unique<Smoother>(params);
+      _smoother->initialize(minimum_turning_radius_global_coords);
+    }
+  }
 }
 
 }  // namespace nav2_smac_planner


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #956  |
| Primary OS tested on | Ubuntu 20.04|
| Robotic platform tested on | Personal Laptop |

---

## Description of contribution in a few bullet points
* Added runtime configuration for Hybrid A* planner parameters
---


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
