### PR TITLE
Add Container Retention Policy

### DIFF
--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -37,7 +37,7 @@ jobs:
       trigger: ${{ steps.check.outputs.trigger }}
       no_cache: ${{ steps.check.outputs.no_cache }}
     container:
-      image: ghcr.io/ros-planning/navigation2:${{ github.ref_name }}
+      image: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
     steps:
       - name: "Check apt updates"
         id: check
@@ -102,12 +102,12 @@ jobs:
           pull: true
           push: true
           no-cache: ${{ steps.config.outputs.no_cache }}
-          cache-from: type=registry,ref=ghcr.io/ros-planning/navigation2:${{ github.ref_name }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           cache-to: type=inline
           target: builder
           tags: |
-            ghcr.io/ros-planning/navigation2:${{ github.ref_name }}
-            ghcr.io/ros-planning/navigation2:${{ github.ref_name }}-${{ steps.config.outputs.timestamp }}
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ steps.config.outputs.timestamp }}
       - name: Image digest
         if: steps.config.outputs.trigger == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -109,3 +109,13 @@ jobs:
       - name: Image digest
         if: steps.config.outputs.trigger == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Delete '${{ github.ref_name }}' images older than a month
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: ${{ github.event.repository.name }}
+          filter-tags: ${{ github.ref_name }}-*
+          cut-off: A month ago UTC
+          account-type: org
+          org-name: ${{ github.repository_owner }}
+          keep-at-least: 12
+          token: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -76,6 +76,8 @@ jobs:
         run: |
           timestamp=$(date --utc +%Y%m%d%H%M%S)
           echo "timestamp=${timestamp}" >> $GITHUB_OUTPUT
+          datestamp=$(date --utc +%Y%m)
+          echo "datestamp=${datestamp}" >> $GITHUB_OUTPUT
 
           no_cache=false
           if  [ "${{needs.check_ci_files.outputs.no_cache}}" == 'true' ] || \
@@ -109,6 +111,16 @@ jobs:
       - name: Image digest
         if: steps.config.outputs.trigger == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Delete '${{ github.ref_name }}' images newer than a month
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: ${{ github.event.repository.name }}
+          filter-tags: ${{ github.ref_name }}-${{ steps.config.outputs.datestamp }}*
+          cut-off: now UTC
+          account-type: org
+          org-name: ${{ github.repository_owner }}
+          keep-at-least: 1
+          token: ${{ secrets.GHCR_PAT }}
       - name: Delete '${{ github.ref_name }}' images older than a month
         uses: snok/container-retention-policy@v2
         with:


### PR DESCRIPTION
To try and archive only one image per month over the past year to date.

- https://github.com/marketplace/actions/container-retention-policy
- https://github.com/ros-planning/navigation2/pkgs/container/navigation2/versions

As we seem to be hoarding a large number of old images, and I'd rather not have to manually deleting them from the web UI.