### PR TITLE
Fix various issues found while compiling against Rolling on Ubuntu 22.04

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/CMakeLists.txt
+++ b/nav2_regulated_pure_pursuit_controller/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 nav2_package()
 set(CMAKE_CXX_STANDARD 17)
@@ -28,6 +29,7 @@ set(dependencies
   nav2_util
   nav2_core
   tf2
+  tf2_geometry_msgs
 )
 
 set(library_name nav2_regulated_pure_pursuit_controller)

--- a/nav2_regulated_pure_pursuit_controller/package.xml
+++ b/nav2_regulated_pure_pursuit_controller/package.xml
@@ -19,6 +19,7 @@
   <depend>nav2_msgs</depend>
   <depend>pluginlib</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/nav2_regulated_pure_pursuit_controller/test/CMakeLists.txt
+++ b/nav2_regulated_pure_pursuit_controller/test/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(test_regulated_pp
 
 # Path utils test
 ament_add_gtest(test_path_utils path_utils/test_path_utils.cpp path_utils/path_utils.cpp)
-ament_target_dependencies(test_path_utils nav_msgs geometry_msgs)
+ament_target_dependencies(test_path_utils nav_msgs geometry_msgs tf2_geometry_msgs)

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -678,7 +678,7 @@ protected:
       path_to_costmap,
       costmap_to_robot
     };
-    for (const auto transform : tf_message.transforms) {
+    for (const auto & transform : tf_message.transforms) {
       tf_buffer_->setTransform(transform, "test", false);
     }
     tf_buffer_->setUsingDedicatedThread(true);  // lying to let it do transforms

--- a/nav2_rviz_plugins/CMakeLists.txt
+++ b/nav2_rviz_plugins/CMakeLists.txt
@@ -33,8 +33,8 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
 set(nav2_rviz_plugins_headers_to_moc
-  include/nav2_rviz_plugins/goal_pose_updater
-  include/nav2_rviz_plugins/goal_common
+  include/nav2_rviz_plugins/goal_pose_updater.hpp
+  include/nav2_rviz_plugins/goal_common.hpp
   include/nav2_rviz_plugins/goal_tool.hpp
   include/nav2_rviz_plugins/nav2_panel.hpp
   include/nav2_rviz_plugins/particle_cloud_display/flat_weighted_arrows_array.hpp

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -249,7 +249,7 @@ bool AStarAlgorithm<NodeT>::createPath(
   NodeGetter neighborGetter =
     [&, this](const unsigned int & index, NodePtr & neighbor_rtn) -> bool
     {
-      if (index < 0 || index >= max_index) {
+      if (index >= max_index) {
         return false;
       }
 


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | None |

---

## Description of contribution in a few bullet points

Fix a bunch of small issues found while compiling against Rolling on Ubuntu 22.04.

## Description of documentation updates required from your changes

None needed.

---

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
