### PR TITLE
Patch CI actions and Dockerfiles

### DIFF
--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -26,8 +26,8 @@ jobs:
         id: check
         if: github.event_name == 'push'
         run: |
-          echo "::set-output name=trigger::true"
-          echo "::set-output name=no_cache::false"
+          echo "trigger=true" >> $GITHUB_OUTPUT
+          echo "no_cache=false" >> $GITHUB_OUTPUT
   check_ci_image:
     name: Check CI Image
     if: github.event_name == 'schedule'
@@ -52,9 +52,9 @@ jobs:
           cat upgrade.log
           cat upgrade.log \
             | grep "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" \
-            && echo "::set-output name=trigger::false" \
-            || echo "::set-output name=trigger::true"
-          echo "::set-output name=no_cache::true"
+            && echo "trigger=false" >> $GITHUB_OUTPUT \
+            || echo "trigger=true" >> $GITHUB_OUTPUT
+          echo "no_cache=true" >> $GITHUB_OUTPUT
   rebuild_ci_image:
     name: Rebuild CI Image
     if: always()
@@ -75,7 +75,7 @@ jobs:
         id: config
         run: |
           timestamp=$(date --utc +%Y%m%d%H%M%S)
-          echo "::set-output name=timestamp::${timestamp}"
+          echo "timestamp=${timestamp}" >> $GITHUB_OUTPUT
 
           no_cache=false
           if  [ "${{needs.check_ci_files.outputs.no_cache}}" == 'true' ] || \
@@ -83,7 +83,7 @@ jobs:
           then
             no_cache=true
           fi
-          echo "::set-output name=no_cache::${no_cache}"
+          echo "no_cache=${no_cache}" >> $GITHUB_OUTPUT
 
           trigger=false
           if  [ "${{needs.check_ci_files.outputs.trigger}}" == 'true' ] || \
@@ -91,7 +91,7 @@ jobs:
           then
             trigger=true
           fi
-          echo "::set-output name=trigger::${trigger}"
+          echo "trigger=${trigger}" >> $GITHUB_OUTPUT
       - name: Build and push ${{ github.ref_name }}
         if: steps.config.outputs.trigger == 'true'
         id: docker_build

--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -122,7 +122,6 @@ jobs:
           cache-to: type=inline
           build-args: |
             RUN_TESTS=True
-            FAIL_ON_TEST_FAILURE=''
           target: tester
           tags: |
             ghcr.io/ros-planning/navigation2:${{ github.ref_name }}-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ RUN sed --in-place \
 
 # test overlay build
 ARG RUN_TESTS
-ARG FAIL_ON_TEST_FAILURE=True
+ARG FAIL_ON_TEST_FAILURE
 RUN if [ -n "$RUN_TESTS" ]; then \
         . install/setup.sh && \
         colcon test && \

--- a/tools/distro.Dockerfile
+++ b/tools/distro.Dockerfile
@@ -92,7 +92,7 @@ RUN sed --in-place \
 
 # test overlay build
 ARG RUN_TESTS
-ARG FAIL_ON_TEST_FAILURE=True
+ARG FAIL_ON_TEST_FAILURE
 RUN if [ -n "$RUN_TESTS" ]; then \
         . install/setup.sh && \
         colcon test && \

--- a/tools/source.Dockerfile
+++ b/tools/source.Dockerfile
@@ -117,7 +117,7 @@ FROM ros2_builder AS ros2_tester
 
 # test overlay build
 ARG RUN_TESTS
-ARG FAIL_ON_TEST_FAILURE=True
+ARG FAIL_ON_TEST_FAILURE
 RUN if [ -n "$RUN_TESTS" ]; then \
         . install/setup.sh && \
         colcon test && \
@@ -165,7 +165,7 @@ FROM underlay_builder AS underlay_tester
 
 # test overlay build
 ARG RUN_TESTS
-ARG FAIL_ON_TEST_FAILURE=True
+ARG FAIL_ON_TEST_FAILURE
 RUN if [ -n "$RUN_TESTS" ]; then \
         . install/setup.sh && \
         colcon test && \
@@ -216,7 +216,7 @@ FROM overlay_builder AS overlay_tester
 
 # test overlay build
 ARG RUN_TESTS
-ARG FAIL_ON_TEST_FAILURE=True
+ARG FAIL_ON_TEST_FAILURE
 RUN if [ -n "$RUN_TESTS" ]; then \
         . install/setup.sh && \
         colcon test && \


### PR DESCRIPTION
To avoid errors and warnings when updating CI images, such as issues when passing empty strings to `--build-arg`.
E.g: `FAIL_ON_TEST_FAILURE=''`

```
 > [tester 4/4] RUN if [ -n "True" ]; then         . install/setup.sh &&         colcon test &&         colcon test-result           || ([ -z "''" ] || exit 1)     fi:
```
> https://github.com/ros-planning/navigation2/actions/runs/4386514560/jobs/7680671404#step:7:702

or deprications warnings for github action commands.