### PR TITLE
remove unused odometry smoother in bt navigator

### DIFF
--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -89,6 +89,9 @@ protected:
   poses_navigator_;
   nav2_bt_navigator::NavigatorMuxer plugin_muxer_;
 
+  // Odometry smoother object
+  std::shared_ptr<nav2_util::OdomSmoother> odom_smoother_;
+
   // Metrics for feedback
   std::string robot_frame_;
   std::string global_frame_;

--- a/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/bt_navigator.hpp
@@ -89,9 +89,6 @@ protected:
   poses_navigator_;
   nav2_bt_navigator::NavigatorMuxer plugin_muxer_;
 
-  // Odometry smoother object
-  std::unique_ptr<nav2_util::OdomSmoother> odom_smoother_;
-
   // Metrics for feedback
   std::string robot_frame_;
   std::string global_frame_;

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
@@ -135,13 +135,15 @@ public:
    * @param feedback_utils Some utilities useful for navigators to have
    * @param plugin_muxer The muxing object to ensure only one navigator
    * can be active at a time
+   * @param odom_smoother Object to get current smoothed robot's speed
    * @return bool If successful
    */
   bool on_configure(
     rclcpp_lifecycle::LifecycleNode::WeakPtr parent_node,
     const std::vector<std::string> & plugin_lib_names,
     const FeedbackUtils & feedback_utils,
-    nav2_bt_navigator::NavigatorMuxer * plugin_muxer)
+    nav2_bt_navigator::NavigatorMuxer * plugin_muxer,
+    std::shared_ptr<nav2_util::OdomSmoother> odom_smoother)
   {
     auto node = parent_node.lock();
     logger_ = node->get_logger();
@@ -173,7 +175,7 @@ public:
     blackboard->set<bool>("initial_pose_received", false);  // NOLINT
     blackboard->set<int>("number_recoveries", 0);  // NOLINT
 
-    return configure(parent_node) && ok;
+    return configure(parent_node, odom_smoother) && ok;
   }
 
   /**
@@ -293,7 +295,12 @@ protected:
   /**
    * @param Method to configure resources.
    */
-  virtual bool configure(rclcpp_lifecycle::LifecycleNode::WeakPtr /*node*/) {return true;}
+  virtual bool configure(
+    rclcpp_lifecycle::LifecycleNode::WeakPtr /*node*/
+    std::shared_ptr<nav2_util::OdomSmoother> /*odom_smoother*/)
+  {
+    return true;
+  }
 
   /**
    * @brief Method to cleanup resources.

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_through_poses.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_through_poses.hpp
@@ -51,9 +51,11 @@ public:
   /**
    * @brief A configure state transition to configure navigator's state
    * @param node Weakptr to the lifecycle node
+   * @param odom_smoother Object to get current smoothed robot's speed
    */
   bool configure(
-    rclcpp_lifecycle::LifecycleNode::WeakPtr node) override;
+    rclcpp_lifecycle::LifecycleNode::WeakPtr node,
+    std::shared_ptr<nav2_util::OdomSmoother> odom_smoother) override;
 
   /**
    * @brief Get action name for this navigator
@@ -106,7 +108,7 @@ protected:
   std::string path_blackboard_id_;
 
   // Odometry smoother object
-  std::unique_ptr<nav2_util::OdomSmoother> odom_smoother_;
+  std::shared_ptr<nav2_util::OdomSmoother> odom_smoother_;
 };
 
 }  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_to_pose.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_to_pose.hpp
@@ -50,9 +50,11 @@ public:
   /**
    * @brief A configure state transition to configure navigator's state
    * @param node Weakptr to the lifecycle node
+   * @param odom_smoother Object to get current smoothed robot's speed
    */
   bool configure(
-    rclcpp_lifecycle::LifecycleNode::WeakPtr node) override;
+    rclcpp_lifecycle::LifecycleNode::WeakPtr node,
+    std::shared_ptr<nav2_util::OdomSmoother> odom_smoother) override;
 
   /**
    * @brief A cleanup state transition to remove memory allocated
@@ -122,7 +124,7 @@ protected:
   std::string path_blackboard_id_;
 
   // Odometry smoother object
-  std::unique_ptr<nav2_util::OdomSmoother> odom_smoother_;
+  std::shared_ptr<nav2_util::OdomSmoother> odom_smoother_;
 };
 
 }  // namespace nav2_bt_navigator

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -111,14 +111,17 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   feedback_utils.robot_frame = robot_frame_;
   feedback_utils.transform_tolerance = transform_tolerance_;
 
+  // Odometry smoother object for getting current speed
+  odom_smoother_ = std::make_shared<nav2_util::OdomSmoother>(shared_from_this(), 0.3, odom_topic_)
+
   if (!pose_navigator_->on_configure(
-      shared_from_this(), plugin_lib_names, feedback_utils, &plugin_muxer_))
+      shared_from_this(), plugin_lib_names, feedback_utils, &plugin_muxer_, odom_smoother_))
   {
     return nav2_util::CallbackReturn::FAILURE;
   }
 
   if (!poses_navigator_->on_configure(
-      shared_from_this(), plugin_lib_names, feedback_utils, &plugin_muxer_))
+      shared_from_this(), plugin_lib_names, feedback_utils, &plugin_muxer_, odom_smoother_))
   {
     return nav2_util::CallbackReturn::FAILURE;
   }

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -123,9 +123,6 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
     return nav2_util::CallbackReturn::FAILURE;
   }
 
-  // Odometry smoother object for getting current speed
-  odom_smoother_ = std::make_unique<nav2_util::OdomSmoother>(shared_from_this(), 0.3, odom_topic_);
-
   return nav2_util::CallbackReturn::SUCCESS;
 }
 

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -24,7 +24,8 @@ namespace nav2_bt_navigator
 
 bool
 NavigateThroughPosesNavigator::configure(
-  rclcpp_lifecycle::LifecycleNode::WeakPtr parent_node)
+  rclcpp_lifecycle::LifecycleNode::WeakPtr parent_node,
+  std::shared_ptr<nav2_util::OdomSmoother> odom_smoother)
 {
   start_time_ = rclcpp::Time(0);
   auto node = parent_node.lock();
@@ -36,7 +37,7 @@ NavigateThroughPosesNavigator::configure(
   path_blackboard_id_ = node->get_parameter("path_blackboard_id").as_string();
 
   // Odometry smoother object for getting current speed
-  odom_smoother_ = std::make_unique<nav2_util::OdomSmoother>(node, 0.3);
+  odom_smoother_ = odom_smoother;
 
   return true;
 }

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -24,7 +24,8 @@ namespace nav2_bt_navigator
 
 bool
 NavigateToPoseNavigator::configure(
-  rclcpp_lifecycle::LifecycleNode::WeakPtr parent_node)
+  rclcpp_lifecycle::LifecycleNode::WeakPtr parent_node,
+  std::shared_ptr<nav2_util::OdomSmoother> odom_smoother)
 {
   start_time_ = rclcpp::Time(0);
   auto node = parent_node.lock();
@@ -36,7 +37,7 @@ NavigateToPoseNavigator::configure(
   path_blackboard_id_ = node->get_parameter("path_blackboard_id").as_string();
 
   // Odometry smoother object for getting current speed
-  odom_smoother_ = std::make_unique<nav2_util::OdomSmoother>(node, 0.3);
+  odom_smoother_ = odom_smoother;
 
   self_client_ = rclcpp_action::create_client<ActionT>(node, getName());
 


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description of contribution in a few bullet points

There's an unused `OdomSmoother` object in the BT Navigator code.
Removing it to avoid creation of unnecessary subscription.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
