### PR TITLE
Bugfix tf lookup of goal pose in nav2_controller

### DIFF
--- a/nav2_controller/include/nav2_controller/controller_server.hpp
+++ b/nav2_controller/include/nav2_controller/controller_server.hpp
@@ -256,7 +256,7 @@ protected:
   double failure_tolerance_;
 
   // Whether we've published the single controller warning yet
-  geometry_msgs::msg::Pose end_pose_;
+  geometry_msgs::msg::PoseStamped end_pose_;
 
   // Last time the controller generated a valid command
   rclcpp::Time last_valid_cmd_time_;


### PR DESCRIPTION
Signed-off-by: Erik Örjehag <erik@orjehag.se>

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation of other diff drive robot) |

## Description of contribution in a few bullet points

* Move tf lookup of goal pose in nav2_controller from `setPlannerPath` to `isGoalReached`. This is needed because the local planner will otherwise have a much more recently transformed goal compared to the goal checker causing the local planner to stop when it has reached its goal but the goal checker will not trigger (we use pure pursuit). If setPlannerPath is called with 1Hz this is barely noticeable but we have a different behavior tree that only plans when we have a new goal (and in the future we'll try to check if the plan in illegal) and then this is a big problem.

![Screenshot_2022-01-21_10-43-48](https://user-images.githubusercontent.com/3470402/150504483-25bc404f-40b4-4189-b5e0-8d6b7168a549.png)

Maybe others will run into a similar issue once this (https://github.com/ros-planning/navigation2/pull/2591#issuecomment-947945404) is in.

## Description of documentation updates required from your changes

None

## Future work that may be required in bullet points

* I tested this change by overlaying nav2_controller in our project repo (container running galactic) but our project does automatic code formatting so the changes in this PR is just copy pasted from our project into a fork of mine and I was not able to build the navigation2 repo, hoping the CI will complain if it doesn't build.
* Ideally I would like to have this change in galactic as well but I don't know the process.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
