### PR TITLE
Get parameters on configure transition addressing #2985

### DIFF
--- a/nav2_map_server/include/nav2_map_server/map_saver.hpp
+++ b/nav2_map_server/include/nav2_map_server/map_saver.hpp
@@ -56,7 +56,6 @@ public:
     const std::string & map_topic,
     const SaveParameters & save_parameters);
 
-protected:
   /**
    * @brief Sets up map saving service
    * @param state Lifecycle Node's state
@@ -88,6 +87,7 @@ protected:
    */
   nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
 
+protected:
   /**
    * @brief Map saving service callback
    * @param request_header Service request header

--- a/nav2_map_server/src/map_saver/main_cli.cpp
+++ b/nav2_map_server/src/map_saver/main_cli.cpp
@@ -164,6 +164,7 @@ int main(int argc, char ** argv)
   int retcode;
   try {
     auto map_saver = std::make_shared<nav2_map_server::MapSaver>();
+    map_saver->on_configure(rclcpp_lifecycle::State());
     if (map_saver->saveMapTopicToFile(map_topic, save_parameters)) {
       retcode = 0;
     } else {

--- a/nav2_map_server/src/map_saver/map_saver.cpp
+++ b/nav2_map_server/src/map_saver/map_saver.cpp
@@ -46,12 +46,11 @@ MapSaver::MapSaver(const rclcpp::NodeOptions & options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
-  save_map_timeout_ = std::make_shared<rclcpp::Duration>(
-    rclcpp::Duration::from_seconds(declare_parameter("save_map_timeout", 2.0)));
-
-  free_thresh_default_ = declare_parameter("free_thresh_default", 0.25),
-  occupied_thresh_default_ = declare_parameter("occupied_thresh_default", 0.65);
-  map_subscribe_transient_local_ = declare_parameter("map_subscribe_transient_local", true);
+  // Declare the node parameters
+  declare_parameter("save_map_timeout", 2.0);
+  declare_parameter("free_thresh_default", 0.25);
+  declare_parameter("occupied_thresh_default", 0.65);
+  declare_parameter("map_subscribe_transient_local", true);
 }
 
 MapSaver::~MapSaver()
@@ -66,6 +65,8 @@ MapSaver::on_configure(const rclcpp_lifecycle::State & /*state*/)
   // Make name prefix for services
   const std::string service_prefix = get_name() + std::string("/");
 
+  save_map_timeout_ = std::make_shared<rclcpp::Duration>(
+    rclcpp::Duration::from_seconds(get_parameter("save_map_timeout").as_double()));
   free_thresh_default_ = get_parameter("free_thresh_default").as_double();
   occupied_thresh_default_ = get_parameter("occupied_thresh_default").as_double();
   map_subscribe_transient_local_ = get_parameter("map_subscribe_transient_local").as_bool();

--- a/nav2_map_server/src/map_saver/map_saver.cpp
+++ b/nav2_map_server/src/map_saver/map_saver.cpp
@@ -66,6 +66,10 @@ MapSaver::on_configure(const rclcpp_lifecycle::State & /*state*/)
   // Make name prefix for services
   const std::string service_prefix = get_name() + std::string("/");
 
+  free_thresh_default_ = get_parameter("free_thresh_default").as_double();
+  occupied_thresh_default_ = get_parameter("occupied_thresh_default").as_double();
+  map_subscribe_transient_local_ = get_parameter("map_subscribe_transient_local").as_bool();
+
   // Create a service that saves the occupancy grid from map topic to a file
   save_map_service_ = create_service<nav2_msgs::srv::SaveMap>(
     service_prefix + save_map_service_name_,


### PR DESCRIPTION
Signed-off-by: MartiBolet <mboletboixeda@gmail.com>

Map saver has getting only the parameters in the constructor of the class.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2985|
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | None |

---

## Description of contribution in a few bullet points

Added the `get_parameter` in `on_configure` transition for `map_saver`.


## Description of documentation updates required from your changes

None

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
