### PR TITLE
create new package nav2_composition

### DIFF
--- a/nav2_composition/CMakeLists.txt
+++ b/nav2_composition/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.5)
+project(nav2_composition)
+
+find_package(ament_cmake REQUIRED)
+find_package(nav2_common REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(nav2_map_server REQUIRED)
+find_package(nav2_amcl REQUIRED)
+find_package(nav2_controller REQUIRED)
+find_package(nav2_planner REQUIRED)
+find_package(nav2_recoveries REQUIRED)
+find_package(nav2_bt_navigator REQUIRED)
+find_package(nav2_waypoint_follower REQUIRED)
+find_package(nav2_lifecycle_manager REQUIRED)
+
+nav2_package()
+
+set(executable_name loc_and_nav)
+add_executable(${executable_name}
+  src/main.cpp
+)
+
+set(dependencies
+  rclcpp
+  nav2_map_server
+  nav2_amcl
+  nav2_controller
+  nav2_planner
+  nav2_recoveries
+  nav2_bt_navigator
+  nav2_waypoint_follower
+  nav2_lifecycle_manager
+)
+
+ament_target_dependencies(${executable_name}
+  ${dependencies}
+)
+
+install(TARGETS ${executable_name}
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/nav2_composition/README.md
+++ b/nav2_composition/README.md
@@ -1,0 +1,38 @@
+# nav2_compostion
+
+The `nav2_compistion` package is a composition-based bringup for Nav2, which is useful for embedded systems users that need to make optimizations due to harsh resource constraints.
+
+### Pre-requisites:
+
+- [Install ROS 2](https://index.ros.org/doc/ros2/Installation/Dashing/)
+
+- Install Nav2
+
+  `sudo apt install ros-<ros2_distro>-navigation2`
+
+- Install Nav2 Bringup
+
+  `sudo apt install ros-<ros2_distro>-nav2-bringup`
+
+- Install your robot specific package (ex:[Turtlebot 3](http://emanual.robotis.com/docs/en/platform/turtlebot3/ros2/))
+
+## Launch Nav2 in *Simulation* with Gazebo
+
+refer to package `nav2_bringup`,  there is only difference when you run `Terminal 3: Launch Nav2` , which just replaces `bringup_launch.py` with  `compostion_bringup_launch.py`.
+
+```bash
+source /opt/ros/dashing/setup.bash
+ros2 launch nav2_compostion compostion_bringup_launch.py use_sim_time:=True autostart:=True \
+map:=<full/path/to/map.yaml>
+```
+
+### Advanced: single-terminal launch
+
+A convenience file is provided to launch Gazebo, RVIZ and Nav2 using a single command:
+
+```bash
+ros2 launch nav2_compostion tb3_simulation_launch.py
+```
+
+
+

--- a/nav2_composition/launch/composition_bringup_launch.py
+++ b/nav2_composition/launch/composition_bringup_launch.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from nav2_common.launch import RewrittenYaml
+
+
+def generate_launch_description():
+    # Get the launch directory
+    bringup_dir = get_package_share_directory('nav2_bringup')
+
+    namespace = LaunchConfiguration('namespace')
+    map_yaml_file = LaunchConfiguration('map')
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    autostart = LaunchConfiguration('autostart')
+    params_file = LaunchConfiguration('params_file')
+
+    # Map fully qualified names to relative ones so the node's namespace can be prepended.
+    # In case of the transforms (tf), currently, there doesn't seem to be a better alternative
+    # https://github.com/ros/geometry2/issues/32
+    # https://github.com/ros/robot_state_publisher/pull/30
+    # TODO(orduno) Substitute with `PushNodeRemapping`
+    #              https://github.com/ros2/launch_ros/issues/56
+    remappings = [('/tf', 'tf'),
+                  ('/tf_static', 'tf_static')]
+
+    # Create our own temporary YAML files that include substitutions
+    param_substitutions = {
+        'yaml_filename': map_yaml_file,
+        'use_sim_time': use_sim_time,
+        'autostart': autostart}
+
+    configured_params = RewrittenYaml(
+        source_file=params_file,
+        root_key=namespace,
+        param_rewrites=param_substitutions,
+        convert_types=True)
+
+    return LaunchDescription([
+        # Set env var to print messages to stdout immediately
+        SetEnvironmentVariable('RCUTILS_LOGGING_BUFFERED_STREAM', '1'),
+
+        DeclareLaunchArgument(
+            'namespace', default_value='',
+            description='Top-level namespace'),
+
+        DeclareLaunchArgument(
+            'map',
+            default_value=os.path.join(bringup_dir, 'maps', 'turtlebot3_world.yaml'),
+            description='Full path to map yaml file to load'),
+
+        DeclareLaunchArgument(
+            'use_sim_time', default_value='false',
+            description='Use simulation (Gazebo) clock if true'),
+
+        DeclareLaunchArgument(
+            'autostart', default_value='true',
+            description='Automatically startup the nav2 stack'),
+
+        DeclareLaunchArgument(
+            'params_file',
+            default_value=os.path.join(bringup_dir, 'params', 'nav2_params.yaml'),
+            description='Full path to the ROS2 parameters file to use'),
+
+        Node(
+            package='nav2_composition',
+            executable='loc_and_nav',
+            output='screen',
+            parameters=[configured_params,
+                        {'use_sim_time': use_sim_time},
+                        {'autostart': autostart}],
+            remappings=remappings)
+    ])

--- a/nav2_composition/launch/tb3_simulation_launch.py
+++ b/nav2_composition/launch/tb3_simulation_launch.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This is all-in-one launch script intended for use by nav2 developers."""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    # Get the launch directory
+    bringup_dir = get_package_share_directory('nav2_bringup')
+    launch_dir = os.path.join(bringup_dir, 'launch')
+    bringup_cmd_file = os.path.join(get_package_share_directory('nav2_composition'), 'launch',
+                                    'composition_bringup_launch.py')
+
+    # Create the launch configuration variables
+    slam = LaunchConfiguration('slam')
+    namespace = LaunchConfiguration('namespace')
+    use_namespace = LaunchConfiguration('use_namespace')
+    map_yaml_file = LaunchConfiguration('map')
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    params_file = LaunchConfiguration('params_file')
+    autostart = LaunchConfiguration('autostart')
+
+    # Launch configuration variables specific to simulation
+    rviz_config_file = LaunchConfiguration('rviz_config_file')
+    use_simulator = LaunchConfiguration('use_simulator')
+    use_robot_state_pub = LaunchConfiguration('use_robot_state_pub')
+    use_rviz = LaunchConfiguration('use_rviz')
+    headless = LaunchConfiguration('headless')
+    world = LaunchConfiguration('world')
+    pose = {'x': LaunchConfiguration('x_pose', default='-2.00'),
+            'y': LaunchConfiguration('y_pose', default='-0.50'),
+            'z': LaunchConfiguration('z_pose', default='0.01'),
+            'R': LaunchConfiguration('roll', default='0.00'),
+            'P': LaunchConfiguration('pitch', default='0.00'),
+            'Y': LaunchConfiguration('yaw', default='0.00')}
+    robot_name = LaunchConfiguration('robot_name')
+    robot_sdf = LaunchConfiguration('robot_sdf')
+
+    # Map fully qualified names to relative ones so the node's namespace can be prepended.
+    # In case of the transforms (tf), currently, there doesn't seem to be a better alternative
+    # https://github.com/ros/geometry2/issues/32
+    # https://github.com/ros/robot_state_publisher/pull/30
+    # TODO(orduno) Substitute with `PushNodeRemapping`
+    #              https://github.com/ros2/launch_ros/issues/56
+    remappings = [('/tf', 'tf'),
+                  ('/tf_static', 'tf_static')]
+
+    # Declare the launch arguments
+    declare_namespace_cmd = DeclareLaunchArgument(
+        'namespace',
+        default_value='',
+        description='Top-level namespace')
+
+    declare_use_namespace_cmd = DeclareLaunchArgument(
+        'use_namespace',
+        default_value='false',
+        description='Whether to apply a namespace to the navigation stack')
+
+    declare_slam_cmd = DeclareLaunchArgument(
+        'slam',
+        default_value='False',
+        description='Whether run a SLAM')
+
+    declare_map_yaml_cmd = DeclareLaunchArgument(
+        'map',
+        default_value=os.path.join(
+            bringup_dir, 'maps', 'turtlebot3_world.yaml'),
+        description='Full path to map file to load')
+
+    declare_use_sim_time_cmd = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='true',
+        description='Use simulation (Gazebo) clock if true')
+
+    declare_params_file_cmd = DeclareLaunchArgument(
+        'params_file',
+        default_value=os.path.join(bringup_dir, 'params', 'nav2_params.yaml'),
+        description='Full path to the ROS2 parameters file to use for all launched nodes')
+
+    declare_autostart_cmd = DeclareLaunchArgument(
+        'autostart', default_value='true',
+        description='Automatically startup the nav2 stack')
+
+    declare_rviz_config_file_cmd = DeclareLaunchArgument(
+        'rviz_config_file',
+        default_value=os.path.join(
+            bringup_dir, 'rviz', 'nav2_default_view.rviz'),
+        description='Full path to the RVIZ config file to use')
+
+    declare_use_simulator_cmd = DeclareLaunchArgument(
+        'use_simulator',
+        default_value='True',
+        description='Whether to start the simulator')
+
+    declare_use_robot_state_pub_cmd = DeclareLaunchArgument(
+        'use_robot_state_pub',
+        default_value='True',
+        description='Whether to start the robot state publisher')
+
+    declare_use_rviz_cmd = DeclareLaunchArgument(
+        'use_rviz',
+        default_value='True',
+        description='Whether to start RVIZ')
+
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='False',
+        description='Whether to execute gzclient)')
+
+    declare_world_cmd = DeclareLaunchArgument(
+        'world',
+        # TODO(orduno) Switch back once ROS argument passing has been fixed upstream
+        #              https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/91
+        # default_value=os.path.join(get_package_share_directory('turtlebot3_gazebo'),
+        # worlds/turtlebot3_worlds/waffle.model')
+        default_value=os.path.join(bringup_dir, 'worlds', 'world_only.model'),
+        description='Full path to world model file to load')
+
+    declare_robot_name_cmd = DeclareLaunchArgument(
+        'robot_name',
+        default_value='turtlebot3_waffle',
+        description='name of the robot')
+
+    declare_robot_sdf_cmd = DeclareLaunchArgument(
+        'robot_sdf',
+        default_value=os.path.join(bringup_dir, 'worlds', 'waffle.model'),
+        description='Full path to robot sdf file to spawn the robot in gazebo')
+
+    # Specify the actions
+    start_gazebo_server_cmd = ExecuteProcess(
+        condition=IfCondition(use_simulator),
+        cmd=['gzserver', '-s', 'libgazebo_ros_init.so',  '-s', 'libgazebo_ros_factory.so', world],
+        cwd=[launch_dir], output='screen')
+
+    start_gazebo_client_cmd = ExecuteProcess(
+        condition=IfCondition(PythonExpression(
+            [use_simulator, ' and not ', headless])),
+        cmd=['gzclient'],
+        cwd=[launch_dir], output='screen')
+
+    urdf = os.path.join(bringup_dir, 'urdf', 'turtlebot3_waffle.urdf')
+    with open(urdf, 'r') as infp:
+        robot_description = infp.read()
+
+    start_robot_state_publisher_cmd = Node(
+        condition=IfCondition(use_robot_state_pub),
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        name='robot_state_publisher',
+        namespace=namespace,
+        output='screen',
+        parameters=[{'use_sim_time': use_sim_time,
+                     'robot_description': robot_description}],
+        remappings=remappings)
+
+    start_gazebo_spawner_cmd = Node(
+        package='gazebo_ros',
+        executable='spawn_entity.py',
+        output='screen',
+        arguments=[
+            '-entity', robot_name,
+            '-file', robot_sdf,
+            '-robot_namespace', namespace,
+            '-x', pose['x'], '-y', pose['y'], '-z', pose['z'],
+            '-R', pose['R'], '-P', pose['P'], '-Y', pose['Y']])
+
+    rviz_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(launch_dir, 'rviz_launch.py')),
+        condition=IfCondition(use_rviz),
+        launch_arguments={'namespace': namespace,
+                          'use_namespace': use_namespace,
+                          'rviz_config': rviz_config_file}.items())
+
+    bringup_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(bringup_cmd_file),
+        launch_arguments={'namespace': namespace,
+                          'use_namespace': use_namespace,
+                          'slam': slam,
+                          'map': map_yaml_file,
+                          'use_sim_time': use_sim_time,
+                          'params_file': params_file,
+                          'autostart': autostart}.items())
+
+    # Create the launch description and populate
+    ld = LaunchDescription()
+
+    # Declare the launch options
+    ld.add_action(declare_namespace_cmd)
+    ld.add_action(declare_use_namespace_cmd)
+    ld.add_action(declare_slam_cmd)
+    ld.add_action(declare_map_yaml_cmd)
+    ld.add_action(declare_use_sim_time_cmd)
+    ld.add_action(declare_params_file_cmd)
+    ld.add_action(declare_autostart_cmd)
+
+    ld.add_action(declare_rviz_config_file_cmd)
+    ld.add_action(declare_use_simulator_cmd)
+    ld.add_action(declare_use_robot_state_pub_cmd)
+    ld.add_action(declare_use_rviz_cmd)
+    ld.add_action(declare_simulator_cmd)
+    ld.add_action(declare_world_cmd)
+    ld.add_action(declare_robot_name_cmd)
+    ld.add_action(declare_robot_sdf_cmd)
+
+    # Add any conditioned actions
+    ld.add_action(start_gazebo_server_cmd)
+    ld.add_action(start_gazebo_client_cmd)
+    ld.add_action(start_gazebo_spawner_cmd)
+
+    # Add the actions to launch all of the navigation nodes
+    ld.add_action(start_robot_state_publisher_cmd)
+    ld.add_action(rviz_cmd)
+    ld.add_action(bringup_cmd)
+
+    return ld

--- a/nav2_composition/package.xml
+++ b/nav2_composition/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nav2_composition</name>
+  <version>1.0.0</version>
+  <description>Compose all Nav2 nodes in a single process for the Nav2 stack</description>
+  <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
+  <maintainer email="zhenpeng.ge@qq.com">Zhenpeng Ge</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>nav2_common</build_depend>
+
+  <build_depend>navigation2</build_depend>
+  <build_depend>launch_ros</build_depend>
+
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>navigation2</exec_depend>
+  <exec_depend>nav2_common</exec_depend>
+  <exec_depend>slam_toolbox</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_testing</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/nav2_composition/src/main.cpp
+++ b/nav2_composition/src/main.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2020, Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include <memory>
+#include <vector>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_map_server/map_server.hpp"
+#include "nav2_amcl/amcl_node.hpp"
+#include "nav2_controller/nav2_controller.hpp"
+#include "nav2_planner/planner_server.hpp"
+#include "nav2_recoveries/recovery_server.hpp"
+#include "nav2_lifecycle_manager/lifecycle_manager.hpp"
+#include "nav2_bt_navigator/bt_navigator.hpp"
+#include "nav2_waypoint_follower/waypoint_follower.hpp"
+
+template<typename NodeT>
+std::shared_ptr<std::thread> create_spin_thread(NodeT & node)
+{
+  return std::make_shared<std::thread>(
+    [node]() {
+      rclcpp::executors::SingleThreadedExecutor executor;
+      executor.add_node(node->get_node_base_interface());
+      executor.spin();
+      executor.remove_node(node->get_node_base_interface());
+    });
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  // localiztion nodes
+  std::vector<std::string> localiztion_node_names;
+  auto map_node = std::make_shared<nav2_map_server::MapServer>();
+  localiztion_node_names.push_back(map_node->get_name());
+  auto amcl_node = std::make_shared<nav2_amcl::AmclNode>();
+  localiztion_node_names.push_back(amcl_node->get_name());
+  // lifecycle manager of localiztion
+  auto loc_manager_options = rclcpp::NodeOptions();
+  loc_manager_options.arguments(
+    {"--ros-args", "-r", std::string("__node:=") + "lifecycle_manager_localization", "--"});
+  loc_manager_options.append_parameter_override("node_names", localiztion_node_names);
+  auto lifecycle_manager_localization_node =
+    std::make_shared<nav2_lifecycle_manager::LifecycleManager>(loc_manager_options);
+
+  // navigation nodes
+  std::vector<std::string> navigation_node_names;
+  auto controller_node = std::make_shared<nav2_controller::ControllerServer>();
+  navigation_node_names.push_back(controller_node->get_name());
+  auto planner_node = std::make_shared<nav2_planner::PlannerServer>();
+  navigation_node_names.push_back(planner_node->get_name());
+  auto recoveries_node = std::make_shared<recovery_server::RecoveryServer>();
+  navigation_node_names.push_back(recoveries_node->get_name());
+  auto bt_navigator_node = std::make_shared<nav2_bt_navigator::BtNavigator>();
+  navigation_node_names.push_back(bt_navigator_node->get_name());
+  auto waypoint_follower_node = std::make_shared<nav2_waypoint_follower::WaypointFollower>();
+  navigation_node_names.push_back(waypoint_follower_node->get_name());
+  // lifecycle manager of navigation
+  auto nav_manager_options = rclcpp::NodeOptions();
+  nav_manager_options.arguments(
+    {"--ros-args", "-r", std::string("__node:=") + "lifecycle_manager_navigation", "--"});
+  nav_manager_options.append_parameter_override("node_names", navigation_node_names);
+  auto lifecycle_manager_navigation_node =
+    std::make_shared<nav2_lifecycle_manager::LifecycleManager>(nav_manager_options);
+
+  // spin threads
+  std::vector<std::shared_ptr<std::thread>> threads;
+  threads.push_back(create_spin_thread(map_node));
+  threads.push_back(create_spin_thread(amcl_node));
+  threads.push_back(create_spin_thread(lifecycle_manager_localization_node));
+  threads.push_back(create_spin_thread(controller_node));
+  threads.push_back(create_spin_thread(planner_node));
+  threads.push_back(create_spin_thread(recoveries_node));
+  threads.push_back(create_spin_thread(bt_navigator_node));
+  threads.push_back(create_spin_thread(waypoint_follower_node));
+  threads.push_back(create_spin_thread(lifecycle_manager_navigation_node));
+  for (auto t : threads) {
+    t->join();
+  }
+
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |(tickets:  [#2147](https://github.com/ros-planning/navigation2/issues/2147)) |
| Primary OS tested on | (Ubuntu20.04, ROS 2 Galactic from binaries)  |
| Robotic platform tested on |  (gazebo simulation of turtlebot3)   |
---

## Description of contribution in a few bullet points

create a composition-based bringup package for Nav2, in other word, compose all Nav2 nodes in a single process instead of launching these nodes separately, which is useful for embedded systems users that need to make optimizations due to harsh resource constraints.

* create multiple nodes in a single `main()` (manual composition).
* create a bunch of single threaded executors to spin these nodes.

you can find some details about performance test(cpu and memory usage) here
* https://discourse.ros.org/t/nav2-composition/22175

---

## Future work that may be required in bullet points

try to enable intra-process comms until it's stable in ROS2, which are still kind of under development currently, you can find more detials:
* https://github.com/ros2/rclcpp/issues/1753
* https://github.com/ros2/rclcpp/issues/1750

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
