### PR TITLE
Added behaviour_tree as input to action nodes

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
@@ -56,6 +56,7 @@ public:
     return providedBasicPorts(
       {
         BT::InputPort<geometry_msgs::msg::PoseStamped>("goals", "Destinations to plan through"),
+        BT::InputPort<geometry_msgs::msg::PoseStamped>("behavior_tree", "Behavior tree to run"),
       });
   }
 };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp
@@ -56,6 +56,7 @@ public:
     return providedBasicPorts(
       {
         BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination to plan to"),
+        BT::InputPort<geometry_msgs::msg::PoseStamped>("behavior_tree", "Behavior tree to run"),
       });
   }
 };

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -101,12 +101,14 @@
         <input_port name="goal">Goal</input_port>
         <input_port name="service_name">Service name</input_port>
         <input_port name="server_timeout">Server timeout</input_port>
+        <input_port name="behavior_tree">Behavior tree to run</input_port>
     </Action>
 
     <Action ID="NavigateThroughPoses">
         <input_port name="goals">Goals</input_port>
         <input_port name="service_name">Service name</input_port>
         <input_port name="server_timeout">Server timeout</input_port>
+        <input_port name="behavior_tree">Behavior tree to run</input_port>
     </Action>
 
     <Action ID="ReinitializeGlobalLocalization">

--- a/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
@@ -35,6 +35,7 @@ void NavigateThroughPosesAction::on_tick()
       node_->get_logger(),
       "NavigateThroughPosesAction: goal not provided");
     return;
+  getInput("behavior_tree", goal_.behavior_tree);
   }
 }
 

--- a/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
@@ -35,7 +35,7 @@ void NavigateThroughPosesAction::on_tick()
       node_->get_logger(),
       "NavigateThroughPosesAction: goal not provided");
     return;
-  getInput("behavior_tree", goal_.behavior_tree);
+    getInput("behavior_tree", goal_.behavior_tree);
   }
 }
 

--- a/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
@@ -35,8 +35,8 @@ void NavigateThroughPosesAction::on_tick()
       node_->get_logger(),
       "NavigateThroughPosesAction: goal not provided");
     return;
-    getInput("behavior_tree", goal_.behavior_tree);
   }
+  getInput("behavior_tree", goal_.behavior_tree);
 }
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
@@ -35,8 +35,8 @@ void NavigateToPoseAction::on_tick()
       node_->get_logger(),
       "NavigateToPoseAction: goal not provided");
     return;
-    getInput("behavior_tree", goal_.behavior_tree);
   }
+  getInput("behavior_tree", goal_.behavior_tree);
 }
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
@@ -35,7 +35,7 @@ void NavigateToPoseAction::on_tick()
       node_->get_logger(),
       "NavigateToPoseAction: goal not provided");
     return;
-  getInput("behavior_tree", goal_.behavior_tree);
+    getInput("behavior_tree", goal_.behavior_tree);
   }
 }
 

--- a/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
@@ -35,6 +35,7 @@ void NavigateToPoseAction::on_tick()
       node_->get_logger(),
       "NavigateToPoseAction: goal not provided");
     return;
+  getInput("behavior_tree", goal_.behavior_tree);
   }
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/pull/1784#issuecomment-1086153629 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Own gazebo simulation |

---

## Description of contribution in a few bullet points

The NavigateToPose Action server [accepts a behavior tree as input](https://github.com/ros-planning/navigation2/blob/609342fa27016a1677768f93fb3c44dec98b1f55/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp#L89) but its corresponding [BT action node ](https://navigation.ros.org/configuration/packages/bt-plugins/actions/NavigateToPose.html)does not have a behavior_tree option. I added the behavior_tree option


## Description of documentation updates required from your changes


* Added new parameter, so need to add that to default configs and documentation page

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
