### PR TITLE
preempt/cancel test for time behavior, spin pluguin

### DIFF
--- a/nav2_system_tests/src/behaviors/spin/spin_behavior_tester.cpp
+++ b/nav2_system_tests/src/behaviors/spin/spin_behavior_tester.cpp
@@ -124,7 +124,7 @@ void SpinBehaviorTester::deactivate()
 bool SpinBehaviorTester::defaultSpinBehaviorTest(
   const float target_yaw,
   const double tolerance,
-  const bool wait_action,
+  const bool nonblocking_action,
   const bool cancel_action)
 {
   if (!is_active_) {
@@ -183,14 +183,12 @@ bool SpinBehaviorTester::defaultSpinBehaviorTest(
     return false;
   }
 
-  if (!wait_action)
-  {
+  if (!nonblocking_action) {
     return true;
   }
-  if (cancel_action)
-  {
+  if (cancel_action) {
     sleep(2);
-    // cancel the goal 
+    // cancel the goal
     auto cancel_response = client_ptr_->async_cancel_goal(goal_handle_future.get());
     rclcpp::spin_until_future_complete(node_, cancel_response);
   }

--- a/nav2_system_tests/src/behaviors/spin/spin_behavior_tester.cpp
+++ b/nav2_system_tests/src/behaviors/spin/spin_behavior_tester.cpp
@@ -123,7 +123,9 @@ void SpinBehaviorTester::deactivate()
 
 bool SpinBehaviorTester::defaultSpinBehaviorTest(
   const float target_yaw,
-  const double tolerance)
+  const double tolerance,
+  const bool wait_action,
+  const bool cancel_action)
 {
   if (!is_active_) {
     RCLCPP_ERROR(node_->get_logger(), "Not activated");
@@ -179,6 +181,18 @@ bool SpinBehaviorTester::defaultSpinBehaviorTest(
   if (!goal_handle) {
     RCLCPP_ERROR(node_->get_logger(), "Goal was rejected by server");
     return false;
+  }
+
+  if (!wait_action)
+  {
+    return true;
+  }
+  if (cancel_action)
+  {
+    sleep(2);
+    // cancel the goal 
+    auto cancel_response = client_ptr_->async_cancel_goal(goal_handle_future.get());
+    rclcpp::spin_until_future_complete(node_, cancel_response);
   }
 
   // Wait for the server to be done with the goal
@@ -347,5 +361,4 @@ void SpinBehaviorTester::amclPoseCallback(
 {
   initial_pose_received_ = true;
 }
-
 }  // namespace nav2_system_tests

--- a/nav2_system_tests/src/behaviors/spin/spin_behavior_tester.hpp
+++ b/nav2_system_tests/src/behaviors/spin/spin_behavior_tester.hpp
@@ -58,7 +58,7 @@ public:
   bool defaultSpinBehaviorTest(
     float target_yaw,
     double tolerance = 0.1,
-    bool wait_action = true,
+    bool nonblocking_action = true,
     bool cancel_action = false);
 
   void activate();

--- a/nav2_system_tests/src/behaviors/spin/spin_behavior_tester.hpp
+++ b/nav2_system_tests/src/behaviors/spin/spin_behavior_tester.hpp
@@ -57,7 +57,9 @@ public:
   // Runs a single test with given target yaw
   bool defaultSpinBehaviorTest(
     float target_yaw,
-    double tolerance = 0.1);
+    double tolerance = 0.1,
+    bool wait_action = true,
+    bool cancel_action = false);
 
   void activate();
 

--- a/nav2_system_tests/src/behaviors/spin/test_spin_behavior_node.cpp
+++ b/nav2_system_tests/src/behaviors/spin/test_spin_behavior_node.cpp
@@ -80,6 +80,56 @@ TEST_P(SpinBehaviorTestFixture, testSpinRecovery)
   }
 }
 
+
+TEST_F(SpinBehaviorTestFixture, testSpinPreemption)
+{
+  // Goal 
+  float target_yaw = 3.0 * M_PIf32;
+  float tolerance = 0.1;
+  bool wait_action = false; 
+  bool success = false;
+
+  //Send the first goal 
+  success = spin_recovery_tester->defaultSpinBehaviorTest(target_yaw, tolerance,wait_action);
+  if (std::getenv("MAKE_FAKE_COSTMAP") != NULL && abs(target_yaw) > M_PI_2f32) {
+    // if this variable is set, make a fake costmap
+    // in the fake spin test, we expect a collision for angles > M_PI_2
+    EXPECT_EQ(false, success);
+  } else {
+    EXPECT_EQ(true, success);
+  }
+
+  // Preempt goal 
+  sleep(2);
+  success = false;
+  float prempt_target_yaw = 4.0 * M_PIf32;
+  float preempt_tolerance = 0.1;
+  success = spin_recovery_tester->defaultSpinBehaviorTest(prempt_target_yaw, preempt_tolerance);
+  if (std::getenv("MAKE_FAKE_COSTMAP") != NULL && abs(prempt_target_yaw) > M_PI_2f32) {
+    // if this variable is set, make a fake costmap
+    // in the fake spin test, we expect a collision for angles > M_PI_2
+    EXPECT_EQ(false, success);
+  } else {
+    EXPECT_EQ(true, success);
+  }
+}
+
+TEST_F(SpinBehaviorTestFixture, testSpinCancel)
+{
+  // Goal
+  float target_yaw = 4.0 * M_PIf32;
+  float tolerance = 0.1; 
+  bool wait_action = true, cancel_action = true, success = false;
+  success = spin_recovery_tester->defaultSpinBehaviorTest(target_yaw, tolerance, wait_action, cancel_action);
+  if (std::getenv("MAKE_FAKE_COSTMAP") != NULL && abs(target_yaw) > M_PI_2f32) {
+    // if this variable is set, make a fake costmap
+    // in the fake spin test, we expect a collision for angles > M_PI_2
+    EXPECT_EQ(true, success);
+  } else {
+    EXPECT_EQ(false, success);
+  }
+}
+
 INSTANTIATE_TEST_SUITE_P(
   SpinRecoveryTests,
   SpinBehaviorTestFixture,

--- a/nav2_system_tests/src/behaviors/spin/test_spin_behavior_node.cpp
+++ b/nav2_system_tests/src/behaviors/spin/test_spin_behavior_node.cpp
@@ -83,14 +83,16 @@ TEST_P(SpinBehaviorTestFixture, testSpinRecovery)
 
 TEST_F(SpinBehaviorTestFixture, testSpinPreemption)
 {
-  // Goal 
+  // Goal
   float target_yaw = 3.0 * M_PIf32;
   float tolerance = 0.1;
-  bool wait_action = false; 
+  bool nonblocking_action = false;
   bool success = false;
 
-  //Send the first goal 
-  success = spin_recovery_tester->defaultSpinBehaviorTest(target_yaw, tolerance,wait_action);
+  // Send the first goal
+  success = spin_recovery_tester->defaultSpinBehaviorTest(
+    target_yaw, tolerance,
+    nonblocking_action);
   if (std::getenv("MAKE_FAKE_COSTMAP") != NULL && abs(target_yaw) > M_PI_2f32) {
     // if this variable is set, make a fake costmap
     // in the fake spin test, we expect a collision for angles > M_PI_2
@@ -99,7 +101,7 @@ TEST_F(SpinBehaviorTestFixture, testSpinPreemption)
     EXPECT_EQ(true, success);
   }
 
-  // Preempt goal 
+  // Preempt goal
   sleep(2);
   success = false;
   float prempt_target_yaw = 4.0 * M_PIf32;
@@ -118,9 +120,11 @@ TEST_F(SpinBehaviorTestFixture, testSpinCancel)
 {
   // Goal
   float target_yaw = 4.0 * M_PIf32;
-  float tolerance = 0.1; 
-  bool wait_action = true, cancel_action = true, success = false;
-  success = spin_recovery_tester->defaultSpinBehaviorTest(target_yaw, tolerance, wait_action, cancel_action);
+  float tolerance = 0.1;
+  bool nonblocking_action = true, cancel_action = true, success = false;
+  success = spin_recovery_tester->defaultSpinBehaviorTest(
+    target_yaw, tolerance,
+    nonblocking_action, cancel_action);
   if (std::getenv("MAKE_FAKE_COSTMAP") != NULL && abs(target_yaw) > M_PI_2f32) {
     // if this variable is set, make a fake costmap
     // in the fake spin test, we expect a collision for angles > M_PI_2

--- a/nav2_system_tests/src/behaviors/spin/test_spin_behavior_node.cpp
+++ b/nav2_system_tests/src/behaviors/spin/test_spin_behavior_node.cpp
@@ -80,7 +80,6 @@ TEST_P(SpinBehaviorTestFixture, testSpinRecovery)
   }
 }
 
-
 TEST_F(SpinBehaviorTestFixture, testSpinPreemption)
 {
   // Goal
@@ -93,27 +92,14 @@ TEST_F(SpinBehaviorTestFixture, testSpinPreemption)
   success = spin_recovery_tester->defaultSpinBehaviorTest(
     target_yaw, tolerance,
     nonblocking_action);
-  if (std::getenv("MAKE_FAKE_COSTMAP") != NULL && abs(target_yaw) > M_PI_2f32) {
-    // if this variable is set, make a fake costmap
-    // in the fake spin test, we expect a collision for angles > M_PI_2
-    EXPECT_EQ(false, success);
-  } else {
-    EXPECT_EQ(true, success);
-  }
-
+  EXPECT_EQ(true, success);
   // Preempt goal
   sleep(2);
   success = false;
   float prempt_target_yaw = 4.0 * M_PIf32;
   float preempt_tolerance = 0.1;
   success = spin_recovery_tester->defaultSpinBehaviorTest(prempt_target_yaw, preempt_tolerance);
-  if (std::getenv("MAKE_FAKE_COSTMAP") != NULL && abs(prempt_target_yaw) > M_PI_2f32) {
-    // if this variable is set, make a fake costmap
-    // in the fake spin test, we expect a collision for angles > M_PI_2
-    EXPECT_EQ(false, success);
-  } else {
-    EXPECT_EQ(true, success);
-  }
+  EXPECT_EQ(false, success);
 }
 
 TEST_F(SpinBehaviorTestFixture, testSpinCancel)
@@ -125,13 +111,7 @@ TEST_F(SpinBehaviorTestFixture, testSpinCancel)
   success = spin_recovery_tester->defaultSpinBehaviorTest(
     target_yaw, tolerance,
     nonblocking_action, cancel_action);
-  if (std::getenv("MAKE_FAKE_COSTMAP") != NULL && abs(target_yaw) > M_PI_2f32) {
-    // if this variable is set, make a fake costmap
-    // in the fake spin test, we expect a collision for angles > M_PI_2
-    EXPECT_EQ(true, success);
-  } else {
-    EXPECT_EQ(false, success);
-  }
+  EXPECT_EQ(false, success);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here ) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (Simulation) |

---

## Description of contribution in a few bullet points
* include preempt/cancel test for time behavior, in the spin plugin
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [x] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
