### PR TITLE
Make mapUpdateLoop() indicator variables to be thread-safe

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -38,6 +38,7 @@
 #ifndef NAV2_COSTMAP_2D__COSTMAP_2D_ROS_HPP_
 #define NAV2_COSTMAP_2D__COSTMAP_2D_ROS_HPP_
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -342,9 +343,9 @@ protected:
    */
   void mapUpdateLoop(double frequency);
   bool map_update_thread_shutdown_{false};
-  bool stop_updates_{false};
-  bool initialized_{false};
-  bool stopped_{true};
+  std::atomic<bool> stop_updates_{false};
+  std::atomic<bool> initialized_{false};
+  std::atomic<bool> stopped_{true};
   std::unique_ptr<std::thread> map_update_thread_;  ///< @brief A thread for updating the map
   rclcpp::Time last_publish_{0, 0, RCL_ROS_TIME};
   rclcpp::Duration publish_cycle_{1, 0};


### PR DESCRIPTION
This is a elaboration of https://github.com/ros-planning/navigation2/pull/3307/files#r1038041946 comment for #3307.
Costmap2DROS contains one `std::thread` parallel execution, which calls `mapUpdateLoop()` routine.

As stated in C++11 standard [docs](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf) in a "5.1.2.4 Multi-threaded executions and data races"

> The execution of a program contains a data race if it contains two conflicting actions in
> different threads, at least one of which is not atomic, and neither happens before the
> other. Any such data race results in undefined behavior.

So, all write-write and write-read parallel operations should be protected by mutex, or `std::atomic` in case if it is the variable.

The `mapUpdateLoop()` thread contains the following boolean indicator variables appeared to be thread-unsafe:
* `stop_updates_`: being read in `Costmap2DROS::updateMap()` loop called from std::thread; and written in parallel in the `Costmap2DROS::start()` routine called from main thread.
* `initialized_`: being read in `Costmap2DROS::start()`, which belongs to main thread; and written in parallel by `Costmap2DROS::updateMap()` from std::thread.
* `stopped_`: to be thread-unsafe since #3307, according to the https://github.com/ros-planning/navigation2/pull/3307/files#r1038041946 comment

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3307 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | `colcon test --packages-select nav2_costmap_2d` |

---

## Description of contribution in a few bullet points

* Protected all bool indicator variables in `mapUpdateLoop()` thread from unsafe usage.

---

## Future work that may be required in bullet points
* It would be cool to check all places with the `std::thread` utilization in Nav2, and find all shared variables (bool, int, string, vectors, etc...) and make them to be thread-safe.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
