### PR TITLE
Smoothness metrics update

### DIFF
--- a/tools/smoother_benchmarking/README.md
+++ b/tools/smoother_benchmarking/README.md
@@ -30,12 +30,14 @@ planner_server:
 ```
  smoother_server:
    ros__parameters:
-    smoother_plugins: ["simple_smoother", "constrained_smoother"]
+    smoother_plugins: ["simple_smoother", "constrained_smoother", "sg_smoother"]
     simple_smoother:
       plugin: "nav2_smoother::SimpleSmoother"
     constrained_smoother:
       plugin: "nav2_constrained_smoother/ConstrainedSmoother"
       w_smooth: 100000.0 # tuned
+    sg_smoother:
+      plugin: "nav2_smoother::SavitzkyGolaySmoother"
 ```
 
 Set global costmap, path planner and smoothers parameters to those desired in `nav2_params.yaml`.

--- a/tools/smoother_benchmarking/metrics.py
+++ b/tools/smoother_benchmarking/metrics.py
@@ -111,7 +111,7 @@ def main():
     costmap.resize(costmap_msg.metadata.size_y, costmap_msg.metadata.size_x)
 
     planner = 'SmacHybrid'
-    smoothers = ['simple_smoother', 'constrained_smoother']
+    smoothers = ['simple_smoother', 'constrained_smoother', 'sg_smoother']
     max_cost = 210
     side_buffer = 10
     time_stamp = navigator.get_clock().now().to_msg()

--- a/tools/smoother_benchmarking/process_data.py
+++ b/tools/smoother_benchmarking/process_data.py
@@ -82,7 +82,7 @@ def getSmoothness(pt_prev, pt, pt_next):
     d1 = pt - pt_prev
     d2 = pt_next - pt
     delta = d2 - d1
-    return np.dot(delta, delta)
+    return np.linalg.norm(delta)
 
 def getPathSmoothnesses(paths):
     smoothnesses = []


### PR DESCRIPTION
Update path smoothers benchmarking scripts with new smoothness metrics and Savitzky-Golay smoother support

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Nav2 simple commander-based benchmarks |

---

## Description of contribution in a few bullet points

Updates in `tools/smoother_benchmarking` scripts:
* Update metrics for path smoothness from quad `( dx(i+1) - dx(i) )^2` to module value `| dx(i+1) - dx(i) |`
* Added a support of Savitzky-Golay smoother


## Description of documentation updates required from your changes
`README.md` in the scripts was already adjusted. No further actions needed.

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
