### PR TITLE
Remove "wrong"/unnecessary dependency

### DIFF
--- a/nav2_amcl/CMakeLists.txt
+++ b/nav2_amcl/CMakeLists.txt
@@ -17,7 +17,6 @@ find_package(tf2 REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(ament_cmake_ros REQUIRED)
 
 nav2_package()
 


### PR DESCRIPTION
## Problem
`ament_cmake_ros` dependency is added in #2642. This breaks build in our repository where navigation2 is dependency.

## Solution
Looking at the changed in #2642 I am not sure why this dependency is added, or it is at least added wrongly because there should equivalent in the package.xml file and there is none.

Based on my experience working on 10+ CPP repositories with ROS2 I think the dependency is not necessary, therefore propose to remove it.