### PR TITLE
Apt upgrade with new pkgs

### DIFF
--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -47,6 +47,9 @@ jobs:
             -o Dir::Etc::sourcelist="${SOURCELIST}"
           apt-get --simulate upgrade \
             -o Dir::Etc::sourcelist="${SOURCELIST}" \
+            > upgrade.log
+          cat upgrade.log
+          cat upgrade.log \
             | grep "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" \
             && echo "::set-output name=trigger::false" \
             || echo "::set-output name=trigger::true"

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ APT::Install-Suggests "0";\n\
 # install CI dependencies
 ARG RTI_NC_LICENSE_ACCEPTED=yes
 RUN apt-get update && \
-    apt-get upgrade -y && \
+    apt-get upgrade -y --with-new-pkgs && \
     apt-get install -y \
       ccache \
       lcov \


### PR DESCRIPTION
using --with-new-pkgs flag.

This ensures all packages in CI image are updated, preventing the Update CI Image workflow from needlessly retriggering and rebuilding the images due packages otherwise having been kept back.

https://unix.stackexchange.com/a/241062/213124