### PR TITLE
Fix size_t format specifier

### DIFF
--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -201,7 +201,7 @@ NavigateThroughPosesNavigator::initializeGoalPoses(ActionT::Goal::ConstSharedPtr
 {
   if (goal->poses.size() > 0) {
     RCLCPP_INFO(
-      logger_, "Begin navigating from current location through %li poses to (%.2f, %.2f)",
+      logger_, "Begin navigating from current location through %zu poses to (%.2f, %.2f)",
       goal->poses.size(), goal->poses.back().pose.position.x, goal->poses.back().pose.position.y);
   }
 

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -171,7 +171,7 @@ InflationLayer::onFootprintChanged()
   need_reinflation_ = true;
 
   RCLCPP_DEBUG(
-    logger_, "InflationLayer::onFootprintChanged(): num footprint points: %lu,"
+    logger_, "InflationLayer::onFootprintChanged(): num footprint points: %zu,"
     " inscribed_radius_ = %.3f, inflation_radius_ = %.3f",
     layered_costmap_->getFootprint().size(), inscribed_radius_, inflation_radius_);
 }

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -332,7 +332,7 @@ bool PlannerServer::validatePath(
 
   RCLCPP_DEBUG(
     get_logger(),
-    "Found valid path of size %lu to (%.2f, %.2f)",
+    "Found valid path of size %zu to (%.2f, %.2f)",
     path.poses.size(), goal.pose.position.x,
     goal.pose.position.y);
 
@@ -422,7 +422,7 @@ PlannerServer::computePlanThroughPoses()
   } catch (std::exception & ex) {
     RCLCPP_WARN(
       get_logger(),
-      "%s plugin failed to plan through %li points with final goal (%.2f, %.2f): \"%s\"",
+      "%s plugin failed to plan through %zu points with final goal (%.2f, %.2f): \"%s\"",
       goal->planner_id.c_str(), goal->goals.size(), goal->goals.back().pose.position.x,
       goal->goals.back().pose.position.y, ex.what());
     action_server_poses_->terminate_current();

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -263,7 +263,7 @@ WaypointFollower::followWaypoints()
       new_goal = true;
       if (goal_index >= goal->poses.size()) {
         RCLCPP_INFO(
-          get_logger(), "Completed all %lu waypoints requested.",
+          get_logger(), "Completed all %zu waypoints requested.",
           goal->poses.size());
         result->missed_waypoints = failed_ids_;
         action_server_->succeeded_current(result);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3002 |
| Primary OS tested on | Ubuntu on arm32 (qemu) |
| Robotic platform tested on | - |

---

## Description of contribution in a few bullet points

- This patch uses a portable string format specifier for size_t (%zu) to replace non-generic specifiers (%lu, %li)
- This patch is necessary (and sufficient) for building navigation2 on arm32 machines
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
