### PR TITLE
Drop unneeded dependency on python-enum34

### DIFF
--- a/nav2_simple_commander/package.xml
+++ b/nav2_simple_commander/package.xml
@@ -7,7 +7,6 @@
   <maintainer email="stevenmacenski@gmail.com">steve</maintainer>
   <license>Apache-2.0</license>
 
-  <exec_depend>python-enum34</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>


### PR DESCRIPTION
The enum module was added in PEP 435 and is present in Python versions 3.4 and newer, which includes all currently supported Python versions.

Additionally, this `rosdep` [is a Python 2 package](https://github.com/ros/rosdistro/blob/685c61ca135f9c80f25be50e93db683837bc7546/rosdep/python.yaml#L1589-L1598), where ROS 2 targets Python 3.

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |

---

## Description of contribution in a few bullet points

* Drop unneeded dependency on python-enum34

## Description of documentation updates required from your changes

N/A

---

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists