### PR TITLE
Fix velocities comparison for rotation at place case

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -15,6 +15,8 @@
 #ifndef NAV2_COLLISION_MONITOR__TYPES_HPP_
 #define NAV2_COLLISION_MONITOR__TYPES_HPP_
 
+#include <cmath>
+
 namespace nav2_collision_monitor
 {
 
@@ -29,7 +31,15 @@ struct Velocity
   {
     const double first_vel = x * x + y * y;
     const double second_vel = second.x * second.x + second.y * second.y;
-    return first_vel < second_vel;
+    if (second_vel > 0.0) {
+      // Robot moves: comparing velocities. In Collision Monitor
+      // twists will change proportionally to linear velocities.
+      // We do not need to compare them in this case.
+      return first_vel < second_vel;
+    } else {
+      // Robot is already stays in place. We need to compare twists.
+      return std::fabs(tw) < std::fabs(second.tw);
+    }
   }
 
   inline Velocity operator*(const double & mul) const

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -29,8 +29,7 @@ struct Velocity
   {
     const double first_vel = x * x + y * y + tw * tw;
     const double second_vel = second.x * second.x + second.y * second.y + second.tw * second.tw;
-    // In Collision Monitor twists will change proportionally to linear velocities,
-    // so this comparison is correct in this case.
+    // This comparison includes rotations in place, where linear velocities are equal to zero
     return first_vel < second_vel;
   }
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -29,17 +29,11 @@ struct Velocity
 
   inline bool operator<(const Velocity & second) const
   {
-    const double first_vel = x * x + y * y;
-    const double second_vel = second.x * second.x + second.y * second.y;
-    if (second_vel > 0.0) {
-      // Robot moves: comparing velocities. In Collision Monitor
-      // twists will change proportionally to linear velocities.
-      // We do not need to compare them in this case.
-      return first_vel < second_vel;
-    } else {
-      // Robot is already stays in place. We need to compare twists.
-      return std::fabs(tw) < std::fabs(second.tw);
-    }
+    const double first_vel = x * x + y * y + tw * tw;
+    const double second_vel = second.x * second.x + second.y * second.y + second.tw * second.tw;
+    // In Collision Monitor twists will change proportionally to linear velocities,
+    // so this comparison is correct in this case.
+    return first_vel < second_vel;
   }
 
   inline Velocity operator*(const double & mul) const

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -15,8 +15,6 @@
 #ifndef NAV2_COLLISION_MONITOR__TYPES_HPP_
 #define NAV2_COLLISION_MONITOR__TYPES_HPP_
 
-#include <cmath>
-
 namespace nav2_collision_monitor
 {
 


### PR DESCRIPTION
Fixes incorrect velocities comparison appeared when robot is rotating on the place. This was leading to failure of `safe_vel < robot_action.req_vel` checks for APPROACH and SLOWDOWN behavioral models, that causes robot to ignoring its intended behavior.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3171 |
| Primary OS tested on | Ubuntu 20.04 with ROS2 Rolling built from sources |
| Robotic platform tested on | TB3 simulation, colcon testing & coverage verification |

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
