### PR TITLE
[MPPI] Fix transformed path oscillations

### DIFF
--- a/nav2_mppi_controller/src/path_handler.cpp
+++ b/nav2_mppi_controller/src/path_handler.cpp
@@ -49,7 +49,7 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
   auto closest_pose_upper_bound =
     nav2_util::geometry_utils::first_after_integrated_distance(
     global_plan_.poses.begin(), global_plan_.poses.end(),
-        std::min(max_robot_pose_search_dist_, prune_distance_));
+    std::min(max_robot_pose_search_dist_, prune_distance_));
 
   // Find closest point to the robot
   auto closest_point = nav2_util::geometry_utils::min_by(

--- a/nav2_mppi_controller/src/path_handler.cpp
+++ b/nav2_mppi_controller/src/path_handler.cpp
@@ -62,7 +62,7 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
   transformed_plan.header.frame_id = costmap_->getGlobalFrameID();
   transformed_plan.header.stamp = global_pose.header.stamp;
 
-  auto pose_above_prune_distance =
+  auto pruned_plan_end =
     nav2_util::geometry_utils::first_after_integrated_distance(
     closest_point, global_plan_.poses.end(), prune_distance_);
 
@@ -70,7 +70,7 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
   // Find the furthest relevent pose on the path to consider within costmap
   // bounds
   // Transforming it to the costmap frame in the same loop
-  for (auto global_plan_pose = closest_point; global_plan_pose != pose_above_prune_distance;
+  for (auto global_plan_pose = closest_point; global_plan_pose != pruned_plan_end;
     ++global_plan_pose)
   {
     // Transform from global plan frame to costmap frame

--- a/nav2_mppi_controller/src/path_handler.cpp
+++ b/nav2_mppi_controller/src/path_handler.cpp
@@ -45,11 +45,10 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
 
   auto begin = global_plan_.poses.begin();
 
-  // Don't search further away than the prune distance
+  // Limit the search for the closest pose up to max_robot_pose_search_dist on the path
   auto closest_pose_upper_bound =
     nav2_util::geometry_utils::first_after_integrated_distance(
-    global_plan_.poses.begin(), global_plan_.poses.end(),
-    std::min(max_robot_pose_search_dist_, prune_distance_));
+    global_plan_.poses.begin(), global_plan_.poses.end(), max_robot_pose_search_dist_);
 
   // Find closest point to the robot
   auto closest_point = nav2_util::geometry_utils::min_by(

--- a/nav2_mppi_controller/test/path_handler_test.cpp
+++ b/nav2_mppi_controller/test/path_handler_test.cpp
@@ -92,7 +92,6 @@ TEST(PathHandlerTests, TestBounds)
   PathHandlerWrapper handler;
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("my_node");
   node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(99999.9));
-  node->declare_parameter("dummy.prune_distance", rclcpp::ParameterValue(99999.9));
   auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
     "dummy_costmap", "", "dummy_costmap", true);
   auto results = costmap_ros->set_parameters_atomically(

--- a/nav2_mppi_controller/test/path_handler_test.cpp
+++ b/nav2_mppi_controller/test/path_handler_test.cpp
@@ -92,6 +92,7 @@ TEST(PathHandlerTests, TestBounds)
   PathHandlerWrapper handler;
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("my_node");
   node->declare_parameter("dummy.max_robot_pose_search_dist", rclcpp::ParameterValue(99999.9));
+  node->declare_parameter("dummy.prune_distance", rclcpp::ParameterValue(99999.9));
   auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
     "dummy_costmap", "", "dummy_costmap", true);
   auto results = costmap_ros->set_parameters_atomically(


### PR DESCRIPTION

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory Robot |

---

## Description of contribution in a few bullet points

This PR fixes one of the issue with looping paths in MPPI. See example of oscillation below:

https://user-images.githubusercontent.com/15727892/222525415-181b87a8-7732-4eb4-9605-eb8c04e7622e.mp4

(global path in green, transformed path in purple arrows)

- For searching the upper bound , we search up to the pruning distance along the path, instead of searching up the euclidean distance.
- For the the lower bound, the closest pose from the robot on the path is still used. But the closest pose search is modified: we look up to the min between `max_robot_pose_search_dist` and `prune_distance`

To discuss: is `max_robot_pose_search_dist` still needed ? Also, its definition is a bit misleading:

> Distance ahead of nearest point on path to robot to prune path to. 

I believe it is actually the max integrated distance/path distance to look for the closest point to the robot, from the first pose of the pruned global path

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
