### PR TITLE
set negative prune values as use full path in RPP and DWB

### DIFF
--- a/nav2_costmap_2d/test/unit/costmap_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/costmap_filter_test.cpp
@@ -83,15 +83,15 @@ TEST(CostmapFilter, testWorldToMask)
   unsigned int mx, my;
   // Point inside mask
   ASSERT_TRUE(cf.worldToMask(mask, 4.0, 5.0, mx, my));
-  ASSERT_EQ(mx, 1);
-  ASSERT_EQ(my, 2);
+  ASSERT_EQ(mx, 1u);
+  ASSERT_EQ(my, 2u);
   // Corner cases
   ASSERT_TRUE(cf.worldToMask(mask, 3.0, 3.0, mx, my));
-  ASSERT_EQ(mx, 0);
-  ASSERT_EQ(my, 0);
+  ASSERT_EQ(mx, 0u);
+  ASSERT_EQ(my, 0u);
   ASSERT_TRUE(cf.worldToMask(mask, 5.9, 5.9, mx, my));
-  ASSERT_EQ(mx, 2);
-  ASSERT_EQ(my, 2);
+  ASSERT_EQ(mx, 2u);
+  ASSERT_EQ(my, 2u);
   // Point outside mask
   ASSERT_FALSE(cf.worldToMask(mask, 2.9, 2.9, mx, my));
   ASSERT_FALSE(cf.worldToMask(mask, 6.0, 6.0, mx, my));

--- a/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
@@ -145,6 +145,13 @@ ParameterHandler::ParameterHandler(
   node->get_parameter(
     plugin_name_ + ".max_robot_pose_search_dist",
     params_.max_robot_pose_search_dist);
+  if (params_.max_robot_pose_search_dist < 0.0) {
+    RCLCPP_WARN(
+      logger_, "Max robot search distance is negative, setting to max to search"
+      " every point on path for the closest value.");
+    params_.max_robot_pose_search_dist = std::numeric_limits<double>::max();
+  }
+
   node->get_parameter(
     plugin_name_ + ".use_interpolation",
     params_.use_interpolation);


### PR DESCRIPTION
See https://github.com/ros-planning/navigation2/issues/3367 and https://github.com/ros-planning/navigation2/issues/3375