### PR TITLE
Change deprecated ceres function

### DIFF
--- a/nav2_constrained_smoother/include/nav2_constrained_smoother/smoother_cost_function.hpp
+++ b/nav2_constrained_smoother/include/nav2_constrained_smoother/smoother_cost_function.hpp
@@ -159,7 +159,7 @@ protected:
     Eigen::Matrix<T, 2, 1> center = arcCenter(
       pt_prev, pt, pt_next,
       next_to_last_length_ratio_ < 0);
-    if (ceres::IsInfinite(center[0])) {
+    if (ceres::isinf(center[0])) {
       return;
     }
     T turning_rad = (pt - center).norm();

--- a/nav2_constrained_smoother/include/nav2_constrained_smoother/utils.hpp
+++ b/nav2_constrained_smoother/include/nav2_constrained_smoother/utils.hpp
@@ -86,7 +86,7 @@ inline Eigen::Matrix<T, 2, 1> tangentDir(
   bool is_cusp)
 {
   Eigen::Matrix<T, 2, 1> center = arcCenter(pt_prev, pt, pt_next, is_cusp);
-  if (ceres::IsInfinite(center[0])) {  // straight line
+  if (ceres::isinf(center[0])) {  // straight line
     Eigen::Matrix<T, 2, 1> d1 = pt - pt_prev;
     Eigen::Matrix<T, 2, 1> d2 = pt_next - pt;
 


### PR DESCRIPTION
error: 'bool ceres::IsInfinite(double)' is deprecated: ceres::IsInfinite will be removed in a future Ceres Solver release. Please use ceres::isinf.