### PR TITLE
catch Extrapolation Exception when a bad map frame location.

### DIFF
--- a/nav2_costmap_2d/src/observation_buffer.cpp
+++ b/nav2_costmap_2d/src/observation_buffer.cpp
@@ -162,6 +162,15 @@ void ObservationBuffer::bufferCloud(const sensor_msgs::msg::PointCloud2 & cloud)
       sensor_frame_.c_str(),
       cloud.header.frame_id.c_str(), ex.what());
     return;
+  } catch (tf2::ExtrapolationException & ex) {
+    // if an exception occurs, we need to remove the empty observation from the list
+    observation_list_.pop_front();
+    RCLCPP_ERROR(
+      logger_,
+      "TF Extrapolation Exception that should never happen for sensor frame: %s, cloud frame: %s, %s",
+      sensor_frame_.c_str(),
+      cloud.header.frame_id.c_str(), ex.what());
+    return;
   }
 
   // if the update was successful, we want to update the last updated time

--- a/nav2_costmap_2d/src/observation_buffer.cpp
+++ b/nav2_costmap_2d/src/observation_buffer.cpp
@@ -171,7 +171,7 @@ void ObservationBuffer::bufferCloud(const sensor_msgs::msg::PointCloud2 & cloud)
       sensor_frame_.c_str(),
       cloud.header.frame_id.c_str(), ex.what());
     return;
-  } 
+  }
 
   // if the update was successful, we want to update the last updated time
   last_updated_ = clock_->now();

--- a/nav2_costmap_2d/src/observation_buffer.cpp
+++ b/nav2_costmap_2d/src/observation_buffer.cpp
@@ -153,15 +153,6 @@ void ObservationBuffer::bufferCloud(const sensor_msgs::msg::PointCloud2 & cloud)
     modifier.resize(point_count);
     observation_cloud.header.stamp = cloud.header.stamp;
     observation_cloud.header.frame_id = global_frame_cloud.header.frame_id;
-  } catch (tf2::TransformException & ex) {
-    // if an exception occurs, we need to remove the empty observation from the list
-    observation_list_.pop_front();
-    RCLCPP_ERROR(
-      logger_,
-      "TF Exception that should never happen for sensor frame: %s, cloud frame: %s, %s",
-      sensor_frame_.c_str(),
-      cloud.header.frame_id.c_str(), ex.what());
-    return;
   } catch (tf2::ExtrapolationException & ex) {
     // if an exception occurs, we need to remove the empty observation from the list
     observation_list_.pop_front();
@@ -171,7 +162,16 @@ void ObservationBuffer::bufferCloud(const sensor_msgs::msg::PointCloud2 & cloud)
       sensor_frame_.c_str(),
       cloud.header.frame_id.c_str(), ex.what());
     return;
-  }
+  } catch (tf2::TransformException & ex) {
+    // if an exception occurs, we need to remove the empty observation from the list
+    observation_list_.pop_front();
+    RCLCPP_ERROR(
+      logger_,
+      "TF Exception that should never happen for sensor frame: %s, cloud frame: %s, %s",
+      sensor_frame_.c_str(),
+      cloud.header.frame_id.c_str(), ex.what());
+    return;
+  } 
 
   // if the update was successful, we want to update the last updated time
   last_updated_ = clock_->now();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |   |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of turtlebot |

---

## Description of contribution in a few bullet points

A simple exception catch for robusting the code with some malformed messages, just like #2511.

The detailed crash info is following:
```
[INFO] [1664191509.857372862] [global_costmap.global_costmap]: Timed out waiting for transform from base_link to map to become available, tf error: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[INFO] [1664191510.357362318] [global_costmap.global_costmap]: Timed out waiting for transform from base_link to map to become available, tf error: Invalid frame ID "map" passed to canTransform argument target_frame - frame does not exist
[INFO] [1664191510.857486959] [global_costmap.global_costmap]: Timed out waiting for transform from base_link to map to become available, tf error: Lookup would require extrapolation into the past.  Requested time 4.486000 but the earliest data is at time 4.776000, when looking up transform from frame [base_link] to frame [map]
[INFO] [1664191511.357613276] [global_costmap.global_costmap]: start
[INFO] [1664191525.125322336] [global_costmap.global_costmap_rclcpp_node]: Message Filter dropping message: frame 'base_scan' at time 6.000 for reason 'Unknown'
terminate called after throwing an instance of 'tf2::ExtrapolationException'
  what():  Lookup would require extrapolation into the past.  Requested time 8.376000 but the earliest data is at time 8.396000, when looking up transform from frame [base_scan] to frame [map]
```
 It seems map_server and navigator got bad observations and failed to get a good `map-odom tf` in some timestamps, so that `base_link-map tf` was not available when extrapolation, which is caught by the function in `robot_utils.cpp`,  as following:
```
bool transformPoseInTargetFrame(
  const geometry_msgs::msg::PoseStamped & input_pose,
  geometry_msgs::msg::PoseStamped & transformed_pose,
  tf2_ros::Buffer & tf_buffer, const std::string target_frame,
  const double transform_timeout)
{
  static rclcpp::Logger logger = rclcpp::get_logger("transformPoseInTargetFrame");
  try {
    transformed_pose = tf_buffer.transform(
      input_pose, target_frame,
      tf2::durationFromSec(transform_timeout));
    return true;
  } catch (tf2::LookupException & ex) {
    ...
  } catch (tf2::ExtrapolationException & ex) {
    RCLCPP_ERROR(
      logger,
      "Extrapolation Error looking up target frame: %s\n", ex.what());
  } catch (tf2::TransformException & ex) {
    RCLCPP_ERROR(
      logger, "Failed to transform from %s to %s",
      input_pose.header.frame_id.c_str(), target_frame.c_str());
  }
  return false;
}
```
and for the globalization of local obseration in `observation_buffer.cpp`, a `base_scan-map tf` is needed to transform the local observation to global space and might be also unavailable for the above reason, the exception is just like the `TransformException`, can be caught in the same way:

```
try {
    // given these observations come from sensors...
    // we'll need to store the origin pt of the sensor
    geometry_msgs::msg::PointStamped local_origin;
    local_origin.header.stamp = cloud.header.stamp;
    local_origin.header.frame_id = origin_frame;
   ...
    sensor_msgs::msg::PointCloud2 global_frame_cloud;
    // transform the point cloud
    tf2_buffer_.transform(cloud, global_frame_cloud, global_frame_, tf_tolerance_);
   ...
     } catch (tf2::TransformException & ex) {
    // if an exception occurs, we need to remove the empty observation from the list
    observation_list_.pop_front();
    RCLCPP_ERROR(
      logger_,
      "TF Exception that should never happen for sensor frame: %s, cloud frame: %s, %s",
      sensor_frame_.c_str(),
      cloud.header.frame_id.c_str(), ex.what());
    return;
  }

```

## Description of documentation updates required from your changes

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
