### PR TITLE
Adds missing commas so default plugin names are not stuck together

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -73,10 +73,10 @@ BtNavigator::BtNavigator(const rclcpp::NodeOptions & options)
     "nav2_controller_selector_bt_node",
     "nav2_goal_checker_selector_bt_node",
     "nav2_controller_cancel_bt_node",
-    "nav2_path_longer_on_approach_bt_node"
+    "nav2_path_longer_on_approach_bt_node",
     "nav2_wait_cancel_bt_node",
     "nav2_spin_cancel_bt_node",
-    "nav2_back_up_cancel_bt_node"
+    "nav2_back_up_cancel_bt_node",
     "nav2_drive_on_heading_cancel_bt_node"
   };
 


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [(add tickets here #1)](https://github.com/ros-planning/navigation2/issues/3092) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

Added missing commas to ensure default plugin lib names are accurate.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
