### PR TITLE
zero z values in rpp transformed plan

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -695,6 +695,7 @@ nav_msgs::msg::Path RegulatedPurePursuitController::transformGlobalPlan(
       stamped_pose.header.stamp = robot_pose.header.stamp;
       stamped_pose.pose = global_plan_pose.pose;
       transformPose(costmap_ros_->getBaseFrameID(), stamped_pose, transformed_pose);
+      transformed_pose.pose.position.z = 0.0;
       return transformed_pose;
     };
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3065 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Proprietary |

---

## Description of contribution in a few bullet points
Zero out transformed global plan z values so it is consistent with lookahead point visualization.

## Description of documentation updates required from your changes
None, I think.

---

## Future work that may be required in bullet points
Maybe think about other implications of 3D issues.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
