### PR TITLE
Export ompl include directories from nav2_smac_planner.

### DIFF
--- a/nav2_smac_planner/CMakeLists.txt
+++ b/nav2_smac_planner/CMakeLists.txt
@@ -158,7 +158,7 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_include_directories(include)
+ament_export_include_directories(include ${OMPL_INCLUDE_DIRS})
 ament_export_libraries(${library_name} ${library_name}_2d ${library_name}_lattice)
 ament_export_dependencies(${dependencies})
 ament_package()


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |https://github.com/ros-planning/navigation2/issues/3357 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | N/A |

---

## Description of contribution in a few bullet points

 * Export necessary ompl include directories from nav2_smac_planner to fix build issue.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
