### PR TITLE
Dynamically changing polygons support

### DIFF
--- a/nav2_collision_monitor/README.md
+++ b/nav2_collision_monitor/README.md
@@ -27,7 +27,7 @@ The following models of safety behaviors are employed by Collision Monitor:
 
 The zones around the robot can take the following shapes:
 
-* Arbitrary user-defined polygon relative to the robot base frame.
+* Arbitrary statically user-defined polygon relative to the robot base frame, or dynamically published in a topic.
 * Circle: is made for the best performance and could be used in the cases where the zone or robot could be approximated by round shape.
 * Robot footprint polygon, which is used in the approach behavior model only. Will use the footprint topic to allow it to be dynamically adjusted over time.
 
@@ -43,7 +43,7 @@ The Collision Monitor is designed to operate below Nav2 as an independent safety
 This acts as a filter on the `cmd_vel` topic coming out of the Controller Server. If no such zone is triggered, then the Controller's `cmd_vel` is used. Else, it is scaled or set to stop as appropriate.
 
 The following diagram is showing the high-level design of Collision Monitor module. All shapes (Polygons and Circles) are derived from base `Polygon` class, so without loss of generality we can call them as polygons. Subscribed footprint is also having the same properties as other polygons, but it is being obtained a footprint topic for the Approach Model.
-![HDL.png](doc/HLD.png)
+![HLD.png](doc/HLD.png)
 
 ## Configuration
 

--- a/nav2_collision_monitor/README.md
+++ b/nav2_collision_monitor/README.md
@@ -28,8 +28,8 @@ The following models of safety behaviors are employed by Collision Monitor:
 The zones around the robot can take the following shapes:
 
 * Arbitrary user-defined polygon relative to the robot base frame, which can be static in a configuration file or dynamically changing via a topic interface.
-* Circle: is made for the best performance and could be used in the cases where the zone or robot could be approximated by round shape.
-* Robot footprint polygon, which is used in the approach behavior model only. Will use the footprint topic to allow it to be dynamically adjusted over time.
+* Robot footprint polygon, which is used in the approach behavior model only. Will use the static user-defined polygon or the footprint topic to allow it to be dynamically adjusted over time.
+* Circle: is made for the best performance and could be used in the cases where the zone or robot footprint could be approximated by round shape.
 
 The data may be obtained from different data sources:
 

--- a/nav2_collision_monitor/README.md
+++ b/nav2_collision_monitor/README.md
@@ -27,7 +27,7 @@ The following models of safety behaviors are employed by Collision Monitor:
 
 The zones around the robot can take the following shapes:
 
-* Arbitrary statically user-defined polygon relative to the robot base frame, or dynamically published in a topic.
+* Arbitrary user-defined polygon relative to the robot base frame, which can be static in a configuration file or dynamically changing via a topic interface.
 * Circle: is made for the best performance and could be used in the cases where the zone or robot could be approximated by round shape.
 * Robot footprint polygon, which is used in the approach behavior model only. Will use the footprint topic to allow it to be dynamically adjusted over time.
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
@@ -66,6 +66,11 @@ public:
    */
   int getPointsInside(const std::vector<Point> & points) const override;
 
+  /**
+   * @brief Specifies that the shape is always set for a circle object
+   */
+  bool isShapeSet() override {return true;}
+
 protected:
   /**
    * @brief Supporting routine obtaining polygon-specific ROS-parameters

--- a/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
@@ -74,7 +74,10 @@ protected:
    * there is no footprint subscription in this class.
    * @return True if all parameters were obtained or false in failure case
    */
-  bool getParameters(std::string & polygon_pub_topic, std::string & footprint_topic) override;
+  bool getParameters(
+    std::string & polygon_sub_topic,
+    std::string & polygon_pub_topic,
+    std::string & footprint_topic) override;
 
   // ----- Variables -----
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
@@ -69,6 +69,7 @@ public:
 protected:
   /**
    * @brief Supporting routine obtaining polygon-specific ROS-parameters
+   * @brief polygon_sub_topic Input name of polygon subscription topic
    * @param polygon_pub_topic Output name of polygon publishing topic
    * @param footprint_topic Output name of footprint topic. For Circle returns empty string,
    * there is no footprint subscription in this class.

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -111,6 +111,16 @@ public:
   virtual void getPolygon(std::vector<Point> & poly) const;
 
   /**
+   * @brief Obtains a transform from source_frame_id -> to base_frame_id_
+   * @param source_frame_id Source frame ID to convert data from
+   * @param tf_transform Output source->base transform
+   * @return True if got correct transform, otherwise false
+   */
+  bool getTransform(
+    const std::string & source_frame_id,
+    tf2::Transform & tf2_transform) const;
+
+  /**
    * @brief Updates polygon from footprint subscriber (if any)
    */
   void updatePolygon();

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -21,7 +21,6 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/polygon_stamped.hpp"
-#include "geometry_msgs/msg/polygon.hpp"
 
 #include "tf2/time.h"
 #include "tf2_ros/buffer.h"
@@ -138,7 +137,7 @@ public:
   /**
    * @brief Publishes polygon message into a its own topic
    */
-  void publish() const;
+  void publish();
 
 protected:
   /**
@@ -171,8 +170,8 @@ protected:
     tf2::Transform & tf2_transform) const;
 
   /**
-   * @brief Updates polygon from geometry_msgs::msg::Polygon points
-   * @param msg Polygon message to update points from
+   * @brief Updates polygon from geometry_msgs::msg::PolygonStamped message
+   * @param msg Message to update polygon from
    */
   void updatePolygon(geometry_msgs::msg::PolygonStamped::ConstSharedPtr msg);
 
@@ -225,8 +224,8 @@ protected:
   // Visualization
   /// @brief Whether to publish the polygon
   bool visualize_;
-  /// @brief Polygon points stored for later publishing
-  geometry_msgs::msg::Polygon polygon_;
+  /// @brief Polygon stored for later publishing
+  geometry_msgs::msg::PolygonStamped polygon_;
   /// @brief Polygon publisher for visualization purposes
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PolygonStamped>::SharedPtr polygon_pub_;
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -150,11 +150,27 @@ protected:
 
   /**
    * @brief Supporting routine obtaining polygon-specific ROS-parameters
+   * @brief polygon_sub_topic Input name of polygon subscription topic
    * @param polygon_pub_topic Output name of polygon publishing topic
    * @param footprint_topic Output name of footprint topic. Empty, if no footprint subscription
    * @return True if all parameters were obtained or false in failure case
    */
-  virtual bool getParameters(std::string & polygon_pub_topic, std::string & footprint_topic);
+  virtual bool getParameters(
+    std::string & polygon_sub_topic,
+    std::string & polygon_pub_topic,
+    std::string & footprint_topic);
+
+  /**
+   * @brief Updates polygon from geometry_msgs::msg::Polygon points
+   * @param msg Polygon message to update points from
+   */
+  void updatePolygon(geometry_msgs::msg::PolygonStamped::ConstSharedPtr msg);
+
+  /**
+   * @brief Dynamic polygon callback
+   * @param msg Shared pointer to the polygon message
+   */
+  void polygonCallback(geometry_msgs::msg::PolygonStamped::ConstSharedPtr msg);
 
   /**
    * @brief Checks if point is inside polygon
@@ -183,6 +199,8 @@ protected:
   double time_before_collision_;
   /// @brief Time step for robot movement simulation
   double simulation_time_step_;
+  /// @brief Polygon subscription
+  rclcpp::Subscription<geometry_msgs::msg::PolygonStamped>::SharedPtr polygon_sub_;
   /// @brief Footprint subscriber
   std::unique_ptr<nav2_costmap_2d::FootprintSubscriber> footprint_sub_;
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -110,6 +110,12 @@ public:
   virtual void getPolygon(std::vector<Point> & poly) const;
 
   /**
+   * @brief Returns true if polygon points were set.
+   * Othewise, prints a warning and returns false.
+   */
+  virtual bool isShapeSet();
+
+  /**
    * @brief Updates polygon from footprint subscriber (if any)
    */
   void updatePolygon();
@@ -149,9 +155,11 @@ protected:
 
   /**
    * @brief Supporting routine obtaining polygon-specific ROS-parameters
-   * @brief polygon_sub_topic Input name of polygon subscription topic
+   * @brief polygon_sub_topic Output name of polygon subscription topic.
+   * Empty, if no polygon subscription.
    * @param polygon_pub_topic Output name of polygon publishing topic
-   * @param footprint_topic Output name of footprint topic. Empty, if no footprint subscription
+   * @param footprint_topic Output name of footprint topic.
+   * Empty, if no footprint subscription.
    * @return True if all parameters were obtained or false in failure case
    */
   virtual bool getParameters(

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -111,16 +111,6 @@ public:
   virtual void getPolygon(std::vector<Point> & poly) const;
 
   /**
-   * @brief Obtains a transform from source_frame_id -> to base_frame_id_
-   * @param source_frame_id Source frame ID to convert data from
-   * @param tf_transform Output source->base transform
-   * @return True if got correct transform, otherwise false
-   */
-  bool getTransform(
-    const std::string & source_frame_id,
-    tf2::Transform & tf2_transform) const;
-
-  /**
    * @brief Updates polygon from footprint subscriber (if any)
    */
   void updatePolygon();
@@ -169,6 +159,16 @@ protected:
     std::string & polygon_sub_topic,
     std::string & polygon_pub_topic,
     std::string & footprint_topic);
+
+  /**
+   * @brief Obtains a transform from source_frame_id -> to base_frame_id_
+   * @param source_frame_id Source frame ID to convert data from
+   * @param tf_transform Output source->base transform
+   * @return True if got correct transform, otherwise false
+   */
+  bool getTransform(
+    const std::string & source_frame_id,
+    tf2::Transform & tf2_transform) const;
 
   /**
    * @brief Updates polygon from geometry_msgs::msg::Polygon points

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -160,16 +160,6 @@ protected:
     std::string & footprint_topic);
 
   /**
-   * @brief Obtains a transform from source_frame_id -> to base_frame_id_
-   * @param source_frame_id Source frame ID to convert data from
-   * @param tf_transform Output source->base transform
-   * @return True if got correct transform, otherwise false
-   */
-  bool getTransform(
-    const std::string & source_frame_id,
-    tf2::Transform & tf2_transform) const;
-
-  /**
    * @brief Updates polygon from geometry_msgs::msg::PolygonStamped message
    * @param msg Message to update polygon from
    */

--- a/nav2_collision_monitor/include/nav2_collision_monitor/source.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/source.hpp
@@ -88,21 +88,6 @@ protected:
     const rclcpp::Time & source_time,
     const rclcpp::Time & curr_time) const;
 
-  /**
-   * @brief Obtains a transform from source_frame_id at source_time ->
-   * to base_frame_id_ at curr_time time
-   * @param source_frame_id Source frame ID to convert data from
-   * @param source_time Source timestamp to convert data from
-   * @param curr_time Current node time to interpolate data to
-   * @param tf_transform Output source->base transform
-   * @return True if got correct transform, otherwise false
-   */
-  bool getTransform(
-    const std::string & source_frame_id,
-    const rclcpp::Time & source_time,
-    const rclcpp::Time & curr_time,
-    tf2::Transform & tf_transform) const;
-
   // ----- Variables -----
 
   /// @brief Collision Monitor node

--- a/nav2_collision_monitor/src/circle.cpp
+++ b/nav2_collision_monitor/src/circle.cpp
@@ -70,7 +70,10 @@ int Circle::getPointsInside(const std::vector<Point> & points) const
   return num;
 }
 
-bool Circle::getParameters(std::string & polygon_pub_topic, std::string & footprint_topic)
+bool Circle::getParameters(
+  std::string & polygon_sub_topic,
+  std::string & polygon_pub_topic,
+  std::string & footprint_topic)
 {
   auto node = node_.lock();
   if (!node) {
@@ -81,7 +84,8 @@ bool Circle::getParameters(std::string & polygon_pub_topic, std::string & footpr
     return false;
   }
 
-  // There is no footprint subscription for the Circle. Thus, set string as empty.
+  // There is no polygon or footprint subscription for the Circle. Thus, set strings as empty.
+  polygon_sub_topic.clear();
   footprint_topic.clear();
 
   try {

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -389,6 +389,10 @@ bool CollisionMonitor::processStopSlowdown(
   const Velocity & velocity,
   Action & robot_action) const
 {
+  if (!polygon->isShapeSet()) {
+    return false;
+  }
+
   if (polygon->getPointsInside(collision_points) > polygon->getMaxPoints()) {
     if (polygon->getActionType() == STOP) {
       // Setting up zero velocity for STOP model
@@ -419,6 +423,10 @@ bool CollisionMonitor::processApproach(
   Action & robot_action) const
 {
   polygon->updatePolygon();
+
+  if (!polygon->isShapeSet()) {
+    return false;
+  }
 
   // Obtain time before a collision
   const double collision_time = polygon->getCollisionTime(collision_points, velocity);

--- a/nav2_collision_monitor/src/pointcloud.cpp
+++ b/nav2_collision_monitor/src/pointcloud.cpp
@@ -19,6 +19,7 @@
 #include "sensor_msgs/point_cloud2_iterator.hpp"
 
 #include "nav2_util/node_utils.hpp"
+#include "nav2_util/robot_utils.hpp"
 
 namespace nav2_collision_monitor
 {
@@ -78,7 +79,12 @@ void PointCloud::getData(
   // Obtaining the transform to get data from source frame and time where it was received
   // to the base frame and current time
   tf2::Transform tf_transform;
-  if (!getTransform(data_->header.frame_id, data_->header.stamp, curr_time, tf_transform)) {
+  if (
+    !nav2_util::getTransform(
+      data_->header.frame_id, data_->header.stamp,
+      base_frame_id_, curr_time, global_frame_id_,
+      transform_tolerance_, tf_buffer_, tf_transform))
+  {
     return;
   }
 

--- a/nav2_collision_monitor/src/range.cpp
+++ b/nav2_collision_monitor/src/range.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 
 #include "nav2_util/node_utils.hpp"
+#include "nav2_util/robot_utils.hpp"
 
 namespace nav2_collision_monitor
 {
@@ -87,7 +88,12 @@ void Range::getData(
   // Obtaining the transform to get data from source frame and time where it was received
   // to the base frame and current time
   tf2::Transform tf_transform;
-  if (!getTransform(data_->header.frame_id, data_->header.stamp, curr_time, tf_transform)) {
+  if (
+    !nav2_util::getTransform(
+      data_->header.frame_id, data_->header.stamp,
+      base_frame_id_, curr_time, global_frame_id_,
+      transform_tolerance_, tf_buffer_, tf_transform))
+  {
     return;
   }
 

--- a/nav2_collision_monitor/src/scan.cpp
+++ b/nav2_collision_monitor/src/scan.cpp
@@ -17,6 +17,8 @@
 #include <cmath>
 #include <functional>
 
+#include "nav2_util/robot_utils.hpp"
+
 namespace nav2_collision_monitor
 {
 
@@ -76,7 +78,12 @@ void Scan::getData(
   // Obtaining the transform to get data from source frame and time where it was received
   // to the base frame and current time
   tf2::Transform tf_transform;
-  if (!getTransform(data_->header.frame_id, data_->header.stamp, curr_time, tf_transform)) {
+  if (
+    !nav2_util::getTransform(
+      data_->header.frame_id, data_->header.stamp,
+      base_frame_id_, curr_time, global_frame_id_,
+      transform_tolerance_, tf_buffer_, tf_transform))
+  {
     return;
   }
 

--- a/nav2_collision_monitor/src/source.cpp
+++ b/nav2_collision_monitor/src/source.cpp
@@ -18,9 +18,6 @@
 
 #include "geometry_msgs/msg/transform_stamped.hpp"
 
-#include "tf2/convert.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
-
 #include "nav2_util/node_utils.hpp"
 
 namespace nav2_collision_monitor
@@ -73,35 +70,6 @@ bool Source::sourceValid(
     return false;
   }
 
-  return true;
-}
-
-bool Source::getTransform(
-  const std::string & source_frame_id,
-  const rclcpp::Time & source_time,
-  const rclcpp::Time & curr_time,
-  tf2::Transform & tf2_transform) const
-{
-  geometry_msgs::msg::TransformStamped transform;
-  tf2_transform.setIdentity();  // initialize by identical transform
-
-  try {
-    // Obtaining the transform to get data from source to base frame.
-    // This also considers the time shift between source and base.
-    transform = tf_buffer_->lookupTransform(
-      base_frame_id_, curr_time,
-      source_frame_id, source_time,
-      global_frame_id_, transform_tolerance_);
-  } catch (tf2::TransformException & e) {
-    RCLCPP_ERROR(
-      logger_,
-      "[%s]: Failed to get \"%s\"->\"%s\" frame transform: %s",
-      source_name_.c_str(), source_frame_id.c_str(), base_frame_id_.c_str(), e.what());
-    return false;
-  }
-
-  // Convert TransformStamped to TF2 transform
-  tf2::fromMsg(transform.transform, tf2_transform);
   return true;
 }
 

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -41,7 +41,8 @@ static constexpr double EPSILON = std::numeric_limits<float>::epsilon();
 
 static const char BASE_FRAME_ID[]{"base_link"};
 static const char FOOTPRINT_TOPIC[]{"footprint"};
-static const char POLYGON_PUB_TOPIC[]{"polygon"};
+static const char POLYGON_SUB_TOPIC[]{"polygon_sub"};
+static const char POLYGON_PUB_TOPIC[]{"polygon_pub"};
 static const char POLYGON_NAME[]{"TestPolygon"};
 static const char CIRCLE_NAME[]{"TestCircle"};
 static const std::vector<double> SQUARE_POLYGON {
@@ -68,7 +69,36 @@ public:
 
   ~TestNode()
   {
+    polygon_pub_.reset();
     footprint_pub_.reset();
+  }
+
+  void publishPolygon(const bool is_correct)
+  {
+    polygon_pub_ = this->create_publisher<geometry_msgs::msg::PolygonStamped>(
+      POLYGON_SUB_TOPIC, rclcpp::SystemDefaultsQoS());
+
+    std::unique_ptr<geometry_msgs::msg::PolygonStamped> msg =
+      std::make_unique<geometry_msgs::msg::PolygonStamped>();
+
+    unsigned int polygon_size;
+    if (is_correct) {
+      polygon_size = SQUARE_POLYGON.size();
+    } else {
+      polygon_size = 2;
+    }
+
+    msg->header.frame_id = BASE_FRAME_ID;
+    msg->header.stamp = this->now();
+
+    geometry_msgs::msg::Point32 p;
+    for (unsigned int i = 0; i < polygon_size; i = i + 2) {
+      p.x = SQUARE_POLYGON[i];
+      p.y = SQUARE_POLYGON[i + 1];
+      msg->polygon.points.push_back(p);
+    }
+
+    polygon_pub_->publish(std::move(msg));
   }
 
   void publishFootprint()
@@ -112,6 +142,7 @@ public:
   }
 
 private:
+  rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr polygon_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr footprint_pub_;
   rclcpp::Subscription<geometry_msgs::msg::PolygonStamped>::SharedPtr polygon_sub_;
 
@@ -177,12 +208,19 @@ public:
 protected:
   // Working with parameters
   void setCommonParameters(const std::string & polygon_name, const std::string & action_type);
-  void setPolygonParameters(const std::vector<double> & points);
+  void setPolygonParameters(
+    const std::vector<double> & points,
+    const std::string polygon_sub_topic);
   void setCircleParameters(const double radius);
   bool checkUndeclaredParameter(const std::string & polygon_name, const std::string & param);
   // Creating routines
-  void createPolygon(const std::string & action_type);
+  void createPolygon(const std::string & action_type, const std::string & polygon_sub_topic);
   void createCircle(const std::string & action_type);
+
+  // Wait until polygon will be received
+  bool waitPolygon(
+    const std::chrono::nanoseconds & timeout,
+    std::vector<nav2_collision_monitor::Point> & poly);
 
   // Wait until footprint will be received
   bool waitFootprint(
@@ -257,17 +295,25 @@ void Tester::setCommonParameters(const std::string & polygon_name, const std::st
     rclcpp::Parameter(polygon_name + ".polygon_pub_topic", POLYGON_PUB_TOPIC));
 }
 
-void Tester::setPolygonParameters(const std::vector<double> & points)
+void Tester::setPolygonParameters(
+  const std::vector<double> & points, const std::string polygon_sub_topic)
 {
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".footprint_topic", rclcpp::ParameterValue(FOOTPRINT_TOPIC));
   test_node_->set_parameter(
     rclcpp::Parameter(std::string(POLYGON_NAME) + ".footprint_topic", FOOTPRINT_TOPIC));
 
-  test_node_->declare_parameter(
-    std::string(POLYGON_NAME) + ".points", rclcpp::ParameterValue(points));
-  test_node_->set_parameter(
-    rclcpp::Parameter(std::string(POLYGON_NAME) + ".points", points));
+  if (!polygon_sub_topic.empty()) {
+    test_node_->declare_parameter(
+      std::string(POLYGON_NAME) + ".polygon_sub_topic", rclcpp::ParameterValue(polygon_sub_topic));
+    test_node_->set_parameter(
+      rclcpp::Parameter(std::string(POLYGON_NAME) + ".polygon_sub_topic", polygon_sub_topic));
+  } else {
+    test_node_->declare_parameter(
+      std::string(POLYGON_NAME) + ".points", rclcpp::ParameterValue(points));
+    test_node_->set_parameter(
+      rclcpp::Parameter(std::string(POLYGON_NAME) + ".points", points));
+  }
 }
 
 void Tester::setCircleParameters(const double radius)
@@ -296,10 +342,10 @@ bool Tester::checkUndeclaredParameter(const std::string & polygon_name, const st
   return ret;
 }
 
-void Tester::createPolygon(const std::string & action_type)
+void Tester::createPolygon(const std::string & action_type, const std::string & polygon_sub_topic)
 {
   setCommonParameters(POLYGON_NAME, action_type);
-  setPolygonParameters(SQUARE_POLYGON);
+  setPolygonParameters(SQUARE_POLYGON, polygon_sub_topic);
 
   polygon_ = std::make_shared<PolygonWrapper>(
     test_node_, POLYGON_NAME,
@@ -318,6 +364,22 @@ void Tester::createCircle(const std::string & action_type)
     tf_buffer_, BASE_FRAME_ID, TRANSFORM_TOLERANCE);
   ASSERT_TRUE(circle_->configure());
   circle_->activate();
+}
+
+bool Tester::waitPolygon(
+  const std::chrono::nanoseconds & timeout,
+  std::vector<nav2_collision_monitor::Point> & poly)
+{
+  rclcpp::Time start_time = test_node_->now();
+  while (rclcpp::ok() && test_node_->now() - start_time <= rclcpp::Duration(timeout)) {
+    polygon_->getPolygon(poly);
+    if (poly.size() > 0) {
+      return true;
+    }
+    rclcpp::spin_some(test_node_->get_node_base_interface());
+    std::this_thread::sleep_for(10ms);
+  }
+  return false;
 }
 
 bool Tester::waitFootprint(
@@ -339,7 +401,7 @@ bool Tester::waitFootprint(
 
 TEST_F(Tester, testPolygonGetStopParameters)
 {
-  createPolygon("stop");
+  createPolygon("stop", "");
 
   // Check that common parameters set correctly
   EXPECT_EQ(polygon_->getName(), POLYGON_NAME);
@@ -363,7 +425,7 @@ TEST_F(Tester, testPolygonGetStopParameters)
 
 TEST_F(Tester, testPolygonGetSlowdownParameters)
 {
-  createPolygon("slowdown");
+  createPolygon("slowdown", "");
 
   // Check that common parameters set correctly
   EXPECT_EQ(polygon_->getName(), POLYGON_NAME);
@@ -376,7 +438,7 @@ TEST_F(Tester, testPolygonGetSlowdownParameters)
 
 TEST_F(Tester, testPolygonGetApproachParameters)
 {
-  createPolygon("approach");
+  createPolygon("approach", "");
 
   // Check that common parameters set correctly
   EXPECT_EQ(polygon_->getName(), POLYGON_NAME);
@@ -431,7 +493,7 @@ TEST_F(Tester, testPolygonUndeclaredPoints)
 TEST_F(Tester, testPolygonIncorrectActionType)
 {
   setCommonParameters(POLYGON_NAME, "incorrect_action_type");
-  setPolygonParameters(SQUARE_POLYGON);
+  setPolygonParameters(SQUARE_POLYGON, "");
 
   polygon_ = std::make_shared<PolygonWrapper>(
     test_node_, POLYGON_NAME,
@@ -486,9 +548,35 @@ TEST_F(Tester, testCircleUndeclaredRadius)
   ASSERT_TRUE(checkUndeclaredParameter(CIRCLE_NAME, "radius"));
 }
 
-TEST_F(Tester, testPolygonUpdate)
+TEST_F(Tester, testPolygonTopicUpdate)
 {
-  createPolygon("approach");
+  createPolygon("stop", POLYGON_SUB_TOPIC);
+
+  std::vector<nav2_collision_monitor::Point> poly;
+  polygon_->getPolygon(poly);
+  ASSERT_EQ(poly.size(), 0u);
+
+  // Publish incorrect shape and check that polygon was not updated
+  test_node_->publishPolygon(false);
+  ASSERT_FALSE(waitPolygon(100ms, poly));
+
+  // Publush correct polygon and make shure that it was set correctly
+  test_node_->publishPolygon(true);
+  ASSERT_TRUE(waitPolygon(500ms, poly));
+  ASSERT_EQ(poly.size(), 4u);
+  EXPECT_NEAR(poly[0].x, SQUARE_POLYGON[0], EPSILON);
+  EXPECT_NEAR(poly[0].y, SQUARE_POLYGON[1], EPSILON);
+  EXPECT_NEAR(poly[1].x, SQUARE_POLYGON[2], EPSILON);
+  EXPECT_NEAR(poly[1].y, SQUARE_POLYGON[3], EPSILON);
+  EXPECT_NEAR(poly[2].x, SQUARE_POLYGON[4], EPSILON);
+  EXPECT_NEAR(poly[2].y, SQUARE_POLYGON[5], EPSILON);
+  EXPECT_NEAR(poly[3].x, SQUARE_POLYGON[6], EPSILON);
+  EXPECT_NEAR(poly[3].y, SQUARE_POLYGON[7], EPSILON);
+}
+
+TEST_F(Tester, testPolygonFootprintUpdate)
+{
+  createPolygon("approach", "");
 
   std::vector<nav2_collision_monitor::Point> poly;
   polygon_->getPolygon(poly);
@@ -512,7 +600,7 @@ TEST_F(Tester, testPolygonUpdate)
 
 TEST_F(Tester, testPolygonGetPointsInside)
 {
-  createPolygon("stop");
+  createPolygon("stop", "");
 
   std::vector<nav2_collision_monitor::Point> points;
 
@@ -533,7 +621,7 @@ TEST_F(Tester, testPolygonGetPointsInsideEdge)
   // Test for checking edge cases in raytracing algorithm.
   // All points are lie on the edge lines parallel to OX, where the raytracing takes place.
   setCommonParameters(POLYGON_NAME, "stop");
-  setPolygonParameters(ARBITRARY_POLYGON);
+  setPolygonParameters(ARBITRARY_POLYGON, "");
 
   polygon_ = std::make_shared<PolygonWrapper>(
     test_node_, POLYGON_NAME,
@@ -572,7 +660,7 @@ TEST_F(Tester, testCircleGetPointsInside)
 
 TEST_F(Tester, testPolygonGetCollisionTime)
 {
-  createPolygon("approach");
+  createPolygon("approach", "");
 
   // Set footprint for Polygon
   test_node_->publishFootprint();
@@ -640,7 +728,7 @@ TEST_F(Tester, testPolygonGetCollisionTime)
 
 TEST_F(Tester, testPolygonPublish)
 {
-  createPolygon("stop");
+  createPolygon("stop", "");
   polygon_->publish();
   geometry_msgs::msg::PolygonStamped::SharedPtr polygon_received =
     test_node_->waitPolygonReceived(500ms);
@@ -666,7 +754,7 @@ TEST_F(Tester, testPolygonDefaultVisualize)
     std::string(POLYGON_NAME) + ".action_type", rclcpp::ParameterValue("stop"));
   test_node_->set_parameter(
     rclcpp::Parameter(std::string(POLYGON_NAME) + ".action_type", "stop"));
-  setPolygonParameters(SQUARE_POLYGON);
+  setPolygonParameters(SQUARE_POLYGON, "");
 
   // Create new polygon
   polygon_ = std::make_shared<PolygonWrapper>(

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -503,7 +503,7 @@ TEST_F(Tester, testPolygonUndeclaredActionType)
 
 TEST_F(Tester, testPolygonUndeclaredPoints)
 {
-  // "points" parameter is not initialized
+  // "points" and "polygon_sub_topic" parameters are not initialized
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + ".action_type", rclcpp::ParameterValue("stop"));
   test_node_->set_parameter(
@@ -512,8 +512,9 @@ TEST_F(Tester, testPolygonUndeclaredPoints)
     test_node_, POLYGON_NAME,
     tf_buffer_, BASE_FRAME_ID, TRANSFORM_TOLERANCE);
   ASSERT_FALSE(polygon_->configure());
-  // Check that "points" parameter is not set after configuring
+  // Check that "points" and "polygon_sub_topic" parameters are not set after configuring
   ASSERT_TRUE(checkUndeclaredParameter(POLYGON_NAME, "points"));
+  ASSERT_TRUE(checkUndeclaredParameter(POLYGON_NAME, "polygon_sub_topic"));
 }
 
 TEST_F(Tester, testPolygonIncorrectActionType)

--- a/nav2_util/include/nav2_util/robot_utils.hpp
+++ b/nav2_util/include/nav2_util/robot_utils.hpp
@@ -18,8 +18,10 @@
 #define NAV2_UTIL__ROBOT_UTILS_HPP_
 
 #include <string>
+#include <memory>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "tf2/time.h"
 #include "tf2_ros/buffer.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -55,6 +57,57 @@ bool transformPoseInTargetFrame(
   geometry_msgs::msg::PoseStamped & transformed_pose,
   tf2_ros::Buffer & tf_buffer, const std::string target_frame,
   const double transform_timeout = 0.1);
+
+/**
+ * @brief Obtains a transform from source_frame_id at source_time ->
+ * to target_frame_id at target_time time
+ * @param source_frame_id Source frame ID to convert from
+ * @param source_time Source timestamp to convert from
+ * @param target_frame_id Target frame ID to convert to
+ * @param target_time Current node time to interpolate to
+ * @param transform_tolerance Transform tolerance
+ * @param tf_transform Output source->target transform
+ * @return True if got correct transform, otherwise false
+ */
+
+/**
+ * @brief Obtains a transform from source_frame_id -> to target_frame_id
+ * @param source_frame_id Source frame ID to convert from
+ * @param target_frame_id Target frame ID to convert to
+ * @param transform_tolerance Transform tolerance
+ * @param tf_buffer TF buffer to use for the transformation
+ * @param tf_transform Output source->target transform
+ * @return True if got correct transform, otherwise false
+ */
+bool getTransform(
+  const std::string & source_frame_id,
+  const std::string & target_frame_id,
+  const tf2::Duration & transform_tolerance,
+  const std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+  tf2::Transform & tf2_transform);
+
+/**
+ * @brief Obtains a transform from source_frame_id at source_time ->
+ * to target_frame_id at target_time time
+ * @param source_frame_id Source frame ID to convert from
+ * @param source_time Source timestamp to convert from
+ * @param target_frame_id Target frame ID to convert to
+ * @param target_time Current node time to interpolate to
+ * @param fixed_frame_id The frame in which to assume the transform is constant in time
+ * @param transform_tolerance Transform tolerance
+ * @param tf_buffer TF buffer to use for the transformation
+ * @param tf_transform Output source->target transform
+ * @return True if got correct transform, otherwise false
+ */
+bool getTransform(
+  const std::string & source_frame_id,
+  const rclcpp::Time & source_time,
+  const std::string & target_frame_id,
+  const rclcpp::Time & target_time,
+  const std::string & fixed_frame_id,
+  const tf2::Duration & transform_tolerance,
+  const std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+  tf2::Transform & tf2_transform);
 
 }  // end namespace nav2_util
 

--- a/nav2_util/include/nav2_util/robot_utils.hpp
+++ b/nav2_util/include/nav2_util/robot_utils.hpp
@@ -64,7 +64,7 @@ bool transformPoseInTargetFrame(
  * @param source_frame_id Source frame ID to convert from
  * @param source_time Source timestamp to convert from
  * @param target_frame_id Target frame ID to convert to
- * @param target_time Current node time to interpolate to
+ * @param target_time Target time to interpolate to
  * @param transform_tolerance Transform tolerance
  * @param tf_transform Output source->target transform
  * @return True if got correct transform, otherwise false

--- a/nav2_util/src/robot_utils.cpp
+++ b/nav2_util/src/robot_utils.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <memory>
 
+#include "tf2/convert.h"
 #include "nav2_util/robot_utils.hpp"
 #include "rclcpp/logger.hpp"
 
@@ -73,6 +74,72 @@ bool transformPoseInTargetFrame(
   }
 
   return false;
+}
+
+bool getTransform(
+  const std::string & source_frame_id,
+  const std::string & target_frame_id,
+  const tf2::Duration & transform_tolerance,
+  const std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+  tf2::Transform & tf2_transform)
+{
+  geometry_msgs::msg::TransformStamped transform;
+  tf2_transform.setIdentity();  // initialize by identical transform
+
+  if (source_frame_id == target_frame_id) {
+    // We are already in required frame
+    return true;
+  }
+
+  try {
+    // Obtaining the transform to get data from source to target frame
+    transform = tf_buffer->lookupTransform(
+      target_frame_id, source_frame_id,
+      tf2::TimePointZero, transform_tolerance);
+  } catch (tf2::TransformException & e) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("getTransform"),
+      "Failed to get \"%s\"->\"%s\" frame transform: %s",
+      source_frame_id.c_str(), target_frame_id.c_str(), e.what());
+    return false;
+  }
+
+  // Convert TransformStamped to TF2 transform
+  tf2::fromMsg(transform.transform, tf2_transform);
+  return true;
+}
+
+bool getTransform(
+  const std::string & source_frame_id,
+  const rclcpp::Time & source_time,
+  const std::string & target_frame_id,
+  const rclcpp::Time & target_time,
+  const std::string & fixed_frame_id,
+  const tf2::Duration & transform_tolerance,
+  const std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+  tf2::Transform & tf2_transform)
+{
+  geometry_msgs::msg::TransformStamped transform;
+  tf2_transform.setIdentity();  // initialize by identical transform
+
+  try {
+    // Obtaining the transform to get data from source to target frame.
+    // This also considers the time shift between source and target.
+    transform = tf_buffer->lookupTransform(
+      target_frame_id, target_time,
+      source_frame_id, source_time,
+      fixed_frame_id, transform_tolerance);
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("getTransform"),
+      "Failed to get \"%s\"->\"%s\" frame transform: %s",
+      source_frame_id.c_str(), target_frame_id.c_str(), ex.what());
+    return false;
+  }
+
+  // Convert TransformStamped to TF2 transform
+  tf2::fromMsg(transform.transform, tf2_transform);
+  return true;
 }
 
 }  // end namespace nav2_util


### PR DESCRIPTION
Adding an ability to dynamically read polygon vertices from input topic for "STOP" and "SLOWDOWN" behavior models.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3196 |
| Primary OS tested on | Ubuntu 20.04 with ROS2 Rolling onboard |
| Robotic platform tested on | TB3 simulation, unit & codecov testing |

---

## Description of contribution in a few bullet points

* New ROS-parameter `polygon_sub_topic`. If it is set, subscribe to the polygon from input `PolygonStamped` messages. If not - use classical static user-defined polygon vertices.
* Allowing to use polygon shape published in a different from `robot_base` frame by reading `PolygonStamped->header.frame_id`.
* The change applied to "STOP" and "SLOWDOWN" behavior models, since for "APPROACH" one we have already utilized footprint subscriber.

## Description of documentation updates required from your changes

After the change will be reviewed and agreed, new `polygon_sub_topic` and its related logic will be added to the documentation pages.

---

## Future work that may be required in bullet points

* Update official Nav2 docs


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
