### PR TITLE
Add initial skeleton for LTTng tracing in navigation2

### DIFF
--- a/nav2_tracetools/.gitignore
+++ b/nav2_tracetools/.gitignore
@@ -1,0 +1,2 @@
+doc_output/
+.DS_Store

--- a/nav2_tracetools/CHANGELOG.rst
+++ b/nav2_tracetools/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package nav2_tracetools
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.1.0 (2021-12-22)
+------------------
+* Fork tracetools and shape it as nav2_tracetools to avoid external
+  dependencies.

--- a/nav2_tracetools/CMakeLists.txt
+++ b/nav2_tracetools/CMakeLists.txt
@@ -1,0 +1,153 @@
+cmake_minimum_required(VERSION 3.5)
+project(nav2_tracetools)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  add_compile_options(/W4)
+endif()
+
+find_package(ament_cmake_ros REQUIRED)
+
+if(WIN32)
+  set(DISABLED_DEFAULT ON)
+else()
+  set(DISABLED_DEFAULT OFF)
+endif()
+option(TRACETOOLS_DISABLED "Explicitly disable support for tracing" ${DISABLED_DEFAULT})
+option(TRACETOOLS_NO_RDYNAMIC "Disable export of -rdynamic link flag" OFF)
+option(TRACETOOLS_STATUS_CHECKING_TOOL "Enable the status checking tool" ON)
+
+if(NOT TRACETOOLS_DISABLED)
+  # Set TRACETOOLS_LTTNG_ENABLED if we can find lttng-ust
+  find_package(PkgConfig)
+  if(PkgConfig_FOUND)
+    pkg_check_modules(LTTNG lttng-ust)
+    if(LTTNG_FOUND)
+      set(TRACETOOLS_LTTNG_ENABLED TRUE)
+      message("LTTng found: tracing enabled")
+    endif()
+  endif()
+endif()
+
+# Store configuration variables for runtime use
+#   TRACETOOLS_DISABLED
+#   TRACETOOLS_LTTNG_ENABLED
+configure_file(include/${PROJECT_NAME}/config.h.in include/${PROJECT_NAME}/config.h)
+
+# nav2_tracetools lib
+set(SOURCES
+  src/tracetools.c
+  src/utils.cpp
+)
+set(HEADERS
+  include/${PROJECT_NAME}/tracetools.h
+  include/${PROJECT_NAME}/utils.hpp
+  include/${PROJECT_NAME}/visibility_control.hpp
+)
+if(TRACETOOLS_LTTNG_ENABLED)
+  # We only need these if we're using LTTng
+  list(APPEND SOURCES
+    src/tp_call.c
+  )
+  list(APPEND HEADERS
+    include/${PROJECT_NAME}/tp_call.h
+  )
+endif()
+
+# Copy select headers to the actual include/ directory that we will use and export
+foreach(_header ${HEADERS})
+  configure_file(
+    ${PROJECT_SOURCE_DIR}/${_header}
+    ${PROJECT_BINARY_DIR}/${_header}
+    COPYONLY
+  )
+endforeach()
+
+add_library(${PROJECT_NAME} ${SOURCES})
+if(TRACETOOLS_LTTNG_ENABLED)
+  target_link_libraries(${PROJECT_NAME} ${LTTNG_LIBRARIES})
+  # Export -rdynamic for downtream packages to use when calling
+  #   ament_target_dependencies()
+  # which is needed to resolve function addresses to symbols when
+  # using function pointers directly/without std::bind()
+  # (the flag should not be used on Windows, but TRACETOOLS_LTTNG_ENABLED
+  # should never be true on Windows anyway, so there is no need to check)
+  if(NOT TRACETOOLS_NO_RDYNAMIC)
+    target_link_libraries(${PROJECT_NAME} "-rdynamic")
+  endif()
+endif()
+if(WIN32)
+  # Causes the visibility macros to use dllexport rather than dllimport
+  # which is appropriate when building the dll but not consuming it.
+  target_compile_definitions(${PROJECT_NAME} PRIVATE "TRACETOOLS_BUILDING_DLL")
+endif()
+
+# Only use output/binary include directory
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+ament_export_targets(${PROJECT_NAME}_export HAS_LIBRARY_TARGET)
+
+if(TRACETOOLS_STATUS_CHECKING_TOOL)
+  # Status checking tool
+  add_executable(status
+    src/status.c
+  )
+  target_link_libraries(status
+    ${PROJECT_NAME}
+  )
+  install(TARGETS
+    status
+    DESTINATION lib/${PROJECT_NAME}
+  )
+endif()
+
+install(
+  DIRECTORY ${PROJECT_BINARY_DIR}/include/
+  DESTINATION include
+)
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}_export
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+ament_export_include_directories(include)
+if(TRACETOOLS_LTTNG_ENABLED)
+  ament_export_libraries(${PROJECT_NAME} ${LTTNG_LIBRARIES})
+  # Export -rdynamic for downstream packages using classic CMake variables
+  if(NOT TRACETOOLS_NO_RDYNAMIC)
+    ament_export_link_flags("-rdynamic")
+  endif()
+else()
+  ament_export_libraries(${PROJECT_NAME})
+endif()
+
+if(BUILD_TESTING)
+  set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${LTTNG_INCLUDE_DIRS})
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  if(TRACETOOLS_STATUS_CHECKING_TOOL)
+    # Run status tool executable as test and set pass/fail expectation appropriately
+    add_test(test_status_tool status)
+    if(NOT TRACETOOLS_LTTNG_ENABLED)
+      set_tests_properties(test_status_tool PROPERTIES WILL_FAIL TRUE)
+    endif()
+  endif()
+
+endif()
+
+ament_package()
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_VERSION="${${PROJECT_NAME}_VERSION}")

--- a/nav2_tracetools/Doxyfile
+++ b/nav2_tracetools/Doxyfile
@@ -1,0 +1,32 @@
+# All settings not listed here will use the Doxygen default values.
+
+PROJECT_NAME           = "nav2_tracetools"
+PROJECT_NUMBER         = master
+PROJECT_BRIEF          = "LTTng tracing provider wrapper for navigation2 ROS 2 meta-package."
+
+INPUT                  = ./include
+
+RECURSIVE              = YES
+OUTPUT_DIRECTORY       = doc_output
+
+EXTRACT_ALL            = YES
+SORT_MEMBER_DOCS       = NO
+
+GENERATE_LATEX         = NO
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = NO
+PREDEFINED             = \
+    "TRACETOOLS_PUBLIC="
+
+EXCLUDE_SYMBOLS        = \
+    "DECLARE_TRACEPOINT" \
+    "_demangle_symbol" \
+    "_get_symbol_funcptr"
+
+# Tag files that do not exist will produce a warning and cross-project linking will not work.
+TAGFILES += "../../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+# Uncomment to generate tag files for cross-project linking.
+#   (path relative to workspace dir: doxygen_tag_files/$PACKAGE_NAME.tag)
+#GENERATE_TAGFILE = "../../../../../doxygen_tag_files/tracetools.tag"

--- a/nav2_tracetools/README.md
+++ b/nav2_tracetools/README.md
@@ -1,0 +1,7 @@
+# nav2_tracetools
+
+LTTng tracing provider wrapper for navigation2 ROS 2 meta-package. `nav2_tracetools` is a fork of [tracetools](https://gitlab.com/ros-tracing/ros2_tracing/-/tree/master/tracetools), refer to this package for the original work.
+
+### Quality Declaration
+
+No quality is claimed according to [REP-2004](https://www.ros.org/reps/rep-2004.html).

--- a/nav2_tracetools/include/nav2_tracetools/config.h.in
+++ b/nav2_tracetools/include/nav2_tracetools/config.h.in
@@ -1,0 +1,22 @@
+// Copyright 2021 Víctor Mayoral-Vilches
+// Copyright 2019 Robert Bosch GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_TRACETOOLS__CONFIG_H_
+#define NAV2_TRACETOOLS__CONFIG_H_
+
+#cmakedefine TRACETOOLS_DISABLED
+#cmakedefine TRACETOOLS_LTTNG_ENABLED
+
+#endif  // NAV2_TRACETOOLS__CONFIG_H_

--- a/nav2_tracetools/include/nav2_tracetools/tp_call.h
+++ b/nav2_tracetools/include/nav2_tracetools/tp_call.h
@@ -1,0 +1,40 @@
+// Copyright 2021 Víctor Mayoral-Vilches
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provide fake header guard for cpplint
+#undef NAV2_TRACETOOLS__TP_CALL_H_
+#ifndef NAV2_TRACETOOLS__TP_CALL_H_
+#define NAV2_TRACETOOLS__TP_CALL_H_
+
+#undef TRACEPOINT_PROVIDER
+#define TRACEPOINT_PROVIDER ros2_navigation2
+
+#undef TRACEPOINT_INCLUDE
+#define TRACEPOINT_INCLUDE "nav2_tracetools/tp_call.h"
+
+#if !defined(_NAV2_TRACETOOLS__TP_CALL_H_) || defined(TRACEPOINT_HEADER_MULTI_READ)
+#define _NAV2_TRACETOOLS__TP_CALL_H_
+
+#include <lttng/tracepoint.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// Add tracepoints
+
+#endif  // _NAV2_TRACETOOLS__TP_CALL_H_
+
+#include <lttng/tracepoint-event.h>
+
+#endif  // NAV2_TRACETOOLS__TP_CALL_H_

--- a/nav2_tracetools/include/nav2_tracetools/tracetools.h
+++ b/nav2_tracetools/include/nav2_tracetools/tracetools.h
@@ -1,0 +1,68 @@
+// Copyright 2021 Víctor Mayoral-Vilches
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/** \mainpage nav2_tracetools: tracing tools and instrumentation for
+ *  for image_pipeline ROS 2 meta-package.
+ *
+ * `nav2_tracetools` provides utilities to instrument ROS image_pipeline.
+ * It provides two main headers:
+ *
+ * - tracetools/tracetools.h
+ *   - instrumentation functions
+ * - tracetools/utils.hpp
+ *   - utility functions
+ */
+
+#ifndef NAV2_TRACETOOLS__TRACETOOLS_H_
+#define NAV2_TRACETOOLS__TRACETOOLS_H_
+
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include "nav2_tracetools/config.h"
+#include "nav2_tracetools/visibility_control.hpp"
+
+#ifndef TRACETOOLS_DISABLED
+/// Call a tracepoint.
+/**
+ * This is the preferred method over calling the actual function directly.
+ */
+#  define TRACEPOINT(event_name, ...) \
+  (ros_trace_ ## event_name)(__VA_ARGS__)
+#  define DECLARE_TRACEPOINT(event_name, ...) \
+  TRACETOOLS_PUBLIC void ros_trace_ ## event_name(__VA_ARGS__);
+#else
+#  define TRACEPOINT(event_name, ...) ((void) (0))
+#  define DECLARE_TRACEPOINT(event_name, ...)
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/// Get tracing compilation status.
+/**
+ * \return `true` if tracing is enabled, `false` otherwise
+ */
+TRACETOOLS_PUBLIC bool ros_trace_compile_status();
+
+// Add tracepoints
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // NAV2_TRACETOOLS__TRACETOOLS_H_

--- a/nav2_tracetools/include/nav2_tracetools/utils.hpp
+++ b/nav2_tracetools/include/nav2_tracetools/utils.hpp
@@ -1,0 +1,66 @@
+// Copyright 2021 Víctor Mayoral-Vilches
+// Copyright 2019 Robert Bosch GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_TRACETOOLS__UTILS_HPP_
+#define NAV2_TRACETOOLS__UTILS_HPP_
+
+#include <stddef.h>
+#include <functional>
+
+#include "nav2_tracetools/visibility_control.hpp"
+
+/// Default symbol, used when address resolution fails.
+#define SYMBOL_UNKNOWN "UNKNOWN"
+
+TRACETOOLS_PUBLIC const char * _demangle_symbol(const char * mangled);
+
+TRACETOOLS_PUBLIC const char * _get_symbol_funcptr(void * funcptr);
+
+/// Get symbol from an std::function object.
+/**
+ * If function address resolution or symbol demangling fails,
+ * this will return a string that starts with \ref SYMBOL_UNKNOWN.
+ *
+ * \param[in] f the std::function object
+ * \return the symbol, or a placeholder
+ */
+template<typename T, typename ... U>
+const char * get_symbol(std::function<T(U...)> f)
+{
+  typedef T (fnType)(U...);
+  fnType ** fnPointer = f.template target<fnType *>();
+  // If we get an actual address
+  if (fnPointer != nullptr) {
+    void * funcptr = reinterpret_cast<void *>(*fnPointer);
+    return _get_symbol_funcptr(funcptr);
+  }
+  // Otherwise we have to go through target_type()
+  return _demangle_symbol(f.target_type().name());
+}
+
+/// Get symbol from a function-related object.
+/**
+ * Fallback meant for lambdas with captures.
+ *
+ * \param[in] l a generic object
+ * \return the symbol
+ */
+template<typename L>
+const char * get_symbol(L && l)
+{
+  return _demangle_symbol(typeid(l).name());
+}
+
+#endif  // NAV2_TRACETOOLS__UTILS_HPP_

--- a/nav2_tracetools/include/nav2_tracetools/visibility_control.hpp
+++ b/nav2_tracetools/include/nav2_tracetools/visibility_control.hpp
@@ -1,0 +1,57 @@
+// Copyright 2021 Víctor Mayoral-Vilches
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This header must be included by all TRACETOOLS headers which declare symbols
+ * which are defined in the TRACETOOLS library. When not building the TRACETOOLS
+ * library, i.e. when using the headers in other package's code, the contents
+ * of this header change the visibility of certain symbols which the TRACETOOLS
+ * library cannot have, but the consuming code must have inorder to link.
+ */
+
+#ifndef NAV2_TRACETOOLS__VISIBILITY_CONTROL_HPP_
+#define NAV2_TRACETOOLS__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define TRACETOOLS_EXPORT __attribute__ ((dllexport))
+    #define TRACETOOLS_IMPORT __attribute__ ((dllimport))
+  #else
+    #define TRACETOOLS_EXPORT __declspec(dllexport)
+    #define TRACETOOLS_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef TRACETOOLS_BUILDING_DLL
+    #define TRACETOOLS_PUBLIC TRACETOOLS_EXPORT
+  #else
+    #define TRACETOOLS_PUBLIC TRACETOOLS_IMPORT
+  #endif
+  #define TRACETOOLS_PUBLIC_TYPE TRACETOOLS_PUBLIC
+  #define TRACETOOLS_LOCAL
+#else
+  #define TRACETOOLS_EXPORT __attribute__ ((visibility("default")))
+  #define TRACETOOLS_IMPORT
+  #if __GNUC__ >= 4
+    #define TRACETOOLS_PUBLIC __attribute__ ((visibility("default")))
+    #define TRACETOOLS_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define TRACETOOLS_PUBLIC
+    #define TRACETOOLS_LOCAL
+  #endif
+  #define TRACETOOLS_PUBLIC_TYPE
+#endif
+
+#endif  // NAV2_TRACETOOLS__VISIBILITY_CONTROL_HPP_

--- a/nav2_tracetools/package.xml
+++ b/nav2_tracetools/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>nav2_tracetools</name>
+  <version>0.1.0</version>
+  <description>
+    LTTng tracing provider wrapper for navigation2 ROS 2 meta-package.
+  </description>
+  <maintainer email="v.mayoralv@gmail.com">Víctor Mayoral-Vilches</maintainer>
+  <license>Apache 2.0</license>
+  <author email="v.mayoralv@gmail.com">Víctor Mayoral-Vilches</author>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/nav2_tracetools/src/status.c
+++ b/nav2_tracetools/src/status.c
@@ -1,0 +1,34 @@
+// Copyright 2021 Víctor Mayoral-Vilches
+// Copyright 2019 Robert Bosch GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdio.h>
+#include "nav2_tracetools/tracetools.h"
+
+int main()
+{
+#ifndef TRACETOOLS_DISABLED
+  printf("Tracing ");
+  if (ros_trace_compile_status()) {
+    printf("enabled\n");
+    return 0;
+  } else {
+    printf("disabled\n");
+    return 1;
+  }
+#else
+  printf("Tracing disabled through configuration\n");
+  return 1;
+#endif
+}

--- a/nav2_tracetools/src/tp_call.c
+++ b/nav2_tracetools/src/tp_call.c
@@ -1,0 +1,19 @@
+// Copyright 2021 Víctor Mayoral-Vilches
+// Copyright 2019 Robert Bosch GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define TRACEPOINT_CREATE_PROBES
+
+#define TRACEPOINT_DEFINE
+#include "nav2_tracetools/tp_call.h"

--- a/nav2_tracetools/src/tracetools.c
+++ b/nav2_tracetools/src/tracetools.c
@@ -1,0 +1,52 @@
+// Copyright 2021 Víctor Mayoral-Vilches
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_tracetools/tracetools.h"
+
+#ifndef TRACETOOLS_DISABLED
+
+#ifdef TRACETOOLS_LTTNG_ENABLED
+# include "nav2_tracetools/tp_call.h"
+# define CONDITIONAL_TP(...) \
+  tracepoint(TRACEPOINT_PROVIDER, __VA_ARGS__)
+#else
+# define CONDITIONAL_TP(...)
+#endif
+
+bool ros_trace_compile_status()
+{
+#ifdef TRACETOOLS_LTTNG_ENABLED
+  return true;
+#else
+  return false;
+#endif
+}
+
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#else
+# pragma warning(push)
+# pragma warning(disable: 4100)
+#endif
+
+// Add tracepoints
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
+
+#endif  // TRACETOOLS_DISABLED

--- a/nav2_tracetools/src/utils.cpp
+++ b/nav2_tracetools/src/utils.cpp
@@ -1,0 +1,51 @@
+// Copyright 2021 Víctor Mayoral-Vilches
+// Copyright 2019 Robert Bosch GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_tracetools/config.h"
+
+#ifdef TRACETOOLS_LTTNG_ENABLED
+#include <dlfcn.h>
+#include <cxxabi.h>
+#endif
+#include "nav2_tracetools/utils.hpp"
+
+const char * _demangle_symbol(const char * mangled)
+{
+#ifdef TRACETOOLS_LTTNG_ENABLED
+  char * demangled = nullptr;
+  int status;
+  demangled = abi::__cxa_demangle(mangled, NULL, 0, &status);
+  // Use demangled symbol if possible
+  const char * demangled_val = (status == 0 ? demangled : mangled);
+  return demangled_val != 0 ? demangled_val : "UNKNOWN_demangling_failed";
+#else
+  (void)mangled;
+  return "DISABLED__demangle_symbol";
+#endif
+}
+
+const char * _get_symbol_funcptr(void * funcptr)
+{
+#ifdef TRACETOOLS_LTTNG_ENABLED
+  Dl_info info;
+  if (dladdr(funcptr, &info) == 0) {
+    return SYMBOL_UNKNOWN;
+  }
+  return _demangle_symbol(info.dli_sname);
+#else
+  (void)funcptr;
+  return "DISABLED__get_symbol_funcptr";
+#endif
+}


### PR DESCRIPTION
## Basic Info

This contribution aims to bring the first few building blocks of LTTng instrumentation to the ROS 2 navigation stack. It  aligns with https://github.com/ros-perception/image_pipeline/pull/717 which added instrumentation to a perception stack package and also with [REP-2008 PR benchmarking architecture](https://github.com/ros-infrastructure/rep/pull/324/files#diff-f230b6aa06d86bf594d8e431300e453ad7343e8f4b1932252b6d36c62a8b5e0aR203-R267).

Particularly, in a similar fashion to what was discussed [here](https://github.com/ros-perception/image_pipeline/pull/717#issuecomment-998005478) for `image_pipeline`, this PR forks [tracetools](https://gitlab.com/ros-tracing/ros2_tracing/-/tree/master/tracetools) and creates a new ROS 2 package named `nav2_tracetools` which hopes to include **only** the meta data and `TRACEPOINTS` for `navigation2`. This should increase the granularity level of the LTTng instrumentation making it more easy to maintain (instead of having to send PRs to [tracetools](https://gitlab.com/ros-tracing/ros2_tracing/-/tree/master/tracetools) and iterate in longer cycles).

The current PR adds the building blocks but no package has been instrumented just yet to simplify the review and testing of these initial changes. First candidates for instrumentation are *costmaps* and *controllers* as indicated in past WG meetings. Such instrumentation can come in follow up PRs with analysis examples of the probes and resulting LTTng traces, as well as documentation extensions on how to benchmark such components with practical examples.

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | New feature, similar to https://github.com/ros-perception/image_pipeline/pull/717  |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | ROS 2 Rolling (so *None*, really) |

---

## Description of contribution in a few bullet points

* Creates `nav2_tracetools` package within the navigation2 meta-package
* Adds basic building blocks for LTTng instrumentation
* Proposes a new tracepoint provider named `ros2_navigation2` (i.e. all *traces* related to nav2 could be filtered by using this tracepoint provider). Similarly, launch files can easily enable/disable traces of nav2 using this tracepoint provider.


## Description of documentation updates required from your changes

No direct documentation changes required as part of this PR. Once first navigation2 components get instrumented, it'd be nice to have that aligned with documentation tutorials that show how to make use of it.


---

## Future work that may be required in bullet points

To simplify review of changes, this PR is limited to the initial skeleton of the required changes for LLTng integration into nav2. The following work should be delivered in upcoming PRs:

* Instrument navigation2 components. Initial targets:
  * costmaps
  * controllers
* Documentation
  * Create an introductory section of *benchmarking* in the documentation that explains a rationale similar to what's proposed at [REP-2008 PR](https://github.com/ros-infrastructure/rep/pull/324/files#diff-f230b6aa06d86bf594d8e431300e453ad7343e8f4b1932252b6d36c62a8b5e0aR203-R267).
* Document how to instrument a navigation2 component
* Document how to trace and analyze the results of an instrumented LTTng component

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
