### PR TITLE
Fix Path Angle Critic for bi-directionality

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
@@ -418,13 +418,20 @@ inline void setPathCostsIfNotSet(
  * @param point_y Point to find angle relative to Y axis
  * @return Angle between two points
  */
-inline double posePointAngle(const geometry_msgs::msg::Pose & pose, double point_x, double point_y)
+inline double posePointAngle(
+  const geometry_msgs::msg::Pose & pose, double point_x, double point_y,
+  double point_yaw)
 {
   double pose_x = pose.position.x;
   double pose_y = pose.position.y;
   double pose_yaw = tf2::getYaw(pose.orientation);
 
   double yaw = atan2(point_y - pose_y, point_x - pose_x);
+
+  if (abs(angles::shortest_angular_distance(yaw, point_yaw)) > M_PI_2) {
+    yaw = angles::normalize_angle(yaw + M_PI);
+  }
+
   return abs(angles::shortest_angular_distance(yaw, pose_yaw));
 }
 

--- a/nav2_mppi_controller/src/critics/path_angle_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_angle_critic.cpp
@@ -59,7 +59,7 @@ void PathAngleCritic::score(CriticData & data)
   const float goal_y = xt::view(data.path.y, offseted_idx);
 
   double forward_angle = utils::posePointAngle(data.state.pose.pose, goal_x, goal_y);
-  double backward_angle = angles::normalize_angle(forward_angle + M_PI);
+  double backward_angle = abs(angles::normalize_angle(forward_angle + M_PI));
 
   if (forward_angle < max_angle_to_furthest_ ||
     backward_angle < max_angle_to_furthest_)

--- a/nav2_mppi_controller/src/critics/path_angle_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_angle_critic.cpp
@@ -57,12 +57,11 @@ void PathAngleCritic::score(CriticData & data)
 
   const float goal_x = xt::view(data.path.x, offseted_idx);
   const float goal_y = xt::view(data.path.y, offseted_idx);
+  const float goal_yaw = xt::view(data.path.yaws, offseted_idx);
 
-  double forward_angle = utils::posePointAngle(data.state.pose.pose, goal_x, goal_y);
-  double backward_angle = abs(angles::normalize_angle(forward_angle + M_PI));
-
-  if (forward_angle < max_angle_to_furthest_ ||
-    backward_angle < max_angle_to_furthest_)
+  if (utils::posePointAngle(
+      data.state.pose.pose, goal_x, goal_y,
+      goal_yaw) < max_angle_to_furthest_)
   {
     return;
   }
@@ -70,14 +69,20 @@ void PathAngleCritic::score(CriticData & data)
   const auto yaws_between_points = xt::atan2(
     goal_y - data.trajectories.y,
     goal_x - data.trajectories.x);
-  const auto yaws_plus_pi_between_points = utils::normalize_angles(yaws_between_points + M_PI);
-  const auto yaws =
-    xt::abs(utils::shortest_angular_distance(data.trajectories.yaws, yaws_between_points));
-  const auto yaws_plus_pi =
-    xt::abs(utils::shortest_angular_distance(data.trajectories.yaws, yaws_plus_pi_between_points));
-  const auto min_yaws = xt::minimum(yaws, yaws_plus_pi);
 
-  data.costs += xt::pow(xt::mean(min_yaws, {1}, immediate) * weight_, power_);
+  const auto yaws_between_points_corrected = xt::eval(
+    xt::where(
+      xt::abs(utils::shortest_angular_distance(yaws_between_points, goal_yaw)) <= M_PI_2,
+      yaws_between_points,
+      utils::normalize_angles(yaws_between_points + M_PI)));
+
+  const auto yaws =
+    xt::abs(
+    utils::shortest_angular_distance(
+      data.trajectories.yaws,
+      yaws_between_points_corrected));
+
+  data.costs += xt::pow(xt::mean(yaws, {1}, immediate) * weight_, power_);
 }
 
 }  // namespace mppi::critics


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/3351 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory simulation |

---

## Description of contribution in a few bullet points

Draft PR for addressing the asymmetric behavior of the Path Angle Critic between forward and backward motion. 
Currently, as the angle calculation for scoring is done between the trajectory poses direction to the goal (on path) and the trajectories yaws, there is an asymmetric scoring between the forward and backward movement as backward yaws are inverted relative to the direction of motion:
https://github.com/ros-planning/navigation2/blob/34f18d9222e33a2fddb2e45653cd5c0ef7b3bb11/nav2_mppi_controller/src/critics/path_angle_critic.cpp#L65-L69

Also, the filter for discarding scoring if the difference between the robot pose and the robot direction to the goal (on path) is below `max_angle_to_furthest`, is using the yaw of the robot pose, hence never acting if the robot is moving backward:
https://github.com/ros-planning/navigation2/blob/34f18d9222e33a2fddb2e45653cd5c0ef7b3bb11/nav2_mppi_controller/src/critics/path_angle_critic.cpp#L61-L63

This draft PR makes the Path Angle Critics symmetric  by using the minimum angle of the +X and -X orientation.

(on a system with over-weighted `PathAngleCritic`)

Without this PR:

https://user-images.githubusercontent.com/15727892/223572581-467edbea-0907-4546-b63c-a895c361a453.mp4


With this PR:

https://user-images.githubusercontent.com/15727892/223573089-cd24e9a5-0025-45c3-aec5-54ea0d7c5075.mp4

Maybe we should also discuss if the symmetric bi-directional behavior of the Path Angle Critics should be optional.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
