### PR TITLE
Updates to Nav2 Theta Star Planner docs

### DIFF
--- a/nav2_theta_star_planner/README.md
+++ b/nav2_theta_star_planner/README.md
@@ -51,7 +51,6 @@ The parameters of the planner are :
 - ` .how_many_corners ` : to choose between 4-connected and 8-connected graph expansions, the accepted values are 4 and 8
 - ` .w_euc_cost ` : weight applied on the length of the path. 
 - ` .w_traversal_cost ` : it tunes how harshly the nodes of high cost are penalised. From the above g(neigh) equation you can see that the cost-aware component of the cost function forms a parabolic curve, thus this parameter would, on increasing its value, make that curve steeper allowing for a greater differentiation (as the delta of costs would increase, when the graph becomes steep) among the nodes of different costs.
-- `w_heuristic_cost ` : it has been provided to have an admissible heuristic; it is **not** a user configurable parameter
 Below are the default values of the parameters :
 ```
 planner_server:
@@ -73,6 +72,8 @@ Before starting off, do note that the costmap_cost(curr,neigh) component after b
 This planner uses the costs associated with each cell from the `global_costmap` as a measure of the point's proximity to the obstacles. Providing a gentle potential field that covers the entirety of the region (thus leading to only small pocket like regions of cost = 0) is recommended in order to achieve paths that pass through the middle of the spaces. A good starting point could be to set the `inflation_layer`'s parameters as - `cost_scaling_factor: 10.0`, `inflation_radius: 5.5` and then decrease the value of `cost_scaling_factor` to achieve the said potential field.
 
 Providing a gentle potential field over the region allows the planner to exchange the increase in path lengths for a decrease in the accumulated traversal cost, thus leading to an increase in the distance from the obstacles. This around a corner allows for naturally smoothing the turns and removes the requirement for an external path smoother.
+
+`w_heuristic_cost` is an internal setting that is not user changable. It has been provided to have an admissible heuristic, restricting its value to the minimum of `w_euc_cost` and `1.0` to make sure the heuristic and travel costs are admissible and consistent.
 
 To begin with, you can set the parameters to its default values and then try increasing the value of `w_traversal_cost` to achieve those middling paths, but this would adversly make the paths less taut. So it is recommend ed that you simultaneously tune the value of `w_euc_cost`. Increasing `w_euc_cost` increases the tautness of the path, which leads to more straight line like paths (any-angled paths). Do note that the query time from the planner would increase for higher values of `w_traversal_cost` as more nodes would have to be expanded to lower the cost of the path, to counteract this you may also try setting `w_euc_cost` to a higher value and check if it reduces the query time.
 

--- a/nav2_theta_star_planner/README.md
+++ b/nav2_theta_star_planner/README.md
@@ -13,7 +13,7 @@ The Theta Star Planner is a global planning plugin meant to be used with the Nav
 For the below example the planner took ~46ms (averaged value) to compute the path of 87.5m -
 ![example.png](img/00-37.png)
 
-The parameters were set to - `w_euc_cost: 1.0`, `w_traversal_cost: 5.0`, `w_heuristic_cost: 1.0` and the `global_costmap`'s `inflation_layer` parameters are set as - `cost_scaling_factor:5.0`, `inflation_radius: 5.5`
+The parameters were set to - `w_euc_cost: 1.0`, `w_traversal_cost: 5.0` and the `global_costmap`'s `inflation_layer` parameters are set as - `cost_scaling_factor:5.0`, `inflation_radius: 5.5`
 
 ## Cost Function Details
 ### Symbols and their meanings
@@ -51,8 +51,7 @@ The parameters of the planner are :
 - ` .how_many_corners ` : to choose between 4-connected and 8-connected graph expansions, the accepted values are 4 and 8
 - ` .w_euc_cost ` : weight applied on the length of the path. 
 - ` .w_traversal_cost ` : it tunes how harshly the nodes of high cost are penalised. From the above g(neigh) equation you can see that the cost-aware component of the cost function forms a parabolic curve, thus this parameter would, on increasing its value, make that curve steeper allowing for a greater differentiation (as the delta of costs would increase, when the graph becomes steep) among the nodes of different costs.
-- ` .w_heuristic_cost ` : it has been provided to have an admissible heuristic
-
+- `w_heuristic_cost ` : it has been provided to have an admissible heuristic; it is **not** a user configurable parameter
 Below are the default values of the parameters :
 ```
 planner_server:
@@ -64,7 +63,6 @@ planner_server:
       how_many_corners: 8
       w_euc_cost: 1.0
       w_traversal_cost: 2.0
-      w_heuristic_cost: 1.0
 ```
 
 ## Usage Notes
@@ -78,8 +76,6 @@ Providing a gentle potential field over the region allows the planner to exchang
 
 To begin with, you can set the parameters to its default values and then try increasing the value of `w_traversal_cost` to achieve those middling paths, but this would adversly make the paths less taut. So it is recommend ed that you simultaneously tune the value of `w_euc_cost`. Increasing `w_euc_cost` increases the tautness of the path, which leads to more straight line like paths (any-angled paths). Do note that the query time from the planner would increase for higher values of `w_traversal_cost` as more nodes would have to be expanded to lower the cost of the path, to counteract this you may also try setting `w_euc_cost` to a higher value and check if it reduces the query time.
 
-Usually set `w_heuristic_cost` at the same value as `w_euc_cost` or 1.0 (whichever is lower). Though as a last resort you may increase the value of `w_heuristic_cost` to speed up the planning process, this is not recommended as it might not always lead to shorter query times, but would definitely give you sub optimal paths
-
 Also note that changes to `w_traversal_cost` might cause slow downs, in case the number of node expanisions increase thus tuning it along with `w_euc_cost` is the way to go to.
 
 While tuning the planner's parameters you can also change the `inflation_layer`'s parameters (of the global costmap) to tune the behavior of the paths.
@@ -91,5 +87,5 @@ This planner is recommended to be used with local planners like DWB or TEB (or o
 
 While smoother paths can be achieved by increasing the costmap resolution (ie using a costmap of 1cm resolution rather than a 5cm one) it is not recommended to do so because it might increase the query times from the planner. Test the planners performance on the higher cm/px costmaps before making a switch to finer costmaps.
 
-### Possible Applications
-This planner could be used in scenarios where planning speed matters over an extremely smooth path, which could anyways be handled by using a local planner/controller as mentioned above. Because of the any-angled nature of paths you can traverse environments diagonally (wherever it is allowed, eg: in a wide open region).
+### When to use this planner?
+This planner could be used in scenarios where planning speed matters over an extremely smooth path, which could anyways be handled by using a local planner/controller as mentioned above. Because of the any-angled nature of paths you can traverse environments diagonally (wherever it is allowed, eg: in a wide open region). Another use case would be when you have corridors that are misaligned in the map image, in such a case this planner would be able to give straight-line like paths as it considers line of sight and thus avoid giving jagged paths which arises with other planners because of the finite directions of motion they consider.

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star_planner.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star_planner.hpp
@@ -32,7 +32,10 @@
 #include "nav2_costmap_2d/cost_values.hpp"
 #include "nav2_util/node_utils.hpp"
 #include "nav2_theta_star_planner/theta_star.hpp"
+<<<<<<< HEAD
+=======
 #include "nav2_util/geometry_utils.hpp"
+>>>>>>> d47aba651ffa89225aaa006f05a59f87478aecf2
 
 namespace nav2_theta_star_planner
 {
@@ -60,7 +63,10 @@ protected:
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Logger logger_{rclcpp::get_logger("ThetaStarPlanner")};
   std::string global_frame_, name_;
+<<<<<<< HEAD
+=======
   bool use_final_approach_orientation_;
+>>>>>>> d47aba651ffa89225aaa006f05a59f87478aecf2
 
   std::unique_ptr<theta_star::ThetaStar> planner_;
 

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star_planner.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star_planner.hpp
@@ -32,10 +32,7 @@
 #include "nav2_costmap_2d/cost_values.hpp"
 #include "nav2_util/node_utils.hpp"
 #include "nav2_theta_star_planner/theta_star.hpp"
-<<<<<<< HEAD
-=======
 #include "nav2_util/geometry_utils.hpp"
->>>>>>> d47aba651ffa89225aaa006f05a59f87478aecf2
 
 namespace nav2_theta_star_planner
 {
@@ -63,10 +60,7 @@ protected:
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Logger logger_{rclcpp::get_logger("ThetaStarPlanner")};
   std::string global_frame_, name_;
-<<<<<<< HEAD
-=======
   bool use_final_approach_orientation_;
->>>>>>> d47aba651ffa89225aaa006f05a59f87478aecf2
 
   std::unique_ptr<theta_star::ThetaStar> planner_;
 

--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -117,7 +117,7 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
     planner_->src_.x, planner_->src_.y, planner_->dst_.x, planner_->dst_.y);
   getPlan(global_path);
   global_path.poses.push_back(goal);
-  
+
   // If use_final_approach_orientation=true, interpolate the last pose orientation from the
   // previous pose to set the orientation to the 'final approach' orientation of the robot so
   // it does not rotate.
@@ -166,15 +166,15 @@ nav_msgs::msg::Path ThetaStarPlanner::linearInterpolation(
   const double & dist_bw_points)
 {
   nav_msgs::msg::Path pa;
-   
+
   geometry_msgs::msg::PoseStamped p1;
-  for (unsigned int j = 0; j < raw_path.size() - 1; j++) {    
+  for (unsigned int j = 0; j < raw_path.size() - 1; j++) {
     coordsW pt1 = raw_path[j];
     p1.pose.position.x = pt1.x;
     p1.pose.position.y = pt1.y;
     pa.poses.push_back(p1);
 
-    coordsW pt2 = raw_path[j + 1];    
+    coordsW pt2 = raw_path[j + 1];
     double distance = std::hypot(pt2.x - pt1.x, pt2.y - pt1.y);
     int loops = static_cast<int>(distance / dist_bw_points);
     double sin_alpha = (pt2.y - pt1.y) / distance;
@@ -185,7 +185,7 @@ nav_msgs::msg::Path ThetaStarPlanner::linearInterpolation(
       pa.poses.push_back(p1);
     }
   }
-   
+
   return pa;
 }
 

--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -116,7 +116,7 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
     logger_, "Got the src and dst... (%i, %i) && (%i, %i)",
     planner_->src_.x, planner_->src_.y, planner_->dst_.x, planner_->dst_.y);
   getPlan(global_path);
-  global_path.poses.push_back(goal);
+  global_path.poses.back().pose.orientation = goal.pose.orientation;
 
   // If use_final_approach_orientation=true, interpolate the last pose orientation from the
   // previous pose to set the orientation to the 'final approach' orientation of the robot so

--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -116,7 +116,8 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
     logger_, "Got the src and dst... (%i, %i) && (%i, %i)",
     planner_->src_.x, planner_->src_.y, planner_->dst_.x, planner_->dst_.y);
   getPlan(global_path);
-
+  global_path.poses.push_back(goal);
+  
   // If use_final_approach_orientation=true, interpolate the last pose orientation from the
   // previous pose to set the orientation to the 'final approach' orientation of the robot so
   // it does not rotate.
@@ -165,16 +166,15 @@ nav_msgs::msg::Path ThetaStarPlanner::linearInterpolation(
   const double & dist_bw_points)
 {
   nav_msgs::msg::Path pa;
-
-  for (unsigned int j = 0; j < raw_path.size() - 1; j++) {
-    geometry_msgs::msg::PoseStamped p;
+   
+  geometry_msgs::msg::PoseStamped p1;
+  for (unsigned int j = 0; j < raw_path.size() - 1; j++) {    
     coordsW pt1 = raw_path[j];
-    p.pose.position.x = pt1.x;
-    p.pose.position.y = pt1.y;
-    pa.poses.push_back(p);
+    p1.pose.position.x = pt1.x;
+    p1.pose.position.y = pt1.y;
+    pa.poses.push_back(p1);
 
-    coordsW pt2 = raw_path[j + 1];
-    geometry_msgs::msg::PoseStamped p1;
+    coordsW pt2 = raw_path[j + 1];    
     double distance = std::hypot(pt2.x - pt1.x, pt2.y - pt1.y);
     int loops = static_cast<int>(distance / dist_bw_points);
     double sin_alpha = (pt2.y - pt1.y) / distance;
@@ -185,6 +185,7 @@ nav_msgs::msg::Path ThetaStarPlanner::linearInterpolation(
       pa.poses.push_back(p1);
     }
   }
+   
   return pa;
 }
 

--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -52,20 +52,14 @@ void ThetaStarPlanner::configure(
     node, name_ + ".w_traversal_cost", rclcpp::ParameterValue(2.0));
   node->get_parameter(name_ + ".w_traversal_cost", planner_->w_traversal_cost_);
 
-<<<<<<< HEAD
   planner_->w_heuristic_cost_ = planner_->w_euc_cost_ < 1.0 ? planner_->w_euc_cost_ : 1.0;
-=======
   nav2_util::declare_parameter_if_not_declared(
     node, name_ + ".w_heuristic_cost", rclcpp::ParameterValue(1.0));
   node->get_parameter(name_ + ".w_heuristic_cost", planner_->w_heuristic_cost_);
-<<<<<<< HEAD
-=======
->>>>>>> 9047f74111e7c07dfe33e87de7a8fd5146a634b8
 
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".use_final_approach_orientation", rclcpp::ParameterValue(false));
   node->get_parameter(name + ".use_final_approach_orientation", use_final_approach_orientation_);
->>>>>>> d47aba651ffa89225aaa006f05a59f87478aecf2
 }
 
 void ThetaStarPlanner::cleanup()
@@ -90,8 +84,6 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
 {
   nav_msgs::msg::Path global_path;
   auto start_time = std::chrono::steady_clock::now();
-<<<<<<< HEAD
-=======
 
   // Corner case of start and goal beeing on the same cell
   unsigned int mx_start, my_start, mx_goal, my_goal;
@@ -119,14 +111,11 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
     return global_path;
   }
 
->>>>>>> d47aba651ffa89225aaa006f05a59f87478aecf2
   planner_->setStartAndGoal(start, goal);
   RCLCPP_DEBUG(
     logger_, "Got the src and dst... (%i, %i) && (%i, %i)",
     planner_->src_.x, planner_->src_.y, planner_->dst_.x, planner_->dst_.y);
   getPlan(global_path);
-<<<<<<< HEAD
-=======
 
   // If use_final_approach_orientation=true, interpolate the last pose orientation from the
   // previous pose to set the orientation to the 'final approach' orientation of the robot so
@@ -148,7 +137,6 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
     }
   }
 
->>>>>>> d47aba651ffa89225aaa006f05a59f87478aecf2
   auto stop_time = std::chrono::steady_clock::now();
   auto dur = std::chrono::duration_cast<std::chrono::microseconds>(stop_time - start_time);
   RCLCPP_DEBUG(logger_, "the time taken is : %i", static_cast<int>(dur.count()));

--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -52,13 +52,20 @@ void ThetaStarPlanner::configure(
     node, name_ + ".w_traversal_cost", rclcpp::ParameterValue(2.0));
   node->get_parameter(name_ + ".w_traversal_cost", planner_->w_traversal_cost_);
 
+<<<<<<< HEAD
+  planner_->w_heuristic_cost_ = planner_->w_euc_cost_ < 1.0 ? planner_->w_euc_cost_ : 1.0;
+=======
   nav2_util::declare_parameter_if_not_declared(
     node, name_ + ".w_heuristic_cost", rclcpp::ParameterValue(1.0));
   node->get_parameter(name_ + ".w_heuristic_cost", planner_->w_heuristic_cost_);
+<<<<<<< HEAD
+=======
+>>>>>>> 9047f74111e7c07dfe33e87de7a8fd5146a634b8
 
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".use_final_approach_orientation", rclcpp::ParameterValue(false));
   node->get_parameter(name + ".use_final_approach_orientation", use_final_approach_orientation_);
+>>>>>>> d47aba651ffa89225aaa006f05a59f87478aecf2
 }
 
 void ThetaStarPlanner::cleanup()
@@ -83,11 +90,13 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
 {
   nav_msgs::msg::Path global_path;
   auto start_time = std::chrono::steady_clock::now();
+<<<<<<< HEAD
+=======
 
   // Corner case of start and goal beeing on the same cell
   unsigned int mx_start, my_start, mx_goal, my_goal;
   planner_->costmap_->worldToMap(start.pose.position.x, start.pose.position.y, mx_start, my_start);
-  planner_->costmap_->worldToMap(start.pose.position.x, start.pose.position.y, mx_goal, my_goal);
+  planner_->costmap_->worldToMap(goal.pose.position.x, goal.pose.position.y, mx_goal, my_goal);
   if (mx_start == mx_goal && my_start == my_goal) {
     if (planner_->costmap_->getCost(mx_start, my_start) == nav2_costmap_2d::LETHAL_OBSTACLE) {
       RCLCPP_WARN(logger_, "Failed to create a unique pose path because of obstacles");
@@ -110,11 +119,14 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
     return global_path;
   }
 
+>>>>>>> d47aba651ffa89225aaa006f05a59f87478aecf2
   planner_->setStartAndGoal(start, goal);
   RCLCPP_DEBUG(
     logger_, "Got the src and dst... (%i, %i) && (%i, %i)",
     planner_->src_.x, planner_->src_.y, planner_->dst_.x, planner_->dst_.y);
   getPlan(global_path);
+<<<<<<< HEAD
+=======
 
   // If use_final_approach_orientation=true, interpolate the last pose orientation from the
   // previous pose to set the orientation to the 'final approach' orientation of the robot so
@@ -136,9 +148,10 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
     }
   }
 
+>>>>>>> d47aba651ffa89225aaa006f05a59f87478aecf2
   auto stop_time = std::chrono::steady_clock::now();
   auto dur = std::chrono::duration_cast<std::chrono::microseconds>(stop_time - start_time);
-  RCLCPP_DEBUG(logger_, "the time taken for pointy is : %i", static_cast<int>(dur.count()));
+  RCLCPP_DEBUG(logger_, "the time taken is : %i", static_cast<int>(dur.count()));
   RCLCPP_DEBUG(logger_, "the nodes_opened are:  %i", planner_->nodes_opened);
   return global_path;
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points
This PR basically does the following:
- removing 'w_heuristic_cost_' from Nav2 Theta Star Planner as a user configurable parameter
  - updates to nav2_theta_star_planner/README.md to remove its reference wherever applicable
  - updates to nav2_theta_star_planner/src/theta_star_planner.cpp to set w_heuristic_cost as std::min(1.0, w_euc_cost_)
- fixed an incorrect check of whether the start and goal pose are the same in nav2_theta_star_planner/src/theta_star_planner.cpp, this was leading to runtime errors

## Description of documentation updates required from your changes
removing the mention of w_heuristic_cost from Nav2 Theta Star Planner's docs, as it no longer user configurable

---

## Future work that may be required in bullet points

update the docs available on the website for the Nav2 Theta Star Planner

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
