### PR TITLE
do not depend on velocity for approach scaling

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/README.md
+++ b/nav2_regulated_pure_pursuit_controller/README.md
@@ -62,6 +62,7 @@ Note: The maximum allowed time to collision is thresholded by the lookahead poin
 | `use_velocity_scaled_lookahead_dist` | Whether to use the velocity scaled lookahead distances or constant `lookahead_distance` | 
 | `min_approach_linear_velocity` | The minimum velocity threshold to apply when approaching the goal | 
 | `use_approach_linear_velocity_scaling` | Whether to scale the linear velocity down on approach to the goal for a smooth stop | 
+| `approach_velocity_scaling_dist` | Integrated distance from end of transformed path at which to start applying velocity scaling | 
 | `max_allowed_time_to_collision_up_to_carrot` | The time to project a velocity command to check for collisions, limited to maximum distance of lookahead distance selected | 
 | `use_regulated_linear_velocity_scaling` | Whether to use the regulated features for curvature | 
 | `use_cost_regulated_linear_velocity_scaling` | Whether to use the regulated features for proximity to obstacles | 
@@ -111,6 +112,7 @@ controller_server:
       use_velocity_scaled_lookahead_dist: false
       min_approach_linear_velocity: 0.05
       use_approach_linear_velocity_scaling: true
+      approach_velocity_scaling_dist: 1.0
       max_allowed_time_to_collision_up_to_carrot: 1.0
       use_regulated_linear_velocity_scaling: true
       use_cost_regulated_linear_velocity_scaling: false

--- a/nav2_regulated_pure_pursuit_controller/README.md
+++ b/nav2_regulated_pure_pursuit_controller/README.md
@@ -61,7 +61,6 @@ Note: The maximum allowed time to collision is thresholded by the lookahead poin
 | `transform_tolerance` | The TF transform tolerance | 
 | `use_velocity_scaled_lookahead_dist` | Whether to use the velocity scaled lookahead distances or constant `lookahead_distance` | 
 | `min_approach_linear_velocity` | The minimum velocity threshold to apply when approaching the goal | 
-| `use_approach_linear_velocity_scaling` | Whether to scale the linear velocity down on approach to the goal for a smooth stop | 
 | `approach_velocity_scaling_dist` | Integrated distance from end of transformed path at which to start applying velocity scaling. This defaults to the forward extent of the costmap minus one costmap cell length. | 
 | `max_allowed_time_to_collision_up_to_carrot` | The time to project a velocity command to check for collisions, limited to maximum distance of lookahead distance selected | 
 | `use_regulated_linear_velocity_scaling` | Whether to use the regulated features for curvature | 

--- a/nav2_regulated_pure_pursuit_controller/README.md
+++ b/nav2_regulated_pure_pursuit_controller/README.md
@@ -62,7 +62,7 @@ Note: The maximum allowed time to collision is thresholded by the lookahead poin
 | `use_velocity_scaled_lookahead_dist` | Whether to use the velocity scaled lookahead distances or constant `lookahead_distance` | 
 | `min_approach_linear_velocity` | The minimum velocity threshold to apply when approaching the goal | 
 | `use_approach_linear_velocity_scaling` | Whether to scale the linear velocity down on approach to the goal for a smooth stop | 
-| `approach_velocity_scaling_dist` | Integrated distance from end of transformed path at which to start applying velocity scaling | 
+| `approach_velocity_scaling_dist` | Integrated distance from end of transformed path at which to start applying velocity scaling. This defaults to the forward extent of the costmap minus one costmap cell length. | 
 | `max_allowed_time_to_collision_up_to_carrot` | The time to project a velocity command to check for collisions, limited to maximum distance of lookahead distance selected | 
 | `use_regulated_linear_velocity_scaling` | Whether to use the regulated features for curvature | 
 | `use_cost_regulated_linear_velocity_scaling` | Whether to use the regulated features for proximity to obstacles | 

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -208,17 +208,25 @@ protected:
    */
   double costAtPose(const double & x, const double & y);
 
+  double approachVelocityScalingFactor(
+    const nav_msgs::msg::Path::SharedPtr & path
+  ) const;
+
+  void applyApproachVelocityScaling(
+    const nav_msgs::msg::Path::SharedPtr & path
+    double & linear_vel
+  ) const;
+
   /**
    * @brief apply regulation constraints to the system
    * @param linear_vel robot command linear velocity input
-   * @param dist_error error in the carrot distance and lookahead distance
    * @param lookahead_dist optimal lookahead distance
    * @param curvature curvature of path
    * @param speed Speed of robot
    * @param pose_cost cost at this pose
    */
   void applyConstraints(
-    const double & dist_error, const double & lookahead_dist,
+    const double & lookahead_dist,
     const double & curvature, const geometry_msgs::msg::Twist & speed,
     const double & pose_cost, double & linear_vel, double & sign);
 
@@ -281,6 +289,7 @@ protected:
   bool use_velocity_scaled_lookahead_dist_;
   tf2::Duration transform_tolerance_;
   double min_approach_linear_velocity_;
+  double approach_velocity_scaling_dist_;
   double control_duration_;
   double max_allowed_time_to_collision_up_to_carrot_;
   bool use_regulated_linear_velocity_scaling_;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -209,11 +209,11 @@ protected:
   double costAtPose(const double & x, const double & y);
 
   double approachVelocityScalingFactor(
-    const nav_msgs::msg::Path::SharedPtr path
+    const nav_msgs::msg::Path & path
   ) const;
 
   void applyApproachVelocityScaling(
-    const nav_msgs::msg::Path::SharedPtr path
+    const nav_msgs::msg::Path & path,
     double & linear_vel
   ) const;
 
@@ -226,9 +226,9 @@ protected:
    * @param pose_cost cost at this pose
    */
   void applyConstraints(
-    const double & lookahead_dist,
     const double & curvature, const geometry_msgs::msg::Twist & speed,
-    const double & pose_cost, double & linear_vel, double & sign);
+    const double & pose_cost, const nav_msgs::msg::Path & path,
+    double & linear_vel, double & sign);
 
   /**
    * @brief Find the intersection a circle and a line segment.

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -209,11 +209,11 @@ protected:
   double costAtPose(const double & x, const double & y);
 
   double approachVelocityScalingFactor(
-    const nav_msgs::msg::Path::SharedPtr & path
+    const nav_msgs::msg::Path::SharedPtr path
   ) const;
 
   void applyApproachVelocityScaling(
-    const nav_msgs::msg::Path::SharedPtr & path
+    const nav_msgs::msg::Path::SharedPtr path
     double & linear_vel
   ) const;
 

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -576,7 +576,7 @@ double RegulatedPurePursuitController::costAtPose(const double & x, const double
 }
 
 double RegulatedPurePursuitController::approachVelocityScalingFactor(
-  const nav_msgs::msg::Path::SharedPtr & path
+  const nav_msgs::msg::Path::SharedPtr path
 ) const
 {
   double remaining_distance = nav2_util::geometry_utils::calculate_path_length(path);
@@ -588,7 +588,7 @@ double RegulatedPurePursuitController::approachVelocityScalingFactor(
 }
 
 void RegulatedPurePursuitController::applyApproachVelocityScaling(
-  const nav_msgs::msg::Path::SharedPtr & path
+  const nav_msgs::msg::Path::SharedPtr path
   double & linear_vel
 ) const
 {

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -79,8 +79,12 @@ void RegulatedPurePursuitController::configure(
     rclcpp::ParameterValue(false));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".min_approach_linear_velocity", rclcpp::ParameterValue(0.05));
+
+  double forward_costmap_extent = costmap_->getSizeInMetersX() / 2.0;
+
   declare_parameter_if_not_declared(
-    node, plugin_name_ + ".approach_velocity_scaling_dist", rclcpp::ParameterValue(1.0));
+    node, plugin_name_ + ".approach_velocity_scaling_dist",
+    rclcpp::ParameterValue(forward_costmap_extent - costmap_->getResolution()));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".max_allowed_time_to_collision_up_to_carrot",
     rclcpp::ParameterValue(1.0));

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -79,12 +79,9 @@ void RegulatedPurePursuitController::configure(
     rclcpp::ParameterValue(false));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".min_approach_linear_velocity", rclcpp::ParameterValue(0.05));
-
-  double forward_costmap_extent = costmap_->getSizeInMetersX() / 2.0;
-
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".approach_velocity_scaling_dist",
-    rclcpp::ParameterValue(forward_costmap_extent - costmap_->getResolution()));
+    rclcpp::ParameterValue(0.6));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".max_allowed_time_to_collision_up_to_carrot",
     rclcpp::ParameterValue(1.0));
@@ -137,6 +134,11 @@ void RegulatedPurePursuitController::configure(
   node->get_parameter(
     plugin_name_ + ".approach_velocity_scaling_dist",
     approach_velocity_scaling_dist_);
+  if (approach_velocity_scaling_dist_ > costmap_->getSizeInMetersX() / 2.0) {
+    RCLCPP_WARN(
+      logger_, "approach_velocity_scaling_dist is larger than forward costmap extent, "
+      "leading to permanent slowdown");
+  }
   node->get_parameter(
     plugin_name_ + ".max_allowed_time_to_collision_up_to_carrot",
     max_allowed_time_to_collision_up_to_carrot_);

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -93,12 +93,11 @@ public:
   }
 
   void applyConstraintsWrapper(
-    const double & dist_error, const double & lookahead_dist,
     const double & curvature, const geometry_msgs::msg::Twist & curr_speed,
-    const double & pose_cost, double & linear_vel, double & sign)
+    const double & pose_cost, const nav_msgs::msg::Path & path, double & linear_vel, double & sign)
   {
     return applyConstraints(
-      dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
+      curvature, curr_speed, pose_cost, path,
       linear_vel, sign);
   }
 
@@ -469,6 +468,7 @@ TEST(RegulatedPurePursuitTest, rotateTests)
   EXPECT_NEAR(ang_v, 0.84, 0.01);
 }
 
+// TODO(aposhian): fix this test for approach velocity scaling changes
 TEST(RegulatedPurePursuitTest, applyConstraints)
 {
   auto ctrl = std::make_shared<BasicAPIRPP>();
@@ -480,8 +480,6 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   costmap->on_configure(state);
   ctrl->configure(node, name, tf, costmap);
 
-  double dist_error = 0.0;
-  double lookahead_dist = 0.6;
   double curvature = 0.5;
   geometry_msgs::msg::Twist curr_speed;
   double pose_cost = 0.0;
@@ -491,7 +489,7 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   // test curvature regulation (default)
   curr_speed.linear.x = 0.25;
   ctrl->applyConstraintsWrapper(
-    dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
+    curvature, curr_speed, pose_cost, nav_msgs::msg::Path(),
     linear_vel, sign);
   EXPECT_EQ(linear_vel, 0.25);  // min set speed
 
@@ -499,7 +497,7 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   curvature = 0.7407;
   curr_speed.linear.x = 0.5;
   ctrl->applyConstraintsWrapper(
-    dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
+    curvature, curr_speed, pose_cost, nav_msgs::msg::Path(),
     linear_vel, sign);
   EXPECT_NEAR(linear_vel, 0.5, 0.01);  // lower by curvature
 
@@ -507,7 +505,7 @@ TEST(RegulatedPurePursuitTest, applyConstraints)
   curvature = 1000.0;
   curr_speed.linear.x = 0.25;
   ctrl->applyConstraintsWrapper(
-    dist_error, lookahead_dist, curvature, curr_speed, pose_cost,
+    curvature, curr_speed, pose_cost, nav_msgs::msg::Path(),
     linear_vel, sign);
   EXPECT_NEAR(linear_vel, 0.25, 0.01);  // min out by curvature
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3045  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Not yet |

---

## Description of contribution in a few bullet points
Depend only on the path length left on whether to scale velocity on approach, since depending on lookahead distance results in a cyclic dependency

## Description of documentation updates required from your changes
Added a new parameter.

---

## Future work that may be required in bullet points
Need to test this and build it still.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
