### PR TITLE
adding getCostScalingFactor

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -172,6 +172,11 @@ public:
     return access_;
   }
 
+  double getCostScalingFactor()
+  {
+    return cost_scaling_factor_;
+  }
+
 protected:
   /**
    * @brief Process updates on footprint changes to the inflation layer

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -442,7 +442,7 @@ InflationLayer::dynamicParametersCallback(
         need_reinflation_ = true;
         need_cache_recompute = true;
       } else if (param_name == name_ + "." + "cost_scaling_factor" && // NOLINT
-        cost_scaling_factor_ != parameter.as_double())
+        getCostScalingFactor() != parameter.as_double())
       {
         cost_scaling_factor_ = parameter.as_double();
         need_reinflation_ = true;


### PR DESCRIPTION
Makes its easier for other places already dynamically casting layers to get inflation layer metadata to get the cost scaling factor rather than duplicating parameters, e.g. #3289