### PR TITLE
Bug fix: set the BT Navigator "default_nav_to_pose_bt_xml" and "default_nav_through_pose_bt_xml" from the yaml file

### DIFF
--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -47,13 +47,12 @@ NavigateThroughPosesNavigator::getDefaultBTFilepath(
 {
   std::string default_bt_xml_filename;
   auto node = parent_node.lock();
-  if (!node->has_parameter("default_nav_through_poses_bt_xml")) {
-    std::string pkg_share_dir =
-      ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
-    std::string tree_file = pkg_share_dir +
-      "/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml";
-    node->declare_parameter("default_nav_through_poses_bt_xml", tree_file);
-  }
+  std::string pkg_share_dir =
+    ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  node->declare_parameter<std::string>(
+    "default_nav_through_poses_bt_xml",
+    pkg_share_dir +
+    "/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml");
   node->get_parameter("default_nav_through_poses_bt_xml", default_bt_xml_filename);
 
   return default_bt_xml_filename;

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -53,13 +53,12 @@ NavigateToPoseNavigator::getDefaultBTFilepath(
 {
   std::string default_bt_xml_filename;
   auto node = parent_node.lock();
-  if (!node->has_parameter("default_nav_to_pose_bt_xml")) {
-    std::string pkg_share_dir =
-      ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
-    std::string tree_file = pkg_share_dir +
-      "/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml";
-    node->declare_parameter("default_nav_to_pose_bt_xml", tree_file);
-  }
+  std::string pkg_share_dir =
+    ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  node->declare_parameter<std::string>(
+    "default_nav_to_pose_bt_xml",
+    pkg_share_dir +
+    "/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml");
   node->get_parameter("default_nav_to_pose_bt_xml", default_bt_xml_filename);
 
   return default_bt_xml_filename;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2663 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of MPO-700 |

---

## Description of contribution in a few bullet points

* Fixed the issue for setting the `default_nav_to_pose_bt_xml` in the yaml

## Description of documentation updates required from your changes
NA
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points
NA
<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
