### PR TITLE
launch example of map_server

### DIFF
--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -123,7 +123,7 @@ install(TARGETS
 install(DIRECTORY include/
   DESTINATION include/)
 
-install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY launch test DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/nav2_map_server/README.md
+++ b/nav2_map_server/README.md
@@ -100,6 +100,22 @@ Then, one would invoke this process with the params file that contains the param
 $ process_with_multiple_map_servers __params:=combined_params.yaml
 ```
 
+**Attention** : map_server is now a lifecycle node and needs to be transitioned to the active state. There are several ways you can trigger that state transition. The easiest way from the command line is:
+
+
+
+```
+$ ros2 run nav2_util lifecycle_bringup map_server
+```
+
+There is an example launch file that already triggers this state. In the launch file you just need to provide the "map.yaml" file:
+
+
+```
+$ ros2 launch nav2_map_server map_server.launch.py
+```
+
+
 #### Map Saver
 
 Like in ROS1 `map_saver` could be used as CLI-executable. It was renamed to `map_saver_cli`
@@ -107,6 +123,12 @@ and could be invoked by following command:
 
 ```
 $ ros2 run nav2_map_server map_saver_cli [arguments] [--ros-args ROS remapping args]
+```
+
+There is an example launch file:
+
+```
+$ ros2 launch nav2_map_server map_saver_server.launch.py 
 ```
 
 ## Currently Supported Map Types

--- a/nav2_map_server/launch/map_server.launch.py
+++ b/nav2_map_server/launch/map_server.launch.py
@@ -1,0 +1,51 @@
+import os
+import yaml
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import ExecuteProcess
+from launch.substitutions import LaunchConfiguration
+import launch_ros.actions
+
+    
+def generate_launch_description():
+
+    ld = LaunchDescription()
+    
+    # Map server
+    map_server_config_path = os.path.join(
+        get_package_share_directory('nav2_map_server'),
+        'test',
+        'testmap.yaml'
+    )
+     
+    map_server_cmd = Node(
+        package='nav2_map_server',
+        executable='map_server',
+        output='screen',
+        parameters=[{'yaml_filename': map_server_config_path}])        
+             
+              
+
+    lifecycle_nodes = ['map_server']
+    use_sim_time = True
+    autostart = True
+    
+    start_lifecycle_manager_cmd = launch_ros.actions.Node(
+            package='nav2_lifecycle_manager',
+            executable='lifecycle_manager',
+            name='lifecycle_manager',
+            output='screen',
+            emulate_tty=True,  # https://github.com/ros2/launch/issues/188
+            parameters=[{'use_sim_time': use_sim_time},
+                        {'autostart': autostart},
+                        {'node_names': lifecycle_nodes}])
+    
+    
+    
+
+    ld.add_action(map_server_cmd)
+    ld.add_action(start_lifecycle_manager_cmd)
+
+    return ld
+


### PR DESCRIPTION
I added an easy example to use map server with launch file that already triggers the lifecycle

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
