### PR TITLE
Correct CostmapFilters copyrights

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/costmap_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/costmap_filter.hpp
@@ -2,6 +2,7 @@
  *
  * Software License Agreement (BSD License)
  *
+ *  Copyright (c) 2008, 2013, Willow Garage, Inc.
  *  Copyright (c) 2020 Samsung Research Russia
  *  All rights reserved.
  *
@@ -32,7 +33,9 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Alexey Merzlyakov
+ * Author: Eitan Marder-Eppstein
+ *         David V. Lu!!
+ *         Alexey Merzlyakov
  *********************************************************************/
 
 #ifndef NAV2_COSTMAP_2D__COSTMAP_FILTERS__COSTMAP_FILTER_HPP_

--- a/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
@@ -2,6 +2,7 @@
  *
  * Software License Agreement (BSD License)
  *
+ *  Copyright (c) 2008, 2013, Willow Garage, Inc.
  *  Copyright (c) 2020 Samsung Research Russia
  *  All rights reserved.
  *
@@ -32,7 +33,9 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Alexey Merzlyakov
+ * Author: Eitan Marder-Eppstein
+ *         David V. Lu!!
+ *         Alexey Merzlyakov
  *********************************************************************/
 
 #include "nav2_costmap_2d/costmap_filters/costmap_filter.hpp"


### PR DESCRIPTION
Keep original Costmap2D copyrights in CostmapFilters, as it uses some common with it routines.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3420 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | N/A (text fixup)|

---

## Description of contribution in a few bullet points

Keep with respect to original authors Costmap2D copyrights, as CostmapFilters code have common with Costmap2D methods:
* `CostmapFilters::getMaskCost()` [[1](https://github.com/ros-planning/navigation2/blob/99f7ff63129a2eff08011557f0d239dcbaa34956/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp#L218-L227 )], [[2](https://github.com/ros-planning/navigation2/blob/63b690a27a4ba1bde24ebd8e6c592c9894eec169/nav2_costmap_2d/src/costmap_2d.cpp#L80-L89)]
* `CostmapFilters::worldToMask()` [[1](https://github.com/ros-planning/navigation2/blob/99f7ff63129a2eff08011557f0d239dcbaa34956/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp#L199-L209)], [[2](https://github.com/ros-planning/navigation2/blob/63b690a27a4ba1bde24ebd8e6c592c9894eec169/nav2_costmap_2d/src/costmap_2d.cpp#L289-L299)]

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
