### PR TITLE
Changed step_size to 0.5 in collision checker

### DIFF
--- a/nav2_simple_commander/nav2_simple_commander/footprint_collision_checker.py
+++ b/nav2_simple_commander/nav2_simple_commander/footprint_collision_checker.py
@@ -91,7 +91,7 @@ class FootprintCollisionChecker():
 
         return max(float(self.lineCost(xstart, x1, ystart, y1)), footprint_cost)
 
-    def lineCost(self, x0, x1, y0, y1, step_size=0.1):
+    def lineCost(self, x0, x1, y0, y1, step_size=0.5):
         """
         Iterate over all the points along a line and check for collision.
 

--- a/nav2_simple_commander/nav2_simple_commander/footprint_collision_checker.py
+++ b/nav2_simple_commander/nav2_simple_commander/footprint_collision_checker.py
@@ -101,7 +101,7 @@ class FootprintCollisionChecker():
             y0 (float): Ordinate of the initial point in map coordinates
             x1 (float): Abscissa of the final point in map coordinates
             y1 (float): Ordinate of the final point in map coordinates
-            step_size (float): Optional, Increments' resolution, defaults to 0.1
+            step_size (float): Optional, Increments' resolution, defaults to 0.5
 
         Returns
         -------


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3151 |
| Primary OS tested on | Ubuntu 22.04.01 |
| Robotic platform tested on | None |

---

## Description of contribution in a few bullet points

* This PR is to change step_size to 0.5 instead of 0.1 in the footprint collision checker as discussed in https://github.com/ros-planning/navigation.ros.org/pull/382#discussion_r1064964995
---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
