### PR TITLE
Fixing the issue #2781: raytraceLine with same start and end point no…

### DIFF
--- a/nav2_voxel_grid/include/nav2_voxel_grid/voxel_grid.hpp
+++ b/nav2_voxel_grid/include/nav2_voxel_grid/voxel_grid.hpp
@@ -232,12 +232,22 @@ public:
     if ((unsigned int)(dist) < min_length) {
       return;
     }
-    double scale = std::min(1.0, max_length / dist);
+    double scale, min_x0, min_y0, min_z0;
+    if(dist > 0.0){
+      scale = std::min(1.0, max_length / dist);
 
-    // Updating starting point to the point at distance min_length from the initial point
-    double min_x0 = x0 + (x1 - x0) / dist * min_length;
-    double min_y0 = y0 + (y1 - y0) / dist * min_length;
-    double min_z0 = z0 + (z1 - z0) / dist * min_length;
+      // Updating starting point to the point at distance min_length from the initial point
+      min_x0 = x0 + (x1 - x0) / dist * min_length;
+      min_y0 = y0 + (y1 - y0) / dist * min_length;
+      min_z0 = z0 + (z1 - z0) / dist * min_length;
+    }
+    // dist can be 0 if [x0, y0, z0]==[x1, y1, z1]. In this case only this voxel should be processed.
+    else{
+      scale = 1.0;
+      min_x0 = x0;
+      min_y0 = y0;
+      min_z0 = z0;
+    }
 
     int dx = int(x1) - int(min_x0);  // NOLINT
     int dy = int(y1) - int(min_y0);  // NOLINT

--- a/nav2_voxel_grid/include/nav2_voxel_grid/voxel_grid.hpp
+++ b/nav2_voxel_grid/include/nav2_voxel_grid/voxel_grid.hpp
@@ -233,16 +233,16 @@ public:
       return;
     }
     double scale, min_x0, min_y0, min_z0;
-    if(dist > 0.0){
+    if (dist > 0.0) {
       scale = std::min(1.0, max_length / dist);
 
       // Updating starting point to the point at distance min_length from the initial point
       min_x0 = x0 + (x1 - x0) / dist * min_length;
       min_y0 = y0 + (y1 - y0) / dist * min_length;
       min_z0 = z0 + (z1 - z0) / dist * min_length;
-    }
-    // dist can be 0 if [x0, y0, z0]==[x1, y1, z1]. In this case only this voxel should be processed.
-    else{
+    } else {
+      // dist can be 0 if [x0, y0, z0]==[x1, y1, z1].
+      // In this case only this voxel should be processed.
       scale = 1.0;
       min_x0 = x0;
       min_y0 = y0;

--- a/nav2_voxel_grid/test/voxel_grid_bresenham_3d.cpp
+++ b/nav2_voxel_grid/test/voxel_grid_bresenham_3d.cpp
@@ -49,6 +49,10 @@ public:
     ASSERT_TRUE(off < size_);
     data_[off] = val;
   }
+  inline unsigned int operator()(unsigned int off)
+  {
+    return data_[off];
+  }
 
 private:
   uint32_t * data_;
@@ -120,6 +124,29 @@ TEST(voxel_grid, bresenham3DBoundariesCheck)
     }
     vg.raytraceLine(tv, x0, y0, z0, x1, y1, z1, max_length, min_length);
   }
+}
+
+TEST(voxel_grid, bresenham3DSamePoint)
+{
+  const int sz_x = 60;
+  const int sz_y = 60;
+  const int sz_z = 2;
+  const unsigned int max_length = 60;
+  const unsigned int min_length = 0;
+  nav2_voxel_grid::VoxelGrid vg(sz_x, sz_y, sz_z);
+  TestVoxel tv(vg.getData(), sz_x, sz_y);
+
+  // Initial point
+  const double x0 = 2.2;
+  const double y0 = 3.8;
+  const double z0 = 0.4;
+
+  unsigned int offset = int(y0) * sz_x + int(x0);
+  unsigned int val_before = tv(offset);
+  // Same point to check
+  vg.raytraceLine(tv, x0, y0, z0, x0, y0, z0, max_length, min_length);
+  unsigned int val_after = tv(offset);
+  ASSERT_FALSE(val_before == val_after);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
… longer causes segmentation fault

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2781 |
| Primary OS tested on | Ubuntu 20.04, ROS galactic |
| Robotic platform tested on | Webots 2022a simulation of Turtlebot3 |

---

## Description of contribution in a few bullet points

* in rare cases raytraceLine causes a segmentation fault
* this occurs if start and end point of the line are the same and the length of the line is therefore 0
* my changes now check if the length is greater than 0
* if the length is not greater than 0, some variables are set so that the voxel (= start point = end point) is processed anyway (i.e. either marked or deleted, depending on the context)

## Description of documentation updates required from your changes

* none


---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
