### PR TITLE
Use checkout action to set version output

### DIFF
--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -22,10 +22,13 @@ jobs:
       trigger: ${{ steps.check.outputs.trigger }}
       no_cache: ${{ steps.check.outputs.no_cache }}
     steps:
+      - uses: actions/checkout@v3
       - name: "Check package updates"
         id: check
         if: github.event_name == 'push'
         run: |
+          version=$(grep -oP '(?<=<version>).*?(?=</version>)' navigation2/package.xml)
+          echo "version=${version}" >> $GITHUB_OUTPUT
           echo "trigger=true" >> $GITHUB_OUTPUT
           echo "no_cache=false" >> $GITHUB_OUTPUT
   check_ci_image:
@@ -74,9 +77,6 @@ jobs:
       - name: Set build config
         id: config
         run: |
-          version=$(grep -oP '(?<=<version>).*?(?=</version>)' navigation2/package.xml)
-          echo "version=${version}" >> $GITHUB_OUTPUT
-
           no_cache=false
           if  [ "${{needs.check_ci_files.outputs.no_cache}}" == 'true' ] || \
               [ "${{needs.check_ci_image.outputs.no_cache}}" == 'true' ]


### PR DESCRIPTION
Otherwise there is no source code to use to set the version output.

Fixes: https://github.com/ros-planning/navigation2/pull/3491