### PR TITLE
Do only consider enabled costmap plugins/filters in the isCurrent() method of a LayeredCostmap

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layer.hpp
@@ -139,6 +139,12 @@ public:
     return current_;
   }
 
+  /**@brief Gets whether the layer is enabled. */
+  bool isEnabled() const
+  {
+    return enabled_;
+  }
+
   /** @brief Convenience function for layered_costmap_->getFootprint(). */
   const std::vector<geometry_msgs::msg::Point> & getFootprint() const;
 

--- a/nav2_costmap_2d/src/layered_costmap.cpp
+++ b/nav2_costmap_2d/src/layered_costmap.cpp
@@ -256,12 +256,12 @@ bool LayeredCostmap::isCurrent()
   for (vector<std::shared_ptr<Layer>>::iterator plugin = plugins_.begin();
     plugin != plugins_.end(); ++plugin)
   {
-    current_ = current_ && (*plugin)->isCurrent();
+    current_ = current_ && ((*plugin)->isCurrent() || !(*plugin)->isEnabled());
   }
   for (vector<std::shared_ptr<Layer>>::iterator filter = filters_.begin();
     filter != filters_.end(); ++filter)
   {
-    current_ = current_ && (*filter)->isCurrent();
+    current_ = current_ && ((*filter)->isCurrent() || !(*filter)->isEnabled());
   }
   return current_;
 }


### PR DESCRIPTION
When clearing entirely a costmap (see the `clear_entirely_*` service), its layers are reset. This sets their `current_` attribute to False, until they are updated (`updateCosts()`). However, for disabled plugins/filters, the `updateCosts()` is bypassed so that the `current_` attribute is never reset to True, and the costmap never becomes "current" again; because of that the controller_server used to get stuck in an endless loop (see `while (!costmap_ros_->isCurrent())` in `ControllerServer::computeControl()`).

This patch fixes that by adding a condition for not considering disabled plugins/filters in the `LayeredCostmap::isCurrent()`.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3353  |
| Primary OS tested on |  |
| Robotic platform tested on |  |

---

## Description of contribution in a few bullet points

- fix #3353

## Description of documentation updates required from your changes

N/A

---

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [x] Check that any new parameters added are updated in navigation.ros.org
- [x] Check that any significant change is added to the migration guide
- [x] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [x] Check that any new features have test coverage
- [x] Check that any new plugins is added to the plugins page
- [x] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
