### PR TITLE
forward porting #3053

### DIFF
--- a/nav2_costmap_2d/plugins/range_sensor_layer.cpp
+++ b/nav2_costmap_2d/plugins/range_sensor_layer.cpp
@@ -293,7 +293,9 @@ void RangeSensorLayer::updateCostmap(
   in.header.frame_id = range_message.header.frame_id;
 
   if (!tf_->canTransform(
-      in.header.frame_id, global_frame_, tf2_ros::fromMsg(in.header.stamp)))
+      in.header.frame_id, global_frame_,
+      tf2_ros::fromMsg(in.header.stamp),
+      tf2_ros::fromRclcpp(transform_tolerance_)))
   {
     RCLCPP_INFO(
       logger_, "Range sensor layer can't transform from %s to %s",


### PR DESCRIPTION
Supersedes https://github.com/ros-planning/navigation2/pull/3053 and completes https://github.com/ros-planning/navigation2/issues/2975