### PR TITLE
Add default service name to BTServiceNode

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -44,8 +44,10 @@ public:
    */
   BtServiceNode(
     const std::string & service_node_name,
-    const BT::NodeConfiguration & conf)
-  : BT::ActionNodeBase(service_node_name, conf), service_node_name_(service_node_name)
+    const BT::NodeConfiguration & conf,
+    const std::string & service_name = "")
+  : BT::ActionNodeBase(service_node_name, conf), service_node_name_(service_node_name),
+    service_name_(service_name)
   {
     node_ = config().blackboard->template get<rclcpp::Node::SharedPtr>("node");
     callback_group_ = node_->create_callback_group(

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -41,7 +41,7 @@ public:
    * @brief A nav2_behavior_tree::BtServiceNode constructor
    * @param service_node_name BT node name
    * @param conf BT node configuration
-   * @param service_name Service name this node creates a client for
+   * @param service_name Optional service name this node creates a client for instead of from input port
    */
   BtServiceNode(
     const std::string & service_node_name,

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -47,8 +47,8 @@ public:
     const std::string & service_node_name,
     const BT::NodeConfiguration & conf,
     const std::string & service_name = "")
-  : BT::ActionNodeBase(service_node_name, conf), service_node_name_(service_node_name),
-    service_name_(service_name)
+  : BT::ActionNodeBase(service_node_name, conf), service_name_(service_name), service_node_name_(
+      service_node_name)
   {
     node_ = config().blackboard->template get<rclcpp::Node::SharedPtr>("node");
     callback_group_ = node_->create_callback_group(

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -39,8 +39,9 @@ class BtServiceNode : public BT::ActionNodeBase
 public:
   /**
    * @brief A nav2_behavior_tree::BtServiceNode constructor
-   * @param service_node_name Service name this node creates a client for
+   * @param service_node_name BT node name
    * @param conf BT node configuration
+   * @param service_name Service name this node creates a client for
    */
   BtServiceNode(
     const std::string & service_node_name,


### PR DESCRIPTION
---

## Basic Info

| Info | Add default service name to BTServiceNode |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/3442 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

* Added service_name to BtServiceNode constructor, so that it could be passed from nodes that inherit BtServiceNode

If the service_name is not specified in xml -> `getInput("service_name", service_name_)` would just [return false](https://github.com/BehaviorTree/BehaviorTree.CPP/blob/bbfd51c68c352aaaa537cc9f722ddae178f89237/include/behaviortree_cpp/tree_node.h#L379) and service node would try to subscribe to the default service name. 
If default service name wasn't specified either the node would throw `Invalid service name: topic name must not be empty string` as usual.

---


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
