### PR TITLE
Fix Costmap Filters system tests

### DIFF
--- a/nav2_system_tests/src/costmap_filters/keepout_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/keepout_params.yaml
@@ -124,6 +124,7 @@ controller_server:
     FollowPath:
       plugin: "dwb_core::DWBLocalPlanner"
       debug_trajectory_details: True
+      prune_distance: 1.0
       min_vel_x: 0.0
       min_vel_y: 0.0
       max_vel_x: 0.26

--- a/nav2_system_tests/src/costmap_filters/speed_global_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/speed_global_params.yaml
@@ -248,7 +248,7 @@ map_server:
 map_saver:
   ros__parameters:
     use_sim_time: True
-    save_map_timeout: 5000
+    save_map_timeout: 5.0
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65
     map_subscribe_transient_local: True

--- a/nav2_system_tests/src/costmap_filters/speed_local_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/speed_local_params.yaml
@@ -248,7 +248,7 @@ map_server:
 map_saver:
   ros__parameters:
     use_sim_time: True
-    save_map_timeout: 5000
+    save_map_timeout: 5.0
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65
     map_subscribe_transient_local: True

--- a/nav2_system_tests/src/costmap_filters/test_keepout_launch.py
+++ b/nav2_system_tests/src/costmap_filters/test_keepout_launch.py
@@ -89,7 +89,7 @@ def generate_launch_description():
             parameters=[{
                             'node_names':
                             [
-                                'filter_mask_server', 'costmap_filter_info_server', 'bt_navigator'
+                                'filter_mask_server', 'costmap_filter_info_server'
                             ]
                         },
                         {'autostart': True}]),

--- a/nav2_system_tests/src/costmap_filters/test_speed_launch.py
+++ b/nav2_system_tests/src/costmap_filters/test_speed_launch.py
@@ -87,7 +87,7 @@ def generate_launch_description():
             parameters=[{
                             'node_names':
                             [
-                                'filter_mask_server', 'costmap_filter_info_server', 'bt_navigator'
+                                'filter_mask_server', 'costmap_filter_info_server'
                             ]
                         },
                         {'autostart': True}]),


### PR DESCRIPTION
Continue PR of #3098 (fixes failing in CI `test_keepout_filter`, `test_speed_filter_global`, `test_speed_filter_local tests`)

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
