### PR TITLE
Register nodes as components

### DIFF
--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(ament_cmake REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -50,6 +51,7 @@ endif()
 set(dependencies
   rclcpp
   rclcpp_lifecycle
+  rclcpp_components
   message_filters
   tf2_geometry_msgs
   geometry_msgs
@@ -77,6 +79,8 @@ ament_target_dependencies(${library_name}
 target_link_libraries(${library_name}
   map_lib motions_lib sensors_lib
 )
+
+rclcpp_components_register_nodes(${library_name} "nav2_amcl::AmclNode")
 
 install(TARGETS ${library_name}
   ARCHIVE DESTINATION lib

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1376,3 +1376,10 @@ AmclNode::initLaserScan()
 }
 
 }  // namespace nav2_amcl
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(nav2_amcl::AmclNode)

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav2_behavior_tree REQUIRED)
@@ -35,6 +36,7 @@ set(dependencies
   rclcpp
   rclcpp_action
   rclcpp_lifecycle
+  rclcpp_components
   std_msgs
   geometry_msgs
   nav2_behavior_tree
@@ -62,6 +64,8 @@ target_link_libraries(${executable_name} ${library_name})
 ament_target_dependencies(${library_name}
   ${dependencies}
 )
+
+rclcpp_components_register_nodes(${library_name} "nav2_bt_navigator::BtNavigator")
 
 install(TARGETS ${library_name}
   ARCHIVE DESTINATION lib

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -182,3 +182,10 @@ BtNavigator::on_shutdown(const rclcpp_lifecycle::State & /*state*/)
 }
 
 }  // namespace nav2_bt_navigator
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(nav2_bt_navigator::BtNavigator)

--- a/nav2_controller/CMakeLists.txt
+++ b/nav2_controller/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(nav2_common REQUIRED)
 find_package(angles REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(nav2_msgs REQUIRED)
@@ -28,7 +29,7 @@ add_executable(${executable_name}
 
 set(library_name ${executable_name}_core)
 
-add_library(${library_name}
+add_library(${library_name} SHARED
   src/nav2_controller.cpp
 )
 
@@ -36,6 +37,7 @@ set(dependencies
   angles
   rclcpp
   rclcpp_action
+  rclcpp_components
   std_msgs
   nav2_msgs
   nav_2d_utils
@@ -74,6 +76,8 @@ ament_target_dependencies(${executable_name}
 )
 
 target_link_libraries(${executable_name} ${library_name})
+
+rclcpp_components_register_nodes(${library_name} "nav2_controller::ControllerServer")
 
 install(TARGETS simple_progress_checker simple_goal_checker stopped_goal_checker ${library_name}
   ARCHIVE DESTINATION lib

--- a/nav2_controller/src/nav2_controller.cpp
+++ b/nav2_controller/src/nav2_controller.cpp
@@ -580,3 +580,10 @@ void ControllerServer::speedLimitCallback(const nav2_msgs::msg::SpeedLimit::Shar
 }
 
 }  // namespace nav2_controller
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(nav2_controller::ControllerServer)

--- a/nav2_lifecycle_manager/CMakeLists.txt
+++ b/nav2_lifecycle_manager/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(nav2_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
@@ -36,6 +37,7 @@ set(dependencies
   rclcpp
   rclcpp_action
   rclcpp_lifecycle
+  rclcpp_components
   std_msgs
   std_srvs
   tf2_geometry_msgs
@@ -57,6 +59,8 @@ target_link_libraries(lifecycle_manager
 ament_target_dependencies(lifecycle_manager
   ${dependencies}
 )
+
+rclcpp_components_register_nodes(${library_name} "nav2_lifecycle_manager::LifecycleManager")
 
 install(TARGETS
   ${library_name}

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -375,3 +375,10 @@ LifecycleManager::message(const std::string & msg)
 }
 
 }  // namespace nav2_lifecycle_manager
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(nav2_lifecycle_manager::LifecycleManager)

--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(ament_cmake REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
@@ -61,6 +62,7 @@ set(map_io_dependencies
 set(map_server_dependencies
   rclcpp
   rclcpp_lifecycle
+  rclcpp_components
   nav_msgs
   nav2_msgs
   yaml_cpp_vendor
@@ -122,6 +124,9 @@ if(WIN32)
   target_compile_definitions(${map_io_library_name} PRIVATE
     YAML_CPP_DLL)
 endif()
+
+rclcpp_components_register_nodes(${library_name} "nav2_map_server::MapSaver")
+rclcpp_components_register_nodes(${library_name} "nav2_map_server::MapServer")
 
 install(TARGETS
     ${library_name} ${map_io_library_name}

--- a/nav2_map_server/src/map_saver/map_saver.cpp
+++ b/nav2_map_server/src/map_saver/map_saver.cpp
@@ -228,3 +228,10 @@ bool MapSaver::saveMapTopicToFile(
 }
 
 }  // namespace nav2_map_server
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(nav2_map_server::MapSaver)

--- a/nav2_map_server/src/map_server/map_server.cpp
+++ b/nav2_map_server/src/map_server/map_server.cpp
@@ -235,3 +235,10 @@ void MapServer::updateMsgHeader()
 }
 
 }  // namespace nav2_map_server
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(nav2_map_server::MapServer)

--- a/nav2_planner/CMakeLists.txt
+++ b/nav2_planner/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
@@ -31,6 +32,7 @@ set(dependencies
   rclcpp
   rclcpp_action
   rclcpp_lifecycle
+  rclcpp_components
   std_msgs
   visualization_msgs
   nav2_util
@@ -61,6 +63,8 @@ target_link_libraries(${executable_name} ${library_name})
 ament_target_dependencies(${executable_name}
   ${dependencies}
 )
+
+rclcpp_components_register_nodes(${library_name} "nav2_planner::PlannerServer")
 
 install(TARGETS ${library_name}
   ARCHIVE DESTINATION lib

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -511,3 +511,10 @@ PlannerServer::publishPlan(const nav_msgs::msg::Path & path)
 }
 
 }  // namespace nav2_planner
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(nav2_planner::PlannerServer)

--- a/nav2_recoveries/CMakeLists.txt
+++ b/nav2_recoveries/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(nav2_behavior_tree REQUIRED)
 find_package(nav2_util REQUIRED)
@@ -31,6 +32,7 @@ set(dependencies
   rclcpp
   rclcpp_action
   rclcpp_lifecycle
+  rclcpp_components
   std_msgs
   nav2_util
   nav2_behavior_tree
@@ -72,7 +74,7 @@ ament_target_dependencies(nav2_wait_recovery
 pluginlib_export_plugin_description_file(nav2_core recovery_plugin.xml)
 
 # Library
-add_library(${library_name}
+add_library(${library_name} SHARED
   src/recovery_server.cpp
 )
 
@@ -91,6 +93,7 @@ ament_target_dependencies(${executable_name}
   ${dependencies}
 )
 
+rclcpp_components_register_nodes(${library_name} "recovery_server::RecoveryServer")
 
 install(TARGETS ${library_name}
                 nav2_backup_recovery

--- a/nav2_recoveries/src/recovery_server.cpp
+++ b/nav2_recoveries/src/recovery_server.cpp
@@ -182,3 +182,10 @@ RecoveryServer::on_shutdown(const rclcpp_lifecycle::State &)
 }
 
 }  // end namespace recovery_server
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(recovery_server::RecoveryServer)

--- a/nav2_waypoint_follower/CMakeLists.txt
+++ b/nav2_waypoint_follower/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(nav2_common REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav2_util REQUIRED)
@@ -46,6 +47,7 @@ set(dependencies
   rclcpp
   rclcpp_action
   rclcpp_lifecycle
+  rclcpp_components
   nav_msgs
   nav2_msgs
   nav2_util
@@ -75,6 +77,8 @@ ament_target_dependencies(photo_at_waypoint ${dependencies})
 
 add_library(input_at_waypoint SHARED plugins/input_at_waypoint.cpp)
 ament_target_dependencies(input_at_waypoint ${dependencies})
+
+rclcpp_components_register_nodes(${library_name} "nav2_waypoint_follower::WaypointFollower")
 
 install(TARGETS ${library_name} wait_at_waypoint photo_at_waypoint input_at_waypoint
   ARCHIVE DESTINATION lib

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -306,3 +306,10 @@ WaypointFollower::goalResponseCallback(
 }
 
 }  // namespace nav2_waypoint_follower
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(nav2_waypoint_follower::WaypointFollower)


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |(tickets:  [#1013](https://github.com/ros-planning/navigation2/issues/1013)) |
| Primary OS tested on | -  |
| Robotic platform tested on |  -  |
---

## Description of contribution in a few bullet points

Register Nav2 nodes as rclcpp components so that they could be launched in a same container (i.e. a single process).

---

## Future work that may be required in bullet points

add launch files to use component container （blocked by some problems）

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
