### PR TITLE
Change directory to inside checked out repo

### DIFF
--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -27,6 +27,7 @@ jobs:
         id: check
         if: github.event_name == 'push'
         run: |
+          cd navigation2
           version=$(grep -oP '(?<=<version>).*?(?=</version>)' navigation2/package.xml)
           echo "version=${version}" >> $GITHUB_OUTPUT
           echo "trigger=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
or relative path under $GITHUB_WORKSPACE
that actions/checkout places the repository

Fixes: https://github.com/ros-planning/navigation2/pull/3492
Grr... I wish I could easily test these patches to action locally.