### PR TITLE
Container retention via version tagging

### DIFF
--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -37,7 +37,7 @@ jobs:
       trigger: ${{ steps.check.outputs.trigger }}
       no_cache: ${{ steps.check.outputs.no_cache }}
     container:
-      image: ghcr.io/ros-planning/navigation2:${{ github.ref_name }}
+      image: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
     steps:
       - name: "Check apt updates"
         id: check
@@ -100,12 +100,12 @@ jobs:
           pull: true
           push: true
           no-cache: ${{ steps.config.outputs.no_cache }}
-          cache-from: type=registry,ref=ghcr.io/ros-planning/navigation2:${{ github.ref_name }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           cache-to: type=inline
           target: builder
           tags: |
-            ghcr.io/ros-planning/navigation2:${{ github.ref_name }}
-            ghcr.io/ros-planning/navigation2:${{ github.ref_name }}-${{ steps.config.outputs.timestamp }}
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ steps.config.outputs.timestamp }}
       - name: Image digest
         if: steps.config.outputs.trigger == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -74,8 +74,8 @@ jobs:
       - name: Set build config
         id: config
         run: |
-          timestamp=$(date --utc +%Y%m%d%H%M%S)
-          echo "timestamp=${timestamp}" >> $GITHUB_OUTPUT
+          version=$(grep -oP '(?<=<version>).*?(?=</version>)' navigation2/package.xml)
+          echo "version=${version}" >> $GITHUB_OUTPUT
 
           no_cache=false
           if  [ "${{needs.check_ci_files.outputs.no_cache}}" == 'true' ] || \
@@ -105,7 +105,7 @@ jobs:
           target: builder
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ steps.config.outputs.timestamp }}
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ steps.config.outputs.version }}
       - name: Image digest
         if: steps.config.outputs.trigger == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -97,6 +97,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v4
         with:
+          provenance: false
           pull: true
           push: true
           no-cache: ${{ steps.config.outputs.no_cache }}


### PR DESCRIPTION
Tag by version instead of by timestamp, to keep archive sustainable and more semantically useful. Timesamps of images can still be inferred from metadata. This also tries to avoid pushing untagged manifests.
 
Replaces: https://github.com/ros-planning/navigation2/pull/3474