### PR TITLE
Added goal accepted check before flagging navigator as running

### DIFF
--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
@@ -255,9 +255,13 @@ protected:
       return false;
     }
 
-    plugin_muxer_->startNavigating(getName());
+    bool goal_accepted = goalReceived(goal);
 
-    return goalReceived(goal);
+    if (goal_accepted) {
+      plugin_muxer_->startNavigating(getName());
+    }
+
+    return goal_accepted;
   }
 
   /**


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [#2946](https://github.com/ros-planning/navigation2/issues/2946) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

When an initial goal is received, the plugin muxer only calls startNavigating() if goalReceived() returns true. This will allow the client to try sending another goal if the initial goal is not accepted by the server rather than being stuck 

## Description of documentation updates required from your changes

None

---

## Future work that may be required in bullet points


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
