### PR TITLE
Added real frequency to log 

### DIFF
--- a/nav2_controller/include/nav2_controller/controller_server.hpp
+++ b/nav2_controller/include/nav2_controller/controller_server.hpp
@@ -258,6 +258,9 @@ protected:
   // Whether we've published the single controller warning yet
   geometry_msgs::msg::PoseStamped end_pose_;
 
+  // Clock
+  rclcpp::Clock steady_clock_{RCL_STEADY_TIME};
+
   // Last time the controller generated a valid command
   rclcpp::Time last_valid_cmd_time_;
 

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -405,7 +405,8 @@ void ControllerServer::computeControl()
       if (!loop_rate.sleep()) {
         real_frequency = 1.0e9 / (steady_clock_.now() - begin).nanoseconds();
         RCLCPP_WARN(
-          get_logger(), "Control loop missed its desired rate of %.4fHz. Achieved rate: %.4fHz", controller_frequency_,
+          get_logger(), "Control loop missed its desired rate of %.4fHz. Achieved rate: %.4fHz",
+          controller_frequency_,
           real_frequency);
       }
     }

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -404,13 +404,14 @@ void ControllerServer::computeControl()
 
       if (!loop_rate.sleep()) {
         real_frequency =
-            1.0e6 / std::chrono::duration_cast<std::chrono::microseconds>(
-                        std::chrono::steady_clock::now() - begin)
-                        .count();
-        RCLCPP_WARN(get_logger(),
-                    "Control loop missed its desired rate of %.4fHz. Achieved "
-                    "rate: %.4fHz",
-                    controller_frequency_, real_frequency);
+          1.0e6 / std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - begin)
+          .count();
+        RCLCPP_WARN(
+          get_logger(),
+          "Control loop missed its desired rate of %.4fHz. Achieved "
+          "rate: %.4fHz",
+          controller_frequency_, real_frequency);
       }
     }
   } catch (nav2_core::PlannerException & e) {

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -403,15 +403,11 @@ void ControllerServer::computeControl()
       }
 
       if (!loop_rate.sleep()) {
-        real_frequency =
-          1.0e6 / std::chrono::duration_cast<std::chrono::microseconds>(
-          std::chrono::steady_clock::now() - begin)
-          .count();
+        real_frequency = 1.0e6 / std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - begin).count();
         RCLCPP_WARN(
-          get_logger(),
-          "Control loop missed its desired rate of %.4fHz. Achieved "
-          "rate: %.4fHz",
-          controller_frequency_, real_frequency);
+          get_logger(), "Control loop missed its desired rate of %.4fHz. Achieved rate: %.4fHz", controller_frequency_,
+          real_frequency);
       }
     }
   } catch (nav2_core::PlannerException & e) {

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -372,9 +372,9 @@ void ControllerServer::computeControl()
     last_valid_cmd_time_ = now();
     rclcpp::WallRate loop_rate(controller_frequency_);
     double real_frequency = controller_frequency_;
-    std::chrono::steady_clock::time_point begin;
+    rclcpp::Time begin;
     while (rclcpp::ok()) {
-      begin = std::chrono::steady_clock::now();
+      begin = steady_clock_.now();
       if (action_server_ == nullptr || !action_server_->is_server_active()) {
         RCLCPP_DEBUG(get_logger(), "Action server unavailable or inactive. Stopping.");
         return;
@@ -403,8 +403,7 @@ void ControllerServer::computeControl()
       }
 
       if (!loop_rate.sleep()) {
-        real_frequency = 1.0e6 / std::chrono::duration_cast<std::chrono::microseconds>(
-          std::chrono::steady_clock::now() - begin).count();
+        real_frequency = 1.0e9 / (steady_clock_.now() - begin).nanoseconds();
         RCLCPP_WARN(
           get_logger(), "Control loop missed its desired rate of %.4fHz. Achieved rate: %.4fHz", controller_frequency_,
           real_frequency);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Own gazebo simulation |

---

## Description of contribution in a few bullet points

* I added logging of the real achieved frequency when the target is not reached. Context: we were getting the "Control loop missed" warning but wanted to know at what rate we are running to know over time if this gets worse.

It's unfortunate that rclcpp::WallRate doesn't offer a way to get the achieved period/frequency when sleep returns fals

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
