### PR TITLE
Fix Costmap Filters system tests

### DIFF
--- a/nav2_system_tests/src/costmap_filters/keepout_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/keepout_params.yaml
@@ -124,6 +124,7 @@ controller_server:
     FollowPath:
       plugin: "dwb_core::DWBLocalPlanner"
       debug_trajectory_details: True
+      prune_distance: 1.0
       min_vel_x: 0.0
       min_vel_y: 0.0
       max_vel_x: 0.26

--- a/nav2_system_tests/src/costmap_filters/speed_global_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/speed_global_params.yaml
@@ -248,7 +248,7 @@ map_server:
 map_saver:
   ros__parameters:
     use_sim_time: True
-    save_map_timeout: 5000
+    save_map_timeout: 5.0
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65
     map_subscribe_transient_local: True

--- a/nav2_system_tests/src/costmap_filters/speed_local_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/speed_local_params.yaml
@@ -248,7 +248,7 @@ map_server:
 map_saver:
   ros__parameters:
     use_sim_time: True
-    save_map_timeout: 5000
+    save_map_timeout: 5.0
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65
     map_subscribe_transient_local: True

--- a/nav2_system_tests/src/costmap_filters/test_keepout_launch.py
+++ b/nav2_system_tests/src/costmap_filters/test_keepout_launch.py
@@ -89,7 +89,7 @@ def generate_launch_description():
             parameters=[{
                             'node_names':
                             [
-                                'filter_mask_server', 'costmap_filter_info_server', 'bt_navigator'
+                                'filter_mask_server', 'costmap_filter_info_server'
                             ]
                         },
                         {'autostart': True}]),

--- a/nav2_system_tests/src/costmap_filters/test_speed_launch.py
+++ b/nav2_system_tests/src/costmap_filters/test_speed_launch.py
@@ -87,7 +87,7 @@ def generate_launch_description():
             parameters=[{
                             'node_names':
                             [
-                                'filter_mask_server', 'costmap_filter_info_server', 'bt_navigator'
+                                'filter_mask_server', 'costmap_filter_info_server'
                             ]
                         },
                         {'autostart': True}]),


### PR DESCRIPTION
This PR fixes failing in CI `test_keepout_filter`, `test_speed_filter_global`, `test_speed_filter_local` tests.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Docker container from `ghcr.io/ros-planning/navigation2:main` (Ubuntu 22.04, ros2 rolling), local testing at Ubuntu 20.04 |
| Robotic platform tested on | TB3 simulation |

---

## Description of contribution in a few bullet points

The following problems were detected on CircleCI testing with Costmap Filters system tests:

**Problem1**
During all Costmap Filters testcases run the following problem appear:
```
...
[lifecycle_manager-4] [INFO] [1658849612.200747157] [lifecycle_manager_filters]: Server filter_mask_server connected with bond.
[lifecycle_manager-4] [INFO] [1658849612.200798773] [lifecycle_manager_filters]: Activating costmap_filter_info_server
[costmap_filter_info_server-6] [INFO] [1658849612.201114481] [costmap_filter_info_server]: Activating
[costmap_filter_info_server-6] [INFO] [1658849612.201221979] [costmap_filter_info_server]: Creating bond (costmap_filter_info_server) to lifecycle manager.
[component_container_isolated-7] [INFO] [1658849612.207924607] [behavior_server]: Creating behavior plugin wait of type nav2_behaviors/Wait
[component_container_isolated-7] [INFO] [1658849612.209603098] [behavior_server]: Configuring wait
[component_container_isolated-7] [INFO] [1658849612.217752899] [lifecycle_manager_navigation]: Configuring bt_navigator
[component_container_isolated-7] [WARN] [1658849612.217944090] [rcl_lifecycle]: No transition matching 1 found for current state inactive
[component_container_isolated-7] [ERROR] [1658849612.217964847] []: Unable to start transition 1 from current state inactive: Transition is not registered., at ./src/rcl_lifecycle.c:355
```

This appears due to double-attempt to configure already configured (by `navigation_launch.py` script) `bt_navigator` node. Appeared since 35561ba7088f5de1f702fb1df816cf815dc60740. Removal of `bt_navigator` from the list of lifecycle nodes in testing scripts resolves the problem.

**Problem2**

Adding the keepout zone to the global/local costmap for the `test_keepout_filter` test forces robot to plan on non-straight line around this zone. However, instead of bypassing of the obstacle on costmap, robot became to turn left/right in place as shown at the picture below:
![controller_issue](https://user-images.githubusercontent.com/60094858/181236135-cc9c0ad0-050a-46f1-b695-08065d4bbafe.gif)

This behavior change is concerned with DWB part of 7872c73362985a95cdacf2df3ef15526fcd7f260 commit, that increased default `prune_distance` parameter from `1.0` to `2.0` meters. It seems that robot tries to cut-down for the shortened distance between its actual start and pruned end point on the prepared local plan and is being getting stuck. Decreasing the `prune_distance` back to the `1.0` value restores robot normal behavior in keepout test (checked locally and on Docker container).

**Problem3**

The problem appeared only on `FastRTPS` implementation for `test_keepout_filter` test . It concerned with that Keepout Filter fails to set the constmap filter info subscriber, does not receive the costmap filter info message, then misses filter mask and thus passes through keepout area. This is being indicating by following errors:
```
[component_container_isolated-7] [WARN] [1658897733.717745904] [global_costmap.global_costmap]: KeepoutFilter: Filter mask was not received
...
[tester_node-9] [ERROR] [1658897734.353552345] [nav2_tester]: Pose (-1.2776365887766588, -0.5532248043004415) belongs to keepout zone
[tester_node-9] [ERROR] [1658897734.354292778] [nav2_tester]: Path plan intersects with keepout zone
```

This problem is most probably related to the https://github.com/ros-planning/navigation2/issues/3014, which is yet to be resolved.
One `CycloneDDS` this issue was never detected.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
