### PR TITLE
Additional revision for costmap_bresenham_2d test

### DIFF
--- a/nav2_costmap_2d/test/regression/costmap_bresenham_2d.cpp
+++ b/nav2_costmap_2d/test/regression/costmap_bresenham_2d.cpp
@@ -50,6 +50,7 @@ public:
     ASSERT_TRUE(off < size_);
     costmap_[off] = mark_val_;
   }
+
   inline unsigned int get(unsigned int off)
   {
     return costmap_[off];
@@ -107,29 +108,25 @@ TEST(costmap_2d, bresenham2DBoundariesCheck)
 
   // Running on (x, 0) edge
   y1 = 0;
-  for (unsigned int i = 0; i < sz_x; i++) {
-    x1 = i;
+  for (x1 = 0; x1 < sz_x; x1++) {
     ct.raytraceLine(ca, x0, y0, x1, y1, max_length, min_length);
   }
 
   // Running on (x, sz_y) edge
   y1 = sz_y - 1;
-  for (unsigned int i = 0; i < sz_x; i++) {
-    x1 = i;
+  for (x1 = 0; x1 < sz_x; x1++) {
     ct.raytraceLine(ca, x0, y0, x1, y1, max_length, min_length);
   }
 
   // Running on (0, y) edge
   x1 = 0;
-  for (unsigned int j = 0; j < sz_y; j++) {
-    y1 = j;
+  for (y1 = 0; y1 < sz_y; y1++) {
     ct.raytraceLine(ca, x0, y0, x1, y1, max_length, min_length);
   }
 
   // Running on (sz_x, y) edge
-  x1 = sz_x;
-  for (unsigned int j = 0; j < sz_y; j++) {
-    y1 = j;
+  x1 = sz_x - 1;
+  for (y1 = 0; y1 < sz_y; y1++) {
     ct.raytraceLine(ca, x0, y0, x1, y1, max_length, min_length);
   }
 }


### PR DESCRIPTION
Minor test optimizations/fixups for 2D `raytraceLine()` costmap_bresenham_2d test

---
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2835 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | `colcon test` for nav2_cosmap_2d |

---

## Description of contribution in a few bullet points

* Corrected `(sz_x, y)` array edge index check
* Test code optimized

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
