### PR TITLE
Fix deprecated type conversion (#2538)

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -118,7 +118,7 @@ public:
   {
     if (!request_sent_) {
       on_tick();
-      future_result_ = service_client_->async_send_request(request_);
+      future_result_ = service_client_->async_send_request(request_).share();
       sent_time_ = node_->now();
       request_sent_ = true;
     }


### PR DESCRIPTION
---
## Basic Info

| Info | Please fill out this column
| ----------- | ----------- |
| Ticket(s) this addresses   | #2538 |
| Primary OS tested on | Ubuntu 20.04 |

---

## Description of contribution in a few bullet points

Fix build failure (#2538) by replacing implicit deprecated type conversion from `rclcpp::Client::FutureAndRequestId` to `std::shared_future` with call to convenience method `FutureAndRequestId::share()`

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
