### PR TITLE
Clean .gcda files for invalidated package tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,12 @@ _commands:
         - restore_cache:
             name: Restore Cache << parameters.key >>
             keys:
-              - "<< parameters.key >>-v4\
+              - "<< parameters.key >>-v5\
                 -{{ arch }}\
                 -{{ .Branch }}\
                 -{{ .Environment.CIRCLE_PR_NUMBER }}\
                 -{{ checksum  \"<< parameters.workspace >>/lockfile.txt\" }}"
-              - "<< parameters.key >>-v4\
+              - "<< parameters.key >>-v5\
                 -{{ arch }}\
                 -main\
                 -<no value>\
@@ -58,7 +58,7 @@ _commands:
       steps:
         - save_cache:
             name: Save Cache << parameters.key >>
-            key: "<< parameters.key >>-v4\
+            key: "<< parameters.key >>-v5\
               -{{ arch }}\
               -{{ .Branch }}\
               -{{ .Environment.CIRCLE_PR_NUMBER }}\

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,11 @@ _commands:
                     colcon clean packages --yes \
                       --packages-select ${BUILD_PACKAGES} \
                       --base-select install
+                    colcon clean packages --yes \
+                      --packages-select ${BUILD_PACKAGES} \
+                      --base-select build \
+                      --clean-match \
+                        "*.gcno"
 
                     . << parameters.underlay >>/install/setup.sh
                     colcon build \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,11 +186,6 @@ _commands:
                     colcon clean packages --yes \
                       --packages-select ${BUILD_PACKAGES} \
                       --base-select install
-                    colcon clean packages --yes \
-                      --packages-select ${BUILD_PACKAGES} \
-                      --base-select build \
-                      --clean-match \
-                        "*.gcno"
 
                     . << parameters.underlay >>/install/setup.sh
                     colcon build \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,13 @@ _commands:
             name: Test Workspace | << parameters.workspace >>
             working_directory: << parameters.workspace >>
             command: |
+              TEST_UNPASSED=$(
+                colcon list \
+                  --names-only \
+                  --packages-skip-test-passed \
+                | xargs)
+              echo TEST_UNPASSED: $TEST_UNPASSED
+
               TEST_FAILURES=$(
                 colcon list \
                   --names-only \
@@ -236,13 +243,15 @@ _commands:
               echo TEST_INVALID: $TEST_INVALID
 
               TEST_PACKAGES=""
-              if [ -n "$TEST_FAILURES" ] || \
+              if [ -n "$TEST_UNPASSED" ] || \
+                 [ -n "$TEST_FAILURES" ] || \
                  [ -n "$TEST_INVALID" ]
               then
                 TEST_PACKAGES=$(
                   colcon list \
                     --names-only \
                     --packages-above \
+                      $TEST_UNPASSED \
                       $TEST_FAILURES \
                       $TEST_INVALID)
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,12 @@ _commands:
         - restore_cache:
             name: Restore Cache << parameters.key >>
             keys:
-              - "<< parameters.key >>-v3\
+              - "<< parameters.key >>-v4\
                 -{{ arch }}\
                 -{{ .Branch }}\
                 -{{ .Environment.CIRCLE_PR_NUMBER }}\
                 -{{ checksum  \"<< parameters.workspace >>/lockfile.txt\" }}"
-              - "<< parameters.key >>-v3\
+              - "<< parameters.key >>-v4\
                 -{{ arch }}\
                 -main\
                 -<no value>\
@@ -58,7 +58,7 @@ _commands:
       steps:
         - save_cache:
             name: Save Cache << parameters.key >>
-            key: "<< parameters.key >>-v3\
+            key: "<< parameters.key >>-v4\
               -{{ arch }}\
               -{{ .Branch }}\
               -{{ .Environment.CIRCLE_PR_NUMBER }}\

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,12 @@ _commands:
         - restore_cache:
             name: Restore Cache << parameters.key >>
             keys:
-              - "<< parameters.key >>-v5\
+              - "<< parameters.key >>-v6\
                 -{{ arch }}\
                 -{{ .Branch }}\
                 -{{ .Environment.CIRCLE_PR_NUMBER }}\
                 -{{ checksum  \"<< parameters.workspace >>/lockfile.txt\" }}"
-              - "<< parameters.key >>-v5\
+              - "<< parameters.key >>-v6\
                 -{{ arch }}\
                 -main\
                 -<no value>\
@@ -58,7 +58,7 @@ _commands:
       steps:
         - save_cache:
             name: Save Cache << parameters.key >>
-            key: "<< parameters.key >>-v5\
+            key: "<< parameters.key >>-v6\
               -{{ arch }}\
               -{{ .Branch }}\
               -{{ .Environment.CIRCLE_PR_NUMBER }}\

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ _commands:
               - << parameters.path >>/build
               - << parameters.path >>/install
               - << parameters.path >>/log
+              - << parameters.path >>/test_results
             when: << parameters.when >>
     install_dependencies:
       description: "Install Dependencies"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,11 @@ _commands:
               colcon clean packages --yes \
                 --packages-select ${TEST_PACKAGES} \
                 --base-select test_result
+              colcon clean packages --yes \
+                --packages-select ${TEST_PACKAGES} \
+                --base-select build \
+                --clean-match \
+                  "*.gcda"
 
               . install/setup.sh
               set -o xtrace


### PR DESCRIPTION
"Each time you run the program, the execution counts are summed into any existing .gcda files, so be sure to remove any old files if you do not want their contents to be included."
https://llvm.org/docs/CommandGuide/llvm-cov.html

Example:

<details>

```
    libgcov profiling error:/opt/overlay_ws/build/nav2_util/test/CMakeFiles/test_node_utils.dir/test_node_utils.cpp.gcda:overwriting an existing profile data with a different timestamp
    libgcov profiling error:/opt/overlay_ws/build/nav2_util/src/CMakeFiles/nav2_util_core.dir/odometry_utils.cpp.gcda:overwriting an existing profile data with a different timestamp
    libgcov profiling error:/opt/overlay_ws/build/nav2_util/src/CMakeFiles/nav2_util_core.dir/node_thread.cpp.gcda:overwriting an existing profile data with a different timestamp
    libgcov profiling error:/opt/overlay_ws/build/nav2_util/src/CMakeFiles/nav2_util_core.dir/robot_utils.cpp.gcda:overwriting an existing profile data with a different timestamp
    libgcov profiling error:/opt/overlay_ws/build/nav2_util/src/CMakeFiles/nav2_util_core.dir/lifecycle_node.cpp.gcda:overwriting an existing profile data with a different timestamp
    libgcov profiling error:/opt/overlay_ws/build/nav2_util/src/CMakeFiles/nav2_util_core.dir/lifecycle_utils.cpp.gcda:overwriting an existing profile data with a different timestamp
    libgcov profiling error:/opt/overlay_ws/build/nav2_util/src/CMakeFiles/nav2_util_core.dir/string_utils.cpp.gcda:overwriting an existing profile data with a different timestamp
    libgcov profiling error:/opt/overlay_ws/build/nav2_util/src/CMakeFiles/nav2_util_core.dir/lifecycle_service_client.cpp.gcda:overwriting an existing profile data with a different timestamp
    libgcov profiling error:/opt/overlay_ws/build/nav2_util/src/CMakeFiles/nav2_util_core.dir/node_utils.cpp.gcda:overwriting an existing profile data with a different timestamp
    libgcov profiling error:/opt/overlay_ws/build/nav2_util/src/CMakeFiles/nav2_util_core.dir/costmap.cpp.gcda:overwriting an existing profile data with a different timestamp
```

https://app.circleci.com/pipelines/github/ros-planning/navigation2/6480/workflows/e9f7aefe-808c-4465-bebb-d63c7136dade/jobs/23842