### PR TITLE
adding backwards state update

### DIFF
--- a/nav2_smac_planner/src/node_lattice.cpp
+++ b/nav2_smac_planner/src/node_lattice.cpp
@@ -518,9 +518,7 @@ void NodeLattice::getNeighbors(
       {
         neighbor->setMotionPrimitive(motion_primitives[i]);
         // Marking if this search was obtained in the reverse direction
-        if (backwards) {
-          neighbor->backwards();
-        }
+        neighbor->backwards(backwards);
         neighbors.push_back(neighbor);
       } else {
         neighbor->setPose(initial_node_coords);


### PR DESCRIPTION
https://github.com/ros-planning/navigation2/issues/2710

> One more observation (not tested): Shouldn't these three lines (521, 522, 523) be replaced by just neighbor->backwards(backwards); so that also an originally backward neighbor can be reset to a forward one?