### PR TITLE
nav2_controller: stop mutex from deadlocking on parameter change

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -344,6 +344,7 @@ bool ControllerServer::findGoalCheckerId(
 void ControllerServer::computeControl()
 {
   std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+
   RCLCPP_INFO(get_logger(), "Received a goal, begin computing control effort.");
 
   try {
@@ -596,12 +597,24 @@ void ControllerServer::speedLimitCallback(const nav2_msgs::msg::SpeedLimit::Shar
 rcl_interfaces::msg::SetParametersResult
 ControllerServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters)
 {
-  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
   rcl_interfaces::msg::SetParametersResult result;
 
   for (auto parameter : parameters) {
     const auto & type = parameter.get_type();
     const auto & name = parameter.get_name();
+
+    // If we are trying to change the parameter of a plugin we can just skip it at this point
+    // as they handle parameter changes themselves and don't need to lock the mutex
+    if (name.find('.') != std::string::npos)
+      continue;
+
+    if (!dynamic_params_lock_.try_lock())
+    {
+      RCLCPP_WARN(get_logger(), "Unable to dynamically change Parameters while the controller is currently running");
+      result.successful = false;
+      result.reason = "Unable to dynamically change Parameters while the controller is currently running";
+      return result;
+    }
 
     if (type == ParameterType::PARAMETER_DOUBLE) {
       if (name == "controller_frequency") {
@@ -616,6 +629,8 @@ ControllerServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> param
         failure_tolerance_ = parameter.as_double();
       }
     }
+
+    dynamic_params_lock_.unlock();
   }
 
   result.successful = true;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2833 |
| Primary OS tested on | Debian |
| Robotic platform tested on | gazebo simulation|

---
## Description of contribution in a few bullet points

* Don't cause a deadlock when we try to dynamically change controller
parameters while the controller is running.
* Also provide a appropriate
error message on failure to change parameters.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

Shouldn't be necessary

## Future work that may be required in bullet points

* Maybe add correct handling of dynamic parameter changes to the plugins

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
