### PR TITLE
Address code cov loss due to unclean shutdown (issue #3271)

### DIFF
--- a/nav2_bringup/launch/localization_launch.py
+++ b/nav2_bringup/launch/localization_launch.py
@@ -107,7 +107,7 @@ def generate_launch_description():
     load_nodes = GroupAction(
         condition=IfCondition(PythonExpression(['not ', use_composition])),
         actions=[
-            SetParameter("use_sim_time", use_sim_time),
+            SetParameter('use_sim_time', use_sim_time),
             Node(
                 condition=LaunchConfigurationEquals('map', ''),
                 package='nav2_map_server',
@@ -165,7 +165,7 @@ def generate_launch_description():
     load_composable_nodes = GroupAction(
         condition=IfCondition(use_composition),
         actions=[
-            SetParameter("use_sim_time", use_sim_time),
+            SetParameter('use_sim_time', use_sim_time),
             LoadComposableNodes(
                 target_container=container_name_full,
                 condition=LaunchConfigurationEquals('map', ''),

--- a/nav2_bringup/launch/navigation_launch.py
+++ b/nav2_bringup/launch/navigation_launch.py
@@ -108,7 +108,7 @@ def generate_launch_description():
     load_nodes = GroupAction(
         condition=IfCondition(PythonExpression(['not ', use_composition])),
         actions=[
-            SetParameter("use_sim_time", use_sim_time),
+            SetParameter('use_sim_time', use_sim_time),
             Node(
                 package='nav2_controller',
                 executable='controller_server',
@@ -193,7 +193,7 @@ def generate_launch_description():
     load_composable_nodes = GroupAction(
         condition=IfCondition(use_composition),
         actions=[
-            SetParameter("use_sim_time", use_sim_time),
+            SetParameter('use_sim_time', use_sim_time),
             LoadComposableNodes(
                 target_container=container_name_full,
                 composable_node_descriptions=[

--- a/nav2_bringup/launch/slam_launch.py
+++ b/nav2_bringup/launch/slam_launch.py
@@ -17,7 +17,7 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, GroupAction
+from launch.actions import DeclareLaunchArgument, GroupAction, IncludeLaunchDescription
 from launch.conditions import IfCondition, UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
@@ -81,7 +81,7 @@ def generate_launch_description():
 
     start_map_server = GroupAction(
         actions=[
-            SetParameter("use_sim_time", use_sim_time),
+            SetParameter('use_sim_time', use_sim_time),
             Node(
                 package='nav2_map_server',
                 executable='map_saver_server',

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <limits>
 
+#include "lifecycle_msgs/msg/state.hpp"
 #include "nav2_core/controller_exceptions.hpp"
 #include "nav_2d_utils/conversions.hpp"
 #include "nav_2d_utils/tf_help.hpp"
@@ -246,7 +247,19 @@ ControllerServer::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   for (it = controllers_.begin(); it != controllers_.end(); ++it) {
     it->second->deactivate();
   }
-  costmap_ros_->deactivate();
+
+  /*
+   * The costmap is also a lifecycle node, so it may have already fired on_deactivate
+   * via rcl preshutdown cb. Despite the rclcpp docs saying on_shutdown callbacks fire
+   * in the order added, the preshutdown callbacks clearly don't per se, due to using an
+   * unordered_set iteration. Once this issue is resolved, we can maybe make a stronger
+   * ordering assumption: https://github.com/ros2/rclcpp/issues/2096
+   */
+  if (costmap_ros_->get_current_state().id() ==
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+  {
+    costmap_ros_->deactivate();
+  }
 
   publishZeroVelocity();
   vel_publisher_->on_deactivate();
@@ -271,11 +284,16 @@ ControllerServer::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   controllers_.clear();
 
   goal_checkers_.clear();
-  costmap_ros_->cleanup();
+  if (costmap_ros_->get_current_state().id() ==
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+  {
+    costmap_ros_->cleanup();
+  }
 
   // Release any allocated resources
   action_server_.reset();
   odom_sub_.reset();
+  costmap_thread_.reset();
   vel_publisher_.reset();
   speed_limit_sub_.reset();
 

--- a/nav2_costmap_2d/src/costmap_2d_cloud.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_cloud.cpp
@@ -225,6 +225,11 @@ int main(int argc, char ** argv)
     "voxel_grid", rclcpp::SystemDefaultsQoS(), voxelCallback);
 
   rclcpp::spin(g_node->get_node_base_interface());
+
+  g_node.reset();
+  pub_marked.reset();
+  pub_unknown.reset();
+
   rclcpp::shutdown();
 
   return 0;

--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -114,6 +114,13 @@ protected:
    */
   bool resume();
 
+  /**
+   * @brief Perform preshutdown activities before our Context is shutdown.
+   * Note that this is related to our Context's shutdown sequence, not the
+   * lifecycle node state machine or shutdown().
+   */
+  void onRclPreshutdown();
+
   // Support function for creating service clients
   /**
    * @brief Support function for creating service clients
@@ -185,6 +192,14 @@ protected:
    * @brief function to check if the Nav2 system is active
    */
   void CreateActiveDiagnostic(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
+  /**
+   * Register our preshutdown callback for this Node's rcl Context.
+   * The callback fires before this Node's Context is shutdown.
+   * Note this is not directly related to the lifecycle state machine or the
+   * shutdown() instance function.
+   */
+  void registerRclPreshutdownCallback();
 
   // Timer thread to look at bond connections
   rclcpp::TimerBase::SharedPtr init_timer_;

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -45,6 +45,8 @@ LifecycleManager::LifecycleManager(const rclcpp::NodeOptions & options)
   declare_parameter("bond_respawn_max_duration", 10.0);
   declare_parameter("attempt_respawn_reconnection", true);
 
+  registerRclPreshutdownCallback();
+
   node_names_ = get_parameter("node_names").as_string_array();
   get_parameter("autostart", autostart_);
   double bond_timeout_s;
@@ -376,6 +378,35 @@ LifecycleManager::destroyBondTimer()
     bond_timer_->cancel();
     bond_timer_.reset();
   }
+}
+
+void
+LifecycleManager::onRclPreshutdown()
+{
+  RCLCPP_INFO(
+    get_logger(), "Running Nav2 LifecycleManager rcl preshutdown (%s)",
+    this->get_name());
+
+  destroyBondTimer();
+
+  /*
+   * Dropping the bond map is what we really need here, but we drop the others
+   * to prevent the bond map being used. Likewise, squash the service thread.
+   */
+  service_thread_.reset();
+  node_names_.clear();
+  node_map_.clear();
+  bond_map_.clear();
+}
+
+void
+LifecycleManager::registerRclPreshutdownCallback()
+{
+  rclcpp::Context::SharedPtr context = get_node_base_interface()->get_context();
+
+  context->add_pre_shutdown_callback(
+    std::bind(&LifecycleManager::onRclPreshutdown, this)
+  );
 }
 
 void

--- a/nav2_simple_commander/nav2_simple_commander/footprint_collision_checker.py
+++ b/nav2_simple_commander/nav2_simple_commander/footprint_collision_checker.py
@@ -22,10 +22,10 @@ and calculate the cost of a Footprint
 """
 
 from math import cos, sin
-from nav2_simple_commander.line_iterator import LineIterator
+
+from geometry_msgs.msg import Point32, Polygon
 from nav2_simple_commander.costmap_2d import PyCostmap2D
-from geometry_msgs.msg import Polygon
-from geometry_msgs.msg import Point32
+from nav2_simple_commander.line_iterator import LineIterator
 
 NO_INFORMATION = 255
 LETHAL_OBSTACLE = 254
@@ -146,7 +146,7 @@ class FootprintCollisionChecker():
         """
         if self.costmap_ is None:
             raise ValueError(
-                "Costmap not specified, use setCostmap to specify the costmap first")
+                'Costmap not specified, use setCostmap to specify the costmap first')
         return self.costmap_.worldToMapValidated(wx, wy)
 
     def pointCost(self, x: int, y: int):
@@ -165,7 +165,7 @@ class FootprintCollisionChecker():
         """
         if self.costmap_ is None:
             raise ValueError(
-                "Costmap not specified, use setCostmap to specify the costmap first")
+                'Costmap not specified, use setCostmap to specify the costmap first')
         return self.costmap_.getCostXY(x, y)
 
     def setCostmap(self, costmap: PyCostmap2D):

--- a/nav2_simple_commander/nav2_simple_commander/line_iterator.py
+++ b/nav2_simple_commander/nav2_simple_commander/line_iterator.py
@@ -50,22 +50,22 @@ class LineIterator():
 
         """
         if type(x0) not in [int, float]:
-            raise TypeError("x0 must be a number (int or float)")
+            raise TypeError('x0 must be a number (int or float)')
 
         if type(y0) not in [int, float]:
-            raise TypeError("y0 must be a number (int or float)")
+            raise TypeError('y0 must be a number (int or float)')
 
         if type(x1) not in [int, float]:
-            raise TypeError("x1 must be a number (int or float)")
+            raise TypeError('x1 must be a number (int or float)')
 
         if type(y1) not in [int, float]:
-            raise TypeError("y1 must be a number (int or float)")
+            raise TypeError('y1 must be a number (int or float)')
 
         if type(step_size) not in [int, float]:
-            raise TypeError("step_size must be a number (int or float)")
+            raise TypeError('step_size must be a number (int or float)')
 
         if step_size <= 0:
-            raise ValueError("step_size must be a positive number")
+            raise ValueError('step_size must be a positive number')
 
         self.x0_ = x0
         self.y0_ = y0
@@ -88,7 +88,7 @@ class LineIterator():
         else:
             self.valid_ = False
             raise ValueError(
-                "Line has zero length (All 4 points have same coordinates)")
+                'Line has zero length (All 4 points have same coordinates)')
 
     def isValid(self):
         """Check if line is valid."""

--- a/nav2_simple_commander/test/test_footprint_collision_checker.py
+++ b/nav2_simple_commander/test/test_footprint_collision_checker.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import unittest
-from nav2_simple_commander.footprint_collision_checker import FootprintCollisionChecker
+
+from geometry_msgs.msg import Point32, Polygon
 from nav2_simple_commander.costmap_2d import PyCostmap2D
+from nav2_simple_commander.footprint_collision_checker import FootprintCollisionChecker
 from nav_msgs.msg import OccupancyGrid
-from geometry_msgs.msg import Polygon
-from geometry_msgs.msg import Point32
 
 LETHAL_OBSTACLE = 254
 

--- a/nav2_simple_commander/test/test_line_iterator.py
+++ b/nav2_simple_commander/test/test_line_iterator.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 from cmath import sqrt
+import unittest
+
 from nav2_simple_commander.line_iterator import LineIterator
 
 

--- a/nav2_system_tests/src/error_codes/test_error_codes.py
+++ b/nav2_system_tests/src/error_codes/test_error_codes.py
@@ -17,11 +17,10 @@ import sys
 import time
 
 from geometry_msgs.msg import PoseStamped
-from nav_msgs.msg import Path
+from nav2_msgs.action import ComputePathThroughPoses, ComputePathToPose, FollowPath, SmoothPath
 from nav2_simple_commander.robot_navigator import BasicNavigator
-
+from nav_msgs.msg import Path
 import rclpy
-from nav2_msgs.action import FollowPath, ComputePathToPose, ComputePathThroughPoses, SmoothPath
 
 
 def main(argv=sys.argv[1:]):
@@ -53,7 +52,7 @@ def main(argv=sys.argv[1:]):
     path.poses.append(goal_pose)
     path.poses.append(goal_pose1)
 
-    navigator._waitForNodeToActivate("controller_server")
+    navigator._waitForNodeToActivate('controller_server')
     follow_path = {
         'unknown': FollowPath.Goal().UNKNOWN,
         'invalid_controller': FollowPath.Goal().INVALID_CONTROLLER,
@@ -72,10 +71,10 @@ def main(argv=sys.argv[1:]):
                 time.sleep(0.5)
 
             assert navigator.result_future.result().result.error_code == error_code, \
-                "Follow path error code does not match"
+                'Follow path error code does not match'
 
         else:
-            assert False, "Follow path was rejected"
+            assert False, 'Follow path was rejected'
 
     goal_pose = PoseStamped()
     goal_pose.header.frame_id = 'map'
@@ -87,7 +86,7 @@ def main(argv=sys.argv[1:]):
     goal_pose.pose.orientation.z = 0.0
     goal_pose.pose.orientation.w = 1.0
 
-    navigator._waitForNodeToActivate("planner_server")
+    navigator._waitForNodeToActivate('planner_server')
     compute_path_to_pose = {
         'unknown': ComputePathToPose.Goal().UNKNOWN,
         'invalid_planner': ComputePathToPose.Goal().INVALID_PLANNER,
@@ -101,7 +100,7 @@ def main(argv=sys.argv[1:]):
 
     for planner, error_code in compute_path_to_pose.items():
         result = navigator._getPathImpl(initial_pose, goal_pose, planner)
-        assert result.error_code == error_code, "Compute path to pose error does not match"
+        assert result.error_code == error_code, 'Compute path to pose error does not match'
 
     # Check compute path through error codes
     goal_pose1 = goal_pose
@@ -121,7 +120,7 @@ def main(argv=sys.argv[1:]):
 
     for planner, error_code in compute_path_through_poses.items():
         result = navigator._getPathThroughPosesImpl(initial_pose, goal_poses, planner)
-        assert result.error_code == error_code, "Compute path through pose error does not match"
+        assert result.error_code == error_code, 'Compute path through pose error does not match'
 
     # Check compute path to pose error codes
     pose = PoseStamped()
@@ -140,7 +139,7 @@ def main(argv=sys.argv[1:]):
     a_path.poses.append(pose)
     a_path.poses.append(pose1)
 
-    navigator._waitForNodeToActivate("smoother_server")
+    navigator._waitForNodeToActivate('smoother_server')
     smoother = {
         'invalid_smoother': SmoothPath.Goal().INVALID_SMOOTHER,
         'unknown': SmoothPath.Goal().UNKNOWN,
@@ -152,7 +151,7 @@ def main(argv=sys.argv[1:]):
 
     for smoother, error_code in smoother.items():
         result = navigator._smoothPathImpl(a_path, smoother)
-        assert result.error_code == error_code, "Smoother error does not match"
+        assert result.error_code == error_code, 'Smoother error does not match'
 
     navigator.lifecycleShutdown()
     rclpy.shutdown()

--- a/nav2_system_tests/src/error_codes/test_error_codes_launch.py
+++ b/nav2_system_tests/src/error_codes/test_error_codes_launch.py
@@ -19,9 +19,9 @@ import sys
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess
-from launch_testing.legacy import LaunchTestService
-from launch_ros.actions import Node
 from launch.actions import GroupAction
+from launch_ros.actions import Node
+from launch_testing.legacy import LaunchTestService
 
 
 def generate_launch_description():

--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -18,7 +18,7 @@ import time
 
 from action_msgs.msg import GoalStatus
 from geometry_msgs.msg import PoseStamped, PoseWithCovarianceStamped
-from nav2_msgs.action import FollowWaypoints, ComputePathToPose
+from nav2_msgs.action import ComputePathToPose, FollowWaypoints
 from nav2_msgs.srv import ManageLifecycleNodes
 from rcl_interfaces.srv import SetParameters
 

--- a/nav2_util/include/nav2_util/lifecycle_node.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_node.hpp
@@ -168,6 +168,13 @@ public:
   }
 
   /**
+   * @brief Perform preshutdown activities before our Context is shutdown.
+   * Note that this is related to our Context's shutdown sequence, not the
+   * lifecycle node state machine.
+   */
+  virtual void on_rcl_preshutdown();
+
+  /**
    * @brief Create bond connection to lifecycle manager
    */
   void createBond();
@@ -182,6 +189,19 @@ protected:
    * @brief Print notifications for lifecycle node
    */
   void printLifecycleNodeNotification();
+
+  /**
+   * Register our preshutdown callback for this Node's rcl Context.
+   * The callback fires before this Node's Context is shutdown.
+   * Note this is not directly related to the lifecycle state machine.
+   */
+  void register_rcl_preshutdown_callback();
+  std::unique_ptr<rclcpp::PreShutdownCallbackHandle> rcl_preshutdown_cb_handle_{nullptr};
+
+  /**
+   * Run some common cleanup steps shared between rcl preshutdown and destruction.
+   */
+  void runCleanups();
 
   // Connection to tell that server is still up
   std::unique_ptr<bond::Bond> bond_{nullptr};


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | 3271 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | nav2_system_tests (i.e. turtlebot3_waffle?) |

---

## Description of contribution in a few bullet points

In brief: unclean shutdown of several processes resulted in code coverage data being dropped on the floor, rather than flushed to the .gcda files. So to get the code coverage data, we fix the unclean shutdowns. There are a few instances fixed in this PR, but likely not all (see Future work below).

The gist of all these fixes is that rclcpp::shutdown() invalidates a bunch of state, and if something attempts to touch that state again after the shutdown(), exceptions and seg faults can occur, resulting in unclean shutdown. rclcpp provides a preshutdown callback mechanism for use cases like these. The fixes are:

* Add a preshutdown callback to `lifecycle_node` which tosses `bond_`. If a lifecycle_node is destructed after `shutdown()` while the `bond_` still exists, the `Bond` destructor will fire, which touches invalidated state. The result is an RCLError in the destructor code path. The fix is to drop the `bond_` prior to shutdown, i.e. in the preshutdown callback.
* Subclass the preshutdown callback in planner_server in order to drop additional state, for the same reason.
* Address a segfault in `nav2_costmap_2d_cloud main()` by manual destructing some global state prior to shutdown(). This one could not be reproduced on @SteveMacenski's machine, so it may be version dependent? Not sure.

The first two of these appeared in the circleCI output during code cov runs, as well as in my local sandbox, and fixing them drastically improved code coverage on the Nav2 plugins. I have not spotted the 3rd of these in the circleCI logs (though I haven't tried very hard), but it's low enough risk to justify, reasoning that this is probably version dependent somehow.

## Description of documentation updates required from your changes

None, unless we want to give an example of a preshutdown callback?

---

## Future work that may be required in bullet points
* Additional shutdown bugs are likely lurking, but they seem hard to pin down, and it's unclear what is due to this developer's local setup.
* We should probably change our nav2_system_tests to fail if unexpected exit codes are encountered, in order to catch the issues in the prior bullet point.
* Because of the shutdown issues or other reasons, we may still be missing code coverage somewhere. Additional work could be done to find where. This present fix addresses Assisted Teleop and Drive-on-Heading coverage issues, and likely many others, but no effort was made to be systematic about finding all such issues.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
