### PR TITLE
Include test cases waypoint follwer

### DIFF
--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -193,7 +193,7 @@ def main(argv=sys.argv[1:]):
     rclpy.init()
 
     # wait a few seconds to make sure entire stacks are up
-    time.sleep(5)
+    time.sleep(10)
 
     wps = [[-0.52, -0.54], [0.58, -0.55], [0.58, 0.52]]
     starting_pose = [-2.0, -0.5]

--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -40,6 +40,7 @@ class WaypointFollowerTest(Node):
                                                       'initialpose', 10)
         self.initial_pose_received = False
         self.goal_handle = None
+        self.action_result = None
 
         pose_qos = QoSProfile(
           durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
@@ -51,8 +52,6 @@ class WaypointFollowerTest(Node):
                                                        'amcl_pose', self.poseCallback, pose_qos)
         self.param_cli = self.create_client(SetParameters,
                                             '/waypoint_follower/set_parameters')
-        while not self.param_cli.wait_for_service(timeout_sec=3.0):
-            self.info_msg('/waypoint_follower/set_parameters service not available')
 
     def setInitialPose(self, pose):
         self.init_pose = PoseWithCovarianceStamped()
@@ -77,9 +76,9 @@ class WaypointFollowerTest(Node):
             self.waypoints.append(msg)
 
     def run(self, block, cancel):
-        if not self.waypoints:
-            rclpy.error_msg('Did not set valid waypoints before running test!')
-            return False
+        # if not self.waypoints:
+        #     rclpy.error_msg('Did not set valid waypoints before running test!')
+        #     return False
 
         while not self.action_client.wait_for_server(timeout_sec=1.0):
             self.info_msg("'follow_waypoints' action server not available, waiting...")
@@ -194,7 +193,7 @@ def main(argv=sys.argv[1:]):
     rclpy.init()
 
     # wait a few seconds to make sure entire stacks are up
-    time.sleep(10)
+    time.sleep(5)
 
     wps = [[-0.52, -0.54], [0.58, -0.55], [0.58, 0.52]]
     starting_pose = [-2.0, -0.5]
@@ -242,7 +241,7 @@ def main(argv=sys.argv[1:]):
     assert not result
     result = not result
     mwps = test.action_result.missed_waypoints
-    result = (len(mwps) == 1) & (int(mwps[0][0]) == 100) & (int(mwps[0][1]) == 100)
+    result = (len(mwps) == 1) & (mwps[0] == 1)
     test.setStopFailureParam(False)
 
     # Zero goal test

--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -39,6 +39,7 @@ class WaypointFollowerTest(Node):
                                                       'initialpose', 10)
         self.initial_pose_received = False
         self.goal_handle = None
+        self.action_result = None
 
         pose_qos = QoSProfile(
           durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
@@ -105,6 +106,7 @@ class WaypointFollowerTest(Node):
             rclpy.spin_until_future_complete(self, get_result_future)
             status = get_result_future.result().status
             result = get_result_future.result().result
+            self.action_result = result
         except Exception as e:  # noqa: B902
             self.error_msg(f'Service call failed {e!r}')
 
@@ -221,7 +223,6 @@ def main(argv=sys.argv[1:]):
     result = not result
 
     # stop on failure test with bogous waypoint
-    # WIP
     test.changeParamValue('stop_on_failure', True)
     wps = [[-0.52, -0.54], [100.0, 100.0], [0.58, 0.52]]
     starting_pose = [-2.0, -0.5]
@@ -229,7 +230,11 @@ def main(argv=sys.argv[1:]):
     test.setInitialPose(starting_pose)
     assert not result
     result = not result
+    mwps = test.action_result.missed_waypoints
+    result = len(mwps) > 0
     test.changeParamValue('stop_on_failure', False)
+
+    #
 
     test.shutdown()
     test.info_msg('Done Shutting Down.')

--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -32,6 +32,7 @@ class WaypointFollowerTest(Node):
 
     def __init__(self):
         super().__init__(node_name='nav2_waypoint_tester', namespace='')
+        self.waypoint_follower_ns = 'waypoint_follower'
         self.waypoints = None
         self.action_client = ActionClient(self, FollowWaypoints, 'follow_waypoints')
         self.initial_pose_pub = self.create_publisher(PoseWithCovarianceStamped,
@@ -120,6 +121,10 @@ class WaypointFollowerTest(Node):
 
     def publishInitialPose(self):
         self.initial_pose_pub.publish(self.init_pose)
+
+    def changeParamValue(self, param, value):
+        param_ns = self.waypoint_follower_ns + '.' + param
+        self.declare_paramter(param_ns, value)
 
     def shutdown(self):
         self.info_msg('Shutting down')
@@ -214,6 +219,17 @@ def main(argv=sys.argv[1:]):
     result = test.run(True)
     assert not result
     result = not result
+
+    # stop on failure test with bogous waypoint
+    # WIP
+    test.changeParamValue('stop_on_failure', True)
+    wps = [[-0.52, -0.54], [100.0, 100.0], [0.58, 0.52]]
+    starting_pose = [-2.0, -0.5]
+    test.setWaypoints(wps)
+    test.setInitialPose(starting_pose)
+    assert not result
+    result = not result
+    test.changeParamValue('stop_on_failure', False)
 
     test.shutdown()
     test.info_msg('Done Shutting Down.')


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here) |
| Primary OS tested on | (Ubuntu jammy, docker) |
| Robotic platform tested on | (Turtlebot simulatino) |

---

## Description of contribution in a few bullet points
Include the following test cases to waypoint follower tests 
* Param stop_on_failure set to true and create a situation of waypoint following (such as a bogus impossible goal off the map) and check that it terminates as failed + the result message contains the correct missed_waypoints field.
* A test where we send 0 goal poses in the request, make sure it returns successfully
* During a waypoint navigation run, cancel it
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
