### PR TITLE
add getRobotRadius() in costmap_2d_ros

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -294,6 +294,14 @@ public:
    */
   bool getUseRadius() {return use_radius_;}
 
+  /**
+   * @brief  Get the costmap's robot_radius_ parameter, corresponding to
+   * raidus of the robot footprint when it is defined as as circle
+   * (i.e. when use_radius_ == true).
+   * @return  robot_radius_
+   */
+  double getRobotRadius() {return robot_radius_;}
+
 protected:
   rclcpp::Node::SharedPtr client_node_;
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Wyca Elodie |

---

## Description of contribution in a few bullet points

Added `getRobotRadius()` to `costmap_2d_ros` in a similar fashion to `getUseRadius()` (and to complete it).
This was missing if one needed to accurately get the footprint when it is defined as a circle (for instance to be able to manipulate it, think inflation). When it is defined as a circle, a polygonial footprint is interpolated, hence the loss of precision (but the information that it was generated from a circle was already there).

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
