### PR TITLE
[bt_navigator] plugin_lib_names default: Remove duplicate of nav2_back_up_cancel_bt_node

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -77,7 +77,6 @@ BtNavigator::BtNavigator(const rclcpp::NodeOptions & options)
     "nav2_spin_cancel_bt_node",
     "nav2_assisted_teleop_cancel_bt_node",
     "nav2_back_up_cancel_bt_node",
-    "nav2_back_up_cancel_bt_node",
     "nav2_drive_on_heading_cancel_bt_node"
   };
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

The duplicate led to a failure during configuration stage of bt_navigator, when the parameter fallbacks to its default.   
(A ticket was not created in order to avoid unnecessary noise.)

---

## Description of contribution in a few bullet points

- Removed the duplicate of nav2_back_up_cancel_bt_node

## Future work that may be required in bullet points

Nice to have:
- One could remove duplicates in the list programmatically, i.e. turn the list into a set and back to a list to avoid this kind of problems forever, and for custom configurations, too.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
