### PR TITLE
Fix for different ceres isinf() API

### DIFF
--- a/nav2_constrained_smoother/CMakeLists.txt
+++ b/nav2_constrained_smoother/CMakeLists.txt
@@ -17,6 +17,10 @@ find_package(Ceres REQUIRED COMPONENTS SuiteSparse)
 
 set(CMAKE_CXX_STANDARD 17)
 
+if(${CERES_VERSION} VERSION_LESS_EQUAL 2.0.0)
+  add_definitions(-DUSE_OLD_CERES_API)
+endif()
+
 nav2_package()
 
 set(library_name nav2_constrained_smoother)

--- a/nav2_constrained_smoother/include/nav2_constrained_smoother/smoother_cost_function.hpp
+++ b/nav2_constrained_smoother/include/nav2_constrained_smoother/smoother_cost_function.hpp
@@ -159,7 +159,7 @@ protected:
     Eigen::Matrix<T, 2, 1> center = arcCenter(
       pt_prev, pt, pt_next,
       next_to_last_length_ratio_ < 0);
-    if (ceres::isinf(center[0])) {
+    if (CERES_ISINF(center[0])) {
       return;
     }
     T turning_rad = (pt - center).norm();

--- a/nav2_constrained_smoother/include/nav2_constrained_smoother/utils.hpp
+++ b/nav2_constrained_smoother/include/nav2_constrained_smoother/utils.hpp
@@ -20,6 +20,16 @@
 
 #define EPSILON 0.0001
 
+/**
+ * Compatibility with different ceres::isinf() and ceres::IsInfinite() API
+ * used in Ceres Solver 2.1.0+ and 2.0.0- versions respectively
+ */
+#if defined(USE_OLD_CERES_API)
+  #define CERES_ISINF(x) ceres::IsInfinite(x)
+#else
+  #define CERES_ISINF(x) ceres::isinf(x)
+#endif
+
 namespace nav2_constrained_smoother
 {
 
@@ -86,7 +96,7 @@ inline Eigen::Matrix<T, 2, 1> tangentDir(
   bool is_cusp)
 {
   Eigen::Matrix<T, 2, 1> center = arcCenter(pt_prev, pt, pt_next, is_cusp);
-  if (ceres::isinf(center[0])) {  // straight line
+  if (CERES_ISINF(center[0])) {  // straight line
     Eigen::Matrix<T, 2, 1> d1 = pt - pt_prev;
     Eigen::Matrix<T, 2, 1> d2 = pt_next - pt;
 


### PR DESCRIPTION
Fix for different `ceres::IsInfinite()`/`ceres::isinf()` API on different Ceres Solver versions (`2.0.0-`/`2.1.0+` respectively), causing build regression on Ubuntu 20.04 where Ceres is being distributed under older version.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3158 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | `colcon test --packages-select nav2_constrained_smoother`, TB3 simulation |

---

## Description of contribution in a few bullet points

* The regression appeared since on Ubuntu 20.04 since #3158 commit. This commit is adjusting for newer `ceres::isinf()` API used in Ubuntu 22.04, but Ubuntu 20.04 begins out of support
* Since Ubuntu 20.04 is in the [officially supported](https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Development-Setup.html#system-requirements) by ROS2 Rolling list, it should be fixed
* In the [docs](http://ceres-solver.org/version_history.html#backward-incompatible-api-changes,), Ceres Solver proposes to switch on `std::isinf()` API, that was made in this change:
> Classification functions like `IsFinite` are deprecated. Use the `C++11` functions (`isfinite`, `isnan` etc) going forward. However to maintain consistent behaviour with comparison operators, these functions only inspect the scalar part of the `Jet`.

* The fix is made for both instantiations of templated typename `T`:
  * `std::isinf(d)`: for `T = Scalar (a.k.a. double)` and
  * for `T = ceres::Jet(D, N)` as comparison for scalar part of Ceres jets
* Using of `std::isinf()` API will allow to be independent of Ceres API version and thus support both Ubuntu 22.04 and Ubuntu 20.04 builds

## Description of documentation updates required from your changes

No documentation changes required

---

## Future work that may be required in bullet points

* No future works are expected

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
