### PR TITLE
Fix for #3078, fix image path in YAML

### DIFF
--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -8,7 +8,7 @@
  * modification, are permitted provided that the following conditions are met:
  *
  *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
+ *       notice, this list of conditions and the following disclaimer.151
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
@@ -148,7 +148,7 @@ LoadParameters loadMapYaml(const std::string & yaml_filename)
     load_parameters.mode = MapMode::Trinary;
   } else {
     load_parameters.mode = map_mode_from_string(map_mode_node.as<std::string>());
-  }f
+  }
 
   try {
     load_parameters.negate = yaml_get_value<int>(doc, "negate");

--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -8,7 +8,7 @@
  * modification, are permitted provided that the following conditions are met:
  *
  *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.151
+ *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.

--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -148,7 +148,7 @@ LoadParameters loadMapYaml(const std::string & yaml_filename)
     load_parameters.mode = MapMode::Trinary;
   } else {
     load_parameters.mode = map_mode_from_string(map_mode_node.as<std::string>());
-  }
+  }f
 
   try {
     load_parameters.negate = yaml_get_value<int>(doc, "negate");
@@ -506,7 +506,7 @@ void tryWriteMapToFile(
     mat.getEulerYPR(yaw, pitch, roll);
     
     int file_name_index = mapdatafile.find_last_of("/\\");
-    string image_name = mapdatafile.substr(file_name_index + 1);
+    std::string image_name = mapdatafile.substr(file_name_index + 1);
 
     YAML::Emitter e;
     e << YAML::Precision(3);

--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -504,11 +504,14 @@ void tryWriteMapToFile(
     tf2::Matrix3x3 mat(tf2::Quaternion(orientation.x, orientation.y, orientation.z, orientation.w));
     double yaw, pitch, roll;
     mat.getEulerYPR(yaw, pitch, roll);
+    
+    int file_name_index = mapdatafile.find_last_of("/\\");
+    string image_name = mapdatafile.substr(file_name_index + 1);
 
     YAML::Emitter e;
     e << YAML::Precision(3);
     e << YAML::BeginMap;
-    e << YAML::Key << "image" << YAML::Value << mapdatafile;
+    e << YAML::Key << "image" << YAML::Value << image_name;
     e << YAML::Key << "mode" << YAML::Value << map_mode_to_string(save_parameters.mode);
     e << YAML::Key << "resolution" << YAML::Value << map.info.resolution;
     e << YAML::Key << "origin" << YAML::Flow << YAML::BeginSeq << map.info.origin.position.x <<

--- a/nav2_map_server/src/map_io.cpp
+++ b/nav2_map_server/src/map_io.cpp
@@ -505,7 +505,7 @@ void tryWriteMapToFile(
     double yaw, pitch, roll;
     mat.getEulerYPR(yaw, pitch, roll);
     
-    int file_name_index = mapdatafile.find_last_of("/\\");
+    const int file_name_index = mapdatafile.find_last_of("/\\");
     std::string image_name = mapdatafile.substr(file_name_index + 1);
 
     YAML::Emitter e;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3078  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Own robot |

---

## Description of contribution in a few bullet points

* Extraced only the image file name instead of the whole path when saving the meta data YAML file. 

## Description of documentation updates required from your changes
N/A

---

## Future work that may be required in bullet points
I wanted to avoid having to add another dependency, but it could also be done using std::filesystem, like here: https://en.cppreference.com/w/cpp/filesystem/path/filename

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
