### PR TITLE
Added str cast to parse int

### DIFF
--- a/nav2_common/nav2_common/launch/rewritten_yaml.py
+++ b/nav2_common/nav2_common/launch/rewritten_yaml.py
@@ -161,7 +161,7 @@ class RewrittenYaml(launch.Substitution):
         if isinstance(d, dict):
             for k in d:
                 v = d[k]
-                self.pathify(v, pn + k, paths, joinchar=joinchar)
+                self.pathify(v, str(pn) + str(k), paths, joinchar=joinchar)
         elif isinstance(d, list):
             for idx, e in enumerate(d):
                 self.pathify(e, pn + str(idx), paths, joinchar=joinchar)


### PR DESCRIPTION
## Basic Info
| Info | Please fill out this column |
| ------------------------------------|-----------------------------------------------------------------------|
| Ticket(s) this addresses      | RewrittenYaml does not parse integers keys #3483 |
| Primary OS tested on         | Ubuntu                                                                        |
| Robotic platform tested on | gazebo simulation                                                       |

---

## Description of contribution in a few bullet points

Added string casting inside RewrittenYaml to yaml keys in order to correctly parse integers keys such as:
```
nodes_number: 3
  0:
    node_name: name1
  1:
    node_name: name2
  2:
    node_name: name3
```
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
