### PR TITLE
fix: correct curvature signal on RPP

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -330,7 +330,7 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
       costAtPose(pose.pose.position.x, pose.pose.position.y), linear_vel, sign);
 
     // Apply curvature to angular velocity after constraining linear velocity
-    angular_vel = linear_vel * curvature;
+    angular_vel = linear_vel * sign *curvature;
   }
 
   // Collision checking on this velocity heading


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on |Ubuntu |
| Robotic platform tested on | Ackermann robot model|

---

## Description of contribution in a few bullet points
* Testing the RPP with an Ackermann robot moving backwards the robot was moving directions randomly not following the global path: 
![error](https://user-images.githubusercontent.com/38788618/171050991-4c55c420-839a-4be8-967c-5df8db115031.gif)
Taking a closer look into the RPP at this line https://github.com/ros-planning/navigation2/blob/80d7d0a080d7401607fd85216f9c450518e7ed42/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp#L628 the linear_vel is being multiplied by the signal, changing the direction of the curvature at line 
https://github.com/ros-planning/navigation2/blob/80d7d0a080d7401607fd85216f9c450518e7ed42/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp#L333
My solution was to also multiply at line 333 by the sign to revert the multiplication and not messing with the applyConstraints function. The result is:
![correct](https://user-images.githubusercontent.com/38788618/171051567-80f92ef3-fea5-4312-be70-dee5e6399adb.gif)

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
