### PR TITLE
Adding the missing "feedback definition" for the action interface 

### DIFF
--- a/nav2_msgs/action/BackUp.action
+++ b/nav2_msgs/action/BackUp.action
@@ -6,4 +6,5 @@ builtin_interfaces/Duration time_allowance
 #result definition
 builtin_interfaces/Duration total_elapsed_time
 ---
+#feedback definition
 float32 distance_traveled

--- a/nav2_msgs/action/ComputePathThroughPoses.action
+++ b/nav2_msgs/action/ComputePathThroughPoses.action
@@ -8,4 +8,4 @@ bool use_start # If false, use current robot pose as path start, if true, use st
 nav_msgs/Path path
 builtin_interfaces/Duration planning_time
 ---
-#feedback
+#feedback definition

--- a/nav2_msgs/action/ComputePathToPose.action
+++ b/nav2_msgs/action/ComputePathToPose.action
@@ -8,4 +8,4 @@ bool use_start # If false, use current robot pose as path start, if true, use st
 nav_msgs/Path path
 builtin_interfaces/Duration planning_time
 ---
-#feedback
+#feedback definition

--- a/nav2_msgs/action/DummyBehavior.action
+++ b/nav2_msgs/action/DummyBehavior.action
@@ -4,4 +4,4 @@ std_msgs/String command
 #result definition
 builtin_interfaces/Duration total_elapsed_time
 ---
-#feedback
+#feedback definition

--- a/nav2_msgs/action/FollowPath.action
+++ b/nav2_msgs/action/FollowPath.action
@@ -6,6 +6,6 @@ string goal_checker_id
 #result definition
 std_msgs/Empty result
 ---
-#feedback
+#feedback definition
 float32 distance_to_goal
 float32 speed

--- a/nav2_msgs/action/FollowWaypoints.action
+++ b/nav2_msgs/action/FollowWaypoints.action
@@ -4,5 +4,5 @@ geometry_msgs/PoseStamped[] poses
 #result definition
 int32[] missed_waypoints
 ---
-#feedback
+#feedback definition
 uint32 current_waypoint

--- a/nav2_msgs/action/NavigateThroughPoses.action
+++ b/nav2_msgs/action/NavigateThroughPoses.action
@@ -5,6 +5,7 @@ string behavior_tree
 #result definition
 std_msgs/Empty result
 ---
+#feedback definition
 geometry_msgs/PoseStamped current_pose
 builtin_interfaces/Duration navigation_time
 builtin_interfaces/Duration estimated_time_remaining

--- a/nav2_msgs/action/NavigateToPose.action
+++ b/nav2_msgs/action/NavigateToPose.action
@@ -5,6 +5,7 @@ string behavior_tree
 #result definition
 std_msgs/Empty result
 ---
+#feedback definition
 geometry_msgs/PoseStamped current_pose
 builtin_interfaces/Duration navigation_time
 builtin_interfaces/Duration estimated_time_remaining

--- a/nav2_msgs/action/SmoothPath.action
+++ b/nav2_msgs/action/SmoothPath.action
@@ -9,4 +9,4 @@ nav_msgs/Path path
 builtin_interfaces/Duration smoothing_duration
 bool was_completed
 ---
-#feedback
+#feedback definition

--- a/nav2_msgs/action/Spin.action
+++ b/nav2_msgs/action/Spin.action
@@ -5,4 +5,5 @@ builtin_interfaces/Duration time_allowance
 #result definition
 builtin_interfaces/Duration total_elapsed_time
 ---
+#feedback definition
 float32 angular_distance_traveled

--- a/nav2_msgs/action/Wait.action
+++ b/nav2_msgs/action/Wait.action
@@ -4,5 +4,5 @@ builtin_interfaces/Duration time
 #result definition
 builtin_interfaces/Duration total_elapsed_time
 ---
-#feedback
+#feedback definition
 builtin_interfaces/Duration time_left


### PR DESCRIPTION
Just a very small change in the `nav_msgs`, that would allow a very new user for ROS-2 to easily find out the details of the interfaces that we provide. 