### PR TITLE
Fixed first_map_only parameter issue

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -221,7 +221,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions & options)
   add_parameter(
     "map_topic", rclcpp::ParameterValue("map"),
     "Topic to subscribe to in order to receive the map to localize on");
-  
+
   add_parameter(
     "first_map_only", rclcpp::ParameterValue(false),
     "Set this to true, when you want to load a new map published from the map_server");

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -223,7 +223,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions & options)
     "Topic to subscribe to in order to receive the map to localize on");
   
   add_parameter(
-    "first_map_only", rclcpp::ParameterValue(true),
+    "first_map_only", rclcpp::ParameterValue(false),
     "Set this to true, when you want to load a new map published from the map_server");
 }
 

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -221,6 +221,10 @@ AmclNode::AmclNode(const rclcpp::NodeOptions & options)
   add_parameter(
     "map_topic", rclcpp::ParameterValue("map"),
     "Topic to subscribe to in order to receive the map to localize on");
+  
+  add_parameter(
+    "first_map_only", rclcpp::ParameterValue(true),
+    "Set this to true, when you want to load a new map published from the map_server");
 }
 
 AmclNode::~AmclNode()
@@ -1055,7 +1059,7 @@ AmclNode::initParameters()
   get_parameter("z_max", z_max_);
   get_parameter("z_rand", z_rand_);
   get_parameter("z_short", z_short_);
-  get_parameter("first_map_only_", first_map_only_);
+  get_parameter("first_map_only", first_map_only_);
   get_parameter("always_reset_initial_pose", always_reset_initial_pose_);
   get_parameter("scan_topic", scan_topic_);
   get_parameter("map_topic", map_topic_);

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -38,6 +38,7 @@ amcl:
     z_rand: 0.5
     z_short: 0.05
     scan_topic: scan
+    first_map_only: true
 
 amcl_map_client:
   ros__parameters:

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -38,7 +38,6 @@ amcl:
     z_rand: 0.5
     z_short: 0.05
     scan_topic: scan
-    first_map_only: true
 
 amcl_map_client:
   ros__parameters:


### PR DESCRIPTION
Signed-off-by: Harshal Deshpande <hardesh1deshpande@gmail.com>

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation.ros.org/pull/284 |
| Primary OS tested on | Ubuntu) |
| Robotic platform tested on | gazebo simulation of Turtlebot) |

---

## Description of contribution in a few bullet points

- Fixed first_map_only parameter issue in AMCL


## Description of documentation updates required from your changes

- Updated its documentation in the docs repo. PR is mentioned in the above table

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
