### PR TITLE
Clean up pending service client request on interrupt/timeout

### DIFF
--- a/nav2_util/include/nav2_util/service_client.hpp
+++ b/nav2_util/include/nav2_util/service_client.hpp
@@ -81,6 +81,8 @@ public:
     if (callback_group_executor_.spin_until_future_complete(future_result, timeout) !=
       rclcpp::FutureReturnCode::SUCCESS)
     {
+      // Pending request must be manually cleaned up if execution is interrupted or timed out
+      client_->remove_pending_request(future_result);
       throw std::runtime_error(service_name_ + " service client: async_send_request failed");
     }
 
@@ -115,6 +117,8 @@ public:
     if (callback_group_executor_.spin_until_future_complete(future_result) !=
       rclcpp::FutureReturnCode::SUCCESS)
     {
+      // Pending request must be manually cleaned up if execution is interrupted or timed out
+      client_->remove_pending_request(future_result);
       return false;
     }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3477 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |

---

## Description of contribution in a few bullet points
- Avoids memory leak by removing the pending request if interrupted before executed

## Description of documentation updates required from your changes
N/A

## Future work that may be required in bullet points
N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
