### PR TITLE
Add allow_unknown parameter to theta star planner

### DIFF
--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
@@ -95,7 +95,9 @@ public:
    */
   inline bool isSafe(const int & cx, const int & cy) const
   {
-    return (costmap_->getCost(cx, cy) == UNKNOWN_COST && allow_unknown_) || costmap_->getCost(cx, cy) < LETHAL_COST;
+    return (costmap_->getCost(
+             cx,
+             cy) == UNKNOWN_COST && allow_unknown_) || costmap_->getCost(cx, cy) < LETHAL_COST;
   }
 
   /**
@@ -190,7 +192,7 @@ protected:
   {
     double curr_cost = getCost(cx, cy);
     if ((costmap_->getCost(cx, cy) == UNKNOWN_COST && allow_unknown_) || curr_cost < LETHAL_COST) {
-      if(costmap_->getCost(cx, cy) == UNKNOWN_COST) {
+      if (costmap_->getCost(cx, cy) == UNKNOWN_COST) {
         curr_cost = OBS_COST - 1;
       }
       cost += w_traversal_cost_ * curr_cost * curr_cost / LETHAL_COST / LETHAL_COST;

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
@@ -24,8 +24,9 @@
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 
 const double INF_COST = DBL_MAX;
-const int LETHAL_COST = 252;
 const int UNKNOWN_COST = 255;
+const int OBS_COST = 254;
+const int LETHAL_COST = 252;
 
 struct coordsM
 {
@@ -189,6 +190,9 @@ protected:
   {
     double curr_cost = getCost(cx, cy);
     if ((costmap_->getCost(cx, cy) == UNKNOWN_COST && allow_unknown_) || curr_cost < LETHAL_COST) {
+      if(costmap_->getCost(cx, cy) == UNKNOWN_COST) {
+        curr_cost = OBS_COST - 1;
+      }
       cost += w_traversal_cost_ * curr_cost * curr_cost / LETHAL_COST / LETHAL_COST;
       return true;
     } else {

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
@@ -25,6 +25,7 @@
 
 const double INF_COST = DBL_MAX;
 const int LETHAL_COST = 252;
+const int UNKNOWN_COST = 255;
 
 struct coordsM
 {
@@ -70,6 +71,8 @@ public:
   double w_heuristic_cost_;
   /// parameter to set the number of adjacent nodes to be searched on
   int how_many_corners_;
+  /// parameter to set weather the planner can plan through unknown space
+  bool allow_unknown_;
   /// the x-directional and y-directional lengths of the map respectively
   int size_x_, size_y_;
 
@@ -91,7 +94,7 @@ public:
    */
   inline bool isSafe(const int & cx, const int & cy) const
   {
-    return costmap_->getCost(cx, cy) < LETHAL_COST;
+    return (costmap_->getCost(cx, cy) == UNKNOWN_COST && allow_unknown_) || costmap_->getCost(cx, cy) < LETHAL_COST;
   }
 
   /**
@@ -185,7 +188,7 @@ protected:
   bool isSafe(const int & cx, const int & cy, double & cost) const
   {
     double curr_cost = getCost(cx, cy);
-    if (curr_cost < LETHAL_COST) {
+    if ((costmap_->getCost(cx, cy) == UNKNOWN_COST && allow_unknown_) || curr_cost < LETHAL_COST) {
       cost += w_traversal_cost_ * curr_cost * curr_cost / LETHAL_COST / LETHAL_COST;
       return true;
     } else {

--- a/nav2_theta_star_planner/src/theta_star.cpp
+++ b/nav2_theta_star_planner/src/theta_star.cpp
@@ -23,6 +23,7 @@ ThetaStar::ThetaStar()
   w_euc_cost_(2.0),
   w_heuristic_cost_(1.0),
   how_many_corners_(8),
+  allow_unknown_(true),
   size_x_(0),
   size_y_(0),
   index_generated_(0)

--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -46,6 +46,10 @@ void ThetaStarPlanner::configure(
   }
 
   nav2_util::declare_parameter_if_not_declared(
+    node, name_ + ".allow_unknown", rclcpp::ParameterValue(true));
+  node->get_parameter(name_ + ".allow_unknown", planner_->allow_unknown_);
+
+  nav2_util::declare_parameter_if_not_declared(
     node, name_ + ".w_euc_cost", rclcpp::ParameterValue(1.0));
   node->get_parameter(name_ + ".w_euc_cost", planner_->w_euc_cost_);
 
@@ -237,6 +241,8 @@ ThetaStarPlanner::dynamicParametersCallback(std::vector<rclcpp::Parameter> param
     } else if (type == ParameterType::PARAMETER_BOOL) {
       if (name == name_ + ".use_final_approach_orientation") {
         use_final_approach_orientation_ = parameter.as_bool();
+      } else if (name == name_ + ".allow_unknown") {
+        planner_->allow_unknown_ = parameter.as_bool();
       }
     }
   }

--- a/nav2_theta_star_planner/test/test_theta_star.cpp
+++ b/nav2_theta_star_planner/test/test_theta_star.cpp
@@ -212,7 +212,8 @@ TEST(ThetaStarPlanner, test_theta_star_reconfigure)
     {rclcpp::Parameter("test.how_many_corners", 8),
       rclcpp::Parameter("test.w_euc_cost", 1.0),
       rclcpp::Parameter("test.w_traversal_cost", 2.0),
-      rclcpp::Parameter("test.use_final_approach_orientation", false)});
+      rclcpp::Parameter("test.use_final_approach_orientation", false)
+      rclcpp::Parameter("test.allow_unknown", false)});
 
   rclcpp::spin_until_future_complete(
     life_node->get_node_base_interface(),
@@ -224,6 +225,7 @@ TEST(ThetaStarPlanner, test_theta_star_reconfigure)
     1.0);
   EXPECT_EQ(life_node->get_parameter("test.w_traversal_cost").as_double(), 2.0);
   EXPECT_EQ(life_node->get_parameter("test.use_final_approach_orientation").as_bool(), false);
+  EXPECT_EQ(life_node->get_parameter("test.allow_unknown").as_bool(), false);
 
   rclcpp::spin_until_future_complete(
     life_node->get_node_base_interface(),

--- a/nav2_theta_star_planner/test/test_theta_star.cpp
+++ b/nav2_theta_star_planner/test/test_theta_star.cpp
@@ -212,7 +212,7 @@ TEST(ThetaStarPlanner, test_theta_star_reconfigure)
     {rclcpp::Parameter("test.how_many_corners", 8),
       rclcpp::Parameter("test.w_euc_cost", 1.0),
       rclcpp::Parameter("test.w_traversal_cost", 2.0),
-      rclcpp::Parameter("test.use_final_approach_orientation", false)
+      rclcpp::Parameter("test.use_final_approach_orientation", false),
       rclcpp::Parameter("test.allow_unknown", false)});
 
   rclcpp::spin_until_future_complete(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3285 |
| Primary OS tested on | Ubuntu 22 |
| Robotic platform tested on | Custom gazebo robot |

---

## Description of contribution in a few bullet points

Added the allow_unknown parameter to the theta star planner to make it possible to plan through unknown space

## Description of documentation updates required from your changes

I need to add the new parameter to the configuration guide in navigation.ros.org

---


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
