### PR TITLE
Support result codes for path planner in benchmarking

### DIFF
--- a/tools/planner_benchmarking/metrics.py
+++ b/tools/planner_benchmarking/metrics.py
@@ -36,9 +36,10 @@ def getPlannerResults(navigator, initial_pose, goal_pose, planners):
     results = []
     for planner in planners:
         path = navigator._getPathImpl(initial_pose, goal_pose, planner, use_start=True)
-        if path is not None:
+        if path is not None and path.error_code == 0:
             results.append(path)
         else:
+            print(planner, "planner failed to produce the path")
             return results
     return results
 

--- a/tools/planner_benchmarking/planning_benchmark_bringup.py
+++ b/tools/planner_benchmarking/planning_benchmark_bringup.py
@@ -23,7 +23,7 @@ from ament_index_python.packages import get_package_share_directory
 def generate_launch_description():
     nav2_bringup_dir = get_package_share_directory('nav2_bringup')
     config = os.path.join(get_package_share_directory('nav2_bringup'), 'params', 'nav2_params.yaml')
-    map_file = os.path.join(nav2_bringup_dir, 'maps', 'map.yaml')
+    map_file = os.path.join(nav2_bringup_dir, 'maps', 'turtlebot3_world.yaml')
     lifecycle_nodes = ['map_server', 'planner_server']
 
     return LaunchDescription([

--- a/tools/smoother_benchmarking/metrics.py
+++ b/tools/smoother_benchmarking/metrics.py
@@ -33,7 +33,11 @@ from transforms3d.euler import euler2quat
 # Note: Map origin is assumed to be (0,0)
 
 def getPlannerResults(navigator, initial_pose, goal_pose, planner):
-    return navigator._getPathImpl(initial_pose, goal_pose, planner, use_start=True)
+    result = navigator._getPathImpl(initial_pose, goal_pose, planner, use_start=True)
+    if result is None or result.error_code != 0:
+        print(planner, "planner failed to produce the path")
+        return None
+    return result
 
 def getSmootherResults(navigator, path, smoothers):
     smoothed_results = []
@@ -42,7 +46,7 @@ def getSmootherResults(navigator, path, smoothers):
         if smoothed_result is not None:
             smoothed_results.append(smoothed_result)
         else:
-            print(smoother, " failed to smooth the path")
+            print(smoother, "failed to smooth the path")
             return None
     return smoothed_results
 
@@ -134,8 +138,6 @@ def main():
               results.append(result)
               results.append(smoothed_results)
               i += 1
-        else:
-            print(planner, " planner failed to produce the path")
 
     print("Write Results...")
     benchmark_dir = os.getcwd()


### PR DESCRIPTION
Support new result codes of Path Planner in Nav2 benchmarking suite, added since 1c106173dbc5b2321e9d3f1bf111e40293d36a4f

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3043 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | TB3 simulation |

---

## Description of contribution in a few bullet points

* Added the support of non-NULL return states from `computePlan()` (passed as `action_server->terminate_current(result)` with non-empty argument).
* Fixed the bug in `planning_benchmark_bringup.py` when the Map Server can not start with non-existing map.

## Description of documentation updates required from your changes
Not required

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
