### PR TITLE
implemented 'update costmap on request' option

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -182,6 +182,7 @@ local_costmap:
   local_costmap:
     ros__parameters:
       update_frequency: 5.0
+      update_on_request: True
       publish_frequency: 2.0
       global_frame: odom
       robot_base_frame: base_link
@@ -225,6 +226,7 @@ global_costmap:
   global_costmap:
     ros__parameters:
       update_frequency: 1.0
+      update_on_request: True
       publish_frequency: 1.0
       global_frame: map
       robot_base_frame: base_link

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -384,10 +384,16 @@ void ControllerServer::computeControl()
         return;
       }
 
-      // Don't compute a trajectory until costmap is valid (after clear costmap)
-      rclcpp::Rate r(100);
-      while (!costmap_ros_->isCurrent()) {
-        r.sleep();
+      if (costmap_ros_->isUpdateOnRequest()){
+        RCLCPP_DEBUG(get_logger(), "Updating costmap on request!");
+        costmap_ros_->updateMapOnRequest();
+      }
+      else {
+        // Don't compute a trajectory until costmap is valid (after clear costmap)
+        rclcpp::Rate r(100);
+        while (!costmap_ros_->isCurrent()) {
+          r.sleep();
+        }
       }
 
       updateGlobalPath();

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -302,6 +302,21 @@ public:
    */
   double getRobotRadius() {return robot_radius_;}
 
+  /**
+   * @brief Returns the value of the "update_on_request" parameter, 
+   * used to check if the costmap is to be updated on request or periodically.
+   * 
+   * @return true 
+   * @return false 
+   */
+  bool isUpdateOnRequest() {return update_on_request_;} 
+
+  /**
+   * @brief Update the and publish the costmap once.
+   * 
+   */
+  void updateMapOnRequest();
+
 protected:
   // Publishers and subscribers
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PolygonStamped>::SharedPtr
@@ -348,6 +363,7 @@ protected:
   int map_height_meters_{0};
   double map_publish_frequency_{0};
   double map_update_frequency_{0};
+  bool update_on_request_{false};
   int map_width_meters_{0};
   double origin_x_{0};
   double origin_y_{0};

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -250,6 +250,11 @@ bool PlannerServer::isServerInactive(
 
 void PlannerServer::waitForCostmap()
 {
+  if (costmap_ros_->isUpdateOnRequest()){
+    RCLCPP_DEBUG(get_logger(), "Updating costmap on request!");
+    costmap_ros_->updateMapOnRequest();
+    return;
+  }
   // Don't compute a plan until costmap is valid (after clear costmap)
   rclcpp::Rate r(100);
   while (!costmap_ros_->isCurrent()) {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

This PR targets #3121, adding the 'update costmap on request' option via the parameter `update_on_request` which can be specified on the costmap layer, as shown in [nav2_bringup/params/nav2_params.yaml](https://github.com/JohnTGZ/navigation2/blob/0917791a0be38e52241acafa93b13459b726713e/nav2_bringup/params/nav2_params.yaml#L185).

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#3121) |
| Primary OS tested on | (Ubuntu 22.04) |
| Robotic platform tested on | (turtlebot gazebo simulation) |

---

## Description of contribution in a few bullet points

- The implementation is such that if `update_on_request` is set to `TRUE`, the value of `update_frequency` is set to `0.0`, therefore disabling the costmap update loop on the thread. 
- Then, planner server will update the costmap on each call to [`waitForCostmap()`](https://github.com/JohnTGZ/navigation2/blob/0917791a0be38e52241acafa93b13459b726713e/nav2_planner/src/planner_server.cpp#L251-L263) instead of the costmap being updated on a fixed loop. 
- Similarly, the costmap for the controller server will be updated the call to [`computeControl()`](https://github.com/JohnTGZ/navigation2/blob/0917791a0be38e52241acafa93b13459b726713e/nav2_controller/src/controller_server.cpp#L387-390).
- If `update_on_request` is `FALSE`, the behaviour is as default.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

Will need to update the documentation for the `update_on_request` parameter and how setting it to `TRUE` will affect the value of `update_frequency` internally.

---

## Future work that may be required in bullet points

If `update_on_request` is set to `TRUE`, it is possible to disable initializing the thread for the map update loop as it won't be utilised.

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
