### PR TITLE
Decouple minimum xy speed check from the minimum theta speed check

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -99,9 +99,10 @@ bool XYThetaIterator::isValidSpeed(double x, double y, double theta)
   if (kinematics.getMaxSpeedXY() >= 0.0 && vmag_sq > kinematics.getMaxSpeedXY_SQ() + EPSILON) {
     return false;
   }
-  if (kinematics.getMinSpeedXY() >= 0.0 && vmag_sq + EPSILON < kinematics.getMinSpeedXY_SQ() &&
-    kinematics.getMinSpeedTheta() >= 0.0 && fabs(theta) + EPSILON < kinematics.getMinSpeedTheta())
-  {
+  if (kinematics.getMinSpeedXY() >= 0.0 && vmag_sq + EPSILON < kinematics.getMinSpeedXY_SQ()) {
+    return false;
+  }
+  if (kinematics.getMinSpeedTheta() >= 0.0 && fabs(theta) + EPSILON < kinematics.getMinSpeedTheta()) {
     return false;
   }
   if (vmag_sq == 0.0 && th_it_->getVelocity() == 0.0) {


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [3134](https://github.com/ros-planning/navigation2/issues/3134) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | None. In simulation only. |

---

## Description of contribution in a few bullet points
* This PR decouples the logic check in the `dwb_plugins::XYThetaIterator` to determine if a twist's speed is valid and as per the user-defined configuration.
* For a speed combination to be invalid the logic checks on lines 99, 102, 105 need to be true. However, for a system configured with `min_speed_xy > 0` and `min_speed_theta = 0` the logic defined in xy_theta_iterator.cpp [L102](https://github.com/ros-planning/navigation2/blob/d49e4053b7d9de52b42aaeb041f6450800dedb9d/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp#L102) will always resolve to false, meaning a speed combination (specifically a lower than configured minimum xy speed) can incorrectly be deemed valid.
* The logic checks that are currently using an `&&`  are split into two independent checks. If either of the checks are true (essentially a `||` condition) the speed combination is invalid and returns the method returns `false`.
* There are no tests for the `XYThetaIterator` class, so no tests have been modified.

## Description of documentation updates required from your changes
* None
---

## Future work that may be required in bullet points
* None

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
