### PR TITLE
Fix missing dependency on nav2_collision_monitor

### DIFF
--- a/navigation2/package.xml
+++ b/navigation2/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>nav2_amcl</exec_depend>
   <exec_depend>nav2_behavior_tree</exec_depend>
   <exec_depend>nav2_bt_navigator</exec_depend>
+  <exec_depend>nav2_collision_monitor</exec_depend>
   <exec_depend>nav2_constrained_smoother</exec_depend>
   <exec_depend>nav2_controller</exec_depend>
   <exec_depend>nav2_core</exec_depend>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2982 |
| Primary OS tested on | Ubuntu 22.04.1 LTS |
| Robotic platform tested on | ----- |

---

## Description of contribution in a few bullet points

* I  added missing dependency on nav2_collision_monitor module 

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
