### PR TITLE
Revert "added result codes for global planner"

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
@@ -75,8 +75,6 @@ public:
     return providedBasicPorts(
       {
         BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputePathToPose node"),
-        BT::OutputPort<nav2_msgs::action::ComputePathToPose::Result::_error_code_type>(
-          "compute_path_to_pose_error_code", "The compute path to pose error code"),
         BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination to plan to"),
         BT::InputPort<geometry_msgs::msg::PoseStamped>(
           "start", "Start pose of the path if overriding current robot pose"),

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -77,7 +77,6 @@
       <input_port name="service_name">Service name</input_port>
       <input_port name="server_timeout">Server timeout</input_port>
       <output_port name="path">Path created by ComputePathToPose node</output_port>
-      <output_port name="compute_path_to_pose_error_code">"The compute path to pose error code"</output_port>
     </Action>
 
     <Action ID="ComputePathThroughPoses">

--- a/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
@@ -40,9 +40,6 @@ void ComputePathToPoseAction::on_tick()
 BT::NodeStatus ComputePathToPoseAction::on_success()
 {
   setOutput("path", result_.result->path);
-  // Set empty error code, action was successful
-  result_.result->error_code = nav2_msgs::action::ComputePathToPose::Goal::NONE;
-  setOutput("compute_path_to_pose_error_code", result_.result->error_code);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -50,7 +47,6 @@ BT::NodeStatus ComputePathToPoseAction::on_aborted()
 {
   nav_msgs::msg::Path empty_path;
   setOutput("path", empty_path);
-  setOutput("compute_path_to_pose_error_code", result_.result->error_code);
   return BT::NodeStatus::FAILURE;
 }
 
@@ -58,9 +54,6 @@ BT::NodeStatus ComputePathToPoseAction::on_cancelled()
 {
   nav_msgs::msg::Path empty_path;
   setOutput("path", empty_path);
-  // Set empty error code, action was cancelled
-  result_.result->error_code = nav2_msgs::action::ComputePathToPose::Goal::NONE;
-  setOutput("compute_path_to_pose_error_code", result_.result->error_code);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_core/include/nav2_core/exceptions.hpp
+++ b/nav2_core/include/nav2_core/exceptions.hpp
@@ -46,57 +46,9 @@ namespace nav2_core
 class PlannerException : public std::runtime_error
 {
 public:
-  explicit PlannerException(const std::string & description)
+  explicit PlannerException(const std::string description)
   : std::runtime_error(description) {}
-};
-
-class StartOccupied : public PlannerException
-{
-public:
-  explicit StartOccupied(const std::string & description)
-  : PlannerException(description) {}
-};
-
-class GoalOccupied : public PlannerException
-{
-public:
-  explicit GoalOccupied(const std::string & description)
-  : PlannerException(description) {}
-};
-
-class StartOutsideMapBounds : public PlannerException
-{
-public:
-  explicit StartOutsideMapBounds(const std::string & description)
-  : PlannerException(description) {}
-};
-
-class GoalOutsideMapBounds : public PlannerException
-{
-public:
-  explicit GoalOutsideMapBounds(const std::string & description)
-  : PlannerException(description) {}
-};
-
-class NoValidPathCouldBeFound : public PlannerException
-{
-public:
-  explicit NoValidPathCouldBeFound(const std::string & description)
-  : PlannerException(description) {}
-};
-
-class PlannerTimedOut : public PlannerException
-{
-public:
-  explicit PlannerTimedOut(const std::string & description)
-  : PlannerException(description) {}
-};
-
-class PlannerTFError : public PlannerException
-{
-public:
-  explicit PlannerTFError(const std::string & description)
-  : PlannerException(description) {}
+  using Ptr = std::shared_ptr<PlannerException>;
 };
 
 }  // namespace nav2_core

--- a/nav2_msgs/action/ComputePathToPose.action
+++ b/nav2_msgs/action/ComputePathToPose.action
@@ -1,15 +1,3 @@
-# Error codes
-# Note: The expected priority order of the errors should match the message order
-int16 NONE=0
-int16 UNKNOWN=1
-int16 TF_ERROR=2
-int16 START_OUTSIDE_MAP=3
-int16 GOAL_OUTSIDE_MAP=4
-int16 START_OCCUPIED=5
-int16 GOAL_OCCUPIED=6
-int16 TIMEOUT=7
-int16 NO_VALID_PATH=8
-
 #goal definition
 geometry_msgs/PoseStamped goal
 geometry_msgs/PoseStamped start
@@ -19,6 +7,5 @@ bool use_start # If false, use current robot pose as path start, if true, use st
 #result definition
 nav_msgs/Path path
 builtin_interfaces/Duration planning_time
-int16 error_code
 ---
 #feedback definition

--- a/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
+++ b/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
@@ -25,7 +25,6 @@
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_core/global_planner.hpp"
-#include "nav2_core/exceptions.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "nav2_navfn_planner/navfn.hpp"
 #include "nav2_util/robot_utils.hpp"

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -134,30 +134,6 @@ nav_msgs::msg::Path NavfnPlanner::createPlan(
 #ifdef BENCHMARK_TESTING
   steady_clock::time_point a = steady_clock::now();
 #endif
-  unsigned int mx_start, my_start, mx_goal, my_goal;
-  if (!costmap_->worldToMap(start.pose.position.x, start.pose.position.y, mx_start, my_start)) {
-    throw nav2_core::StartOutsideMapBounds(
-            "Start Coordinates of(" + std::to_string(start.pose.position.x) + ", " +
-            std::to_string(start.pose.position.y) + ") was outside bounds");
-  }
-
-  if (!costmap_->worldToMap(goal.pose.position.x, goal.pose.position.y, mx_goal, my_goal)) {
-    throw nav2_core::GoalOutsideMapBounds(
-            "Goal Coordinates of(" + std::to_string(goal.pose.position.x) + ", " +
-            std::to_string(goal.pose.position.y) + ") was outside bounds");
-  }
-
-  if (costmap_->getCost(mx_start, my_goal) == nav2_costmap_2d::LETHAL_OBSTACLE) {
-    throw nav2_core::StartOccupied(
-            "Start Coordinates of(" + std::to_string(start.pose.position.x) + ", " +
-            std::to_string(start.pose.position.y) + ") was in lethal cost");
-  }
-
-  if (tolerance_ == 0 && costmap_->getCost(mx_goal, my_goal) == nav2_costmap_2d::LETHAL_OBSTACLE) {
-    throw nav2_core::GoalOccupied(
-            "Goal Coordinates of(" + std::to_string(goal.pose.position.x) + ", " +
-            std::to_string(goal.pose.position.y) + ") was in lethal cost");
-  }
 
   // Update planner based on the new costmap size
   if (isPlannerOutOfDate()) {
@@ -172,6 +148,12 @@ nav_msgs::msg::Path NavfnPlanner::createPlan(
   if (start.pose.position.x == goal.pose.position.x &&
     start.pose.position.y == goal.pose.position.y)
   {
+    unsigned int mx, my;
+    costmap_->worldToMap(start.pose.position.x, start.pose.position.y, mx, my);
+    if (costmap_->getCost(mx, my) == nav2_costmap_2d::LETHAL_OBSTACLE) {
+      RCLCPP_WARN(logger_, "Failed to create a unique pose path because of obstacles");
+      return path;
+    }
     path.header.stamp = clock_->now();
     path.header.frame_id = global_frame_;
     geometry_msgs::msg::PoseStamped pose;
@@ -190,8 +172,9 @@ nav_msgs::msg::Path NavfnPlanner::createPlan(
   }
 
   if (!makePlan(start.pose, goal.pose, tolerance_, path)) {
-    throw nav2_core::NoValidPathCouldBeFound(
-            "Failed to create plan with tolerance of: " + std::to_string(tolerance_) );
+    RCLCPP_WARN(
+      logger_, "%s: failed to create plan with "
+      "tolerance %.2f.", name_.c_str(), tolerance_);
   }
 
 
@@ -238,7 +221,14 @@ NavfnPlanner::makePlan(
     start.position.x, start.position.y, goal.position.x, goal.position.y);
 
   unsigned int mx, my;
-  worldToMap(wx, wy, mx, my);
+  if (!worldToMap(wx, wy, mx, my)) {
+    RCLCPP_WARN(
+      logger_,
+      "Cannot create a plan: the robot's start position is off the global"
+      " costmap. Planning will always fail, are you sure"
+      " the robot has been properly localized?");
+    return false;
+  }
 
   // clear the starting cell within the costmap because we know it can't be an obstacle
   clearRobotCell(mx, my);
@@ -261,7 +251,14 @@ NavfnPlanner::makePlan(
   wx = goal.position.x;
   wy = goal.position.y;
 
-  worldToMap(wx, wy, mx, my);
+  if (!worldToMap(wx, wy, mx, my)) {
+    RCLCPP_WARN(
+      logger_,
+      "The goal sent to the planner is off the global costmap."
+      " Planning will always fail to this goal.");
+    return false;
+  }
+
   int map_goal[2];
   map_goal[0] = mx;
   map_goal[1] = my;
@@ -388,7 +385,13 @@ NavfnPlanner::getPlanFromPotential(
 
   // the potential has already been computed, so we won't update our copy of the costmap
   unsigned int mx, my;
-  worldToMap(wx, wy, mx, my);
+  if (!worldToMap(wx, wy, mx, my)) {
+    RCLCPP_WARN(
+      logger_,
+      "The goal sent to the navfn planner is off the global costmap."
+      " Planning will always fail to this goal.");
+    return false;
+  }
 
   int map_goal[2];
   map_goal[0] = mx;

--- a/nav2_planner/include/nav2_planner/planner_server.hpp
+++ b/nav2_planner/include/nav2_planner/planner_server.hpp
@@ -39,7 +39,6 @@
 #include "pluginlib/class_list_macros.hpp"
 #include "nav2_core/global_planner.hpp"
 #include "nav2_msgs/srv/is_path_valid.hpp"
-#include "nav2_core/exceptions.hpp"
 
 namespace nav2_planner
 {
@@ -153,17 +152,21 @@ protected:
    */
   template<typename T>
   bool getStartPose(
+    std::unique_ptr<nav2_util::SimpleActionServer<T>> & action_server,
     typename std::shared_ptr<const typename T::Goal> goal,
     geometry_msgs::msg::PoseStamped & start);
 
   /**
    * @brief Transform start and goal poses into the costmap
    * global frame for path planning plugins to utilize
+   * @param action_server Action server to terminate if required
    * @param start The starting pose to transform
    * @param goal Goal pose to transform
    * @return bool If successful in transforming poses
    */
+  template<typename T>
   bool transformPosesToGlobalFrame(
+    std::unique_ptr<nav2_util::SimpleActionServer<T>> & action_server,
     geometry_msgs::msg::PoseStamped & curr_start,
     geometry_msgs::msg::PoseStamped & curr_goal);
 
@@ -177,9 +180,14 @@ protected:
    */
   template<typename T>
   bool validatePath(
+    std::unique_ptr<nav2_util::SimpleActionServer<T>> & action_server,
     const geometry_msgs::msg::PoseStamped & curr_goal,
     const nav_msgs::msg::Path & path,
     const std::string & planner_id);
+
+  // Our action server implements the ComputePathToPose action
+  std::unique_ptr<ActionServerToPose> action_server_pose_;
+  std::unique_ptr<ActionServerThroughPoses> action_server_poses_;
 
   /**
    * @brief The action server callback which calls planner to get the path
@@ -208,22 +216,12 @@ protected:
    */
   void publishPlan(const nav_msgs::msg::Path & path);
 
-  void exceptionWarning(
-    const geometry_msgs::msg::PoseStamped & start,
-    const geometry_msgs::msg::PoseStamped & goal,
-    const std::string & planner_id,
-    const std::exception & ex);
-
   /**
    * @brief Callback executed when a parameter change is detected
    * @param event ParameterEvent message
    */
   rcl_interfaces::msg::SetParametersResult
   dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
-
-  // Our action server implements the ComputePathToPose action
-  std::unique_ptr<ActionServerToPose> action_server_pose_;
-  std::unique_ptr<ActionServerThroughPoses> action_server_poses_;
 
   // Dynamic parameters handler
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -282,25 +282,32 @@ void PlannerServer::getPreemptedGoalIfRequested(
 
 template<typename T>
 bool PlannerServer::getStartPose(
+  std::unique_ptr<nav2_util::SimpleActionServer<T>> & action_server,
   typename std::shared_ptr<const typename T::Goal> goal,
   geometry_msgs::msg::PoseStamped & start)
 {
   if (goal->use_start) {
     start = goal->start;
   } else if (!costmap_ros_->getRobotPose(start)) {
+    action_server->terminate_current();
     return false;
   }
 
   return true;
 }
 
+template<typename T>
 bool PlannerServer::transformPosesToGlobalFrame(
+  std::unique_ptr<nav2_util::SimpleActionServer<T>> & action_server,
   geometry_msgs::msg::PoseStamped & curr_start,
   geometry_msgs::msg::PoseStamped & curr_goal)
 {
   if (!costmap_ros_->transformPoseToGlobalFrame(curr_start, curr_start) ||
     !costmap_ros_->transformPoseToGlobalFrame(curr_goal, curr_goal))
   {
+    RCLCPP_WARN(
+      get_logger(), "Could not transform the start or goal pose in the costmap frame");
+    action_server->terminate_current();
     return false;
   }
 
@@ -309,15 +316,17 @@ bool PlannerServer::transformPosesToGlobalFrame(
 
 template<typename T>
 bool PlannerServer::validatePath(
+  std::unique_ptr<nav2_util::SimpleActionServer<T>> & action_server,
   const geometry_msgs::msg::PoseStamped & goal,
   const nav_msgs::msg::Path & path,
   const std::string & planner_id)
 {
-  if (path.poses.empty()) {
+  if (path.poses.size() == 0) {
     RCLCPP_WARN(
       get_logger(), "Planning algorithm %s failed to generate a valid"
       " path to (%.2f, %.2f)", planner_id.c_str(),
       goal.pose.position.x, goal.pose.position.y);
+    action_server->terminate_current();
     return false;
   }
 
@@ -330,7 +339,8 @@ bool PlannerServer::validatePath(
   return true;
 }
 
-void PlannerServer::computePlanThroughPoses()
+void
+PlannerServer::computePlanThroughPoses()
 {
   std::lock_guard<std::mutex> lock(dynamic_params_lock_);
 
@@ -359,8 +369,8 @@ void PlannerServer::computePlanThroughPoses()
 
     // Use start pose if provided otherwise use current robot pose
     geometry_msgs::msg::PoseStamped start;
-    if (!getStartPose<ActionThroughPoses>(goal, start)) {
-      throw nav2_core::PlannerTFError("Unable to get start pose");
+    if (!getStartPose(action_server_poses_, goal, start)) {
+      return;
     }
 
     // Get consecutive paths through these points
@@ -376,15 +386,16 @@ void PlannerServer::computePlanThroughPoses()
       curr_goal = goal->goals[i];
 
       // Transform them into the global frame
-      if (!transformPosesToGlobalFrame(curr_start, curr_goal)) {
-        throw nav2_core::PlannerTFError("Unable to transform poses to global frame");
+      if (!transformPosesToGlobalFrame(action_server_poses_, curr_start, curr_goal)) {
+        return;
       }
 
       // Get plan from start -> goal
       nav_msgs::msg::Path curr_path = getPlan(curr_start, curr_goal, goal->planner_id);
 
-      if (!validatePath<ActionThroughPoses>(curr_goal, curr_path, goal->planner_id)) {
-        throw nav2_core::NoValidPathCouldBeFound(goal->planner_id + "generated a empty path");
+      // check path for validity
+      if (!validatePath(action_server_poses_, curr_goal, curr_path, goal->planner_id)) {
+        return;
       }
 
       // Concatenate paths together
@@ -429,8 +440,6 @@ PlannerServer::computePlan()
   auto goal = action_server_pose_->get_current_goal();
   auto result = std::make_shared<ActionToPose::Result>();
 
-  geometry_msgs::msg::PoseStamped start;
-
   try {
     if (isServerInactive(action_server_pose_) || isCancelRequested(action_server_pose_)) {
       return;
@@ -441,20 +450,21 @@ PlannerServer::computePlan()
     getPreemptedGoalIfRequested(action_server_pose_, goal);
 
     // Use start pose if provided otherwise use current robot pose
-    if (!getStartPose<ActionToPose>(goal, start)) {
-      throw nav2_core::PlannerTFError("Unable to get start pose");
+    geometry_msgs::msg::PoseStamped start;
+    if (!getStartPose(action_server_pose_, goal, start)) {
+      return;
     }
 
     // Transform them into the global frame
     geometry_msgs::msg::PoseStamped goal_pose = goal->goal;
-    if (!transformPosesToGlobalFrame(start, goal_pose)) {
-      throw nav2_core::PlannerTFError("Unable to transform poses to global frame");
+    if (!transformPosesToGlobalFrame(action_server_pose_, start, goal_pose)) {
+      return;
     }
 
     result->path = getPlan(start, goal_pose, goal->planner_id);
 
-    if (!validatePath<ActionThroughPoses>(goal_pose, result->path, goal->planner_id)) {
-      throw nav2_core::NoValidPathCouldBeFound(goal->planner_id + "generated a empty path");
+    if (!validatePath(action_server_pose_, goal_pose, result->path, goal->planner_id)) {
+      return;
     }
 
     // Publish the plan for visualization purposes
@@ -471,38 +481,12 @@ PlannerServer::computePlan()
     }
 
     action_server_pose_->succeeded_current(result);
-  } catch (nav2_core::StartOccupied & ex) {
-    exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = nav2_msgs::action::ComputePathToPose::Goal::START_OCCUPIED;
-    action_server_pose_->terminate_current(result);
-  } catch (nav2_core::GoalOccupied & ex) {
-    exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = nav2_msgs::action::ComputePathToPose::Goal::GOAL_OCCUPIED;
-    action_server_pose_->terminate_current(result);
-  } catch (nav2_core::NoValidPathCouldBeFound & ex) {
-    exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = nav2_msgs::action::ComputePathToPose::Goal::NO_VALID_PATH;
-    action_server_pose_->terminate_current(result);
-  } catch (nav2_core::PlannerTimedOut & ex) {
-    exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = nav2_msgs::action::ComputePathToPose::Goal::TIMEOUT;
-    action_server_pose_->terminate_current(result);
-  } catch (nav2_core::StartOutsideMapBounds & ex) {
-    exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = nav2_msgs::action::ComputePathToPose::Goal::START_OUTSIDE_MAP;
-    action_server_pose_->terminate_current(result);
-  } catch (nav2_core::GoalOutsideMapBounds & ex) {
-    exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = nav2_msgs::action::ComputePathToPose::Goal::GOAL_OUTSIDE_MAP;
-    action_server_pose_->terminate_current(result);
-  } catch (nav2_core::PlannerTFError & ex) {
-    exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = nav2_msgs::action::ComputePathToPose::Goal::TF_ERROR;
-    action_server_pose_->terminate_current(result);
   } catch (std::exception & ex) {
-    exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = nav2_msgs::action::ComputePathToPose::Goal::UNKNOWN;
-    action_server_pose_->terminate_current(result);
+    RCLCPP_WARN(
+      get_logger(), "%s plugin failed to plan calculation to (%.2f, %.2f): \"%s\"",
+      goal->planner_id.c_str(), goal->goal.pose.position.x,
+      goal->goal.pose.position.y, ex.what());
+    action_server_pose_->terminate_current();
   }
 }
 
@@ -602,6 +586,7 @@ PlannerServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramete
 {
   std::lock_guard<std::mutex> lock(dynamic_params_lock_);
   rcl_interfaces::msg::SetParametersResult result;
+
   for (auto parameter : parameters) {
     const auto & type = parameter.get_type();
     const auto & name = parameter.get_name();
@@ -623,20 +608,6 @@ PlannerServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramete
 
   result.successful = true;
   return result;
-}
-
-void PlannerServer::exceptionWarning(
-  const geometry_msgs::msg::PoseStamped & start,
-  const geometry_msgs::msg::PoseStamped & goal,
-  const std::string & planner_id,
-  const std::exception & ex)
-{
-  RCLCPP_WARN(
-    get_logger(), "%s plugin failed to plan from (%.2f, %.2f) to (%0.2f, %.2f): \"%s\"",
-    planner_id.c_str(),
-    start.pose.position.x, start.pose.position.y,
-    goal.pose.position.x, goal.pose.position.y,
-    ex.what());
 }
 
 }  // namespace nav2_planner

--- a/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
@@ -25,7 +25,6 @@
 #include "Eigen/Core"
 
 #include "nav2_costmap_2d/costmap_2d.hpp"
-#include "nav2_core/exceptions.hpp"
 
 #include "nav2_smac_planner/thirdparty/robin_hood.h"
 #include "nav2_smac_planner/analytic_expansion.hpp"

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -207,12 +207,12 @@ bool AStarAlgorithm<NodeT>::areInputsValid()
   if (getToleranceHeuristic() < 0.001 &&
     !_goal->isNodeValid(_traverse_unknown, _collision_checker))
   {
-    throw nav2_core::GoalOccupied("Goal was in lethal cost");
+    throw std::runtime_error("Failed to compute path, goal is occupied with no tolerance.");
   }
 
   // Check if starting point is valid
   if (!_start->isNodeValid(_traverse_unknown, _collision_checker)) {
-    throw nav2_core::StartOccupied("Start was in lethal cost");
+    throw std::runtime_error("Starting point in lethal space! Cannot create feasible plan.");
   }
 
   return true;

--- a/nav2_smac_planner/src/smac_planner_2d.cpp
+++ b/nav2_smac_planner/src/smac_planner_2d.cpp
@@ -211,19 +211,11 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
 
   // Set starting point
   unsigned int mx_start, my_start, mx_goal, my_goal;
-  if (!costmap->worldToMap(start.pose.position.x, start.pose.position.y, mx_start, my_start)) {
-    throw nav2_core::StartOutsideMapBounds(
-            "Start Coordinates of(" + std::to_string(start.pose.position.x) + ", " +
-            std::to_string(start.pose.position.y) + ") was outside bounds");
-  }
+  costmap->worldToMap(start.pose.position.x, start.pose.position.y, mx_start, my_start);
   _a_star->setStart(mx_start, my_start, 0);
 
   // Set goal point
-  if (!costmap->worldToMap(goal.pose.position.x, goal.pose.position.y, mx_goal, my_goal)) {
-    throw nav2_core::GoalOutsideMapBounds(
-            "Goal Coordinates of(" + std::to_string(goal.pose.position.x) + ", " +
-            std::to_string(goal.pose.position.y) + ") was outside bounds");
-  }
+  costmap->worldToMap(goal.pose.position.x, goal.pose.position.y, mx_goal, my_goal);
   _a_star->setGoal(mx_goal, my_goal, 0);
 
   // Setup message
@@ -241,7 +233,8 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
   // Corner case of start and goal beeing on the same cell
   if (mx_start == mx_goal && my_start == my_goal) {
     if (costmap->getCost(mx_start, my_start) == nav2_costmap_2d::LETHAL_OBSTACLE) {
-      throw nav2_core::StartOccupied("Start was in lethal cost");
+      RCLCPP_WARN(_logger, "Failed to create a unique pose path because of obstacles");
+      return plan;
     }
     pose.pose = start.pose;
     // if we have a different start and goal orientation, set the unique path pose to the goal
@@ -257,16 +250,28 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
   // Compute plan
   Node2D::CoordinateVector path;
   int num_iterations = 0;
-  // Note: All exceptions thrown are handled by the planner server and returned to the action
-  if (!_a_star->createPath(
-      path, num_iterations,
-      _tolerance / static_cast<float>(costmap->getResolution())))
-  {
-    if (num_iterations < _a_star->getMaxIterations()) {
-      throw nav2_core::NoValidPathCouldBeFound("no valid path found");
-    } else {
-      throw nav2_core::PlannerTimedOut("exceeded maximum iterations");
+  std::string error;
+  try {
+    if (!_a_star->createPath(
+        path, num_iterations, _tolerance / static_cast<float>(costmap->getResolution())))
+    {
+      if (num_iterations < _a_star->getMaxIterations()) {
+        error = std::string("no valid path found");
+      } else {
+        error = std::string("exceeded maximum iterations");
+      }
     }
+  } catch (const std::runtime_error & e) {
+    error = "invalid use: ";
+    error += e.what();
+  }
+
+  if (!error.empty()) {
+    RCLCPP_WARN(
+      _logger,
+      "%s: failed to create plan, %s.",
+      _name.c_str(), error.c_str());
+    return plan;
   }
 
   // Convert to world coordinates

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -287,12 +287,7 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
 
   // Set starting point, in A* bin search coordinates
   unsigned int mx, my;
-  if (!costmap->worldToMap(start.pose.position.x, start.pose.position.y, mx, my)) {
-    throw nav2_core::StartOutsideMapBounds(
-            "Start Coordinates of(" + std::to_string(start.pose.position.x) + ", " +
-            std::to_string(start.pose.position.y) + ") was outside bounds");
-  }
-
+  costmap->worldToMap(start.pose.position.x, start.pose.position.y, mx, my);
   double orientation_bin = tf2::getYaw(start.pose.orientation) / _angle_bin_size;
   while (orientation_bin < 0.0) {
     orientation_bin += static_cast<float>(_angle_quantizations);
@@ -305,11 +300,7 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
   _a_star->setStart(mx, my, orientation_bin_id);
 
   // Set goal point, in A* bin search coordinates
-  if (!costmap->worldToMap(goal.pose.position.x, goal.pose.position.y, mx, my)) {
-    throw nav2_core::GoalOutsideMapBounds(
-            "Goal Coordinates of(" + std::to_string(goal.pose.position.x) + ", " +
-            std::to_string(goal.pose.position.y) + ") was outside bounds");
-  }
+  costmap->worldToMap(goal.pose.position.x, goal.pose.position.y, mx, my);
   orientation_bin = tf2::getYaw(goal.pose.orientation) / _angle_bin_size;
   while (orientation_bin < 0.0) {
     orientation_bin += static_cast<float>(_angle_quantizations);
@@ -336,14 +327,28 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
   // Compute plan
   NodeHybrid::CoordinateVector path;
   int num_iterations = 0;
-
-  // Note: All exceptions thrown are handled by the planner server and returned to the action
-  if (!_a_star->createPath(path, num_iterations, 0)) {
-    if (num_iterations < _a_star->getMaxIterations()) {
-      throw nav2_core::NoValidPathCouldBeFound("no valid path found");
-    } else {
-      throw nav2_core::PlannerTimedOut("exceeded maximum iterations");
+  std::string error;
+  try {
+    if (!_a_star->createPath(
+        path, num_iterations, _tolerance / static_cast<float>(costmap->getResolution())))
+    {
+      if (num_iterations < _a_star->getMaxIterations()) {
+        error = std::string("no valid path found");
+      } else {
+        error = std::string("exceeded maximum iterations");
+      }
     }
+  } catch (const std::runtime_error & e) {
+    error = "invalid use: ";
+    error += e.what();
+  }
+
+  if (!error.empty()) {
+    RCLCPP_WARN(
+      _logger,
+      "%s: failed to create plan, %s.",
+      _name.c_str(), error.c_str());
+    return plan;
   }
 
   // Convert to world coordinates

--- a/nav2_smac_planner/src/smac_planner_lattice.cpp
+++ b/nav2_smac_planner/src/smac_planner_lattice.cpp
@@ -247,21 +247,13 @@ nav_msgs::msg::Path SmacPlannerLattice::createPlan(
 
   // Set starting point, in A* bin search coordinates
   unsigned int mx, my;
-  if (!_costmap->worldToMap(start.pose.position.x, start.pose.position.y, mx, my)) {
-    throw nav2_core::StartOutsideMapBounds(
-            "Start Coordinates of(" + std::to_string(start.pose.position.x) + ", " +
-            std::to_string(start.pose.position.y) + ") was outside bounds");
-  }
+  _costmap->worldToMap(start.pose.position.x, start.pose.position.y, mx, my);
   _a_star->setStart(
     mx, my,
     NodeLattice::motion_table.getClosestAngularBin(tf2::getYaw(start.pose.orientation)));
 
   // Set goal point, in A* bin search coordinates
-  if (!_costmap->worldToMap(goal.pose.position.x, goal.pose.position.y, mx, my)) {
-    throw nav2_core::GoalOutsideMapBounds(
-            "Goal Coordinates of(" + std::to_string(goal.pose.position.x) + ", " +
-            std::to_string(goal.pose.position.y) + ") was outside bounds");
-  }
+  _costmap->worldToMap(goal.pose.position.x, goal.pose.position.y, mx, my);
   _a_star->setGoal(
     mx, my,
     NodeLattice::motion_table.getClosestAngularBin(tf2::getYaw(goal.pose.orientation)));
@@ -282,14 +274,27 @@ nav_msgs::msg::Path SmacPlannerLattice::createPlan(
   NodeLattice::CoordinateVector path;
   int num_iterations = 0;
   std::string error;
-
-  // Note: All exceptions thrown are handled by the planner server and returned to the action
-  if (!_a_star->createPath(path, num_iterations, 0 /*no tolerance*/)) {
-    if (num_iterations < _a_star->getMaxIterations()) {
-      throw nav2_core::NoValidPathCouldBeFound("no valid path found");
-    } else {
-      throw nav2_core::PlannerTimedOut("exceeded maximum iterations");
+  try {
+    if (!_a_star->createPath(
+        path, num_iterations, _tolerance / static_cast<float>(_costmap->getResolution())))
+    {
+      if (num_iterations < _a_star->getMaxIterations()) {
+        error = std::string("no valid path found");
+      } else {
+        error = std::string("exceeded maximum iterations");
+      }
     }
+  } catch (const std::runtime_error & e) {
+    error = "invalid use: ";
+    error += e.what();
+  }
+
+  if (!error.empty()) {
+    RCLCPP_WARN(
+      _logger,
+      "%s: failed to create plan, %s.",
+      _name.c_str(), error.c_str());
+    return plan;
   }
 
   // Convert to world coordinates

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star_planner.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star_planner.hpp
@@ -25,7 +25,6 @@
 #include <vector>
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_core/global_planner.hpp"
-#include "nav2_core/exceptions.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "nav2_util/robot_utils.hpp"
 #include "nav2_util/lifecycle_node.hpp"

--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -89,35 +89,13 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
 
   // Corner case of start and goal beeing on the same cell
   unsigned int mx_start, my_start, mx_goal, my_goal;
-  if (!planner_->costmap_->worldToMap(
-      start.pose.position.x, start.pose.position.y, mx_start, my_start))
-  {
-    throw nav2_core::StartOutsideMapBounds(
-            "Start Coordinates of(" + std::to_string(start.pose.position.x) + ", " +
-            std::to_string(start.pose.position.y) + ") was outside bounds");
-  }
-
-  if (!planner_->costmap_->worldToMap(
-      goal.pose.position.x, goal.pose.position.y, mx_goal, my_goal))
-  {
-    throw nav2_core::GoalOutsideMapBounds(
-            "Goal Coordinates of(" + std::to_string(goal.pose.position.x) + ", " +
-            std::to_string(goal.pose.position.y) + ") was outside bounds");
-  }
-
-  if (planner_->costmap_->getCost(mx_start, my_start) == nav2_costmap_2d::LETHAL_OBSTACLE) {
-    throw nav2_core::StartOccupied(
-            "Start Coordinates of(" + std::to_string(start.pose.position.x) + ", " +
-            std::to_string(start.pose.position.y) + ") was in lethal cost");
-  }
-
-  if (planner_->costmap_->getCost(mx_goal, my_goal) == nav2_costmap_2d::LETHAL_OBSTACLE) {
-    throw nav2_core::GoalOccupied(
-            "Goal Coordinates of(" + std::to_string(goal.pose.position.x) + ", " +
-            std::to_string(goal.pose.position.y) + ") was in lethal cost");
-  }
-
+  planner_->costmap_->worldToMap(start.pose.position.x, start.pose.position.y, mx_start, my_start);
+  planner_->costmap_->worldToMap(goal.pose.position.x, goal.pose.position.y, mx_goal, my_goal);
   if (mx_start == mx_goal && my_start == my_goal) {
+    if (planner_->costmap_->getCost(mx_start, my_start) == nav2_costmap_2d::LETHAL_OBSTACLE) {
+      RCLCPP_WARN(logger_, "Failed to create a unique pose path because of obstacles");
+      return global_path;
+    }
     global_path.header.stamp = clock_->now();
     global_path.header.frame_id = global_frame_;
     geometry_msgs::msg::PoseStamped pose;
@@ -176,13 +154,13 @@ void ThetaStarPlanner::getPlan(nav_msgs::msg::Path & global_path)
 {
   std::vector<coordsW> path;
   if (planner_->isUnsafeToPlan()) {
+    RCLCPP_ERROR(logger_, "Either of the start or goal pose are an obstacle! ");
     global_path.poses.clear();
-    throw nav2_core::PlannerException("Either of the start or goal pose are an obstacle! ");
   } else if (planner_->generatePath(path)) {
     global_path = linearInterpolation(path, planner_->costmap_->getResolution());
   } else {
+    RCLCPP_ERROR(logger_, "Could not generate path between the given poses");
     global_path.poses.clear();
-    throw nav2_core::NoValidPathCouldBeFound("Could not generate path between the given poses");
   }
   global_path.header.stamp = clock_->now();
   global_path.header.frame_id = global_frame_;

--- a/nav2_theta_star_planner/test/test_theta_star.cpp
+++ b/nav2_theta_star_planner/test/test_theta_star.cpp
@@ -174,8 +174,8 @@ TEST(ThetaStarPlanner, test_theta_star_planner) {
   }
   goal.pose.position.x = 1.0;
   goal.pose.position.y = 1.0;
-
-  EXPECT_THROW(planner_2d->createPlan(start, goal), nav2_core::GoalOccupied);
+  path = planner_2d->createPlan(start, goal);
+  EXPECT_EQ(static_cast<int>(path.poses.size()), 0);
 
   planner_2d->deactivate();
   planner_2d->cleanup();


### PR DESCRIPTION
Reverts ros-planning/navigation2#3146

Having issues where its randomly saying that the start is occupied when clearly isn't. Example:

![Screenshot from 2022-10-10 17-00-27](https://user-images.githubusercontent.com/14944147/194970572-59b89edd-e8af-479d-aee8-9ac53dc8f709.png)

Makes navigation highly unreliable 