### PR TITLE
Update Spin.Action in Galactic branch

### DIFF
--- a/nav2_msgs/action/Spin.action
+++ b/nav2_msgs/action/Spin.action
@@ -1,5 +1,6 @@
 #goal definition
 float32 target_yaw
+builtin_interfaces/Duration time_allowance
 ---
 #result definition
 builtin_interfaces/Duration total_elapsed_time


### PR DESCRIPTION
Update to include time_allowance in the goal definition.  robot_navigator.py attempts to set this in the spin command and crashes because its not defined.  Reference https://github.com/ros-planning/navigation2/issues/3191#issue-1373760857

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
