### PR TITLE
Nav2 msgs/rm nav2common depency

### DIFF
--- a/nav2_msgs/CMakeLists.txt
+++ b/nav2_msgs/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(nav2_msgs)
 
+
 find_package(ament_cmake REQUIRED)
-find_package(nav2_common REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -10,7 +10,6 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(action_msgs REQUIRED)
 
-nav2_package()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Costmap.msg"

--- a/nav2_msgs/package.xml
+++ b/nav2_msgs/package.xml
@@ -10,7 +10,6 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>nav2_common</build_depend>
 
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Debian |

---

## Description of contribution in a few bullet points

As part of the changes introduced by  https://github.com/ros-planning/navigation2/pull/536 , `nav2_msgs` now depends on `nav2_common` package which is used to set CMake environment. 

As message interfaces sometimes needs to be built independently as part on interfacing systems, it is usually the case in ros that interfaces do not require any dependency to remain decoupled of build-systems, or the build-tree they are a part of. 

* Removed dependency of `nav2_msgs` on `nav2_common` from `CMakeLists` and `packages`
## Future work that may be required in bullet points

* I think one still needs to validate if changes to `nav2_msgs` (replaced in https://github.com/ros-planning/navigation2/pull/536) are really needed for building as part of nav2 stack
That is:
```
# Default to C++14
if(NOT CMAKE_CXX_STANDARD)
  set(CMAKE_CXX_STANDARD 14)
endif()

if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
endif()
```

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists

