### PR TITLE
Revert "remove exec_depend on behaviortree_cpp_v3"

### DIFF
--- a/nav2_behavior_tree/package.xml
+++ b/nav2_behavior_tree/package.xml
@@ -36,6 +36,7 @@
   <exec_depend>rclcpp_action</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>behaviortree_cpp_v3</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>

--- a/nav2_bt_navigator/package.xml
+++ b/nav2_bt_navigator/package.xml
@@ -24,6 +24,7 @@
   <build_depend>nav2_util</build_depend>
   <build_depend>nav2_core</build_depend>
 
+  <exec_depend>behaviortree_cpp_v3</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_action</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>


### PR DESCRIPTION
Reverts ros-planning/navigation2#3279 @Aposhian

Causes build failure in build farm https://build.ros2.org/job/Hbin_uJ64__nav2_behaviors__ubuntu_jammy_amd64__binary/22/consoleFull

```
16:41:26 -- Found nav2_behavior_tree: 1.1.4 (/opt/ros/humble/share/nav2_behavior_tree/cmake)
16:41:27 CMake Error at /opt/ros/humble/share/nav2_behavior_tree/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package):
16:41:27   By not providing "Findbehaviortree_cpp_v3.cmake" in CMAKE_MODULE_PATH this
16:41:27   project has asked CMake to find a package configuration file provided by
16:41:27   "behaviortree_cpp_v3", but CMake did not find one.
16:41:27 
16:41:27   Could not find a package configuration file provided by
16:41:27   "behaviortree_cpp_v3" with any of the following names:
16:41:27 
16:41:27     behaviortree_cpp_v3Config.cmake
16:41:27     behaviortree_cpp_v3-config.cmake
16:41:27 
16:41:27   Add the installation prefix of "behaviortree_cpp_v3" to CMAKE_PREFIX_PATH
16:41:27   or set "behaviortree_cpp_v3_DIR" to a directory containing one of the above
16:41:27   files.  If "behaviortree_cpp_v3" provides a separate development package or
16:41:27   SDK, be sure it has been installed.
16:41:27 Call Stack (most recent call first):
16:41:27   /opt/ros/humble/share/nav2_behavior_tree/cmake/nav2_behavior_treeConfig.cmake:41 (include)
16:41:27   CMakeLists.txt:11 (find_package)
16:41:27 
16:41:27 
```