### PR TITLE
Ci jammy rolling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ _commands:
               sha256sum $PWD/lockfile.txt >> lockfile.txt
 
               apt-get update
-              # rosdep update --rosdistro $ROS_DISTRO
+              rosdep update --rosdistro $ROS_DISTRO
               dependencies=$(
                 rosdep install -q -y \
                   --from-paths src \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # docker build -t nav2:latest \
 #   --build-arg UNDERLAY_MIXINS \
 #   --build-arg OVERLAY_MIXINS ./
-ARG FROM_IMAGE=ros:rolling-ros-base-focal
+ARG FROM_IMAGE=ros:rolling
 ARG UNDERLAY_WS=/opt/underlay_ws
 ARG OVERLAY_WS=/opt/overlay_ws
 
@@ -60,7 +60,7 @@ RUN apt-get update && \
       fastcov \
       git+https://github.com/ruffsl/colcon-cache.git@a937541bfc496c7a267db7ee9d6cceca61e470ca \
       git+https://github.com/ruffsl/colcon-clean.git@a7f1074d1ebc1a54a6508625b117974f2672f2a9 \
-    # && rosdep update \
+    && rosdep update \
     && colcon mixin update \
     && colcon metadata update \
     && rm -rf /var/lib/apt/lists/*

--- a/tools/distro.Dockerfile
+++ b/tools/distro.Dockerfile
@@ -13,7 +13,7 @@
 #   --build-arg OVERLAY_MIXINS \
 #   -f distro.Dockerfile ../
 
-ARG FROM_IMAGE=ros:rolling-ros-base-focal
+ARG FROM_IMAGE=ros:rolling
 ARG OVERLAY_WS=/opt/overlay_ws
 
 # multi-stage for caching
@@ -56,8 +56,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && apt-get install -q -y \
       ccache \
       lcov \
-      lld
-    # && rosdep update
+      lld \
+    && rosdep update
 
 # install overlay dependencies
 ARG OVERLAY_WS

--- a/tools/source.Dockerfile
+++ b/tools/source.Dockerfile
@@ -82,8 +82,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
       ccache \
       libasio-dev \
       libtinyxml2-dev \
-      lld
-    # && rosdep update
+      lld \
+    && rosdep update
 
 ENV ROS_VERSION=2 \
     ROS_PYTHON_VERSION=3

--- a/tools/underlay.repos
+++ b/tools/underlay.repos
@@ -23,3 +23,7 @@ repositories:
   #   type: git
   #   url: https://github.com/ompl/ompl.git
   #   version: main
+  ros-simulation/gazebo_ros_pkgs:
+    type: git
+    url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+    version: ros2


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2813  |
| Primary OS tested on | NA |
| Robotic platform tested on | NA |

---

## Description of contribution in a few bullet points
This is a hotfix to run CI on `ros:rolling` during the transition to Ubuntu 22.04. This circumvents the missing gazebo package by installing gazebo11 from upstream and compiling gazebo_ros from source in the underlay. It also installs python3.9-dev as a work-around for jammy migration to python3.10.

Alternatives: 
- https://github.com/ros-planning/navigation2/pull/2851

## Description of documentation updates required from your changes
None

---

## Future work that may be required in bullet points
Revert this change when everything is ready to build on Ubuntu 22.04.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
