### PR TITLE
Add Client Thread for costmap_client_node

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -258,6 +258,7 @@ public:
 
 protected:
   rclcpp::Node::SharedPtr client_node_;
+  std::unique_ptr<nav2_util::NodeThread> client_thread_;
 
   // Publishers and subscribers
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PolygonStamped>::SharedPtr

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -83,6 +83,7 @@ Costmap2DROS::Costmap2DROS(
   auto options = rclcpp::NodeOptions().arguments(
     {"--ros-args", "-r", std::string("__node:=") + get_name() + "_client", "--"});
   client_node_ = std::make_shared<rclcpp::Node>("_", options);
+  client_thread_ = std::make_unique<nav2_util::NodeThread>(client_node_);
 
   std::vector<std::string> clearable_layers{"obstacle_layer"};
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A? |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Simulated Jackal |

---

## Description of contribution in a few bullet points

 * `costmap_2d_ros` creates a node but there was nothing spinning it, so getting its parameters (and other operations) were blocked. 
 * I added a `nav2_util::NodeThread`

## Description of documentation updates required from your changes

?

---

## Future work that may be required in bullet points

 * Not needed in `main` because client node has been removed. 
 
#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
