### PR TITLE
Add support for multiple planners for viapoint

### DIFF
--- a/nav2_behavior_tree/CMakeLists.txt
+++ b/nav2_behavior_tree/CMakeLists.txt
@@ -156,6 +156,9 @@ list(APPEND plugin_libs nav2_controller_selector_bt_node)
 add_library(nav2_goal_checker_selector_bt_node SHARED plugins/action/goal_checker_selector_node.cpp)
 list(APPEND plugin_libs nav2_goal_checker_selector_bt_node)
 
+add_library(nav2_remove_passed_goals_with_multiple_planners_bt_node SHARED plugins/action/remove_passed_goals_with_multiple_planners_action.cpp)
+list(APPEND plugin_libs nav2_remove_passed_goals_with_multiple_planners_bt_node)
+
 foreach(bt_plugin ${plugin_libs})
   ament_target_dependencies(${bt_plugin} ${dependencies})
   target_compile_definitions(${bt_plugin} PRIVATE BT_PLUGIN_EXPORT)

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_conversions.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_conversions.hpp
@@ -111,6 +111,26 @@ inline std::chrono::milliseconds convertFromString<std::chrono::milliseconds>(co
   return std::chrono::milliseconds(std::stoul(key.data()));
 }
 
+/**
+ * @brief Parse XML string to string array
+ * @param key XML string
+ * @return std::vector<std::string>
+ */
+template<>
+inline std::vector<std::string> convertFromString(const StringView key)
+{
+  // 7 real numbers separated by semicolons
+  auto parts = BT::splitString(key, ';');
+  std::vector<std::string> string_parts;
+  for (auto& part: parts){
+    string_parts.push_back({part.begin(), part.end()});
+  }
+
+  return string_parts;
+}
+
+
+
 }  // namespace BT
 
 #endif  // NAV2_BEHAVIOR_TREE__BT_CONVERSIONS_HPP_

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_conversions.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_conversions.hpp
@@ -122,7 +122,7 @@ inline std::vector<std::string> convertFromString(const StringView key)
   // 7 real numbers separated by semicolons
   auto parts = BT::splitString(key, ';');
   std::vector<std::string> string_parts;
-  for (auto& part: parts){
+  for (auto & part : parts) {
     string_parts.push_back({part.begin(), part.end()});
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
@@ -68,7 +68,7 @@ public:
           "Destinations to plan through"),
         BT::InputPort<geometry_msgs::msg::PoseStamped>(
           "start", "Start pose of the path if overriding current robot pose"),
-        BT::InputPort<std::string>("planner_ids", ""),
+        BT::InputPort<std::vector<std::string>>("planner_ids", ""),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
@@ -68,7 +68,7 @@ public:
           "Destinations to plan through"),
         BT::InputPort<geometry_msgs::msg::PoseStamped>(
           "start", "Start pose of the path if overriding current robot pose"),
-        BT::InputPort<std::string>("planner_id", ""),
+        BT::InputPort<std::string>("planner_ids", ""),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_passed_goals_with_multiple_planners_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_passed_goals_with_multiple_planners_action.hpp
@@ -41,9 +41,11 @@ public:
   {
     return {
       BT::InputPort<Goals>("input_goals", "Original goals to remove viapoints from"),
-      BT::InputPort<std::string>("input_planner_ids", "Input set of planners"),
+      BT::InputPort<std::vector<std::string>>("input_planner_ids", "Input set of planners"),
 
-      BT::OutputPort<std::string>("output_planner_ids", "Output set of planners. When remove goal from goal list, planner id will be removed too"),
+      BT::OutputPort<std::vector<std::string>>(
+        "output_planner_ids",
+        "Output set of planners. When remove goal from goal list, planner id will be removed too"),
       BT::OutputPort<Goals>("output_goals", "Goals with passed viapoints removed"),
       BT::InputPort<double>("radius", 0.5, "radius to goal for it to be considered for removal"),
       BT::InputPort<std::string>("global_frame", std::string("map"), "Global frame"),
@@ -59,7 +61,7 @@ private:
   std::string robot_base_frame_, global_frame_;
   double transform_tolerance_;
   std::shared_ptr<tf2_ros::Buffer> tf_;
-  std::vector<std::string> planner_ids_;
+  std::vector<std::string> planner_ids_, prev_planner_ids_;
   std::vector<std::string> remaining_planner_ids_;
 };
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_passed_goals_with_multiple_planners_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_passed_goals_with_multiple_planners_action.hpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__REMOVE_PASSED_GOALS_WITH_MULTIPLE_PLANNERS_ACTION_HPP_
+#define NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__REMOVE_PASSED_GOALS_WITH_MULTIPLE_PLANNERS_ACTION_HPP_
+
+#include <vector>
+#include <memory>
+#include <string>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav2_util/geometry_utils.hpp"
+#include "nav2_util/robot_utils.hpp"
+#include "behaviortree_cpp_v3/action_node.h"
+
+namespace nav2_behavior_tree
+{
+
+class RemovePassedGoalsWithMultiplePlanners : public BT::ActionNodeBase
+{
+public:
+  typedef std::vector<geometry_msgs::msg::PoseStamped> Goals;
+
+  RemovePassedGoalsWithMultiplePlanners(
+    const std::string & xml_tag_name,
+    const BT::NodeConfiguration & conf);
+
+
+  static BT::PortsList providedPorts()
+  {
+    return {
+      BT::InputPort<Goals>("input_goals", "Original goals to remove viapoints from"),
+      BT::InputPort<std::string>("input_planner_ids", "Input set of planners"),
+
+      BT::OutputPort<std::string>("output_planner_ids", "Output set of planners. When remove goal from goal list, planner id will be removed too"),
+      BT::OutputPort<Goals>("output_goals", "Goals with passed viapoints removed"),
+      BT::InputPort<double>("radius", 0.5, "radius to goal for it to be considered for removal"),
+      BT::InputPort<std::string>("global_frame", std::string("map"), "Global frame"),
+      BT::InputPort<std::string>("robot_base_frame", std::string("base_link"), "Robot base frame"),
+    };
+  }
+
+private:
+  void halt() override {}
+  BT::NodeStatus tick() override;
+
+  double viapoint_achieved_radius_;
+  std::string robot_base_frame_, global_frame_;
+  double transform_tolerance_;
+  std::shared_ptr<tf2_ros::Buffer> tf_;
+  std::vector<std::string> planner_ids_;
+  std::vector<std::string> remaining_planner_ids_;
+};
+
+}  // namespace nav2_behavior_tree
+
+#endif  // NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__REMOVE_PASSED_GOALS_WITH_MULTIPLE_PLANNERS_ACTION_HPP_

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -41,6 +41,14 @@
       <output_port name="output_goals">Set of goals after removing any passed</output_port>
     </Action>
 
+    <Action ID="RemovePassedGoalsWithMultiplePlanners">
+      <input_port name="input_goals">Input goals to remove if passed</input_port>
+      <input_port name="input_planner_ids">Input planner ids for set of goals</input_port>
+      <input_port name="radius">Radius tolerance on a goal to consider it passed</input_port>
+      <output_port name="output_goals">Set of goals after removing any passed</output_port>
+      <output_port name="output_planner_ids">Remaining planner ids after removing corresponding goals</output_port>
+    </Action>
+
     <Action ID="SmoothPath">
       <input_port name="smoother_id" default="SmoothPath"/>
       <input_port name="unsmoothed_path">Path to be smoothed</input_port>

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -45,6 +45,8 @@
       <input_port name="input_goals">Input goals to remove if passed</input_port>
       <input_port name="input_planner_ids">Input planner ids for set of goals</input_port>
       <input_port name="radius">Radius tolerance on a goal to consider it passed</input_port>
+      <input_port name="robot_base_frame">Robot base frame</input_port>
+      <input_port name="global_frame">Global frame</input_port>
       <output_port name="output_goals">Set of goals after removing any passed</output_port>
       <output_port name="output_planner_ids">Remaining planner ids after removing corresponding goals</output_port>
     </Action>

--- a/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.cpp
@@ -32,7 +32,7 @@ ComputePathThroughPosesAction::ComputePathThroughPosesAction(
 void ComputePathThroughPosesAction::on_tick()
 {
   getInput("goals", goal_.goals);
-  getInput("planner_id", goal_.planner_id);
+  getInput("planner_ids", goal_.planner_ids);
   if (getInput("start", goal_.start)) {
     goal_.use_start = true;
   }

--- a/nav2_behavior_tree/plugins/action/remove_passed_goals_with_multiple_planners_action.cpp
+++ b/nav2_behavior_tree/plugins/action/remove_passed_goals_with_multiple_planners_action.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2021 Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <memory>
+#include <limits>
+
+#include "nav_msgs/msg/path.hpp"
+#include "nav2_util/geometry_utils.hpp"
+
+#include "nav2_behavior_tree/plugins/action/remove_passed_goals_with_multiple_planners_action.hpp"
+
+namespace nav2_behavior_tree
+{
+
+RemovePassedGoalsWithMultiplePlanners::RemovePassedGoalsWithMultiplePlanners(
+  const std::string & name,
+  const BT::NodeConfiguration & conf)
+: BT::ActionNodeBase(name, conf),
+  viapoint_achieved_radius_(0.5)
+{
+  getInput("radius", viapoint_achieved_radius_);
+
+  getInput("global_frame", global_frame_);
+  getInput("robot_base_frame", robot_base_frame_);
+  
+  tf_ = config().blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
+  auto node = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+  node->get_parameter("transform_tolerance", transform_tolerance_);
+}
+
+inline BT::NodeStatus RemovePassedGoalsWithMultiplePlanners::tick()
+{
+  setStatus(BT::NodeStatus::RUNNING);
+
+  auto prev_planner_ids = planner_ids_;
+  getInput("input_planner_ids", planner_ids_);
+
+  // If input planners changed(e.g by another BT node), then we should populate remaining list of planners again.
+  if (prev_planner_ids != planner_ids_){
+    remaining_planner_ids_ = planner_ids_;
+  }  
+
+  
+  Goals goal_poses;
+  getInput("input_goals", goal_poses);
+
+  if (goal_poses.empty()) {
+    setOutput("output_goals", goal_poses);
+    return BT::NodeStatus::SUCCESS;
+  }
+  if (remaining_planner_ids_.size() != goal_poses.size() && planner_ids_.size()  != 1 && planner_ids_.size() != 0){
+    RCLCPP_WARN(
+      config().blackboard->get<rclcpp::Node::SharedPtr>("node")->get_logger(),
+      "RemovePassedGoalsWithMultiplePlanners requested with a planner_ids array length mismatch. It should be either 0 - use default, \
+        1 - use one for all, or length should be equal to the number of goals. Current Planner Ids len %d, goal len %d", planner_ids_.size(), goal_poses.size());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  using namespace nav2_util::geometry_utils;  // NOLINT
+
+  geometry_msgs::msg::PoseStamped current_pose;
+  if (!nav2_util::getCurrentPose(
+      current_pose, *tf_, global_frame_, robot_base_frame_,
+      transform_tolerance_))
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+
+  double dist_to_goal;
+  while (goal_poses.size() > 1) {
+    dist_to_goal = euclidean_distance(goal_poses[0].pose, current_pose.pose);
+
+    if (dist_to_goal > viapoint_achieved_radius_) {
+      break;
+    }
+
+    if (remaining_planner_ids_.size() > 0){
+      remaining_planner_ids_.erase(remaining_planner_ids_.begin());
+    }
+    goal_poses.erase(goal_poses.begin());
+  }
+
+  std::string planner_ids_str = "";
+  for (auto i=0; i < remaining_planner_ids_.size(); i++){
+    planner_ids_str += remaining_planner_ids_[i];
+    if (i != remaining_planner_ids_.size()-1){
+      planner_ids_str += ";";
+    }
+  }
+
+  setOutput("output_goals", goal_poses);
+  setOutput("output_planner_ids", planner_ids_str);
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace nav2_behavior_tree
+
+#include "behaviortree_cpp_v3/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<nav2_behavior_tree::RemovePassedGoalsWithMultiplePlanners>("RemovePassedGoalsWithMultiplePlanners");
+}

--- a/nav2_behavior_tree/plugins/action/remove_passed_goals_with_multiple_planners_action.cpp
+++ b/nav2_behavior_tree/plugins/action/remove_passed_goals_with_multiple_planners_action.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Samsung Research America
+// Copyright (c) 2022 JetBrains TechLab
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ RemovePassedGoalsWithMultiplePlanners::RemovePassedGoalsWithMultiplePlanners(
 
   getInput("global_frame", global_frame_);
   getInput("robot_base_frame", robot_base_frame_);
-  
   tf_ = config().blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
   auto node = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
   node->get_parameter("transform_tolerance", transform_tolerance_);
@@ -44,36 +43,44 @@ inline BT::NodeStatus RemovePassedGoalsWithMultiplePlanners::tick()
 {
   setStatus(BT::NodeStatus::RUNNING);
 
-  auto prev_planner_ids = planner_ids_;
+  prev_planner_ids_ = planner_ids_;
   getInput("input_planner_ids", planner_ids_);
 
-  // If input planners changed(e.g by another BT node), then we should populate remaining list of planners again.
-  if (prev_planner_ids != planner_ids_){
-    remaining_planner_ids_ = planner_ids_;
-  }  
-
-  
   Goals goal_poses;
   getInput("input_goals", goal_poses);
 
   if (goal_poses.empty()) {
     setOutput("output_goals", goal_poses);
+    remaining_planner_ids_.clear();
     return BT::NodeStatus::SUCCESS;
   }
-  if (remaining_planner_ids_.size() != goal_poses.size() && planner_ids_.size()  != 1 && planner_ids_.size() != 0){
-    RCLCPP_WARN(
-      config().blackboard->get<rclcpp::Node::SharedPtr>("node")->get_logger(),
-      "RemovePassedGoalsWithMultiplePlanners requested with a planner_ids array length mismatch. It should be either 0 - use default, \
-        1 - use one for all, or length should be equal to the number of goals. Current Planner Ids len %d, goal len %d", planner_ids_.size(), goal_poses.size());
-    return BT::NodeStatus::FAILURE;
+
+  // If input planners changed(e.g by another BT node), or goals changed
+  // then we should populate remaining list of planners again.
+  if (prev_planner_ids_ != planner_ids_ || remaining_planner_ids_.size() == 0) {
+    remaining_planner_ids_ = planner_ids_;
+  }
+
+  if (remaining_planner_ids_.size() != goal_poses.size() && planner_ids_.size() != 1 &&
+    planner_ids_.size() != 0)
+  {
+    std::stringstream error_msg;
+    error_msg <<
+      "RemovePassedGoalsWithMultiplePlanners requested with a planner_ids array length mismatch."
+      "It should be either 0 - use default, "
+      "1 - use one for all, or length should be equal to the number of goals."
+      "Current Planner Ids len " << remaining_planner_ids_.size() << " "
+        << remaining_planner_ids_[0] <<" goal len " << goal_poses.size();
+
+    throw std::runtime_error(error_msg.str());
   }
 
   using namespace nav2_util::geometry_utils;  // NOLINT
 
   geometry_msgs::msg::PoseStamped current_pose;
   if (!nav2_util::getCurrentPose(
-      current_pose, *tf_, global_frame_, robot_base_frame_,
-      transform_tolerance_))
+        current_pose, *tf_, global_frame_, robot_base_frame_,
+        transform_tolerance_))
   {
     return BT::NodeStatus::FAILURE;
   }
@@ -81,27 +88,19 @@ inline BT::NodeStatus RemovePassedGoalsWithMultiplePlanners::tick()
   double dist_to_goal;
   while (goal_poses.size() > 1) {
     dist_to_goal = euclidean_distance(goal_poses[0].pose, current_pose.pose);
-
     if (dist_to_goal > viapoint_achieved_radius_) {
       break;
     }
 
-    if (remaining_planner_ids_.size() > 0){
+    if (remaining_planner_ids_.size() > 0) {
       remaining_planner_ids_.erase(remaining_planner_ids_.begin());
     }
+
     goal_poses.erase(goal_poses.begin());
   }
 
-  std::string planner_ids_str = "";
-  for (auto i=0; i < remaining_planner_ids_.size(); i++){
-    planner_ids_str += remaining_planner_ids_[i];
-    if (i != remaining_planner_ids_.size()-1){
-      planner_ids_str += ";";
-    }
-  }
-
   setOutput("output_goals", goal_poses);
-  setOutput("output_planner_ids", planner_ids_str);
+  setOutput("output_planner_ids", remaining_planner_ids_);
 
   return BT::NodeStatus::SUCCESS;
 }
@@ -111,5 +110,6 @@ inline BT::NodeStatus RemovePassedGoalsWithMultiplePlanners::tick()
 #include "behaviortree_cpp_v3/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
-  factory.registerNodeType<nav2_behavior_tree::RemovePassedGoalsWithMultiplePlanners>("RemovePassedGoalsWithMultiplePlanners");
+  factory.registerNodeType<nav2_behavior_tree::RemovePassedGoalsWithMultiplePlanners>(
+    "RemovePassedGoalsWithMultiplePlanners");
 }

--- a/nav2_bt_navigator/behavior_trees/navigate_through_poses_w_replanning_and_recovery_multiple_planner_ids.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_through_poses_w_replanning_and_recovery_multiple_planner_ids.xml
@@ -1,0 +1,38 @@
+
+<!--
+  This Behavior Tree replans the global path periodically at 1 Hz through an array of poses continuously
+   and it also has recovery actions specific to planning / control as well as general system issues.
+-->
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <RateController hz="0.333">
+          <RecoveryNode number_of_retries="1" name="ComputePathThroughPoses">
+            <ReactiveSequence>
+              <RemovePassedGoalsWithMultiplePlanners input_goals="{goals}" input_planner_ids="GridBased;SmacPlanner" output_planner_ids="{planner_ids}" output_goals="{goals}" radius="0.7"/>
+              <ComputePathThroughPoses goals="{goals}" path="{path}" planner_ids="{planner_ids}"/>
+            </ReactiveSequence>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap" />
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="{path}" controller_id="FollowPath"/>
+          <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
+        </RecoveryNode>
+      </PipelineSequence>
+      <ReactiveFallback name="RecoveryFallback">
+        <GoalUpdated/>
+        <RoundRobin name="RecoveryActions">
+          <Sequence name="ClearingActions">
+            <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </Sequence>
+          <Spin spin_dist="1.57"/>
+          <Wait wait_duration="5"/>
+          <BackUp backup_dist="0.30" backup_speed="0.05"/>
+        </RoundRobin>
+      </ReactiveFallback>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/nav2_msgs/action/ComputePathThroughPoses.action
+++ b/nav2_msgs/action/ComputePathThroughPoses.action
@@ -1,7 +1,7 @@
 #goal definition
 geometry_msgs/PoseStamped[] goals
 geometry_msgs/PoseStamped start
-string planner_id
+string[] planner_ids
 bool use_start # If false, use current robot pose as path start, if true, use start above instead
 ---
 #result definition

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -354,10 +354,16 @@ PlannerServer::computePlanThroughPoses()
   // By default we will use last default planner id
   std::string current_planner_id = default_ids_.back();
 
-  if(goal->planner_ids.size() != goal->goals.size() && goal->planner_ids.size() != 0 && goal->planner_ids.size() != 1){
+  if (goal->planner_ids.size() != goal->goals.size() && goal->planner_ids.size() != 0 &&
+    goal->planner_ids.size() != 1)
+  {
     RCLCPP_WARN(
       get_logger(),
-      "Compute path through poses requested with a planner_ids array length mismatch. It should be either 0 - use default, 1 - use one for all, or length should be equal to the number of goals. Current Planner Ids len %d, goal len %d", goal->planner_ids.size(), goal->goals.size());
+      "Compute path through poses requested with a planner_ids array length mismatch."
+      "It should be either 0 - use default, 1 - use one for all, "
+      "or length should be equal to the number of goals. "
+      "Current Planner Ids len %d, goal len %d",
+      goal->planner_ids.size(), goal->goals.size());
     action_server_poses_->terminate_current();
   }
 
@@ -399,12 +405,11 @@ PlannerServer::computePlanThroughPoses()
       if (!transformPosesToGlobalFrame(action_server_poses_, curr_start, curr_goal)) {
         return;
       }
-      
-      // Check if size 1 - use specified, if 0 then we use default that was assigned above, otherwise assign corresponding planner_id
-      if(goal->planner_ids.size() == 1){
+      // Check if size 1 - use specified,
+      // if 0 then we use default that was assigned above, otherwise assign corresponding planner_id
+      if (goal->planner_ids.size() == 1) {
         current_planner_id = goal->planner_ids[0];
-      }
-      else if(goal->planner_ids.size() != 0){
+      } else if (goal->planner_ids.size() != 0) {
         current_planner_id = goal->planner_ids[i];
       }
 


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2799 |
| Primary OS tested on | Ubuntu, docker ros:rolling image |
| Robotic platform tested on | default tb3_simulation |

---

## Description of contribution in a few bullet points

Multiple planner support for viapoints mode added. In viapoint mode if 0 planner ids provided - default planner will be
used for all viapoints, if 1 planner id provided - this id will be used for all viapoints, if n planner ids provided for n goal points - for each i-th goal i-th planner id will be used. If number of goals != number of planner ids error will be thrown. (if planner ids != 0 and 1).

I am not sure, I have done it the best way, so any comments are appreciated !

## Description of documentation updates required from your changes

Once we agree on the api and the implementation, I will change following documents:
https://navigation.ros.org/plugins/index.html#behavior-tree-nodes
https://navigation.ros.org/configuration/packages/configuring-bt-xml.html#action-plugins

Same goes for commander api, will test it after discussion:
https://navigation.ros.org/commander_api/index.html

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
