### PR TITLE
Fix mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -31,7 +31,7 @@ pull_request_rules:
       - merged
     actions:
       delete_head_branch:
- 
+
   - name: ask to resolve conflict
     conditions:
       - conflict
@@ -48,7 +48,7 @@ pull_request_rules:
     actions:
         comment:
           message: |
-            @{{author}}, all pull requests must be targeted towards the `main` development branch. 
+            @{{author}}, all pull requests must be targeted towards the `main` development branch.
             Once merged into `main`, it is possible to backport to @{{base}}, but it must be in `main`
             to have these changes reflected into new distributions.
 
@@ -61,19 +61,19 @@ pull_request_rules:
     actions:
         comment:
           message: |
-            @{{author}}, your PR has failed to build. Please check CI outputs and resolve issues. 
+            @{{author}}, your PR has failed to build. Please check CI outputs and resolve issues.
             You may need to rebase or pull in `main` due to API changes (or your contribution genuinely fails).
 
   - name: Removed maintainer checklist
     conditions:
       - and:
-        - "-body~=(?m)^For Maintainers:"
+        - body-raw~=^#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->$
         - author!=SteveMacenski
         - author!=mergify
     actions:
         comment:
           message: |
-            @{{author}}, please properly fill in PR template in the future. @stevemacenski, use this instead. 
+            @{{author}}, please properly fill in PR template in the future. @stevemacenski, use this instead.
             - [ ] Check that any new parameters added are updated in navigation.ros.org
             - [ ] Check that any significant change is added to the migration guide
             - [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -67,7 +67,7 @@ pull_request_rules:
   - name: Removed maintainer checklist
     conditions:
       - and:
-        - body-raw~="^#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->$"
+        - body-raw~=^#### For Maintainers
         - author!=SteveMacenski
         - author!=mergify
     actions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -67,7 +67,7 @@ pull_request_rules:
   - name: Removed maintainer checklist
     conditions:
       - and:
-        - body-raw~=^#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->$
+        - body-raw~="^#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->$"
         - author!=SteveMacenski
         - author!=mergify
     actions:


### PR DESCRIPTION
Related to

From the mergify documentation on attributes, it looks like `body-raw` was still what you wanted, however it seems that the yaml parser was tripping up on the complete regex pattern of the entire line. For example, I couldn't get it to escape the colon punctuation, so I just truncated the pattern.  

https://docs.mergify.com/conditions/#attributes 

Before:
https://github.com/ruffsl/navigation2/pull/10

After:
https://github.com/ruffsl/navigation2/pull/13

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
