### PR TITLE
Rpp curve regulation reference cycle

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/README.md
+++ b/nav2_regulated_pure_pursuit_controller/README.md
@@ -119,7 +119,7 @@ controller_server:
       use_cost_regulated_linear_velocity_scaling: false
       regulated_linear_scaling_min_radius: 0.9
       regulated_linear_scaling_min_speed: 0.25
-      use_fixed_curvature_lookahead: true
+      use_fixed_curvature_lookahead: false
       curvature_lookahead_dist: 1.0
       use_rotate_to_heading: true
       rotate_to_heading_min_angle: 0.785

--- a/nav2_regulated_pure_pursuit_controller/README.md
+++ b/nav2_regulated_pure_pursuit_controller/README.md
@@ -71,6 +71,8 @@ Note: The maximum allowed time to collision is thresholded by the lookahead poin
 | `inflation_cost_scaling_factor` | The value of `cost_scaling_factor` set for the inflation layer in the local costmap. The value should be exactly the same for accurately computing distance from obstacles using the inflated cell values | 
 | `regulated_linear_scaling_min_radius` | The turning radius for which the regulation features are triggered. Remember, sharper turns have smaller radii | 
 | `regulated_linear_scaling_min_speed` | The minimum speed for which the regulated features can send, to ensure process is still achievable even in high cost spaces with high curvature. | 
+| `use_fixed_curvature_lookahead` | Enable fixed lookahead for curvature detection. Useful for systems with long lookahead. | 
+| `curvature_lookahead_dist` | Distance to lookahead to determine curvature for velocity regulation purposes. Only used if `use_fixed_curvature_lookahead` is enabled. | 
 | `use_rotate_to_heading` | Whether to enable rotating to rough heading and goal orientation when using holonomic planners. Recommended on for all robot types except ackermann, which cannot rotate in place. | 
 | `rotate_to_heading_min_angle` | The difference in the path orientation and the starting robot orientation to trigger a rotate in place, if `use_rotate_to_heading` is enabled. | 
 | `max_angular_accel` | Maximum allowable angular acceleration while rotating to heading, if enabled | 
@@ -117,6 +119,8 @@ controller_server:
       use_cost_regulated_linear_velocity_scaling: false
       regulated_linear_scaling_min_radius: 0.9
       regulated_linear_scaling_min_speed: 0.25
+      use_fixed_curvature_lookahead: true
+      curvature_lookahead_dist: 1.0
       use_rotate_to_heading: true
       rotate_to_heading_min_angle: 0.785
       max_angular_accel: 3.2

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
@@ -49,8 +49,6 @@ struct Parameters
   double inflation_cost_scaling_factor;
   double regulated_linear_scaling_min_radius;
   double regulated_linear_scaling_min_speed;
-  bool use_fixed_turn_speed;
-  double fixed_turn_speed;
   bool use_fixed_curvature_lookahead;
   double curvature_lookahead_dist;
   bool use_rotate_to_heading;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
@@ -49,6 +49,10 @@ struct Parameters
   double inflation_cost_scaling_factor;
   double regulated_linear_scaling_min_radius;
   double regulated_linear_scaling_min_speed;
+  bool use_fixed_turn_speed;
+  double fixed_turn_speed;
+  bool use_fixed_curvature_lookahead;
+  double curvature_lookahead_dist;
   bool use_rotate_to_heading;
   double max_angular_accel;
   double rotate_to_heading_min_angle;

--- a/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
@@ -76,10 +76,6 @@ ParameterHandler::ParameterHandler(
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".regulated_linear_scaling_min_speed", rclcpp::ParameterValue(0.25));
   declare_parameter_if_not_declared(
-    node, plugin_name_ + ".use_fixed_turn_speed", rclcpp::ParameterValue(false));
-  declare_parameter_if_not_declared(
-    node, plugin_name_ + ".fixed_turn_speed", rclcpp::ParameterValue(0.25));
-  declare_parameter_if_not_declared(
     node, plugin_name_ + ".use_fixed_curvature_lookahead", rclcpp::ParameterValue(false));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".curvature_lookahead_dist", rclcpp::ParameterValue(0.6));
@@ -145,12 +141,6 @@ ParameterHandler::ParameterHandler(
   node->get_parameter(
     plugin_name_ + ".regulated_linear_scaling_min_speed",
     params_.regulated_linear_scaling_min_speed);
-  node->get_parameter(
-    plugin_name_ + ".use_fixed_turn_speed",
-    params_.use_fixed_turn_speed);
-  node->get_parameter(
-    plugin_name_ + ".fixed_turn_speed",
-    params_.fixed_turn_speed);
   node->get_parameter(
     plugin_name_ + ".use_fixed_curvature_lookahead",
     params_.use_fixed_curvature_lookahead);
@@ -230,8 +220,6 @@ ParameterHandler::dynamicParametersCallback(
         params_.rotate_to_heading_angular_vel = parameter.as_double();
       } else if (name == plugin_name_ + ".min_approach_linear_velocity") {
         params_.min_approach_linear_velocity = parameter.as_double();
-      } else if (name == plugin_name_ + ".fixed_turn_speed") {
-        params_.fixed_turn_speed = parameter.as_double();
       } else if (name == plugin_name_ + ".curvature_lookahead_dist") {
         params_.curvature_lookahead_dist = parameter.as_double();
       } else if (name == plugin_name_ + ".max_allowed_time_to_collision_up_to_carrot") {
@@ -254,8 +242,6 @@ ParameterHandler::dynamicParametersCallback(
         params_.use_velocity_scaled_lookahead_dist = parameter.as_bool();
       } else if (name == plugin_name_ + ".use_regulated_linear_velocity_scaling") {
         params_.use_regulated_linear_velocity_scaling = parameter.as_bool();
-      } else if (name == plugin_name_ + ".use_fixed_turn_speed") {
-        params_.use_fixed_turn_speed = parameter.as_bool();
       } else if (name == plugin_name_ + ".use_fixed_curvature_lookahead") {
         params_.use_fixed_curvature_lookahead = parameter.as_bool();
       } else if (name == plugin_name_ + ".use_cost_regulated_linear_velocity_scaling") {

--- a/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
@@ -76,6 +76,14 @@ ParameterHandler::ParameterHandler(
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".regulated_linear_scaling_min_speed", rclcpp::ParameterValue(0.25));
   declare_parameter_if_not_declared(
+    node, plugin_name_ + ".use_fixed_turn_speed", rclcpp::ParameterValue(false));
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".fixed_turn_speed", rclcpp::ParameterValue(0.25));
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".use_fixed_curvature_lookahead", rclcpp::ParameterValue(false));
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".curvature_lookahead_dist", rclcpp::ParameterValue(0.6));
+  declare_parameter_if_not_declared(
     node, plugin_name_ + ".use_rotate_to_heading", rclcpp::ParameterValue(true));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".rotate_to_heading_min_angle", rclcpp::ParameterValue(0.785));
@@ -137,6 +145,18 @@ ParameterHandler::ParameterHandler(
   node->get_parameter(
     plugin_name_ + ".regulated_linear_scaling_min_speed",
     params_.regulated_linear_scaling_min_speed);
+  node->get_parameter(
+    plugin_name_ + ".use_fixed_turn_speed",
+    params_.use_fixed_turn_speed);
+  node->get_parameter(
+    plugin_name_ + ".fixed_turn_speed",
+    params_.fixed_turn_speed);
+  node->get_parameter(
+    plugin_name_ + ".use_fixed_curvature_lookahead",
+    params_.use_fixed_curvature_lookahead);
+  node->get_parameter(
+    plugin_name_ + ".curvature_lookahead_dist",
+    params_.curvature_lookahead_dist);
   node->get_parameter(plugin_name_ + ".use_rotate_to_heading", params_.use_rotate_to_heading);
   node->get_parameter(
     plugin_name_ + ".rotate_to_heading_min_angle", params_.rotate_to_heading_min_angle);
@@ -210,6 +230,10 @@ ParameterHandler::dynamicParametersCallback(
         params_.rotate_to_heading_angular_vel = parameter.as_double();
       } else if (name == plugin_name_ + ".min_approach_linear_velocity") {
         params_.min_approach_linear_velocity = parameter.as_double();
+      } else if (name == plugin_name_ + ".fixed_turn_speed") {
+        params_.fixed_turn_speed = parameter.as_double();
+      } else if (name == plugin_name_ + ".curvature_lookahead_dist") {
+        params_.curvature_lookahead_dist = parameter.as_double();
       } else if (name == plugin_name_ + ".max_allowed_time_to_collision_up_to_carrot") {
         params_.max_allowed_time_to_collision_up_to_carrot = parameter.as_double();
       } else if (name == plugin_name_ + ".cost_scaling_dist") {
@@ -230,6 +254,10 @@ ParameterHandler::dynamicParametersCallback(
         params_.use_velocity_scaled_lookahead_dist = parameter.as_bool();
       } else if (name == plugin_name_ + ".use_regulated_linear_velocity_scaling") {
         params_.use_regulated_linear_velocity_scaling = parameter.as_bool();
+      } else if (name == plugin_name_ + ".use_fixed_turn_speed") {
+        params_.use_fixed_turn_speed = parameter.as_bool();
+      } else if (name == plugin_name_ + ".use_fixed_curvature_lookahead") {
+        params_.use_fixed_curvature_lookahead = parameter.as_bool();
       } else if (name == plugin_name_ + ".use_cost_regulated_linear_velocity_scaling") {
         params_.use_cost_regulated_linear_velocity_scaling = parameter.as_bool();
       } else if (name == plugin_name_ + ".use_collision_detection") {

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -193,14 +193,12 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
 
   double desired_curvature = calculateCurvature(carrot_pose.pose.position);
 
-  double regulation_curvature;
+  double regulation_curvature = desired_curvature;
   if (params_->use_fixed_curvature_lookahead) {
     auto curvature_lookahead_pose = getLookAheadPoint(
       params_->curvature_lookahead_dist,
       transformed_plan);
     regulation_curvature = calculateCurvature(curvature_lookahead_pose.pose.position);
-  } else {
-    regulation_curvature = desired_curvature;
   }
 
   // Setting the velocity direction

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -134,6 +134,22 @@ double RegulatedPurePursuitController::getLookAheadDistance(
   return lookahead_dist;
 }
 
+double calculateCurvature(geometry_msgs::msg::Point lookahead_point)
+{
+  // Find distance^2 to look ahead point (carrot) in robot base frame
+  // This is the chord length of the circle
+  const double carrot_dist2 =
+    (lookahead_point.x * lookahead_point.x) +
+    (lookahead_point.y * lookahead_point.y);
+
+  // Find curvature of circle (k = 1 / R)
+  if (carrot_dist2 > 0.001) {
+    return 2.0 * lookahead_point.y / carrot_dist2;
+  } else {
+    return 0.0;
+  }
+}
+
 geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocityCommands(
   const geometry_msgs::msg::PoseStamped & pose,
   const geometry_msgs::msg::Twist & speed,
@@ -175,17 +191,10 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
 
   double linear_vel, angular_vel;
 
-  // Find distance^2 to look ahead point (carrot) in robot base frame
-  // This is the chord length of the circle
-  const double carrot_dist2 =
-    (carrot_pose.pose.position.x * carrot_pose.pose.position.x) +
-    (carrot_pose.pose.position.y * carrot_pose.pose.position.y);
-
-  // Find curvature of circle (k = 1 / R)
-  double curvature = 0.0;
-  if (carrot_dist2 > 0.001) {
-    curvature = 2.0 * carrot_pose.pose.position.y / carrot_dist2;
-  }
+  auto curvature_lookahead_pose = params_->use_fixed_curvature_lookahead ?
+    getLookAheadPoint(params_->curvature_lookahead_dist, transformed_plan) :
+    carrot_pose;
+  double curvature = calculateCurvature(curvature_lookahead_pose.pose.position);
 
   // Setting the velocity direction
   double sign = 1.0;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -191,9 +191,9 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
 
   double linear_vel, angular_vel;
 
-  double desired_curvature = calculateCurvature(carrot_pose.pose.position);
+  double lookahead_curvature = calculateCurvature(carrot_pose.pose.position);
 
-  double regulation_curvature = desired_curvature;
+  double regulation_curvature = lookahead_curvature;
   if (params_->use_fixed_curvature_lookahead) {
     auto curvature_lookahead_pose = getLookAheadPoint(
       params_->curvature_lookahead_dist,
@@ -223,7 +223,7 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
       linear_vel, sign);
 
     // Apply curvature to angular velocity after constraining linear velocity
-    angular_vel = linear_vel * desired_curvature;
+    angular_vel = linear_vel * lookahead_curvature;
   }
 
   // Collision checking on this velocity heading


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Custom: Sim and Real |

---

## Description of contribution in a few bullet points
Introduce option to set lookahead for curvature detection to a fixed distance. This breaks a reference cycle that becomes especially problematic with long lookaheads.

## Description of documentation updates required from your changes
Added two new parameters.

---

## Future work that may be required in bullet points
Determine if there is a way to derive this metric so that it can be enabled by default for all users

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
