### PR TITLE
odom alpha restriction to avoid overflow caused by user-misconfiguration

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1164,7 +1164,8 @@ AmclNode::dynamicParametersCallback(
             get_logger(), "You've set alpha1 to be negative,"
             " this isn't allowed, so the alpha1 will be set to be zero.");
           alpha1_ = 0.0;
-        } else if (alpha1_ > 0.0) reinit_odom = true;
+        } 
+        reinit_odom = true;
       } else if (param_name == "alpha2") {
         alpha2_ = parameter.as_double();
         //alpha restricted to be non-negative
@@ -1173,7 +1174,8 @@ AmclNode::dynamicParametersCallback(
             get_logger(), "You've set alpha2 to be negative,"
             " this isn't allowed, so the alpha2 will be set to be zero.");
           alpha2_ = 0.0;
-        } else if (alpha2_ > 0.0) reinit_odom = true;
+        } 
+        reinit_odom = true;
       } else if (param_name == "alpha3") {
         alpha3_ = parameter.as_double();
         //alpha restricted to be non-negative
@@ -1182,7 +1184,8 @@ AmclNode::dynamicParametersCallback(
             get_logger(), "You've set alpha3 to be negative,"
             " this isn't allowed, so the alpha3 will be set to be zero.");
           alpha3_ = 0.0;
-        } else if (alpha3_ > 0.0) reinit_odom = true;
+        } 
+        reinit_odom = true;
       } else if (param_name == "alpha4") {
         alpha4_ = parameter.as_double();
         //alpha restricted to be non-negative
@@ -1191,7 +1194,8 @@ AmclNode::dynamicParametersCallback(
             get_logger(), "You've set alpha4 to be negative,"
             " this isn't allowed, so the alpha4 will be set to be zero.");
           alpha4_ = 0.0;
-        } else if (alpha4_ > 0.0) reinit_odom = true;
+        } 
+        reinit_odom = true;
       } else if (param_name == "alpha5") {
         alpha5_ = parameter.as_double();
         //alpha restricted to be non-negative
@@ -1200,7 +1204,8 @@ AmclNode::dynamicParametersCallback(
             get_logger(), "You've set alpha5 to be negative,"
             " this isn't allowed, so the alpha5 will be set to be zero.");
           alpha5_ = 0.0;
-        } else if (alpha5_ > 0.0) reinit_odom = true;
+        } 
+        reinit_odom = true;
       } else if (param_name == "beam_skip_distance") {
         beam_skip_distance_ = parameter.as_double();
         reinit_laser = true;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1158,19 +1158,54 @@ AmclNode::dynamicParametersCallback(
     if (param_type == ParameterType::PARAMETER_DOUBLE) {
       if (param_name == "alpha1") {
         alpha1_ = parameter.as_double();
-        reinit_odom = true;
+        //alpha restricted to be non-negative
+        if (alpha1_ < 0.0){
+          RCLCPP_WARN(
+            get_logger(), "You've set alpha1 to be negative,"
+            " this isn't allowed, so the alpha1 will be set to be zero.");
+          alpha1_ = 0.0;
+        }
+        else reinit_odom = true;
       } else if (param_name == "alpha2") {
         alpha2_ = parameter.as_double();
-        reinit_odom = true;
+        //alpha restricted to be non-negative
+        if (alpha2_ < 0.0){
+          RCLCPP_WARN(
+            get_logger(), "You've set alpha2 to be negative,"
+            " this isn't allowed, so the alpha2 will be set to be zero.");
+          alpha2_ = 0.0;
+        }
+        else reinit_odom = true;
       } else if (param_name == "alpha3") {
         alpha3_ = parameter.as_double();
-        reinit_odom = true;
+        //alpha restricted to be non-negative
+        if (alpha3_ < 0.0){
+          RCLCPP_WARN(
+            get_logger(), "You've set alpha3 to be negative,"
+            " this isn't allowed, so the alpha3 will be set to be zero.");
+          alpha3_ = 0.0;
+        }
+        else reinit_odom = true;
       } else if (param_name == "alpha4") {
         alpha4_ = parameter.as_double();
-        reinit_odom = true;
+        //alpha restricted to be non-negative
+        if (alpha4_ < 0.0){
+          RCLCPP_WARN(
+            get_logger(), "You've set alpha4 to be negative,"
+            " this isn't allowed, so the alpha4 will be set to be zero.");
+          alpha4_ = 0.0;
+        }
+        else reinit_odom = true;
       } else if (param_name == "alpha5") {
         alpha5_ = parameter.as_double();
-        reinit_odom = true;
+        //alpha restricted to be non-negative
+        if (alpha5_ < 0.0){
+          RCLCPP_WARN(
+            get_logger(), "You've set alpha5 to be negative,"
+            " this isn't allowed, so the alpha5 will be set to be zero.");
+          alpha5_ = 0.0;
+        }
+        else reinit_odom = true;
       } else if (param_name == "beam_skip_distance") {
         beam_skip_distance_ = parameter.as_double();
         reinit_laser = true;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1164,7 +1164,7 @@ AmclNode::dynamicParametersCallback(
             get_logger(), "You've set alpha1 to be negative,"
             " this isn't allowed, so the alpha1 will be set to be zero.");
           alpha1_ = 0.0;
-        } 
+        }
         reinit_odom = true;
       } else if (param_name == "alpha2") {
         alpha2_ = parameter.as_double();
@@ -1174,7 +1174,7 @@ AmclNode::dynamicParametersCallback(
             get_logger(), "You've set alpha2 to be negative,"
             " this isn't allowed, so the alpha2 will be set to be zero.");
           alpha2_ = 0.0;
-        } 
+        }
         reinit_odom = true;
       } else if (param_name == "alpha3") {
         alpha3_ = parameter.as_double();
@@ -1184,7 +1184,7 @@ AmclNode::dynamicParametersCallback(
             get_logger(), "You've set alpha3 to be negative,"
             " this isn't allowed, so the alpha3 will be set to be zero.");
           alpha3_ = 0.0;
-        } 
+        }
         reinit_odom = true;
       } else if (param_name == "alpha4") {
         alpha4_ = parameter.as_double();
@@ -1194,7 +1194,7 @@ AmclNode::dynamicParametersCallback(
             get_logger(), "You've set alpha4 to be negative,"
             " this isn't allowed, so the alpha4 will be set to be zero.");
           alpha4_ = 0.0;
-        } 
+        }
         reinit_odom = true;
       } else if (param_name == "alpha5") {
         alpha5_ = parameter.as_double();
@@ -1204,7 +1204,7 @@ AmclNode::dynamicParametersCallback(
             get_logger(), "You've set alpha5 to be negative,"
             " this isn't allowed, so the alpha5 will be set to be zero.");
           alpha5_ = 0.0;
-        } 
+        }
         reinit_odom = true;
       } else if (param_name == "beam_skip_distance") {
         beam_skip_distance_ = parameter.as_double();

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1159,53 +1159,48 @@ AmclNode::dynamicParametersCallback(
       if (param_name == "alpha1") {
         alpha1_ = parameter.as_double();
         //alpha restricted to be non-negative
-        if (alpha1_ < 0.0){
+        if (alpha1_ < 0.0) {
           RCLCPP_WARN(
             get_logger(), "You've set alpha1 to be negative,"
             " this isn't allowed, so the alpha1 will be set to be zero.");
           alpha1_ = 0.0;
-        }
-        else reinit_odom = true;
+        } else if (alpha1_ > 0.0) reinit_odom = true;
       } else if (param_name == "alpha2") {
         alpha2_ = parameter.as_double();
         //alpha restricted to be non-negative
-        if (alpha2_ < 0.0){
+        if (alpha2_ < 0.0) {
           RCLCPP_WARN(
             get_logger(), "You've set alpha2 to be negative,"
             " this isn't allowed, so the alpha2 will be set to be zero.");
           alpha2_ = 0.0;
-        }
-        else reinit_odom = true;
+        } else if (alpha2_ > 0.0) reinit_odom = true;
       } else if (param_name == "alpha3") {
         alpha3_ = parameter.as_double();
         //alpha restricted to be non-negative
-        if (alpha3_ < 0.0){
+        if (alpha3_ < 0.0) {
           RCLCPP_WARN(
             get_logger(), "You've set alpha3 to be negative,"
             " this isn't allowed, so the alpha3 will be set to be zero.");
           alpha3_ = 0.0;
-        }
-        else reinit_odom = true;
+        } else if (alpha3_ > 0.0) reinit_odom = true;
       } else if (param_name == "alpha4") {
         alpha4_ = parameter.as_double();
         //alpha restricted to be non-negative
-        if (alpha4_ < 0.0){
+        if (alpha4_ < 0.0) {
           RCLCPP_WARN(
             get_logger(), "You've set alpha4 to be negative,"
             " this isn't allowed, so the alpha4 will be set to be zero.");
           alpha4_ = 0.0;
-        }
-        else reinit_odom = true;
+        } else if (alpha4_ > 0.0) reinit_odom = true;
       } else if (param_name == "alpha5") {
         alpha5_ = parameter.as_double();
         //alpha restricted to be non-negative
-        if (alpha5_ < 0.0){
+        if (alpha5_ < 0.0) {
           RCLCPP_WARN(
             get_logger(), "You've set alpha5 to be negative,"
             " this isn't allowed, so the alpha5 will be set to be zero.");
           alpha5_ = 0.0;
-        }
-        else reinit_odom = true;
+        } else if (alpha5_ > 0.0) reinit_odom = true;
       } else if (param_name == "beam_skip_distance") {
         beam_skip_distance_ = parameter.as_double();
         reinit_laser = true;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |   |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of turtlebot |

---

## Description of contribution in a few bullet points

When any of the alphas get a negative value, it was tested that the navigation may be crashed with overflow visiting sample->pose when running pf_update_resample().
It's possibly because the odometryUpdate() went wrong with some sqrt functions in it obtaining a negative input(which is a sum of alpha*positive value)

## Description of documentation updates required from your changes
Add a check when getting the parameters in amcl_node.cpp, if any of them is negative, change it to zero and publish a warning.

---

## Future work that may be required in bullet points

* Maybe more checks during the update of odometry.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
