### PR TITLE
Solve bug when CostmapInfoServer is reactivated

### DIFF
--- a/nav2_map_server/include/nav2_map_server/costmap_filter_info_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/costmap_filter_info_server.hpp
@@ -71,7 +71,7 @@ protected:
 private:
   rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::CostmapFilterInfo>::SharedPtr publisher_;
 
-  std::unique_ptr<nav2_msgs::msg::CostmapFilterInfo> msg_;
+  nav2_msgs::msg::CostmapFilterInfo msg_;
 };  // CostmapFilterInfoServer
 
 }  // namespace nav2_map_server

--- a/nav2_map_server/src/costmap_filter_info/costmap_filter_info_server.cpp
+++ b/nav2_map_server/src/costmap_filter_info/costmap_filter_info_server.cpp
@@ -48,13 +48,13 @@ CostmapFilterInfoServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
   publisher_ = this->create_publisher<nav2_msgs::msg::CostmapFilterInfo>(
     filter_info_topic, rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
 
-  msg_ = std::make_unique<nav2_msgs::msg::CostmapFilterInfo>();
-  msg_->header.frame_id = "";
-  msg_->header.stamp = now();
-  msg_->type = get_parameter("type").as_int();
-  msg_->filter_mask_topic = get_parameter("mask_topic").as_string();
-  msg_->base = static_cast<float>(get_parameter("base").as_double());
-  msg_->multiplier = static_cast<float>(get_parameter("multiplier").as_double());
+  msg_ = nav2_msgs::msg::CostmapFilterInfo();
+  msg_.header.frame_id = "";
+  msg_.header.stamp = now();
+  msg_.type = get_parameter("type").as_int();
+  msg_.filter_mask_topic = get_parameter("mask_topic").as_string();
+  msg_.base = static_cast<float>(get_parameter("base").as_double());
+  msg_.multiplier = static_cast<float>(get_parameter("multiplier").as_double());
 
   return nav2_util::CallbackReturn::SUCCESS;
 }
@@ -65,7 +65,8 @@ CostmapFilterInfoServer::on_activate(const rclcpp_lifecycle::State & /*state*/)
   RCLCPP_INFO(get_logger(), "Activating");
 
   publisher_->on_activate();
-  publisher_->publish(std::move(msg_));
+  auto costmap_filter_info = std::make_unique<nav2_msgs::msg::CostmapFilterInfo>(msg_);
+  publisher_->publish(std::move(costmap_filter_info));
 
   // create bond connection
   createBond();

--- a/nav2_map_server/test/unit/test_costmap_filter_info_server.cpp
+++ b/nav2_map_server/test/unit/test_costmap_filter_info_server.cpp
@@ -59,6 +59,16 @@ public:
     on_cleanup(get_current_state());
     on_shutdown(get_current_state());
   }
+
+  void deactivate()
+  {
+    on_deactivate(get_current_state());
+  }
+
+  void activate()
+  {
+    on_activate(get_current_state());
+  }
 };
 
 class InfoServerTester : public ::testing::Test
@@ -143,4 +153,10 @@ TEST_F(InfoServerTester, testCostmapFilterInfoPublish)
   EXPECT_EQ(info_->filter_mask_topic, MASK_TOPIC);
   EXPECT_NEAR(info_->base, BASE, EPSILON);
   EXPECT_NEAR(info_->multiplier, MULTIPLIER, EPSILON);
+}
+
+TEST_F(InfoServerTester, testCostmapFilterInfoDeactivateActivate)
+{
+  info_server_->deactivate();
+  info_server_->activate();
 }

--- a/nav2_map_server/test/unit/test_costmap_filter_info_server.cpp
+++ b/nav2_map_server/test/unit/test_costmap_filter_info_server.cpp
@@ -158,5 +158,20 @@ TEST_F(InfoServerTester, testCostmapFilterInfoPublish)
 TEST_F(InfoServerTester, testCostmapFilterInfoDeactivateActivate)
 {
   info_server_->deactivate();
+  info_ = nullptr;
   info_server_->activate();
+
+  rclcpp::Time start_time = info_server_->now();
+  while (!isReceived()) {
+    rclcpp::spin_some(info_server_->get_node_base_interface());
+    std::this_thread::sleep_for(100ms);
+    // Waiting no more than 5 seconds
+    ASSERT_TRUE((info_server_->now() - start_time) <= rclcpp::Duration(5000ms));
+  }
+
+  // Checking received CostmapFilterInfo for consistency
+  EXPECT_EQ(info_->type, TYPE);
+  EXPECT_EQ(info_->filter_mask_topic, MASK_TOPIC);
+  EXPECT_NEAR(info_->base, BASE, EPSILON);
+  EXPECT_NEAR(info_->multiplier, MULTIPLIER, EPSILON);
 }


### PR DESCRIPTION
Signed-off-by: MartiBolet <mboletboixeda@gmail.com>

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
Adressing the Issue #3291 when CostmapFilterInfo server is deactivated and then reactivated fails the transition.


---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Issue #3291 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | None |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* Changed the typo of the `msg_` of `CostmapFiterInfoServer` from `unique_ptr` to prevent deleting when publishing using `std::move`
* I added a new test for the class `CostmapFilterInfoServer` that reproduces what was happening in the issue to check it doesn't happen again.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
