### PR TITLE
Fixed vector::reserve exception in smac planner due to precision error

### DIFF
--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -575,11 +575,11 @@ typename AStarAlgorithm<NodeT>::AnalyticExpansionNodes AStarAlgorithm<NodeT>::ge
     node->motion_table.state_space->interpolate(from(), to(), i / num_intervals, s());
     reals = s.reals();
     angle = reals[2] / node->motion_table.bin_size;
-    while (angle >= node->motion_table.num_angle_quantization_float) {
-      angle -= node->motion_table.num_angle_quantization_float;
-    }
     while (angle < 0.0) {
       angle += node->motion_table.num_angle_quantization_float;
+    }
+    while (angle >= node->motion_table.num_angle_quantization_float) {
+      angle -= node->motion_table.num_angle_quantization_float;
     }
     // Turn the pose into a node, and check if it is valid
     index = NodeT::getIndex(

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -230,12 +230,12 @@ MotionPoses HybridMotionTable::getProjections(const NodeHybrid * node)
     const float & node_heading = node->pose.theta;
     float new_heading = node_heading + motion_model._theta;
 
-    if (new_heading >= num_angle_quantization_float) {
-      new_heading -= num_angle_quantization_float;
-    }
-
     if (new_heading < 0.0) {
       new_heading += num_angle_quantization_float;
+    }
+
+    if (new_heading >= num_angle_quantization_float) {
+      new_heading -= num_angle_quantization_float;
     }
 
     projection_list.emplace_back(

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -263,6 +263,10 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
   while (orientation_bin < 0.0) {
     orientation_bin += static_cast<float>(_angle_quantizations);
   }
+  // This is needed to handle precision issues
+  if (orientation_bin >= static_cast<float>(_angle_quantizations)) {
+    orientation_bin -= static_cast<float>(_angle_quantizations);
+  }
   unsigned int orientation_bin_id = static_cast<unsigned int>(floor(orientation_bin));
   _a_star->setStart(mx, my, orientation_bin_id);
 
@@ -271,6 +275,10 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
   orientation_bin = tf2::getYaw(goal.pose.orientation) / _angle_bin_size;
   while (orientation_bin < 0.0) {
     orientation_bin += static_cast<float>(_angle_quantizations);
+  }
+  // This is needed to handle precision issues
+  if (orientation_bin >= static_cast<float>(_angle_quantizations)) {
+    orientation_bin -= static_cast<float>(_angle_quantizations);
   }
   orientation_bin_id = static_cast<unsigned int>(floor(orientation_bin));
   _a_star->setGoal(mx, my, orientation_bin_id);


### PR DESCRIPTION
- Related issue: https://github.com/ros-planning/navigation2/issues/2547