### PR TITLE
fix pf_ use-before-initialized in laserReceived() callback

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -234,12 +234,12 @@ AmclNode::on_configure(const rclcpp_lifecycle::State & /*state*/)
 
   initParameters();
   initTransforms();
+  initParticleFilter();
+  initLaserScan();
   initMessageFilters();
   initPubSub();
   initServices();
   initOdometry();
-  initParticleFilter();
-  initLaserScan();
 
   return nav2_util::CallbackReturn::SUCCESS;
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (-) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation of turtlebot3) |

---

## Description of contribution in a few bullet points
```cpp
nav2_util::CallbackReturn
AmclNode::on_configure(const rclcpp_lifecycle::State & /*state*/)
{
  // initMessageFilters is before initParticleFilter
  initMessageFilters();
  ...
  initParticleFilter();

  return nav2_util::CallbackReturn::SUCCESS;
}
```
```cpp
void
AmclNode::initParticleFilter()
{
  // pf_ is initialzed here, otherwise it is nullptr
  pf_ = pf_alloc(
    min_particles_, max_particles_, alpha_slow_, alpha_fast_,
    (pf_init_model_fn_t)AmclNode::uniformPoseGenerator,
    reinterpret_cast<void *>(map_));
}
```

```cpp
void
AmclNode::initMessageFilters()
{
  ...
  laser_scan_connection_ = laser_scan_filter_->registerCallback(
    std::bind(&AmclNode::laserReceived, this, std::placeholders::_1));
}
void
AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
{
  ...
    if (!(++resample_count_ % resample_interval_)) {
      // pf_, nullptr deference here
      pf_update_resample(pf_);
      resampled = true;
  ..
}
```



<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Additional Information
```
==788420==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7f05ea2d9669 bp 0x7f05dac2cbb0 sp 0x7f05dac2ca20 T12)
==788420==The signal is caused by a READ memory access.
==788420==Hint: address points to the zero page.
    #0 0x7f05ea2d9669 in nav2_amcl::AmclNode::uniformPoseGenerator(void*) /home/r1/ros2_nav_fuzz/src/navigation2/nav2_amcl/src/amcl_node.cpp:474:12
    #1 0x7f05e9bd32ff in pf_update_resample /home/r1/ros2_nav_fuzz/src/navigation2/nav2_amcl/src/pf/pf.c:347:24
    #2 0x7f05ea2dd78d in nav2_amcl::AmclNode::laserReceived(std::shared_ptr<sensor_msgs::msg::LaserScan_<std::allocator<void> > const>) /home/r1/ros2_nav_fuzz/src/navigation2/nav2_amcl/src/amcl_node.cpp:701:7

```

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
