### PR TITLE
add a controller reset due to predictive controllers retaining state

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -606,6 +606,12 @@ void ControllerServer::publishZeroVelocity()
   velocity.header.frame_id = costmap_ros_->getBaseFrameID();
   velocity.header.stamp = now();
   publishVelocity(velocity);
+
+  // Reset the state of the controllers after the task has ended
+  ControllerMap::iterator it;
+  for (it = controllers_.begin(); it != controllers_.end(); ++it) {
+    it->second->reset();
+  }
 }
 
 bool ControllerServer::isGoalReached()

--- a/nav2_core/include/nav2_core/controller.hpp
+++ b/nav2_core/include/nav2_core/controller.hpp
@@ -124,6 +124,11 @@ public:
    * or in absolute values in false case.
    */
   virtual void setSpeedLimit(const double & speed_limit, const bool & percentage) = 0;
+
+  /**
+   * @brief Reset the state of the controller if necessary after task is exited
+   */
+  virtual void reset() {}
 };
 
 }  // namespace nav2_core


### PR DESCRIPTION
Add method to reset the state of a controller plugin when the server is terminating a task so that we can start a new request fresh. 

In response to MPPI development to be released here in ~January