### PR TITLE
Use worldToMapEnforceBounds in clear_costmap_service

### DIFF
--- a/nav2_costmap_2d/src/clear_costmap_service.cpp
+++ b/nav2_costmap_2d/src/clear_costmap_service.cpp
@@ -129,8 +129,8 @@ void ClearCostmapService::clearLayerRegion(
   double end_point_y = start_point_y + reset_distance;
 
   int start_x, start_y, end_x, end_y;
-  costmap->worldToMapNoBounds(start_point_x, start_point_y, start_x, start_y);
-  costmap->worldToMapNoBounds(end_point_x, end_point_y, end_x, end_y);
+  costmap->worldToMapEnforceBounds(start_point_x, start_point_y, start_x, start_y);
+  costmap->worldToMapEnforceBounds(end_point_x, end_point_y, end_x, end_y);
 
   costmap->clearArea(start_x, start_y, end_x, end_y, invert);
 


### PR DESCRIPTION
Use `worldToMapEnforceBounds` in `clear_costmap_service` to avoid buffer overflow

Signed-off-by: zouyonghao <yonghaoz1994@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation turtlebot |

---

## Description of contribution in a few bullet points

I got buffer overflow when I call the clear_except_* service
```
=================================================================
==27609==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x620000005e90 at pc 0x0000005aaa2f bp 0x7f4eed79d2b0 sp 0x7f4eed79ca78
WRITE of size 60 at 0x620000005e90 thread T13
    #0 0x5aaa2e in __asan_memset (/home/r1/ros2_clang_navigation/build/nav2_controller/controller_server+0x5aaa2e)
    #1 0x7f4ef996d176 in nav2_costmap_2d::Costmap2D::resetMapToValue(unsigned int, unsigned int, unsigned int, unsigned int, unsigned char) /home/r1/ros2_clang_navigation/src/navigation2/nav2_costmap_2d/src/costmap_2d.cpp:108:5
    #2 0x7f4ef9c4a53a in nav2_costmap_2d::ClearCostmapService::clearLayerExceptRegion(std::shared_ptr<nav2_costmap_2d::CostmapLayer>&, double, double, double) /home/r1/ros2_clang_navigation/src/navigation2/nav2_costmap_2d/src/clear_costmap_service.cpp:181:12
    #3 0x7f4ef9c4829d in nav2_costmap_2d::ClearCostmapService::clearExceptRegion(double) /home/r1/ros2_clang_navigation/src/navigation2/nav2_costmap_2d/src/clear_costmap_service.cpp:115:7
    #4 0x7f4ef9c46307 in nav2_costmap_2d::ClearCostmapService::clearExceptRegionCallback(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >) /home/r1/ros2_clang_navigation/src/navigation2/nav2_costmap_2d/src/clear_costmap_service.cpp:71:3
    #5 0x7f4ef9c4f231 in void std::__invoke_impl<void, void (nav2_costmap_2d::ClearCostmapService::*&)(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >), nav2_costmap_2d::ClearCostmapService*&, std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > > >(std::__invoke_memfun_deref, void (nav2_costmap_2d::ClearCostmapService::*&)(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >), nav2_costmap_2d::ClearCostmapService*&, std::shared_ptr<rmw_request_id_t>&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/invoke.h:73:14
    #6 0x7f4ef9c4ecf7 in std::__invoke_result<void (nav2_costmap_2d::ClearCostmapService::*&)(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >), nav2_costmap_2d::ClearCostmapService*&, std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > > >::type std::__invoke<void (nav2_costmap_2d::ClearCostmapService::*&)(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >), nav2_costmap_2d::ClearCostmapService*&, std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > > >(void (nav2_costmap_2d::ClearCostmapService::*&)(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >), nav2_costmap_2d::ClearCostmapService*&, std::shared_ptr<rmw_request_id_t>&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/invoke.h:95:14
    #7 0x7f4ef9c4eb05 in void std::_Bind<void (nav2_costmap_2d::ClearCostmapService::* (nav2_costmap_2d::ClearCostmapService*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >)>::__call<void, std::shared_ptr<rmw_request_id_t>&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >&&, 0ul, 1ul, 2ul, 3ul>(std::tuple<std::shared_ptr<rmw_request_id_t>&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >&&>&&, std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/functional:400:11
    #8 0x7f4ef9c4e7f4 in void std::_Bind<void (nav2_costmap_2d::ClearCostmapService::* (nav2_costmap_2d::ClearCostmapService*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >)>::operator()<std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >, void>(std::shared_ptr<rmw_request_id_t>&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/functional:482:17
    #9 0x7f4ef9c4e3a7 in std::_Function_handler<void (std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >), std::_Bind<void (nav2_costmap_2d::ClearCostmapService::* (nav2_costmap_2d::ClearCostmapService*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >)> >::_M_invoke(std::_Any_data const&, std::shared_ptr<rmw_request_id_t>&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >&&, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/std_function.h:300:2
    #10 0x7f4ef9c5d88f in std::function<void (std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >)>::operator()(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >) const /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/std_function.h:688:14
    #11 0x7f4ef9c5b114 in rclcpp::AnyServiceCallback<nav2_msgs::srv::ClearCostmapExceptRegion>::dispatch(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Request_<std::allocator<void> > >, std::shared_ptr<nav2_msgs::srv::ClearCostmapExceptRegion_Response_<std::allocator<void> > >) /opt/ros/foxy/include/rclcpp/any_service_callback.hpp:96:7
    #12 0x7f4ef9c547f8 in rclcpp::Service<nav2_msgs::srv::ClearCostmapExceptRegion>::handle_request(std::shared_ptr<rmw_request_id_t>, std::shared_ptr<void>) /opt/ros/foxy/include/rclcpp/service.hpp:348:19
    #13 0x7f4ef8c135dc  (/opt/ros/foxy/lib/librclcpp.so+0xd65dc)
    #14 0x7f4ef8c1402b  (/opt/ros/foxy/lib/librclcpp.so+0xd702b)
    #15 0x7f4ef8c1429b in rclcpp::Executor::execute_service(std::shared_ptr<rclcpp::ServiceBase>) (/opt/ros/foxy/lib/librclcpp.so+0xd729b)
    #16 0x7f4ef8c1513c in rclcpp::Executor::execute_any_executable(rclcpp::AnyExecutable&) (/opt/ros/foxy/lib/librclcpp.so+0xd813c)
    #17 0x7f4ef8c19a4b in rclcpp::executors::SingleThreadedExecutor::spin() (/opt/ros/foxy/lib/librclcpp.so+0xdca4b)
    #18 0x7f4ef925e679 in nav2_util::NodeThread::NodeThread(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>)::$_0::operator()() const /home/r1/ros2_clang_navigation/src/navigation2/nav2_util/src/node_thread.cpp:29:17
    #19 0x7f4ef925e4d0 in void std::__invoke_impl<void, nav2_util::NodeThread::NodeThread(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>)::$_0>(std::__invoke_other, nav2_util::NodeThread::NodeThread(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>)::$_0&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/invoke.h:60:14
    #20 0x7f4ef925e420 in std::__invoke_result<nav2_util::NodeThread::NodeThread(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>)::$_0>::type std::__invoke<nav2_util::NodeThread::NodeThread(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>)::$_0>(nav2_util::NodeThread::NodeThread(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>)::$_0&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/invoke.h:95:14
    #21 0x7f4ef925e3e8 in void std::thread::_Invoker<std::tuple<nav2_util::NodeThread::NodeThread(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>)::$_0> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:244:13
    #22 0x7f4ef925e3a8 in std::thread::_Invoker<std::tuple<nav2_util::NodeThread::NodeThread(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>)::$_0> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:251:11
    #23 0x7f4ef925e1c2 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<nav2_util::NodeThread::NodeThread(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>)::$_0> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:195:13
    #24 0x7f4ef8577de3  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xd6de3)
    #25 0x7f4ef8ae2608 in start_thread /build/glibc-eX1tMB/glibc-2.31/nptl/pthread_create.c:477:8
    #26 0x7f4ef825c292 in clone /build/glibc-eX1tMB/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

So maybe use `worldToMapEnforceBounds` can avoid that.