### PR TITLE
Ignore feedback from old goals in waypoint follower

### DIFF
--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -291,6 +291,7 @@ WaypointFollower::resultCallback(
       get_logger(),
       "Goal IDs do not match for the current goal handle and received result."
       "Ignoring likely due to receiving result for an old goal.");
+      return;
   }
 
   switch (result.code) {


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3129 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Custom skid steer robot on gazebo |

---

## Description of contribution in a few bullet points

* Added a missing return in #3130 to ignore feedback coming from outdated goals on the waypoint follower action server

## Description of documentation updates required from your changes

* None to my knowledge

---

## Future work that may be required in bullet points

* None to my knowledge

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
