### PR TITLE
Use SetParameter Launch API to set the yaml filename for map_server

### DIFF
--- a/nav2_bringup/launch/bringup_launch.py
+++ b/nav2_bringup/launch/bringup_launch.py
@@ -53,14 +53,10 @@ def generate_launch_description():
     remappings = [('/tf', 'tf'),
                   ('/tf_static', 'tf_static')]
 
-    # Create our own temporary YAML files that include substitutions
-    param_substitutions = {
-        'yaml_filename': map_yaml_file}
-
     configured_params = RewrittenYaml(
         source_file=params_file,
         root_key=namespace,
-        param_rewrites=param_substitutions,
+        param_rewrites={},
         convert_types=True)
 
     stdout_linebuf_envvar = SetEnvironmentVariable(
@@ -83,6 +79,7 @@ def generate_launch_description():
 
     declare_map_yaml_cmd = DeclareLaunchArgument(
         'map',
+        default_value='',
         description='Full path to map yaml file to load')
 
     declare_use_sim_time_cmd = DeclareLaunchArgument(

--- a/nav2_bringup/launch/localization_launch.py
+++ b/nav2_bringup/launch/localization_launch.py
@@ -155,7 +155,12 @@ def generate_launch_description():
     # yaml configuration file. They are separated since the conditions
     # currently only work on the LoadComposableNodes commands and not on the
     # ComposableNode node function itself
-    # See https://github.com/ros2/launch_ros/issues/328
+    # EqualsSubstitution and NotEqualsSubstitution susbsitutions was recently
+    # added to solve this problem but it has not been ported yet to
+    # ros-rolling. See https://github.com/ros2/launch_ros/issues/328.
+    # LaunchConfigurationEquals and LaunchConfigurationNotEquals are scheduled
+    # for deprecation once a Rolling sync is conducted. Switching to this new
+    # would be required for both ComposableNode and normal nodes.
     load_composable_nodes = GroupAction(
         condition=IfCondition(use_composition),
         actions=[

--- a/nav2_bringup/launch/localization_launch.py
+++ b/nav2_bringup/launch/localization_launch.py
@@ -17,8 +17,11 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, GroupAction, SetEnvironmentVariable
+from launch.actions import DeclareLaunchArgument, GroupAction
+from launch.actions import SetEnvironmentVariable
 from launch.conditions import IfCondition
+from launch.conditions import LaunchConfigurationEquals
+from launch.conditions import LaunchConfigurationNotEquals
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import LoadComposableNodes, SetParameter
 from launch_ros.actions import Node
@@ -51,14 +54,10 @@ def generate_launch_description():
     remappings = [('/tf', 'tf'),
                   ('/tf_static', 'tf_static')]
 
-    # Create our own temporary YAML files that include substitutions
-    param_substitutions = {
-        'yaml_filename': map_yaml_file}
-
     configured_params = RewrittenYaml(
         source_file=params_file,
         root_key=namespace,
-        param_rewrites=param_substitutions,
+        param_rewrites={},
         convert_types=True)
 
     stdout_linebuf_envvar = SetEnvironmentVariable(
@@ -71,6 +70,7 @@ def generate_launch_description():
 
     declare_map_yaml_cmd = DeclareLaunchArgument(
         'map',
+        default_value='',
         description='Full path to map yaml file to load')
 
     declare_use_sim_time_cmd = DeclareLaunchArgument(
@@ -108,6 +108,7 @@ def generate_launch_description():
         actions=[
             SetParameter("use_sim_time", use_sim_time),
             Node(
+                condition=LaunchConfigurationEquals('map', ''),
                 package='nav2_map_server',
                 executable='map_server',
                 name='map_server',
@@ -115,6 +116,18 @@ def generate_launch_description():
                 respawn=use_respawn,
                 respawn_delay=2.0,
                 parameters=[configured_params],
+                arguments=['--ros-args', '--log-level', log_level],
+                remappings=remappings),
+            Node(
+                condition=LaunchConfigurationNotEquals('map', ''),
+                package='nav2_map_server',
+                executable='map_server',
+                name='map_server',
+                output='screen',
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[configured_params,
+                            {'yaml_filename': map_yaml_file}],
                 arguments=['--ros-args', '--log-level', log_level],
                 remappings=remappings),
             Node(
@@ -137,13 +150,19 @@ def generate_launch_description():
                             {'node_names': lifecycle_nodes}])
         ]
     )
-
+    # LoadComposableNode for map server twice depending if we should use the
+    # value of map from a CLI or launch default or user defined value in the
+    # yaml configuration file. They are separated since the conditions
+    # currently only work on the LoadComposableNodes commands and not on the
+    # ComposableNode node function itself
+    # See https://github.com/ros2/launch_ros/issues/328
     load_composable_nodes = GroupAction(
         condition=IfCondition(use_composition),
         actions=[
             SetParameter("use_sim_time", use_sim_time),
             LoadComposableNodes(
                 target_container=container_name,
+                condition=LaunchConfigurationEquals('map', ''),
                 composable_node_descriptions=[
                     ComposableNode(
                         package='nav2_map_server',
@@ -151,6 +170,24 @@ def generate_launch_description():
                         name='map_server',
                         parameters=[configured_params],
                         remappings=remappings),
+                ],
+            ),
+            LoadComposableNodes(
+                target_container=container_name,
+                condition=LaunchConfigurationNotEquals('map', ''),
+                composable_node_descriptions=[
+                    ComposableNode(
+                        package='nav2_map_server',
+                        plugin='nav2_map_server::MapServer',
+                        name='map_server',
+                        parameters=[configured_params,
+                                    {'yaml_filename': map_yaml_file}],
+                        remappings=remappings),
+                ],
+            ),
+            LoadComposableNodes(
+                target_container=container_name,
+                composable_node_descriptions=[
                     ComposableNode(
                         package='nav2_amcl',
                         plugin='nav2_amcl::AmclNode',

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -243,11 +243,12 @@ global_costmap:
         inflation_radius: 0.55
       always_send_full_costmap: True
 
-map_server:
-  ros__parameters:
-    # Overridden in launch by the "map" launch configuration or provided default value.
-    # To use in yaml, remove the default "map" value in the tb3_simulation_launch.py file & provide full path to map below.
-    yaml_filename: ""
+# The yaml_filename does not need to be specified since it going to be set by defaults in launch.
+# If you'd rather set it in the yaml, remove the default "map" value in the tb3_simulation_launch.py
+# file & provide full path to map below. If CLI map configuration or launch default is provided, that will be used.
+# map_server:
+#   ros__parameters:
+#     yaml_filename: ""
 
 map_saver:
   ros__parameters:


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #3149 ) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo)|

---

## Description of contribution in a few bullet points
* Use SetParameter Launch API to set the yaml filename for map_server 
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes
* Remove the note added to the navigation.ros.org configuration for map server explaining that yaml_filename is strictly required.
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
