### PR TITLE
[MPPI] Fix segfault in path_follow_critic when path is empty

### DIFF
--- a/nav2_mppi_controller/src/critics/path_follow_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_follow_critic.cpp
@@ -34,7 +34,9 @@ void PathFollowCritic::initialize()
 
 void PathFollowCritic::score(CriticData & data)
 {
-  if (!enabled_ ||
+  const size_t path_size = data.path.x.shape(0) - 1;
+
+  if (!enabled_ || path_size == 0 ||
     utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
   {
     return;
@@ -42,7 +44,6 @@ void PathFollowCritic::score(CriticData & data)
 
   utils::setPathFurthestPointIfNotSet(data);
   utils::setPathCostsIfNotSet(data, costmap_ros_);
-  const size_t path_size = data.path.x.shape(0) - 1;
 
   auto offseted_idx = std::min(
     *data.furthest_reached_path_point + offset_from_furthest_, path_size);


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/3480 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory's robot |

---

## Description of contribution in a few bullet points

Fix https://github.com/ros-planning/navigation2/issues/3480

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
