### PR TITLE
Option allowing to use simple lookupTransform API

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -127,13 +127,16 @@ protected:
    * source->base time inerpolated transform.
    * @param transform_tolerance Transform tolerance
    * @param source_timeout Maximum time interval in which data is considered valid
+   * @param base_shift_correction Whether to correct source data towards to base frame movement,
+   * considering the difference between current time and latest source time
    * @return True if all sources were configured successfully or false in failure case
    */
   bool configureSources(
     const std::string & base_frame_id,
     const std::string & odom_frame_id,
     const tf2::Duration & transform_tolerance,
-    const rclcpp::Duration & source_timeout);
+    const rclcpp::Duration & source_timeout,
+    const bool base_shift_correction);
 
   /**
    * @brief Main processing routine

--- a/nav2_collision_monitor/include/nav2_collision_monitor/pointcloud.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/pointcloud.hpp
@@ -41,6 +41,8 @@ public:
    * @param global_frame_id Global frame ID for correct transform calculation
    * @param transform_tolerance Transform tolerance
    * @param source_timeout Maximum time interval in which data is considered valid
+   * @param base_shift_correction Whether to correct source data towards to base frame movement,
+   * considering the difference between current time and latest source time
    */
   PointCloud(
     const nav2_util::LifecycleNode::WeakPtr & node,
@@ -49,7 +51,8 @@ public:
     const std::string & base_frame_id,
     const std::string & global_frame_id,
     const tf2::Duration & transform_tolerance,
-    const rclcpp::Duration & source_timeout);
+    const rclcpp::Duration & source_timeout,
+    const bool base_shift_correction);
   /**
    * @brief PointCloud destructor
    */

--- a/nav2_collision_monitor/include/nav2_collision_monitor/range.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/range.hpp
@@ -41,6 +41,8 @@ public:
    * @param global_frame_id Global frame ID for correct transform calculation
    * @param transform_tolerance Transform tolerance
    * @param source_timeout Maximum time interval in which data is considered valid
+   * @param base_shift_correction Whether to correct source data towards to base frame movement,
+   * considering the difference between current time and latest source time
    */
   Range(
     const nav2_util::LifecycleNode::WeakPtr & node,
@@ -49,7 +51,8 @@ public:
     const std::string & base_frame_id,
     const std::string & global_frame_id,
     const tf2::Duration & transform_tolerance,
-    const rclcpp::Duration & source_timeout);
+    const rclcpp::Duration & source_timeout,
+    const bool base_shift_correction);
   /**
    * @brief Range destructor
    */

--- a/nav2_collision_monitor/include/nav2_collision_monitor/scan.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/scan.hpp
@@ -41,6 +41,8 @@ public:
    * @param global_frame_id Global frame ID for correct transform calculation
    * @param transform_tolerance Transform tolerance
    * @param source_timeout Maximum time interval in which data is considered valid
+   * @param base_shift_correction Whether to correct source data towards to base frame movement,
+   * considering the difference between current time and latest source time
    */
   Scan(
     const nav2_util::LifecycleNode::WeakPtr & node,
@@ -49,7 +51,8 @@ public:
     const std::string & base_frame_id,
     const std::string & global_frame_id,
     const tf2::Duration & transform_tolerance,
-    const rclcpp::Duration & source_timeout);
+    const rclcpp::Duration & source_timeout,
+    const bool base_shift_correction);
   /**
    * @brief Scan destructor
    */

--- a/nav2_collision_monitor/include/nav2_collision_monitor/source.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/source.hpp
@@ -46,6 +46,8 @@ public:
    * @param global_frame_id Global frame ID for correct transform calculation
    * @param transform_tolerance Transform tolerance
    * @param source_timeout Maximum time interval in which data is considered valid
+   * @param base_shift_correction Whether to correct source data towards to base frame movement,
+   * considering the difference between current time and latest source time
    */
   Source(
     const nav2_util::LifecycleNode::WeakPtr & node,
@@ -54,7 +56,8 @@ public:
     const std::string & base_frame_id,
     const std::string & global_frame_id,
     const tf2::Duration & transform_tolerance,
-    const rclcpp::Duration & source_timeout);
+    const rclcpp::Duration & source_timeout,
+    const bool base_shift_correction);
   /**
    * @brief Source destructor
    */
@@ -110,6 +113,9 @@ protected:
   tf2::Duration transform_tolerance_;
   /// @brief Maximum time interval in which data is considered valid
   rclcpp::Duration source_timeout_;
+  /// @brief Whether to correct source data towards to base frame movement,
+  /// considering the difference between current time and latest source time
+  bool base_shift_correction_;
 };  // class Source
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -6,6 +6,7 @@ collision_monitor:
     cmd_vel_out_topic: "cmd_vel"
     transform_tolerance: 0.5
     source_timeout: 5.0
+    base_shift_correction: True
     stop_pub_timeout: 2.0
     # Polygons represent zone around the robot for "stop" and "slowdown" action types,
     # and robot footprint for "approach" action type.

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -205,6 +205,10 @@ bool CollisionMonitor::getParameters(
     node, "source_timeout", rclcpp::ParameterValue(2.0));
   source_timeout =
     rclcpp::Duration::from_seconds(get_parameter("source_timeout").as_double());
+  nav2_util::declare_parameter_if_not_declared(
+    node, "base_shift_correction", rclcpp::ParameterValue(true));
+  const bool base_shift_correction =
+    get_parameter("base_shift_correction").as_bool();
 
   nav2_util::declare_parameter_if_not_declared(
     node, "stop_pub_timeout", rclcpp::ParameterValue(1.0));
@@ -215,7 +219,10 @@ bool CollisionMonitor::getParameters(
     return false;
   }
 
-  if (!configureSources(base_frame_id, odom_frame_id, transform_tolerance, source_timeout)) {
+  if (
+    !configureSources(
+      base_frame_id, odom_frame_id, transform_tolerance, source_timeout, base_shift_correction))
+  {
     return false;
   }
 
@@ -271,7 +278,8 @@ bool CollisionMonitor::configureSources(
   const std::string & base_frame_id,
   const std::string & odom_frame_id,
   const tf2::Duration & transform_tolerance,
-  const rclcpp::Duration & source_timeout)
+  const rclcpp::Duration & source_timeout,
+  const bool base_shift_correction)
 {
   try {
     auto node = shared_from_this();
@@ -289,7 +297,7 @@ bool CollisionMonitor::configureSources(
       if (source_type == "scan") {
         std::shared_ptr<Scan> s = std::make_shared<Scan>(
           node, source_name, tf_buffer_, base_frame_id, odom_frame_id,
-          transform_tolerance, source_timeout);
+          transform_tolerance, source_timeout, base_shift_correction);
 
         s->configure();
 
@@ -297,7 +305,7 @@ bool CollisionMonitor::configureSources(
       } else if (source_type == "pointcloud") {
         std::shared_ptr<PointCloud> p = std::make_shared<PointCloud>(
           node, source_name, tf_buffer_, base_frame_id, odom_frame_id,
-          transform_tolerance, source_timeout);
+          transform_tolerance, source_timeout, base_shift_correction);
 
         p->configure();
 
@@ -305,7 +313,7 @@ bool CollisionMonitor::configureSources(
       } else if (source_type == "range") {
         std::shared_ptr<Range> r = std::make_shared<Range>(
           node, source_name, tf_buffer_, base_frame_id, odom_frame_id,
-          transform_tolerance, source_timeout);
+          transform_tolerance, source_timeout, base_shift_correction);
 
         r->configure();
 

--- a/nav2_collision_monitor/src/pointcloud.cpp
+++ b/nav2_collision_monitor/src/pointcloud.cpp
@@ -77,7 +77,6 @@ void PointCloud::getData(
     return;
   }
 
-
   tf2::Transform tf_transform;
   if (base_shift_correction_) {
     // Obtaining the transform to get data from source frame and time where it was received
@@ -92,7 +91,8 @@ void PointCloud::getData(
     }
   } else {
     // Obtaining the transform to get data from source frame to base frame without time shift
-    // considered. Less accurate but much more faster option.
+    // considered. Less accurate but much more faster option not dependent on state estimation
+    // frames.
     if (
       !nav2_util::getTransform(
         data_->header.frame_id, base_frame_id_,

--- a/nav2_collision_monitor/src/pointcloud.cpp
+++ b/nav2_collision_monitor/src/pointcloud.cpp
@@ -31,10 +31,11 @@ PointCloud::PointCloud(
   const std::string & base_frame_id,
   const std::string & global_frame_id,
   const tf2::Duration & transform_tolerance,
-  const rclcpp::Duration & source_timeout)
+  const rclcpp::Duration & source_timeout,
+  const bool base_shift_correction)
 : Source(
     node, source_name, tf_buffer, base_frame_id, global_frame_id,
-    transform_tolerance, source_timeout),
+    transform_tolerance, source_timeout, base_shift_correction),
   data_(nullptr)
 {
   RCLCPP_INFO(logger_, "[%s]: Creating PointCloud", source_name_.c_str());
@@ -76,16 +77,29 @@ void PointCloud::getData(
     return;
   }
 
-  // Obtaining the transform to get data from source frame and time where it was received
-  // to the base frame and current time
+
   tf2::Transform tf_transform;
-  if (
-    !nav2_util::getTransform(
-      data_->header.frame_id, data_->header.stamp,
-      base_frame_id_, curr_time, global_frame_id_,
-      transform_tolerance_, tf_buffer_, tf_transform))
-  {
-    return;
+  if (base_shift_correction_) {
+    // Obtaining the transform to get data from source frame and time where it was received
+    // to the base frame and current time
+    if (
+      !nav2_util::getTransform(
+        data_->header.frame_id, data_->header.stamp,
+        base_frame_id_, curr_time, global_frame_id_,
+        transform_tolerance_, tf_buffer_, tf_transform))
+    {
+      return;
+    }
+  } else {
+    // Obtaining the transform to get data from source frame to base frame without time shift
+    // considered. Less accurate but much more faster option.
+    if (
+      !nav2_util::getTransform(
+        data_->header.frame_id, base_frame_id_,
+        transform_tolerance_, tf_buffer_, tf_transform))
+    {
+      return;
+    }
   }
 
   sensor_msgs::PointCloud2ConstIterator<float> iter_x(*data_, "x");

--- a/nav2_collision_monitor/src/range.cpp
+++ b/nav2_collision_monitor/src/range.cpp
@@ -31,10 +31,11 @@ Range::Range(
   const std::string & base_frame_id,
   const std::string & global_frame_id,
   const tf2::Duration & transform_tolerance,
-  const rclcpp::Duration & source_timeout)
+  const rclcpp::Duration & source_timeout,
+  const bool base_shift_correction)
 : Source(
     node, source_name, tf_buffer, base_frame_id, global_frame_id,
-    transform_tolerance, source_timeout),
+    transform_tolerance, source_timeout, base_shift_correction),
   data_(nullptr)
 {
   RCLCPP_INFO(logger_, "[%s]: Creating Range", source_name_.c_str());
@@ -88,13 +89,27 @@ void Range::getData(
   // Obtaining the transform to get data from source frame and time where it was received
   // to the base frame and current time
   tf2::Transform tf_transform;
-  if (
-    !nav2_util::getTransform(
-      data_->header.frame_id, data_->header.stamp,
-      base_frame_id_, curr_time, global_frame_id_,
-      transform_tolerance_, tf_buffer_, tf_transform))
-  {
-    return;
+  if (base_shift_correction_) {
+    // Obtaining the transform to get data from source frame and time where it was received
+    // to the base frame and current time
+    if (
+      !nav2_util::getTransform(
+        data_->header.frame_id, data_->header.stamp,
+        base_frame_id_, curr_time, global_frame_id_,
+        transform_tolerance_, tf_buffer_, tf_transform))
+    {
+      return;
+    }
+  } else {
+    // Obtaining the transform to get data from source frame to base frame without time shift
+    // considered. Less accurate but much more faster option.
+    if (
+      !nav2_util::getTransform(
+        data_->header.frame_id, base_frame_id_,
+        transform_tolerance_, tf_buffer_, tf_transform))
+    {
+      return;
+    }
   }
 
   // Calculate poses and refill data array

--- a/nav2_collision_monitor/src/range.cpp
+++ b/nav2_collision_monitor/src/range.cpp
@@ -86,8 +86,6 @@ void Range::getData(
     return;
   }
 
-  // Obtaining the transform to get data from source frame and time where it was received
-  // to the base frame and current time
   tf2::Transform tf_transform;
   if (base_shift_correction_) {
     // Obtaining the transform to get data from source frame and time where it was received
@@ -102,7 +100,8 @@ void Range::getData(
     }
   } else {
     // Obtaining the transform to get data from source frame to base frame without time shift
-    // considered. Less accurate but much more faster option.
+    // considered. Less accurate but much more faster option not dependent on state estimation
+    // frames.
     if (
       !nav2_util::getTransform(
         data_->header.frame_id, base_frame_id_,

--- a/nav2_collision_monitor/src/scan.cpp
+++ b/nav2_collision_monitor/src/scan.cpp
@@ -76,8 +76,6 @@ void Scan::getData(
     return;
   }
 
-  // Obtaining the transform to get data from source frame and time where it was received
-  // to the base frame and current time
   tf2::Transform tf_transform;
   if (base_shift_correction_) {
     // Obtaining the transform to get data from source frame and time where it was received
@@ -92,7 +90,8 @@ void Scan::getData(
     }
   } else {
     // Obtaining the transform to get data from source frame to base frame without time shift
-    // considered. Less accurate but much more faster option.
+    // considered. Less accurate but much more faster option not dependent on state estimation
+    // frames.
     if (
       !nav2_util::getTransform(
         data_->header.frame_id, base_frame_id_,

--- a/nav2_collision_monitor/src/scan.cpp
+++ b/nav2_collision_monitor/src/scan.cpp
@@ -29,10 +29,11 @@ Scan::Scan(
   const std::string & base_frame_id,
   const std::string & global_frame_id,
   const tf2::Duration & transform_tolerance,
-  const rclcpp::Duration & source_timeout)
+  const rclcpp::Duration & source_timeout,
+  const bool base_shift_correction)
 : Source(
     node, source_name, tf_buffer, base_frame_id, global_frame_id,
-    transform_tolerance, source_timeout),
+    transform_tolerance, source_timeout, base_shift_correction),
   data_(nullptr)
 {
   RCLCPP_INFO(logger_, "[%s]: Creating Scan", source_name_.c_str());
@@ -78,13 +79,27 @@ void Scan::getData(
   // Obtaining the transform to get data from source frame and time where it was received
   // to the base frame and current time
   tf2::Transform tf_transform;
-  if (
-    !nav2_util::getTransform(
-      data_->header.frame_id, data_->header.stamp,
-      base_frame_id_, curr_time, global_frame_id_,
-      transform_tolerance_, tf_buffer_, tf_transform))
-  {
-    return;
+  if (base_shift_correction_) {
+    // Obtaining the transform to get data from source frame and time where it was received
+    // to the base frame and current time
+    if (
+      !nav2_util::getTransform(
+        data_->header.frame_id, data_->header.stamp,
+        base_frame_id_, curr_time, global_frame_id_,
+        transform_tolerance_, tf_buffer_, tf_transform))
+    {
+      return;
+    }
+  } else {
+    // Obtaining the transform to get data from source frame to base frame without time shift
+    // considered. Less accurate but much more faster option.
+    if (
+      !nav2_util::getTransform(
+        data_->header.frame_id, base_frame_id_,
+        transform_tolerance_, tf_buffer_, tf_transform))
+    {
+      return;
+    }
   }
 
   // Calculate poses and refill data array

--- a/nav2_collision_monitor/src/source.cpp
+++ b/nav2_collision_monitor/src/source.cpp
@@ -30,10 +30,12 @@ Source::Source(
   const std::string & base_frame_id,
   const std::string & global_frame_id,
   const tf2::Duration & transform_tolerance,
-  const rclcpp::Duration & source_timeout)
+  const rclcpp::Duration & source_timeout,
+  const bool base_shift_correction)
 : node_(node), source_name_(source_name), tf_buffer_(tf_buffer),
   base_frame_id_(base_frame_id), global_frame_id_(global_frame_id),
-  transform_tolerance_(transform_tolerance), source_timeout_(source_timeout)
+  transform_tolerance_(transform_tolerance), source_timeout_(source_timeout),
+  base_shift_correction_(base_shift_correction)
 {
 }
 

--- a/nav2_collision_monitor/test/sources_test.cpp
+++ b/nav2_collision_monitor/test/sources_test.cpp
@@ -172,10 +172,11 @@ public:
     const std::string & base_frame_id,
     const std::string & global_frame_id,
     const tf2::Duration & transform_tolerance,
-    const rclcpp::Duration & data_timeout)
+    const rclcpp::Duration & data_timeout,
+    const bool base_shift_correction)
   : nav2_collision_monitor::Scan(
       node, source_name, tf_buffer, base_frame_id, global_frame_id,
-      transform_tolerance, data_timeout)
+      transform_tolerance, data_timeout, base_shift_correction)
   {}
 
   bool dataReceived() const
@@ -194,10 +195,11 @@ public:
     const std::string & base_frame_id,
     const std::string & global_frame_id,
     const tf2::Duration & transform_tolerance,
-    const rclcpp::Duration & data_timeout)
+    const rclcpp::Duration & data_timeout,
+    const bool base_shift_correction)
   : nav2_collision_monitor::PointCloud(
       node, source_name, tf_buffer, base_frame_id, global_frame_id,
-      transform_tolerance, data_timeout)
+      transform_tolerance, data_timeout, base_shift_correction)
   {}
 
   bool dataReceived() const
@@ -216,10 +218,11 @@ public:
     const std::string & base_frame_id,
     const std::string & global_frame_id,
     const tf2::Duration & transform_tolerance,
-    const rclcpp::Duration & data_timeout)
+    const rclcpp::Duration & data_timeout,
+    const bool base_shift_correction)
   : nav2_collision_monitor::Range(
       node, source_name, tf_buffer, base_frame_id, global_frame_id,
-      transform_tolerance, data_timeout)
+      transform_tolerance, data_timeout, base_shift_correction)
   {}
 
   bool dataReceived() const
@@ -235,6 +238,9 @@ public:
   ~Tester();
 
 protected:
+  // Data sources creation routine
+  void createSources(const bool base_shift_correction = true);
+
   // Setting TF chains
   void sendTransforms(const rclcpp::Time & stamp);
 
@@ -263,7 +269,22 @@ Tester::Tester()
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(test_node_->get_clock());
   tf_buffer_->setUsingDedicatedThread(true);  // One-thread broadcasting-listening model
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+}
 
+Tester::~Tester()
+{
+  scan_.reset();
+  pointcloud_.reset();
+  range_.reset();
+
+  test_node_.reset();
+
+  tf_listener_.reset();
+  tf_buffer_.reset();
+}
+
+void Tester::createSources(const bool base_shift_correction)
+{
   // Create Scan object
   test_node_->declare_parameter(
     std::string(SCAN_NAME) + ".topic", rclcpp::ParameterValue(SCAN_TOPIC));
@@ -273,7 +294,7 @@ Tester::Tester()
   scan_ = std::make_shared<ScanWrapper>(
     test_node_, SCAN_NAME, tf_buffer_,
     BASE_FRAME_ID, GLOBAL_FRAME_ID,
-    TRANSFORM_TOLERANCE, DATA_TIMEOUT);
+    TRANSFORM_TOLERANCE, DATA_TIMEOUT, base_shift_correction);
   scan_->configure();
 
   // Create PointCloud object
@@ -293,7 +314,7 @@ Tester::Tester()
   pointcloud_ = std::make_shared<PointCloudWrapper>(
     test_node_, POINTCLOUD_NAME, tf_buffer_,
     BASE_FRAME_ID, GLOBAL_FRAME_ID,
-    TRANSFORM_TOLERANCE, DATA_TIMEOUT);
+    TRANSFORM_TOLERANCE, DATA_TIMEOUT, base_shift_correction);
   pointcloud_->configure();
 
   // Create Range object
@@ -308,20 +329,8 @@ Tester::Tester()
   range_ = std::make_shared<RangeWrapper>(
     test_node_, RANGE_NAME, tf_buffer_,
     BASE_FRAME_ID, GLOBAL_FRAME_ID,
-    TRANSFORM_TOLERANCE, DATA_TIMEOUT);
+    TRANSFORM_TOLERANCE, DATA_TIMEOUT, base_shift_correction);
   range_->configure();
-}
-
-Tester::~Tester()
-{
-  scan_.reset();
-  pointcloud_.reset();
-  range_.reset();
-
-  test_node_.reset();
-
-  tf_listener_.reset();
-  tf_buffer_.reset();
 }
 
 void Tester::sendTransforms(const rclcpp::Time & stamp)
@@ -453,6 +462,8 @@ TEST_F(Tester, testGetData)
 {
   rclcpp::Time curr_time = test_node_->now();
 
+  createSources();
+
   sendTransforms(curr_time);
 
   // Publish data for sources
@@ -485,6 +496,8 @@ TEST_F(Tester, testGetOutdatedData)
 {
   rclcpp::Time curr_time = test_node_->now();
 
+  createSources();
+
   sendTransforms(curr_time);
 
   // Publish outdated data for sources
@@ -514,6 +527,8 @@ TEST_F(Tester, testGetOutdatedData)
 TEST_F(Tester, testIncorrectFrameData)
 {
   rclcpp::Time curr_time = test_node_->now();
+
+  createSources();
 
   // Send incorrect transform
   sendTransforms(curr_time - 1s);
@@ -546,6 +561,8 @@ TEST_F(Tester, testIncorrectData)
 {
   rclcpp::Time curr_time = test_node_->now();
 
+  createSources();
+
   sendTransforms(curr_time);
 
   // Publish data for sources
@@ -565,6 +582,41 @@ TEST_F(Tester, testIncorrectData)
   // Range data should be empty
   range_->getData(curr_time, data);
   ASSERT_EQ(data.size(), 0u);
+}
+
+TEST_F(Tester, testIgnoreTimeShift)
+{
+  rclcpp::Time curr_time = test_node_->now();
+
+  createSources(false);
+
+  // Send incorrect transform
+  sendTransforms(curr_time - 1s);
+
+  // Publish data for sources
+  test_node_->publishScan(curr_time, 1.0);
+  test_node_->publishPointCloud(curr_time);
+  test_node_->publishRange(curr_time, 1.0);
+
+  // Wait until all sources will receive the data
+  ASSERT_TRUE(waitScan(500ms));
+  ASSERT_TRUE(waitPointCloud(500ms));
+  ASSERT_TRUE(waitRange(500ms));
+
+  // Scan data should be consistent
+  std::vector<nav2_collision_monitor::Point> data;
+  scan_->getData(curr_time, data);
+  checkScan(data);
+
+  // Pointcloud data should be consistent
+  data.clear();
+  pointcloud_->getData(curr_time, data);
+  checkPointCloud(data);
+
+  // Range data should be consistent
+  data.clear();
+  range_->getData(curr_time, data);
+  checkRange(data);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
ignoring time shifts between source and base frame during the movement
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3402 |
| Primary OS tested on | Ubuntu 20.04 with ROS2 Rolling built from sources |
| Robotic platform tested on | TB3 Gazebo simulation, `colcon test --packages-select nav2_collision_monitor`, code coverage |

---

## Description of contribution in a few bullet points

* Added an new option allowing to control which `lookupTransform()` API to use: [simple](https://docs.ros2.org/latest/api/tf2/classtf2_1_1BufferCore.html#a5d578ecbea2ec0fdb92de1616251e175) or [advanced](https://docs.ros2.org/latest/api/tf2/classtf2_1_1BufferCore.html#a779c28b06b41f9ebc63e8c0d0da77e9b), considering considering the difference between current time and latest source time and allowing to correct source data towards to base frame movement.
* Using advanced `lookupTransform()` API will lead to better accuracy in cost of performance (strongly recommended for fast moving robots)
* Using simple `lookupTransform()` API will lower the accuracy but will improve the performance for `~1/(2*odom_rate)` per each `cmd_vel` calculation cycle, which might be suitable for slow robots.
* Using of simple `lookupTransform()` API is being covered by `testIgnoreTimeShift` testcase (advanced `lookupTransform()` API is already covered by previous tests)


## Description of documentation updates required from your changes

* Added new parameter on `Collision Monitor` configuration page

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
