### PR TITLE
Fix nav2_velocity_smoother for sim time

### DIFF
--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -210,7 +210,7 @@ double VelocitySmoother::applyConstraints(
 void VelocitySmoother::smootherTimer()
 {
   // Wait until the first command is received
-  if (command_==nullptr) {
+  if (!command_) {
     return;
   }
 

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -209,6 +209,11 @@ double VelocitySmoother::applyConstraints(
 
 void VelocitySmoother::smootherTimer()
 {
+  // Wait until the first command is received
+  if (command_==nullptr) {
+    return;
+  }
+
   auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>();
 
   // Check for velocity timeout. If nothing received, publish zeros to stop robot


### PR DESCRIPTION
---

## Basic Info

| Info | Fix nav2_velocity_smoother for sim time |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu  |
| Robotic platform tested on | Gazebo simulation |

---

## Description of contribution in a few bullet points

If sim time is used: `now()` might be close to 0 on startup and `last_command_time_` is defined 0 making the condition `now() - last_command_time_ > velocity_timeout_` False, which assumes that velocity command was received recently and then leads to an error when trying to access command_'s properties ( `command_->linear.x` )
So i added check for command_ being null before proceeding with smoothing

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
