### PR TITLE
Dynamic parameter setting of costmap layers (inflation/static/voxel)

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -237,6 +237,13 @@ private:
   inline void enqueue(
     unsigned int index, unsigned int mx, unsigned int my,
     unsigned int src_x, unsigned int src_y);
+  
+  /**
+   * @brief Callback executed when a parameter change is detected
+   * @param event ParameterEvent message
+   */
+  rcl_interfaces::msg::SetParametersResult
+  dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
 
   double inflation_radius_, inscribed_radius_, cost_scaling_factor_;
   bool inflate_unknown_, inflate_around_unknown_;
@@ -257,6 +264,8 @@ private:
   // Indicates that the entire costmap should be reinflated next time around.
   bool need_reinflation_;
   mutex_t * access_;
+  // Dynamic parameters handler
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -237,7 +237,7 @@ private:
   inline void enqueue(
     unsigned int index, unsigned int mx, unsigned int my,
     unsigned int src_x, unsigned int src_y);
-  
+
   /**
    * @brief Callback executed when a parameter change is detected
    * @param event ParameterEvent message

--- a/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
@@ -152,6 +152,13 @@ private:
    */
   unsigned char interpretValue(unsigned char value);
 
+  /**
+   * @brief Callback executed when a parameter change is detected
+   * @param event ParameterEvent message
+   */
+  rcl_interfaces::msg::SetParametersResult
+  dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
+
   std::string global_frame_;  ///< @brief The global frame for the costmap
   std::string map_frame_;  /// @brief frame that map is located in
 
@@ -178,6 +185,9 @@ private:
   tf2::Duration transform_tolerance_;
   std::atomic<bool> update_in_progress_;
   nav_msgs::msg::OccupancyGrid::SharedPtr map_buffer_;
+  // Dynamic parameters handler
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
+  std::mutex dyn_param_mutex_;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/static_layer.hpp
@@ -187,7 +187,6 @@ private:
   nav_msgs::msg::OccupancyGrid::SharedPtr map_buffer_;
   // Dynamic parameters handler
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
-  std::mutex dyn_param_mutex_;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
@@ -232,7 +232,7 @@ private:
   // Dynamic parameters handler
   std::mutex mutex_;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
-  
+
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
@@ -51,7 +51,6 @@
 #include <message_filters/subscriber.h>
 #include <nav2_costmap_2d/obstacle_layer.hpp>
 #include <nav2_voxel_grid/voxel_grid.hpp>
-#include <mutex>
 
 namespace nav2_costmap_2d
 {

--- a/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
@@ -51,6 +51,7 @@
 #include <message_filters/subscriber.h>
 #include <nav2_costmap_2d/obstacle_layer.hpp>
 #include <nav2_voxel_grid/voxel_grid.hpp>
+#include <mutex>
 
 namespace nav2_costmap_2d
 {
@@ -220,6 +221,18 @@ private:
   {
     return (size_z_ - 1 + 0.5) * z_resolution_;
   }
+
+  /**
+   * @brief Callback executed when a parameter change is detected
+   * @param event ParameterEvent message
+   */
+  rcl_interfaces::msg::SetParametersResult
+  dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
+
+  // Dynamic parameters handler
+  std::mutex mutex_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
+  
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
@@ -230,7 +230,6 @@ private:
   dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
 
   // Dynamic parameters handler
-  std::mutex mutex_;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
 
 };

--- a/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/voxel_layer.hpp
@@ -231,7 +231,6 @@ private:
 
   // Dynamic parameters handler
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
-
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -103,9 +103,9 @@ InflationLayer::onInitialize()
     node->get_parameter(name_ + "." + "inflate_around_unknown", inflate_around_unknown_);
 
     dyn_params_handler_ = node->add_on_set_parameters_callback(
-    std::bind(
-      &InflationLayer::dynamicParametersCallback,
-      this, std::placeholders::_1));
+      std::bind(
+        &InflationLayer::dynamicParametersCallback,
+        this, std::placeholders::_1));
   }
 
   current_ = true;
@@ -453,7 +453,7 @@ InflationLayer::dynamicParametersCallback(
       if (param_name == name_ + "." + "enabled" && enabled_ != parameter.as_bool()) {
         enabled_ = parameter.as_bool();
         need_reinflation_ = true;
-        current_ = false; 
+        current_ = false;
       } else if (param_name == name_ + "." + "inflate_unknown" &&
         inflate_unknown_ != parameter.as_bool())
       {

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -115,7 +115,6 @@ InflationLayer::onInitialize()
   need_reinflation_ = false;
   cell_inflation_radius_ = cellDistance(inflation_radius_);
   matchSize();
-
 }
 
 void
@@ -434,7 +433,6 @@ InflationLayer::dynamicParametersCallback(
   for (auto parameter : parameters) {
     const auto & param_type = parameter.get_type();
     const auto & param_name = parameter.get_name();
-
 
     if (param_type == ParameterType::PARAMETER_DOUBLE) {
       if (param_name == name_ + "." + "inflation_radius" &&

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -439,7 +439,6 @@ InflationLayer::dynamicParametersCallback(
         inflation_radius_ != parameter.as_double())
       {
         inflation_radius_ = parameter.as_double();
-        cell_inflation_radius_ = cellDistance(inflation_radius_);
         need_reinflation_ = true;
         need_cache_recompute = true;
       } else if (param_name == name_ + "." + "cost_scaling_factor" &&
@@ -470,7 +469,7 @@ InflationLayer::dynamicParametersCallback(
   }
 
   if (need_cache_recompute) {
-    computeCaches();
+    matchSize();
   }
 
   result.successful = true;

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -425,7 +425,6 @@ rcl_interfaces::msg::SetParametersResult
 InflationLayer::dynamicParametersCallback(
   std::vector<rclcpp::Parameter> parameters)
 {
-
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   rcl_interfaces::msg::SetParametersResult result;
 

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -425,10 +425,11 @@ rcl_interfaces::msg::SetParametersResult
 InflationLayer::dynamicParametersCallback(
   std::vector<rclcpp::Parameter> parameters)
 {
-  static bool need_cache_recompute = false;
 
-  rcl_interfaces::msg::SetParametersResult result;
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
+  rcl_interfaces::msg::SetParametersResult result;
+
+  bool need_cache_recompute = false;
 
   for (auto parameter : parameters) {
     const auto & param_type = parameter.get_type();
@@ -471,7 +472,6 @@ InflationLayer::dynamicParametersCallback(
 
   if (need_cache_recompute) {
     computeCaches();
-    need_cache_recompute = false;
   }
 
   result.successful = true;

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -101,6 +101,11 @@ InflationLayer::onInitialize()
     node->get_parameter(name_ + "." + "cost_scaling_factor", cost_scaling_factor_);
     node->get_parameter(name_ + "." + "inflate_unknown", inflate_unknown_);
     node->get_parameter(name_ + "." + "inflate_around_unknown", inflate_around_unknown_);
+
+    dyn_params_handler_ = node->add_on_set_parameters_callback(
+    std::bind(
+      &InflationLayer::dynamicParametersCallback,
+      this, std::placeholders::_1));
   }
 
   current_ = true;
@@ -111,10 +116,6 @@ InflationLayer::onInitialize()
   cell_inflation_radius_ = cellDistance(inflation_radius_);
   matchSize();
 
-  dyn_params_handler_ = node_->add_on_set_parameters_callback(
-    std::bind(
-      &InflationLayer::dynamicParametersCallback,
-      this, std::placeholders::_1));
 }
 
 void
@@ -457,7 +458,6 @@ InflationLayer::dynamicParametersCallback(
       if (param_name == name_ + "." + "enabled" && enabled_ != parameter.as_bool()) {
         enabled_ = parameter.as_bool();
         paramChange_s.enabled = true;
-        RCLCPP_INFO(node_->get_logger(), "Updated!");
       } else if (param_name == name_ + "." + "inflate_unknown" &&
         inflate_unknown_ != parameter.as_bool())
       {

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -414,10 +414,10 @@ InflationLayer::generateIntegerDistances()
   return level;
 }
 
- /**
-   * @brief Callback executed when a parameter change is detected
-   * @param event ParameterEvent message
-   */
+/**
+  * @brief Callback executed when a parameter change is detected
+  * @param event ParameterEvent message
+  */
 rcl_interfaces::msg::SetParametersResult
 InflationLayer::dynamicParametersCallback(
   std::vector<rclcpp::Parameter> parameters)
@@ -428,34 +428,24 @@ InflationLayer::dynamicParametersCallback(
   for (auto parameter : parameters) {
     const auto & param_type = parameter.get_type();
     const auto & param_name = parameter.get_name();
-    
-    
+
+
     if (param_type == ParameterType::PARAMETER_DOUBLE) {
-      if(param_name == name_ + "." + "inflation_radius" )
-      {
+      if (param_name == name_ + "." + "inflation_radius") {
         inflation_radius_ = parameter.as_double();
         cell_inflation_radius_ = cellDistance(inflation_radius_);
         need_reinflation_ = true;
         computeCaches();
 
-      }
-      else if(param_name == name_ + "." + "cost_scaling_factor")
-      {
+      } else if (param_name == name_ + "." + "cost_scaling_factor") {
         cost_scaling_factor_ = parameter.as_double();
       }
-    }
-    else if(param_type == ParameterType::PARAMETER_BOOL)
-    {
-      if(param_name == name_ + "." + "enabled")
-      {
+    } else if (param_type == ParameterType::PARAMETER_BOOL) {
+      if (param_name == name_ + "." + "enabled") {
         enabled_ = parameter.as_bool();
-      }
-      else if(param_name == name_ + "." + "inflate_unknown")
-      {
+      } else if (param_name == name_ + "." + "inflate_unknown") {
         inflate_unknown_ = parameter.as_bool();
-      }
-      else if(param_name == name_ + "." + "inflate_around_unknown")
-      {
+      } else if (param_name == name_ + "." + "inflate_around_unknown") {
         inflate_around_unknown_ = parameter.as_bool();
       }
     }

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -455,6 +455,7 @@ ObstacleLayer::updateFootprint(
   double * max_x,
   double * max_y)
 {
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (!footprint_clearing_enabled_) {return;}
   transformFootprint(robot_x, robot_y, robot_yaw, getFootprint(), transformed_footprint_);
 
@@ -469,6 +470,7 @@ ObstacleLayer::updateCosts(
   int max_i,
   int max_j)
 {
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (!enabled_) {
     return;
   }

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -452,8 +452,9 @@ rcl_interfaces::msg::SetParametersResult
 StaticLayer::dynamicParametersCallback(
   std::vector<rclcpp::Parameter> parameters)
 {
-  rcl_interfaces::msg::SetParametersResult result;
+
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
+  rcl_interfaces::msg::SetParametersResult result;
 
   for (auto parameter : parameters) {
     const auto & param_type = parameter.get_type();

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -380,7 +380,7 @@ StaticLayer::updateCosts(
   nav2_costmap_2d::Costmap2D & master_grid,
   int min_i, int min_j, int max_i, int max_j)
 {
-  std::lock_guard<std::mutex> lock_reinit(dyn_param_mutex_);
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (!enabled_) {
     update_in_progress_.store(false);
     return;
@@ -453,7 +453,7 @@ StaticLayer::dynamicParametersCallback(
   std::vector<rclcpp::Parameter> parameters)
 {
   rcl_interfaces::msg::SetParametersResult result;
-  std::lock_guard<std::mutex> lock_reinit(dyn_param_mutex_);
+  std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
 
   for (auto parameter : parameters) {
     const auto & param_type = parameter.get_type();
@@ -478,6 +478,7 @@ StaticLayer::dynamicParametersCallback(
         width_ = size_x_;
         height_ = size_y_;
         has_updated_data_ = true;
+        current_ = false;
       }
     }
 

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -471,8 +471,13 @@ StaticLayer::dynamicParametersCallback(
         transform_tolerance_ = tf2::durationFromSec(parameter.as_double());
       }
     } else if (param_type == ParameterType::PARAMETER_BOOL) {
-      if (param_name == name_ + "." + "enabled") {
+      if (param_name == name_ + "." + "enabled" && enabled_ != parameter.as_bool()) {
         enabled_ = parameter.as_bool();
+
+        x_ = y_ = 0;
+        width_ = size_x_;
+        height_ = size_y_;
+        has_updated_data_ = true;
       }
     }
 

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -459,7 +459,14 @@ StaticLayer::dynamicParametersCallback(
     const auto & param_type = parameter.get_type();
     const auto & param_name = parameter.get_name();
 
-    if (param_type == ParameterType::PARAMETER_DOUBLE) {
+    if (param_name == name_ + "." + "map_subscribe_transient_local" ||
+      param_name == name_ + "." + "map_topic" ||
+      param_name == name_ + "." + "subscribe_to_updates")
+    {
+      RCLCPP_WARN(
+        node_->get_logger(), "%s is not a dynamic parameter "
+        "cannot be changed while running. Rejecting parameter update.", param_name.c_str());
+    } else if (param_type == ParameterType::PARAMETER_DOUBLE) {
       if (param_name == name_ + "." + "transform_tolerance") {
         transform_tolerance_ = tf2::durationFromSec(parameter.as_double());
       }
@@ -467,13 +474,6 @@ StaticLayer::dynamicParametersCallback(
       if (param_name == name_ + "." + "enabled") {
         enabled_ = parameter.as_bool();
       }
-    } else if (param_name == name_ + "." + "map_subscribe_transient_local" ||
-      param_name == name_ + "." + "map_topic" ||
-      param_name == name_ + "." + "subscribe_to_updates")
-    {
-      RCLCPP_WARN(
-        node_->get_logger(), "%s is not a dynamic parameter "
-        "cannot be changed while running. Rejecting parameter update.", param_name);
     }
 
   }

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -452,7 +452,6 @@ rcl_interfaces::msg::SetParametersResult
 StaticLayer::dynamicParametersCallback(
   std::vector<rclcpp::Parameter> parameters)
 {
-
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   rcl_interfaces::msg::SetParametersResult result;
 

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -166,7 +166,7 @@ StaticLayer::getParameters()
   transform_tolerance_ = tf2::durationFromSec(temp_tf_tol);
 
   // Add callback for dynamic parameters
-  dyn_params_handler_ = node_->add_on_set_parameters_callback(
+  dyn_params_handler_ = node->add_on_set_parameters_callback(
     std::bind(
       &StaticLayer::dynamicParametersCallback,
       this, std::placeholders::_1));
@@ -464,7 +464,7 @@ StaticLayer::dynamicParametersCallback(
       param_name == name_ + "." + "subscribe_to_updates")
     {
       RCLCPP_WARN(
-        node_->get_logger(), "%s is not a dynamic parameter "
+        logger_, "%s is not a dynamic parameter "
         "cannot be changed while running. Rejecting parameter update.", param_name.c_str());
     } else if (param_type == ParameterType::PARAMETER_DOUBLE) {
       if (param_name == name_ + "." + "transform_tolerance") {

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -476,9 +476,9 @@ rcl_interfaces::msg::SetParametersResult
 VoxelLayer::dynamicParametersCallback(
   std::vector<rclcpp::Parameter> parameters)
 {
-  static bool resize_map_needed = false;
-  rcl_interfaces::msg::SetParametersResult result;
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
+  rcl_interfaces::msg::SetParametersResult result;
+  bool resize_map_needed = false;
 
   for (auto parameter : parameters) {
     const auto & param_type = parameter.get_type();
@@ -525,7 +525,6 @@ VoxelLayer::dynamicParametersCallback(
 
   if (resize_map_needed) {
     matchSize();
-    resize_map_needed = false;
   }
 
   result.successful = true;

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -468,7 +468,10 @@ void VoxelLayer::updateOrigin(double new_origin_x, double new_origin_y)
   delete[] local_voxel_map;
 }
 
-
+/**
+  * @brief Callback executed when a parameter change is detected
+  * @param event ParameterEvent message
+  */
 rcl_interfaces::msg::SetParametersResult
 VoxelLayer::dynamicParametersCallback(
   std::vector<rclcpp::Parameter> parameters)

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -523,8 +523,7 @@ VoxelLayer::dynamicParametersCallback(
 
   }
 
-  if(resize_map_needed)
-  {
+  if (resize_map_needed) {
     matchSize();
     resize_map_needed = false;
   }

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -105,7 +105,7 @@ void VoxelLayer::onInitialize()
   matchSize();
 
   // Add callback for dynamic parameters
-  dyn_params_handler_ = node_->add_on_set_parameters_callback(
+  dyn_params_handler_ = node->add_on_set_parameters_callback(
     std::bind(
       &VoxelLayer::dynamicParametersCallback,
       this, std::placeholders::_1));
@@ -499,7 +499,7 @@ VoxelLayer::dynamicParametersCallback(
         footprint_clearing_enabled_ = parameter.as_bool();
       } else if (param_name == name_ + "." + "publish_voxel_map") {
         RCLCPP_WARN(
-          node_->get_logger(), "publish voxel map is not a dynamic parameter "
+          logger_, "publish voxel map is not a dynamic parameter "
           "cannot be changed while running. Rejecting parameter update.");
         continue;
       }

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -53,6 +53,7 @@ PLUGINLIB_EXPORT_CLASS(nav2_costmap_2d::VoxelLayer, nav2_costmap_2d::Layer)
 using nav2_costmap_2d::NO_INFORMATION;
 using nav2_costmap_2d::LETHAL_OBSTACLE;
 using nav2_costmap_2d::FREE_SPACE;
+using rcl_interfaces::msg::ParameterType;
 
 namespace nav2_costmap_2d
 {
@@ -102,10 +103,17 @@ void VoxelLayer::onInitialize()
 
   unknown_threshold_ += (VOXEL_BITS - size_z_);
   matchSize();
+
+  // Add callback for dynamic parameters
+  dyn_params_handler_ = node_->add_on_set_parameters_callback(
+    std::bind(
+      &VoxelLayer::dynamicParametersCallback,
+      this, std::placeholders::_1));
 }
 
 VoxelLayer::~VoxelLayer()
 {
+  dyn_params_handler_.reset();
 }
 
 void VoxelLayer::matchSize()
@@ -137,6 +145,8 @@ void VoxelLayer::updateBounds(
   double robot_x, double robot_y, double robot_yaw, double * min_x,
   double * min_y, double * max_x, double * max_y)
 {
+  std::lock_guard<std::mutex> lock_reinit(mutex_);
+
   if (rolling_window_) {
     updateOrigin(robot_x - getSizeInMetersX() / 2, robot_y - getSizeInMetersY() / 2);
   }
@@ -456,6 +466,78 @@ void VoxelLayer::updateOrigin(double new_origin_x, double new_origin_y)
   // make sure to clean up
   delete[] local_map;
   delete[] local_voxel_map;
+}
+
+
+rcl_interfaces::msg::SetParametersResult
+VoxelLayer::dynamicParametersCallback(
+  std::vector<rclcpp::Parameter> parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  std::lock_guard<std::mutex> lock_reinit(mutex_);
+
+  for (auto parameter : parameters) {
+    const auto & param_type = parameter.get_type();
+    const auto & param_name = parameter.get_name();
+
+    if (param_type == ParameterType::PARAMETER_DOUBLE) {
+      
+      if(param_name == name_ + "." + "max_obstacle_height")
+      {
+        max_obstacle_height_ = parameter.as_double();
+      }
+      else if(param_name == name_ + "." + "origin_z")
+      {
+        origin_z_ = parameter.as_double();
+      }
+      else if(param_name == name_ + "." + "z_resolution")
+      {
+        z_resolution_ = parameter.as_double();
+      }
+    }
+    else if (param_type == ParameterType::PARAMETER_BOOL) {
+      if(param_name == name_ + "." + "enabled")
+      {
+        enabled_ = parameter.as_bool();
+      }
+      else if(param_name == name_ + "." + "footprint_clearing_enabled")
+      {
+        footprint_clearing_enabled_ = parameter.as_bool();
+      }
+      else if(param_name == name_ + "." + "publish_voxel_map")
+      {
+        RCLCPP_WARN(
+            node_->get_logger(), "publish voxel map is not a dynamic parameter "
+            "cannot be changed while running. Rejecting parameter update.");
+          continue;
+      }
+      
+    }
+    else if (param_type == ParameterType::PARAMETER_INTEGER) {
+      if(param_name == name_ + "." + "z_voxels")
+      {
+        size_z_ = parameter.as_int();
+      }
+      else if(param_name == name_ + "." + "unknown_threshold")
+      {
+        unknown_threshold_ =  parameter.as_int() + (VOXEL_BITS - size_z_);
+      }
+      else if(param_name == name_ + "." + "mark_threshold")
+      {
+        mark_threshold_ =  parameter.as_int();
+      }
+      else if(param_name == name_ + "." + "combination_method")
+      {
+        combination_method_ =  parameter.as_int();
+      }
+    }
+
+  }
+
+  matchSize();
+
+  result.successful = true;
+  return result;
 }
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -481,54 +481,35 @@ VoxelLayer::dynamicParametersCallback(
     const auto & param_name = parameter.get_name();
 
     if (param_type == ParameterType::PARAMETER_DOUBLE) {
-      
-      if(param_name == name_ + "." + "max_obstacle_height")
-      {
+
+      if (param_name == name_ + "." + "max_obstacle_height") {
         max_obstacle_height_ = parameter.as_double();
-      }
-      else if(param_name == name_ + "." + "origin_z")
-      {
+      } else if (param_name == name_ + "." + "origin_z") {
         origin_z_ = parameter.as_double();
-      }
-      else if(param_name == name_ + "." + "z_resolution")
-      {
+      } else if (param_name == name_ + "." + "z_resolution") {
         z_resolution_ = parameter.as_double();
       }
-    }
-    else if (param_type == ParameterType::PARAMETER_BOOL) {
-      if(param_name == name_ + "." + "enabled")
-      {
+    } else if (param_type == ParameterType::PARAMETER_BOOL) {
+      if (param_name == name_ + "." + "enabled") {
         enabled_ = parameter.as_bool();
-      }
-      else if(param_name == name_ + "." + "footprint_clearing_enabled")
-      {
+      } else if (param_name == name_ + "." + "footprint_clearing_enabled") {
         footprint_clearing_enabled_ = parameter.as_bool();
-      }
-      else if(param_name == name_ + "." + "publish_voxel_map")
-      {
+      } else if (param_name == name_ + "." + "publish_voxel_map") {
         RCLCPP_WARN(
-            node_->get_logger(), "publish voxel map is not a dynamic parameter "
-            "cannot be changed while running. Rejecting parameter update.");
-          continue;
+          node_->get_logger(), "publish voxel map is not a dynamic parameter "
+          "cannot be changed while running. Rejecting parameter update.");
+        continue;
       }
-      
-    }
-    else if (param_type == ParameterType::PARAMETER_INTEGER) {
-      if(param_name == name_ + "." + "z_voxels")
-      {
+
+    } else if (param_type == ParameterType::PARAMETER_INTEGER) {
+      if (param_name == name_ + "." + "z_voxels") {
         size_z_ = parameter.as_int();
-      }
-      else if(param_name == name_ + "." + "unknown_threshold")
-      {
-        unknown_threshold_ =  parameter.as_int() + (VOXEL_BITS - size_z_);
-      }
-      else if(param_name == name_ + "." + "mark_threshold")
-      {
-        mark_threshold_ =  parameter.as_int();
-      }
-      else if(param_name == name_ + "." + "combination_method")
-      {
-        combination_method_ =  parameter.as_int();
+      } else if (param_name == name_ + "." + "unknown_threshold") {
+        unknown_threshold_ = parameter.as_int() + (VOXEL_BITS - size_z_);
+      } else if (param_name == name_ + "." + "mark_threshold") {
+        mark_threshold_ = parameter.as_int();
+      } else if (param_name == name_ + "." + "combination_method") {
+        combination_method_ = parameter.as_int();
       }
     }
 

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -495,6 +495,7 @@ VoxelLayer::dynamicParametersCallback(
     } else if (param_type == ParameterType::PARAMETER_BOOL) {
       if (param_name == name_ + "." + "enabled") {
         enabled_ = parameter.as_bool();
+        current_ = false;
       } else if (param_name == name_ + "." + "footprint_clearing_enabled") {
         footprint_clearing_enabled_ = parameter.as_bool();
       } else if (param_name == name_ + "." + "publish_voxel_map") {

--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -608,8 +608,6 @@ TEST_F(TestNode, testInflation3)
  */
 TEST_F(TestNode, testDynParamsSet)
 {
-  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("inflation_dyn_param_test");
-
   auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("test_costmap");
 
   costmap->set_parameter(rclcpp::Parameter("global_frame", std::string("base_link")));

--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -602,7 +602,6 @@ TEST_F(TestNode, testInflation3)
   ASSERT_EQ(countValues(*costmap, nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE), 4u);
 }
 
-
 /**
  * Test dynamic parameter setting of inflation layer
  */
@@ -642,5 +641,4 @@ TEST_F(TestNode, testDynParamsSet)
   costmap->on_deactivate(rclcpp_lifecycle::State());
   costmap->on_cleanup(rclcpp_lifecycle::State());
   costmap->on_shutdown(rclcpp_lifecycle::State());
-
 }

--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -46,6 +46,7 @@
 #include "nav2_costmap_2d/observation_buffer.hpp"
 #include "../testing_helper.hpp"
 #include "nav2_util/node_utils.hpp"
+#include "nav2_costmap_2d/costmap_2d_ros.hpp"
 
 using geometry_msgs::msg::Point;
 using nav2_costmap_2d::CellData;
@@ -599,4 +600,49 @@ TEST_F(TestNode, testInflation3)
   ASSERT_EQ(countValues(*costmap, nav2_costmap_2d::FREE_SPACE, false), 29u);
   ASSERT_EQ(countValues(*costmap, nav2_costmap_2d::LETHAL_OBSTACLE), 1u);
   ASSERT_EQ(countValues(*costmap, nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE), 4u);
+}
+
+
+/**
+ * Test dynamic parameter setting of inflation layer
+ */
+TEST_F(TestNode, testDynParamsSet)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("inflation_dyn_param_test");
+
+  auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("test_costmap");
+
+  costmap->set_parameter(rclcpp::Parameter("global_frame", std::string("base_link")));
+  costmap->on_configure(rclcpp_lifecycle::State());
+
+  costmap->on_activate(rclcpp_lifecycle::State());
+
+  auto parameter_client = std::make_shared<rclcpp::AsyncParametersClient>(
+    costmap->get_node_base_interface(), costmap->get_node_topics_interface(),
+    costmap->get_node_graph_interface(),
+    costmap->get_node_services_interface());
+
+  auto results = parameter_client->set_parameters_atomically(
+  {
+    rclcpp::Parameter("inflation_layer.inflation_radius", 0.0),
+    rclcpp::Parameter("inflation_layer.cost_scaling_factor", 0.0),
+    rclcpp::Parameter("inflation_layer.inflate_unknown", true),
+    rclcpp::Parameter("inflation_layer.inflate_around_unknown", true),
+    rclcpp::Parameter("inflation_layer.enabled", false)
+  });
+
+  rclcpp::spin_until_future_complete(
+    costmap->get_node_base_interface(),
+    results);
+
+  EXPECT_EQ(costmap->get_parameter("inflation_layer.inflation_radius").as_double(), 0.0);
+  EXPECT_EQ(costmap->get_parameter("inflation_layer.cost_scaling_factor").as_double(), 0.0);
+  EXPECT_EQ(costmap->get_parameter("inflation_layer.inflate_unknown").as_bool(), true);
+  EXPECT_EQ(costmap->get_parameter("inflation_layer.inflate_around_unknown").as_bool(), true);
+  EXPECT_EQ(costmap->get_parameter("inflation_layer.enabled").as_bool(), false);
+
+  costmap->on_deactivate(rclcpp_lifecycle::State());
+  costmap->on_cleanup(rclcpp_lifecycle::State());
+  costmap->on_shutdown(rclcpp_lifecycle::State());
+
 }

--- a/nav2_costmap_2d/test/integration/obstacle_tests.cpp
+++ b/nav2_costmap_2d/test/integration/obstacle_tests.cpp
@@ -413,8 +413,6 @@ TEST_F(TestNode, testRaytracing) {
  */
 TEST_F(TestNode, testDynParamsSetVoxel)
 {
-  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("voxel_dyn_param_test");
-
   auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("test_costmap");
 
   // Add voxel layer
@@ -445,7 +443,8 @@ TEST_F(TestNode, testDynParamsSetVoxel)
     rclcpp::Parameter("voxel_layer.z_voxels", 14),
     rclcpp::Parameter("voxel_layer.max_obstacle_height", 4.0),
     rclcpp::Parameter("voxel_layer.footprint_clearing_enabled", false),
-    rclcpp::Parameter("voxel_layer.enabled", false)
+    rclcpp::Parameter("voxel_layer.enabled", false),
+    rclcpp::Parameter("voxel_layer.publish_voxel_map", true)
   });
 
   rclcpp::spin_until_future_complete(
@@ -461,6 +460,7 @@ TEST_F(TestNode, testDynParamsSetVoxel)
   EXPECT_EQ(costmap->get_parameter("voxel_layer.max_obstacle_height").as_double(), 4.0);
   EXPECT_EQ(costmap->get_parameter("voxel_layer.footprint_clearing_enabled").as_bool(), false);
   EXPECT_EQ(costmap->get_parameter("voxel_layer.enabled").as_bool(), false);
+  EXPECT_EQ(costmap->get_parameter("voxel_layer.publish_voxel_map").as_bool(), true);
 
   costmap->on_deactivate(rclcpp_lifecycle::State());
   costmap->on_cleanup(rclcpp_lifecycle::State());
@@ -474,8 +474,6 @@ TEST_F(TestNode, testDynParamsSetVoxel)
  */
 TEST_F(TestNode, testDynParamsSetStatic)
 {
-  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("static_dyn_param_test");
-
   auto costmap = std::make_shared<nav2_costmap_2d::Costmap2DROS>("test_costmap");
 
   costmap->set_parameter(rclcpp::Parameter("global_frame", std::string("base_link")));
@@ -491,7 +489,10 @@ TEST_F(TestNode, testDynParamsSetStatic)
   auto results = parameter_client->set_parameters_atomically(
   {
     rclcpp::Parameter("static_layer.transform_tolerance", 1.0),
-    rclcpp::Parameter("static_layer.enabled", false)
+    rclcpp::Parameter("static_layer.enabled", false),
+    rclcpp::Parameter("static_layer.map_subscribe_transient_local", false),
+    rclcpp::Parameter("static_layer.map_topic", "dynamic_topic"),
+    rclcpp::Parameter("static_layer.subscribe_to_updates", true)
   });
 
   rclcpp::spin_until_future_complete(
@@ -500,6 +501,9 @@ TEST_F(TestNode, testDynParamsSetStatic)
 
   EXPECT_EQ(costmap->get_parameter("static_layer.transform_tolerance").as_double(), 1.0);
   EXPECT_EQ(costmap->get_parameter("static_layer.enabled").as_bool(), false);
+  EXPECT_EQ(costmap->get_parameter("static_layer.map_subscribe_transient_local").as_bool(), false);
+  EXPECT_EQ(costmap->get_parameter("static_layer.map_topic").as_string(), "dynamic_topic");
+  EXPECT_EQ(costmap->get_parameter("static_layer.subscribe_to_updates").as_bool(), true);
 
   costmap->on_deactivate(rclcpp_lifecycle::State());
   costmap->on_cleanup(rclcpp_lifecycle::State());

--- a/nav2_costmap_2d/test/integration/obstacle_tests.cpp
+++ b/nav2_costmap_2d/test/integration/obstacle_tests.cpp
@@ -465,9 +465,7 @@ TEST_F(TestNode, testDynParamsSetVoxel)
   costmap->on_deactivate(rclcpp_lifecycle::State());
   costmap->on_cleanup(rclcpp_lifecycle::State());
   costmap->on_shutdown(rclcpp_lifecycle::State());
-
 }
-
 
 /**
  * Test dynamic parameter setting of static layer
@@ -508,5 +506,4 @@ TEST_F(TestNode, testDynParamsSetStatic)
   costmap->on_deactivate(rclcpp_lifecycle::State());
   costmap->on_cleanup(rclcpp_lifecycle::State());
   costmap->on_shutdown(rclcpp_lifecycle::State());
-
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | ros-planning#956 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Turtlebot3 simulation |

---

## Description of contribution in a few bullet points

* Dynamic parameter setting callbacks are added in the layers using suitable mutexes to prevent segfaults
* Decision on whether parameters are settable/non-settable dynamically are taken after referring to these layers in the ROS1 nav stack and warning messages are added wherever parameter setting is rejected
* Appropriate functions are called after dynamic parameter changes (also referring to the ROS1 nav stack)
* Changes are tested on the turtlebot3 simulation
* Suitable test cases are added to test parameter setting

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
