### PR TITLE
Provide bt result

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -41,7 +41,7 @@ public:
   typedef std::function<void ()> OnLoopCallback;
   typedef std::function<void (typename ActionT::Goal::ConstSharedPtr)> OnPreemptCallback;
   typedef std::function<void (typename ActionT::Result::SharedPtr,
-    nav2_behavior_tree::BtStatus)> OnCompletionCallback;
+      nav2_behavior_tree::BtStatus)> OnCompletionCallback;
 
   /**
    * @brief A constructor for nav2_behavior_tree::BtActionServer class

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -40,7 +40,7 @@ public:
   typedef std::function<bool (typename ActionT::Goal::ConstSharedPtr)> OnGoalReceivedCallback;
   typedef std::function<void ()> OnLoopCallback;
   typedef std::function<void (typename ActionT::Goal::ConstSharedPtr)> OnPreemptCallback;
-  typedef std::function<void (typename ActionT::Result::SharedPtr)> OnCompletionCallback;
+  typedef std::function<void (typename ActionT::Result::SharedPtr, nav2_behavior_tree::BtStatus)> OnCompletionCallback;
 
   /**
    * @brief A constructor for nav2_behavior_tree::BtActionServer class

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -40,7 +40,8 @@ public:
   typedef std::function<bool (typename ActionT::Goal::ConstSharedPtr)> OnGoalReceivedCallback;
   typedef std::function<void ()> OnLoopCallback;
   typedef std::function<void (typename ActionT::Goal::ConstSharedPtr)> OnPreemptCallback;
-  typedef std::function<void (typename ActionT::Result::SharedPtr, nav2_behavior_tree::BtStatus)> OnCompletionCallback;
+  typedef std::function<void (typename ActionT::Result::SharedPtr,
+      nav2_behavior_tree::BtStatus)> OnCompletionCallback;
 
   /**
    * @brief A constructor for nav2_behavior_tree::BtActionServer class

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -41,7 +41,7 @@ public:
   typedef std::function<void ()> OnLoopCallback;
   typedef std::function<void (typename ActionT::Goal::ConstSharedPtr)> OnPreemptCallback;
   typedef std::function<void (typename ActionT::Result::SharedPtr,
-      nav2_behavior_tree::BtStatus)> OnCompletionCallback;
+    nav2_behavior_tree::BtStatus)> OnCompletionCallback;
 
   /**
    * @brief A constructor for nav2_behavior_tree::BtActionServer class

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -216,7 +216,7 @@ void BtActionServer<ActionT>::executeCallback()
   // Give server an opportunity to populate the result message or simple give
   // an indication that the action is complete.
   auto result = std::make_shared<typename ActionT::Result>();
-  on_completion_callback_(result);
+  on_completion_callback_(result, rc);
 
   switch (rc) {
     case nav2_behavior_tree::BtStatus::SUCCEEDED:

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
@@ -164,7 +164,7 @@ public:
       std::bind(&Navigator::onGoalReceived, this, std::placeholders::_1),
       std::bind(&Navigator::onLoop, this),
       std::bind(&Navigator::onPreempt, this, std::placeholders::_1),
-      std::bind(&Navigator::onCompletion, this, std::placeholders::_1));
+      std::bind(&Navigator::onCompletion, this, std::placeholders::_1, std::placeholders::_2));
 
     bool ok = true;
     if (!bt_action_server_->on_configure()) {
@@ -180,7 +180,7 @@ public:
   }
 
   /**
-   * @brief Actiation of the navigator's backend BT and actions
+   * @brief Activation of the navigator's backend BT and actions
    * @return bool If successful
    */
   bool on_activate()
@@ -195,7 +195,7 @@ public:
   }
 
   /**
-   * @brief Dectiation of the navigator's backend BT and actions
+   * @brief Deactivation of the navigator's backend BT and actions
    * @return bool If successful
    */
   bool on_deactivate()
@@ -265,12 +265,12 @@ protected:
   }
 
   /**
-   * @brief An intermediate compution function to mux navigators
+   * @brief An intermediate completion function to mux navigators
    */
-  void onCompletion(typename ActionT::Result::SharedPtr result)
+  void onCompletion(typename ActionT::Result::SharedPtr result, nav2_behavior_tree::BtStatus final_bt_status)
   {
     plugin_muxer_->stopNavigating(getName());
-    goalCompleted(result);
+    goalCompleted(result, final_bt_status);
   }
 
   /**
@@ -292,10 +292,10 @@ protected:
   virtual void onPreempt(typename ActionT::Goal::ConstSharedPtr goal) = 0;
 
   /**
-   * @brief A callback that is called when a the action is completed, can fill in
+   * @brief A callback that is called when a the action is completed; Can fill in
    * action result message or indicate that this action is done.
    */
-  virtual void goalCompleted(typename ActionT::Result::SharedPtr result) = 0;
+  virtual void goalCompleted(typename ActionT::Result::SharedPtr result, nav2_behavior_tree::BtStatus final_bt_status) = 0;
 
   /**
    * @param Method to configure resources.
@@ -313,12 +313,12 @@ protected:
   virtual bool cleanup() {return true;}
 
   /**
-   * @brief Method to active and any threads involved in execution.
+   * @brief Method to activate any threads involved in execution.
    */
   virtual bool activate() {return true;}
 
   /**
-   * @brief Method to deactive and any threads involved in execution.
+   * @brief Method to deactivate and any threads involved in execution.
    */
   virtual bool deactivate() {return true;}
 

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
@@ -267,7 +267,8 @@ protected:
   /**
    * @brief An intermediate completion function to mux navigators
    */
-  void onCompletion(typename ActionT::Result::SharedPtr result, nav2_behavior_tree::BtStatus final_bt_status)
+  void onCompletion(typename ActionT::Result::SharedPtr result,
+                    nav2_behavior_tree::BtStatus final_bt_status)
   {
     plugin_muxer_->stopNavigating(getName());
     goalCompleted(result, final_bt_status);
@@ -295,7 +296,8 @@ protected:
    * @brief A callback that is called when a the action is completed; Can fill in
    * action result message or indicate that this action is done.
    */
-  virtual void goalCompleted(typename ActionT::Result::SharedPtr result, nav2_behavior_tree::BtStatus final_bt_status) = 0;
+  virtual void goalCompleted(typename ActionT::Result::SharedPtr result,
+                             nav2_behavior_tree::BtStatus final_bt_status) = 0;
 
   /**
    * @param Method to configure resources.

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
@@ -255,9 +255,13 @@ protected:
       return false;
     }
 
-    plugin_muxer_->startNavigating(getName());
+    bool goal_accepted = goalReceived(goal);
 
-    return goalReceived(goal);
+    if (goal_accepted) {
+      plugin_muxer_->startNavigating(getName());
+    }
+
+    return goal_accepted;
   }
 
   /**

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigator.hpp
@@ -267,8 +267,9 @@ protected:
   /**
    * @brief An intermediate completion function to mux navigators
    */
-  void onCompletion(typename ActionT::Result::SharedPtr result,
-                    nav2_behavior_tree::BtStatus final_bt_status)
+  void onCompletion(
+    typename ActionT::Result::SharedPtr result,
+    const nav2_behavior_tree::BtStatus final_bt_status)
   {
     plugin_muxer_->stopNavigating(getName());
     goalCompleted(result, final_bt_status);
@@ -296,8 +297,9 @@ protected:
    * @brief A callback that is called when a the action is completed; Can fill in
    * action result message or indicate that this action is done.
    */
-  virtual void goalCompleted(typename ActionT::Result::SharedPtr result,
-                             nav2_behavior_tree::BtStatus final_bt_status) = 0;
+  virtual void goalCompleted(
+    typename ActionT::Result::SharedPtr result,
+    const nav2_behavior_tree::BtStatus final_bt_status) = 0;
 
   /**
    * @param Method to configure resources.

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_through_poses.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_through_poses.hpp
@@ -95,9 +95,11 @@ protected:
    * @brief A callback that is called when a the action is completed, can fill in
    * action result message or indicate that this action is done.
    * @param result Action template result message to populate
-   * @param final_bt_status Resulting status of the behavior tree execution that may be referenced while populating the result.
+   * @param final_bt_status Resulting status of the behavior tree execution that may be
+   * referenced while populating the result.
    */
-  void goalCompleted(typename ActionT::Result::SharedPtr result, nav2_behavior_tree::BtStatus final_bt_status) override;
+  void goalCompleted(typename ActionT::Result::SharedPtr result,
+                     nav2_behavior_tree::BtStatus final_bt_status) override;
 
   /**
    * @brief Goal pose initialization on the blackboard

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_through_poses.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_through_poses.hpp
@@ -98,8 +98,9 @@ protected:
    * @param final_bt_status Resulting status of the behavior tree execution that may be
    * referenced while populating the result.
    */
-  void goalCompleted(typename ActionT::Result::SharedPtr result,
-                     nav2_behavior_tree::BtStatus final_bt_status) override;
+  void goalCompleted(
+    typename ActionT::Result::SharedPtr result,
+    const nav2_behavior_tree::BtStatus final_bt_status) override;
 
   /**
    * @brief Goal pose initialization on the blackboard

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_through_poses.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_through_poses.hpp
@@ -95,8 +95,9 @@ protected:
    * @brief A callback that is called when a the action is completed, can fill in
    * action result message or indicate that this action is done.
    * @param result Action template result message to populate
+   * @param final_bt_status Resulting status of the behavior tree execution that may be referenced while populating the result.
    */
-  void goalCompleted(typename ActionT::Result::SharedPtr result) override;
+  void goalCompleted(typename ActionT::Result::SharedPtr result, nav2_behavior_tree::BtStatus final_bt_status) override;
 
   /**
    * @brief Goal pose initialization on the blackboard

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_to_pose.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_to_pose.hpp
@@ -106,8 +106,9 @@ protected:
    * @brief A callback that is called when a the action is completed, can fill in
    * action result message or indicate that this action is done.
    * @param result Action template result message to populate
+   * @param final_bt_status Resulting status of the behavior tree execution that may be referenced while populating the result.
    */
-  void goalCompleted(typename ActionT::Result::SharedPtr result) override;
+  void goalCompleted(typename ActionT::Result::SharedPtr result, nav2_behavior_tree::BtStatus final_bt_status) override;
 
   /**
    * @brief Goal pose initialization on the blackboard

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_to_pose.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_to_pose.hpp
@@ -109,8 +109,9 @@ protected:
    * @param final_bt_status Resulting status of the behavior tree execution that may be
    * referenced while populating the result.
    */
-  void goalCompleted(typename ActionT::Result::SharedPtr result,
-                     nav2_behavior_tree::BtStatus final_bt_status) override;
+  void goalCompleted(
+    typename ActionT::Result::SharedPtr result,
+    const nav2_behavior_tree::BtStatus final_bt_status) override;
 
   /**
    * @brief Goal pose initialization on the blackboard

--- a/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_to_pose.hpp
+++ b/nav2_bt_navigator/include/nav2_bt_navigator/navigators/navigate_to_pose.hpp
@@ -106,9 +106,11 @@ protected:
    * @brief A callback that is called when a the action is completed, can fill in
    * action result message or indicate that this action is done.
    * @param result Action template result message to populate
-   * @param final_bt_status Resulting status of the behavior tree execution that may be referenced while populating the result.
+   * @param final_bt_status Resulting status of the behavior tree execution that may be
+   * referenced while populating the result.
    */
-  void goalCompleted(typename ActionT::Result::SharedPtr result, nav2_behavior_tree::BtStatus final_bt_status) override;
+  void goalCompleted(typename ActionT::Result::SharedPtr result,
+                     nav2_behavior_tree::BtStatus final_bt_status) override;
 
   /**
    * @brief Goal pose initialization on the blackboard

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -87,7 +87,8 @@ NavigateThroughPosesNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 }
 
 void
-NavigateThroughPosesNavigator::goalCompleted(typename ActionT::Result::SharedPtr /*result*/, nav2_behavior_tree::BtStatus /*final_bt_status*/)
+NavigateThroughPosesNavigator::goalCompleted(typename ActionT::Result::SharedPtr /*result*/,
+                                             nav2_behavior_tree::BtStatus /*final_bt_status*/)
 {
 }
 

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -87,8 +87,9 @@ NavigateThroughPosesNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 }
 
 void
-NavigateThroughPosesNavigator::goalCompleted(typename ActionT::Result::SharedPtr /*result*/,
-                                             nav2_behavior_tree::BtStatus /*final_bt_status*/)
+NavigateThroughPosesNavigator::goalCompleted(
+  typename ActionT::Result::SharedPtr /*result*/,
+  const nav2_behavior_tree::BtStatus /*final_bt_status*/)
 {
 }
 

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -87,7 +87,7 @@ NavigateThroughPosesNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 }
 
 void
-NavigateThroughPosesNavigator::goalCompleted(typename ActionT::Result::SharedPtr /*result*/)
+NavigateThroughPosesNavigator::goalCompleted(typename ActionT::Result::SharedPtr /*result*/, nav2_behavior_tree::BtStatus /*final_bt_status*/)
 {
 }
 

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -101,8 +101,9 @@ NavigateToPoseNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 }
 
 void
-NavigateToPoseNavigator::goalCompleted(typename ActionT::Result::SharedPtr /*result*/,
-                                       nav2_behavior_tree::BtStatus /*final_bt_status*/)
+NavigateToPoseNavigator::goalCompleted(
+  typename ActionT::Result::SharedPtr /*result*/,
+  const nav2_behavior_tree::BtStatus /*final_bt_status*/)
 {
 }
 

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -101,7 +101,7 @@ NavigateToPoseNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 }
 
 void
-NavigateToPoseNavigator::goalCompleted(typename ActionT::Result::SharedPtr /*result*/)
+NavigateToPoseNavigator::goalCompleted(typename ActionT::Result::SharedPtr /*result*/, nav2_behavior_tree::BtStatus /*final_bt_status*/)
 {
 }
 

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -101,7 +101,8 @@ NavigateToPoseNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 }
 
 void
-NavigateToPoseNavigator::goalCompleted(typename ActionT::Result::SharedPtr /*result*/, nav2_behavior_tree::BtStatus /*final_bt_status*/)
+NavigateToPoseNavigator::goalCompleted(typename ActionT::Result::SharedPtr /*result*/,
+                                       nav2_behavior_tree::BtStatus /*final_bt_status*/)
 {
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [2991](https://github.com/ros-planning/navigation2/issues/2991) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo |

---

## Description of contribution in a few bullet points

Added input parameter 'final_bt_status' of type nav2_behavior_tree::BtStatus to the goalCompleted() function of navigator.hpp that makes the final status of the behavior tree run available to the navigator. This could provide the navigator with important context while populating the result and doing anything else it might do during that function.

None of the navigators that are included in nav2 currently do anything with this goalCompleted() function, but this could be a nice feature for developers who are creating their own custom navigators, and the current nav2 navigators may also benefit from this feature in the future. For example, a parameter in the result message could provide some context to the client as to whether an aborted result corresponds to a preemption or a behavior tree failure.

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
