### PR TITLE
Bt test fix

### DIFF
--- a/nav2_behavior_tree/test/plugins/action/test_back_up_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_cancel_node.cpp
@@ -83,6 +83,7 @@ public:
     config_ = nullptr;
     node_.reset();
     action_server_.reset();
+    client_.reset();
     factory_.reset();
   }
 

--- a/nav2_behavior_tree/test/plugins/action/test_controller_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_controller_cancel_node.cpp
@@ -83,6 +83,7 @@ public:
     config_ = nullptr;
     node_.reset();
     action_server_.reset();
+    client_.reset();
     factory_.reset();
   }
 

--- a/nav2_behavior_tree/test/plugins/action/test_drive_on_heading_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_drive_on_heading_cancel_node.cpp
@@ -86,6 +86,7 @@ public:
     config_ = nullptr;
     node_.reset();
     action_server_.reset();
+    client_.reset();
     factory_.reset();
   }
 

--- a/nav2_behavior_tree/test/plugins/action/test_spin_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_spin_cancel_node.cpp
@@ -83,6 +83,7 @@ public:
     config_ = nullptr;
     node_.reset();
     action_server_.reset();
+    client_.reset();
     factory_.reset();
   }
 

--- a/nav2_behavior_tree/test/plugins/action/test_wait_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_wait_cancel_node.cpp
@@ -83,6 +83,7 @@ public:
     config_ = nullptr;
     node_.reset();
     action_server_.reset();
+    client_.reset();
     factory_.reset();
   }
 

--- a/nav2_behavior_tree/test/plugins/condition/test_is_path_valid.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_path_valid.cpp
@@ -67,9 +67,10 @@ public:
   {
     delete config_;
     config_ = nullptr;
+    server_.reset();
     node_.reset();
     factory_.reset();
-    server_.reset();
+    tree_.reset();
   }
 
   static std::shared_ptr<IsPathValidService> server_;
@@ -98,9 +99,9 @@ TEST_F(IsPathValidTestFixture, test_behavior)
       </root>)";
 
   tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
-  std::this_thread::sleep_for(500ms);
+  // std::this_thread::sleep_for(500ms);
 
-  EXPECT_EQ(tree_->rootNode()->executeTick(), BT::NodeStatus::SUCCESS);
+  // EXPECT_EQ(tree_->rootNode()->executeTick(), BT::NodeStatus::SUCCESS);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_behavior_tree/test/plugins/condition/test_is_path_valid.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_path_valid.cpp
@@ -99,9 +99,9 @@ TEST_F(IsPathValidTestFixture, test_behavior)
       </root>)";
 
   tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
-  // std::this_thread::sleep_for(500ms);
+  std::this_thread::sleep_for(500ms);
 
-  // EXPECT_EQ(tree_->rootNode()->executeTick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(tree_->rootNode()->executeTick(), BT::NodeStatus::SUCCESS);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_behavior_tree/test/plugins/condition/test_path_expiring_timer.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_path_expiring_timer.cpp
@@ -43,6 +43,7 @@ public:
   {
     delete config_;
     config_ = nullptr;
+    node_.reset();
     bt_node_.reset();
   }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info
The main branch had issues successfully running the behavior_tree tests. 
The following error was recorded previously here https://github.com/ros2/rclcpp/issues/1766. 

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu 22.04 LTS |
| Robotic platform tested on | None |

---

## Description of contribution in a few bullet points
Added resets to static vars that were not being reset which caused the test to fail. 

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes
None
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
