### PR TITLE
remove LifecycleNode's argument use_rclcpp_node

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -59,7 +59,7 @@ namespace nav2_amcl
 using nav2_util::geometry_utils::orientationAroundZAxis;
 
 AmclNode::AmclNode(const rclcpp::NodeOptions & options)
-: nav2_util::LifecycleNode("amcl", "", false, options)
+: nav2_util::LifecycleNode("amcl", "", options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 

--- a/nav2_behaviors/src/behavior_server.cpp
+++ b/nav2_behaviors/src/behavior_server.cpp
@@ -23,7 +23,7 @@ namespace behavior_server
 {
 
 BehaviorServer::BehaviorServer(const rclcpp::NodeOptions & options)
-: LifecycleNode("behavior_server", "", false, options),
+: LifecycleNode("behavior_server", "", options),
   plugin_loader_("nav2_core", "nav2_core::Behavior"),
   default_ids_{"spin", "backup", "drive_on_heading", "wait"},
   default_types_{"nav2_behaviors/Spin",

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -29,7 +29,7 @@ namespace nav2_bt_navigator
 {
 
 BtNavigator::BtNavigator(const rclcpp::NodeOptions & options)
-: nav2_util::LifecycleNode("bt_navigator", "", false, options)
+: nav2_util::LifecycleNode("bt_navigator", "", options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -34,7 +34,7 @@ namespace nav2_controller
 {
 
 ControllerServer::ControllerServer(const rclcpp::NodeOptions & options)
-: nav2_util::LifecycleNode("controller_server", "", false, options),
+: nav2_util::LifecycleNode("controller_server", "", options),
   progress_checker_loader_("nav2_core", "nav2_core::ProgressChecker"),
   default_progress_checker_id_{"progress_checker"},
   default_progress_checker_type_{"nav2_controller::SimpleProgressChecker"},

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -311,7 +311,7 @@ protected:
   rclcpp::Subscription<geometry_msgs::msg::Polygon>::SharedPtr footprint_sub_;
   rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr parameter_sub_;
 
-  // Dedicated callback group and executor for tf timer_interface, costmap plugins and filters
+  // Dedicated callback group and executor for tf timer_interface and message fillter
   rclcpp::CallbackGroup::SharedPtr callback_group_;
   rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
   std::unique_ptr<nav2_util::NodeThread> executor_thread_;

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -65,7 +65,7 @@ Costmap2DROS::Costmap2DROS(
   const std::string & name,
   const std::string & parent_namespace,
   const std::string & local_namespace)
-: nav2_util::LifecycleNode(name, "", false,
+: nav2_util::LifecycleNode(name, "",
     // NodeOption arguments take precedence over the ones provided on the command line
     // use this to make sure the node is placed on the provided namespace
     // TODO(orduno) Pass a sub-node instead of creating a new node for better handling

--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -183,7 +183,7 @@ void TestNode::initNode(std::vector<rclcpp::Parameter> parameters)
   options.parameter_overrides(parameters);
 
   node_ = std::make_shared<nav2_util::LifecycleNode>(
-    "inflation_test_node", "", false, options);
+    "inflation_test_node", "", options);
 
   // Declare non-plugin specific costmap parameters
   node_->declare_parameter("map_topic", rclcpp::ParameterValue(std::string("map")));

--- a/nav2_costmap_2d/test/testing_helper.hpp
+++ b/nav2_costmap_2d/test/testing_helper.hpp
@@ -71,30 +71,33 @@ unsigned int countValues(
 void addStaticLayer(
   nav2_costmap_2d::LayeredCostmap & layers,
   tf2_ros::Buffer & tf, nav2_util::LifecycleNode::SharedPtr node,
-  std::shared_ptr<nav2_costmap_2d::StaticLayer> & slayer)
+  std::shared_ptr<nav2_costmap_2d::StaticLayer> & slayer,
+  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr)
 {
   slayer = std::make_shared<nav2_costmap_2d::StaticLayer>();
   layers.addPlugin(std::shared_ptr<nav2_costmap_2d::Layer>(slayer));
-  slayer->initialize(&layers, "static", &tf, node, nullptr);
+  slayer->initialize(&layers, "static", &tf, node, callback_group);
 }
 
 void addObstacleLayer(
   nav2_costmap_2d::LayeredCostmap & layers,
   tf2_ros::Buffer & tf, nav2_util::LifecycleNode::SharedPtr node,
-  std::shared_ptr<nav2_costmap_2d::ObstacleLayer> & olayer)
+  std::shared_ptr<nav2_costmap_2d::ObstacleLayer> & olayer,
+  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr)
 {
   olayer = std::make_shared<nav2_costmap_2d::ObstacleLayer>();
-  olayer->initialize(&layers, "obstacles", &tf, node, nullptr);
+  olayer->initialize(&layers, "obstacles", &tf, node, callback_group);
   layers.addPlugin(std::shared_ptr<nav2_costmap_2d::Layer>(olayer));
 }
 
 void addRangeLayer(
   nav2_costmap_2d::LayeredCostmap & layers,
   tf2_ros::Buffer & tf, nav2_util::LifecycleNode::SharedPtr node,
-  std::shared_ptr<nav2_costmap_2d::RangeSensorLayer> & rlayer)
+  std::shared_ptr<nav2_costmap_2d::RangeSensorLayer> & rlayer,
+  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr)
 {
   rlayer = std::make_shared<nav2_costmap_2d::RangeSensorLayer>();
-  rlayer->initialize(&layers, "range", &tf, node, nullptr);
+  rlayer->initialize(&layers, "range", &tf, node, callback_group);
   layers.addPlugin(std::shared_ptr<nav2_costmap_2d::Layer>(rlayer));
 }
 
@@ -130,10 +133,11 @@ void addObservation(
 void addInflationLayer(
   nav2_costmap_2d::LayeredCostmap & layers,
   tf2_ros::Buffer & tf, nav2_util::LifecycleNode::SharedPtr node,
-  std::shared_ptr<nav2_costmap_2d::InflationLayer> & ilayer)
+  std::shared_ptr<nav2_costmap_2d::InflationLayer> & ilayer,
+  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr)
 {
   ilayer = std::make_shared<nav2_costmap_2d::InflationLayer>();
-  ilayer->initialize(&layers, "inflation", &tf, node, nullptr);
+  ilayer->initialize(&layers, "inflation", &tf, node, callback_group);
   std::shared_ptr<nav2_costmap_2d::Layer> ipointer(ilayer);
   layers.addPlugin(ipointer);
 }

--- a/nav2_map_server/src/map_saver/map_saver.cpp
+++ b/nav2_map_server/src/map_saver/map_saver.cpp
@@ -42,7 +42,7 @@ using namespace std::placeholders;
 namespace nav2_map_server
 {
 MapSaver::MapSaver(const rclcpp::NodeOptions & options)
-: nav2_util::LifecycleNode("map_saver", "", false, options)
+: nav2_util::LifecycleNode("map_saver", "", options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 

--- a/nav2_map_server/src/map_server/map_server.cpp
+++ b/nav2_map_server/src/map_server/map_server.cpp
@@ -63,7 +63,7 @@ namespace nav2_map_server
 {
 
 MapServer::MapServer(const rclcpp::NodeOptions & options)
-: nav2_util::LifecycleNode("map_server", "", false, options)
+: nav2_util::LifecycleNode("map_server", "", options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -40,7 +40,7 @@ namespace nav2_planner
 {
 
 PlannerServer::PlannerServer(const rclcpp::NodeOptions & options)
-: nav2_util::LifecycleNode("planner_server", "", false, options),
+: nav2_util::LifecycleNode("planner_server", "", options),
   gp_loader_("nav2_core", "nav2_core::GlobalPlanner"),
   default_ids_{"GridBased"},
   default_types_{"nav2_navfn_planner/NavfnPlanner"},

--- a/nav2_smoother/src/nav2_smoother.cpp
+++ b/nav2_smoother/src/nav2_smoother.cpp
@@ -34,7 +34,7 @@ namespace nav2_smoother
 {
 
 SmootherServer::SmootherServer(const rclcpp::NodeOptions & options)
-: LifecycleNode("smoother_server", "", false, options),
+: LifecycleNode("smoother_server", "", options),
   lp_loader_("nav2_core", "nav2_core::Smoother"),
   default_ids_{"simple_smoother"},
   default_types_{"nav2_smoother::SimpleSmoother"}

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -30,15 +30,9 @@ namespace nav2_util
 
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
-// The following is a temporary wrapper for rclcpp_lifecycle::LifecycleNode. This class
-// adds the optional creation of an rclcpp::Node that can be used by derived classes
-// to interface to classes, such as MessageFilter and TransformListener, that don't yet
-// support lifecycle nodes. Once we get the fixes into ROS2, this class will be removed.
-
 /**
  * @class nav2_util::LifecycleNode
- * @brief A lifecycle node wrapper to enable common Nav2 needs such as background node threads
- * and manipulating parameters
+ * @brief A lifecycle node wrapper to enable common Nav2 needs such as manipulating parameters
  */
 class LifecycleNode : public rclcpp_lifecycle::LifecycleNode
 {
@@ -47,13 +41,11 @@ public:
    * @brief A lifecycle node constructor
    * @param node_name Name for the node
    * @param namespace Namespace for the node, if any
-   * @param use_rclcpp_node Whether to create an internal client node
    * @param options Node options
    */
   LifecycleNode(
     const std::string & node_name,
     const std::string & ns = "",
-    bool use_rclcpp_node = false,
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   virtual ~LifecycleNode();
 
@@ -190,16 +182,6 @@ protected:
    * @brief Print notifications for lifecycle node
    */
   void printLifecycleNodeNotification();
-
-  // Whether or not to create a local rclcpp::Node which can be used for ROS2 classes that don't
-  // yet support lifecycle nodes
-  bool use_rclcpp_node_;
-
-  // The local node
-  rclcpp::Node::SharedPtr rclcpp_node_;
-
-  // When creating a local node, this class will launch a separate thread created to spin the node
-  std::unique_ptr<NodeThread> rclcpp_thread_;
 
   // Connection to tell that server is still up
   std::unique_ptr<bond::Bond> bond_{nullptr};

--- a/nav2_util/src/lifecycle_node.cpp
+++ b/nav2_util/src/lifecycle_node.cpp
@@ -23,46 +23,17 @@
 namespace nav2_util
 {
 
-// The nav2_util::LifecycleNode class is temporary until we get the
-// required support for lifecycle nodes in MessageFilter, TransformListener,
-// and TransforBroadcaster. We have submitted issues for these and will
-// be submitting PRs to add the fixes:
-//
-//     https://github.com/ros2/geometry2/issues/95
-//     https://github.com/ros2/geometry2/issues/94
-//     https://github.com/ros2/geometry2/issues/70
-//
-// Until then, this class can provide a normal ROS node that has a thread
-// that processes the node's messages. If a derived class needs to interface
-// to one of these classes - MessageFilter, etc. - that don't yet support
-// lifecycle nodes, it can simply set the use_rclcpp_node flag in the
-// constructor and then provide the rclcpp_node_ to the helper classes, like
-// MessageFilter.
-//
-
 LifecycleNode::LifecycleNode(
   const std::string & node_name,
-  const std::string & ns, bool use_rclcpp_node,
+  const std::string & ns,
   const rclcpp::NodeOptions & options)
-: rclcpp_lifecycle::LifecycleNode(node_name, ns, options),
-  use_rclcpp_node_(use_rclcpp_node)
+: rclcpp_lifecycle::LifecycleNode(node_name, ns, options)
 {
   // server side never times out from lifecycle manager
   this->declare_parameter(bond::msg::Constants::DISABLE_HEARTBEAT_TIMEOUT_PARAM, true);
   this->set_parameter(
     rclcpp::Parameter(
       bond::msg::Constants::DISABLE_HEARTBEAT_TIMEOUT_PARAM, true));
-
-  if (use_rclcpp_node_) {
-    std::vector<std::string> new_args = options.arguments();
-    new_args.push_back("--ros-args");
-    new_args.push_back("-r");
-    new_args.push_back(std::string("__node:=") + this->get_name() + "_rclcpp_node");
-    new_args.push_back("--");
-    rclcpp_node_ = std::make_shared<rclcpp::Node>(
-      "_", ns, rclcpp::NodeOptions(options).arguments(new_args));
-    rclcpp_thread_ = std::make_unique<NodeThread>(rclcpp_node_);
-  }
 
   printLifecycleNodeNotification();
 }

--- a/nav2_util/test/test_lifecycle_node.cpp
+++ b/nav2_util/test/test_lifecycle_node.cpp
@@ -33,7 +33,7 @@ RclCppFixture g_rclcppfixture;
 TEST(LifecycleNode, RclcppNodeExitsCleanly)
 {
   // Make sure the node exits cleanly when using an rclcpp_node and associated thread
-  auto node1 = std::make_shared<nav2_util::LifecycleNode>("test_node", "", true);
+  auto node1 = std::make_shared<nav2_util::LifecycleNode>("test_node", "");
   std::this_thread::sleep_for(std::chrono::seconds(1));
   SUCCEED();
 }
@@ -41,11 +41,8 @@ TEST(LifecycleNode, RclcppNodeExitsCleanly)
 TEST(LifecycleNode, MultipleRclcppNodesExitCleanly)
 {
   // Try a couple nodes w/ rclcpp_node and threads
-  auto node1 = std::make_shared<nav2_util::LifecycleNode>("test_node1", "", true);
-  auto node2 = std::make_shared<nav2_util::LifecycleNode>("test_node2", "", true);
-
-  // Another one without rclcpp_node and on the stack
-  nav2_util::LifecycleNode node3("test_node3", "", false);
+  auto node1 = std::make_shared<nav2_util::LifecycleNode>("test_node1", "");
+  auto node2 = std::make_shared<nav2_util::LifecycleNode>("test_node2", "");
 
   std::this_thread::sleep_for(std::chrono::seconds(1));
   SUCCEED();

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -28,7 +28,7 @@ using rcl_interfaces::msg::ParameterType;
 using std::placeholders::_1;
 
 WaypointFollower::WaypointFollower(const rclcpp::NodeOptions & options)
-: nav2_util::LifecycleNode("waypoint_follower", "", false, options),
+: nav2_util::LifecycleNode("waypoint_follower", "", options),
   waypoint_task_executor_loader_("nav2_waypoint_follower",
     "nav2_core::WaypointTaskExecutor")
 {


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (tickets:  [#816](https://github.com/ros-planning/navigation2/issues/816)) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation of turtlebot3) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
this is a final PR to solve https://github.com/ros-planning/navigation2/issues/816

* remove LifecycleNode's argument `use_rclcpp_node` and member `rclcpp_node_` which is unused currently.
* update the construction function of some nodes which derived from LifecycleNode.
* update `test_costmap_topic_collision_checker.cpp` which use  `rclcpp_node_` (like https://github.com/ros-planning/navigation2/pull/2489).

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

update migration documentation : https://github.com/ros-planning/navigation.ros.org/pull/321

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
