### PR TITLE
Allow usage of std::string in searchAndGetParam()

### DIFF
--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
@@ -64,15 +64,6 @@ param_t searchAndGetParam(
   const nav2_util::LifecycleNode::SharedPtr & nh, const std::string & param_name,
   const param_t & default_value)
 {
-  // TODO(crdelsey): Handle searchParam
-  // std::string resolved_name;
-  // if (nh->searchParam(param_name, resolved_name))
-  // {
-  //   param_t value = 0;
-  //   nh->param(resolved_name, value, default_value);
-  //   return value;
-  // }
-  param_t value = 0;
   nav2_util::declare_parameter_if_not_declared(
     nh, param_name,
     rclcpp::ParameterValue(default_value));

--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/parameters.hpp
@@ -64,6 +64,7 @@ param_t searchAndGetParam(
   const nav2_util::LifecycleNode::SharedPtr & nh, const std::string & param_name,
   const param_t & default_value)
 {
+  param_t value;
   nav2_util::declare_parameter_if_not_declared(
     nh, param_name,
     rclcpp::ParameterValue(default_value));


### PR DESCRIPTION
Fixes #2916.

Moreover, I double-checked the snipped that was included in the TODO right above, and realized that was referring to old ROS API. For me, it had no more meaning in this context, but maybe @crdelsey can tell if it's right to do this clean up or not.