### PR TITLE
Allow access to action feedback in nav2_behavior_tree::BtActionNode::on_wait_for_result

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -134,7 +134,7 @@ public:
    * @brief Function to perform some user-defined operation after a timeout
    * waiting for a result that hasn't been received yet. Also provides access to
    * the latest feedback message from the action server. Feedback will be nullptr
-   * in subsequent calls to this function if no new feedback is received.
+   * in subsequent calls to this function if no new feedback is received while waiting for a result.
    * @param feedback shared_ptr to latest feedback message, nullptr if no new feedback was received
    */
   virtual void on_wait_for_result(std::shared_ptr<const typename ActionT::Feedback> /*feedback*/)
@@ -294,16 +294,6 @@ public:
     }
 
     setStatus(BT::NodeStatus::IDLE);
-  }
-
-  /**
-   * @brief Getter function for latest feedback message from action server
-   * This function returns a nullptr if no new feedback is received while waiting for a result.
-   * @return shared_ptr to latest feedback message, nullptr if no new feedback was received
-   */
-  std::shared_ptr<const typename ActionT::Feedback> getFeedback()
-  {
-    return feedback_;
   }
 
 protected:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -137,7 +137,7 @@ public:
    * in subsequent calls to this function if no new feedback is received while waiting for a result.
    * @param feedback shared_ptr to latest feedback message, nullptr if no new feedback was received
    */
-  virtual void on_wait_for_result(std::shared_ptr<const typename ActionT::Feedback> /*feedback*/)
+  virtual void on_wait_for_result(std::shared_ptr<const typename ActionT::Feedback>/*feedback*/)
   {
   }
 
@@ -348,9 +348,9 @@ protected:
       };
     send_goal_options.feedback_callback =
       [this](typename rclcpp_action::ClientGoalHandle<ActionT>::SharedPtr,
-             const std::shared_ptr<const typename ActionT::Feedback> feedback) {
-      feedback_ = feedback;
-    };
+        const std::shared_ptr<const typename ActionT::Feedback> feedback) {
+        feedback_ = feedback;
+      };
 
     future_goal_handle_ = std::make_shared<
       std::shared_future<typename rclcpp_action::ClientGoalHandle<ActionT>::SharedPtr>>(

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
@@ -16,6 +16,7 @@
 #define NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__FOLLOW_PATH_ACTION_HPP_
 
 #include <string>
+#include <memory>
 
 #include "nav2_msgs/action/follow_path.hpp"
 #include "nav2_behavior_tree/bt_action_node.hpp"
@@ -50,7 +51,8 @@ public:
    * waiting for a result that hasn't been received yet
    * @param feedback shared_ptr to latest feedback message
    */
-  void on_wait_for_result(std::shared_ptr<const nav2_msgs::action::FollowPath::Feedback> feedback) override;
+  void on_wait_for_result(
+    std::shared_ptr<const nav2_msgs::action::FollowPath::Feedback> feedback) override;
 
   /**
    * @brief Creates list of BT ports

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
@@ -48,8 +48,9 @@ public:
   /**
    * @brief Function to perform some user-defined operation after a timeout
    * waiting for a result that hasn't been received yet
+   * @param feedback shared_ptr to latest feedback message
    */
-  void on_wait_for_result() override;
+  void on_wait_for_result(std::shared_ptr<const nav2_msgs::action::FollowPath::Feedback> feedback) override;
 
   /**
    * @brief Creates list of BT ports

--- a/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/follow_path_action.cpp
@@ -35,7 +35,8 @@ void FollowPathAction::on_tick()
   getInput("goal_checker_id", goal_.goal_checker_id);
 }
 
-void FollowPathAction::on_wait_for_result(std::shared_ptr<const nav2_msgs::action::FollowPath::Feedback> /*feedback*/)
+void FollowPathAction::on_wait_for_result(
+  std::shared_ptr<const nav2_msgs::action::FollowPath::Feedback>/*feedback*/)
 {
   // Grab the new path
   nav_msgs::msg::Path new_path;

--- a/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/follow_path_action.cpp
@@ -35,7 +35,7 @@ void FollowPathAction::on_tick()
   getInput("goal_checker_id", goal_.goal_checker_id);
 }
 
-void FollowPathAction::on_wait_for_result()
+void FollowPathAction::on_wait_for_result(std::shared_ptr<const nav2_msgs::action::FollowPath::Feedback> /*feedback*/)
 {
   // Grab the new path
   nav_msgs::msg::Path new_path;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2958 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Gazebo simulation of turtlebot3 |

---

## Description of contribution in a few bullet points

* `nav2_behavior_tree::BtActionNode::on_wait_for_result(feedback)` allows access to a shared_ptr to the latest feedback message

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
