### PR TITLE
fix ObstacleLayer not working due to #2489

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
@@ -252,6 +252,7 @@ protected:
   bool rolling_window_;
   bool was_reset_;
   int combination_method_;
+  bool active_{false};
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -319,9 +319,7 @@ ObstacleLayer::laserScanCallback(
   sensor_msgs::msg::LaserScan::ConstSharedPtr message,
   const std::shared_ptr<nav2_costmap_2d::ObservationBuffer> & buffer)
 {
-  if (!active_) {
-    return;
-  }
+  if (!active_) {return;}
 
   // project the laser into a point cloud
   sensor_msgs::msg::PointCloud2 cloud;
@@ -357,9 +355,7 @@ ObstacleLayer::laserScanValidInfCallback(
   sensor_msgs::msg::LaserScan::ConstSharedPtr raw_message,
   const std::shared_ptr<nav2_costmap_2d::ObservationBuffer> & buffer)
 {
-  if(!active_){
-    return;
-  }
+  if (!active_) {return;}
 
   // Filter positive infinities ("Inf"s) to max_range.
   float epsilon = 0.0001;  // a tenth of a millimeter
@@ -404,9 +400,7 @@ ObstacleLayer::pointCloud2Callback(
   sensor_msgs::msg::PointCloud2::ConstSharedPtr message,
   const std::shared_ptr<ObservationBuffer> & buffer)
 {
-  if (!active_) {
-    return;
-  }
+  if (!active_) {return;}
 
   // buffer the point cloud
   buffer->lock();
@@ -708,7 +702,6 @@ ObstacleLayer::activate()
   }
 
   resetBuffersLastUpdated();
-
   active_ = true;
 }
 


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #3014) |
| Primary OS tested on | (Ubuntu22.04) |
| Robotic platform tested on | (gazebo simulation of turtlebot3) |

---

## Description of contribution in a few bullet points

Obstacle Layer not working (the scan data isn't subscribed by Obstacle Layer),  becasue `observation_subscribers_->subsciber()` failed when `ObstacleLayer::activate()` is called since #2489

* use `active_` flag instead of `subscibe()` and `unsubscibe()`  (refer to https://github.com/ros-planning/navigation2/blob/main/nav2_amcl/src/amcl_node.cpp#L614)

i'm not sure the side effect of this change, maybe we could have a better solution.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
