### PR TITLE
nav2_util: don't export test_msgs dependency

### DIFF
--- a/nav2_util/CMakeLists.txt
+++ b/nav2_util/CMakeLists.txt
@@ -28,7 +28,6 @@ set(dependencies
     rclcpp
     lifecycle_msgs
     rclcpp_action
-    test_msgs
     rclcpp_lifecycle
     bondcpp
     bond


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | nixpkgs/nix-ros-overlay |
| Robotic platform tested on | N/A |

---

## Description of contribution in a few bullet points

Since https://github.com/ros-planning/navigation2/pull/2827, nav2_util no longer unconditionally depends on test_msgs, but was still exporting it as a dependency. This caused downstream packages to fail to build if test_msgs is not available.

cc @alsora 

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
