### PR TITLE
Correct params for multi_tb3_simulation_launch.py (galactic)

### DIFF
--- a/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_1.yaml
@@ -275,3 +275,13 @@ recoveries_server:
 robot_state_publisher:
   ros__parameters:
     use_sim_time: True
+    
+waypoint_follower:
+  ros__parameters:
+    loop_rate: 20
+    stop_on_failure: false
+    waypoint_task_executor_plugin: "wait_at_waypoint"   
+    wait_at_waypoint:
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: True
+      waypoint_pause_duration: 200

--- a/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/bringup/params/nav2_multirobot_params_2.yaml
@@ -275,3 +275,13 @@ recoveries_server:
 robot_state_publisher:
   ros__parameters:
     use_sim_time: True
+    
+waypoint_follower:
+  ros__parameters:
+    loop_rate: 20
+    stop_on_failure: false
+    waypoint_task_executor_plugin: "wait_at_waypoint"   
+    wait_at_waypoint:
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: True
+      waypoint_pause_duration: 200


### PR DESCRIPTION
Fix to https://github.com/ros-planning/navigation2/issues/2719 and answer to
https://answers.ros.org/question/394711/nav2-multi_tb3_simulation_launchpy-cannot-get-plugin-param-value-for-wait_at_waypoint/

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2719 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Gazebo simulation of TB3 in `turtlebot3_world` |

---

## Description of contribution in a few bullet points

* Fixed missing parameters name in `nav2_bringup` for `galactic`

## Description of documentation updates required from your changes

* Instructions for multi-robot simulation with independent Nav2 stacks could be added to the "Getting Started" page (https://navigation.ros.org/getting_started/index.html)
---

## Future work that may be required in bullet points

* I think robots ignore each other and possibly collide even if they can sense each other - dynamic obstacles avoidance is needed/isn't working correctly there?

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
