### PR TITLE
Ensure version output is always set

### DIFF
--- a/.github/workflows/update_ci_image.yaml
+++ b/.github/workflows/update_ci_image.yaml
@@ -19,17 +19,13 @@ jobs:
     name: Check CI Files
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.check.outputs.version }}
       trigger: ${{ steps.check.outputs.trigger }}
       no_cache: ${{ steps.check.outputs.no_cache }}
     steps:
-      - uses: actions/checkout@v3
       - name: "Check package updates"
         id: check
         if: github.event_name == 'push'
         run: |
-          version=$(grep -oP '(?<=<version>).*?(?=</version>)' navigation2/package.xml)
-          echo "version=${version}" >> $GITHUB_OUTPUT
           echo "trigger=true" >> $GITHUB_OUTPUT
           echo "no_cache=false" >> $GITHUB_OUTPUT
   check_ci_image:
@@ -67,6 +63,7 @@ jobs:
       - check_ci_image
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
@@ -78,6 +75,9 @@ jobs:
       - name: Set build config
         id: config
         run: |
+          version=$(grep -oP '(?<=<version>).*?(?=</version>)' navigation2/package.xml)
+          echo "version=${version}" >> $GITHUB_OUTPUT
+
           no_cache=false
           if  [ "${{needs.check_ci_files.outputs.no_cache}}" == 'true' ] || \
               [ "${{needs.check_ci_image.outputs.no_cache}}" == 'true' ]
@@ -98,16 +98,17 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v4
         with:
-          provenance: false
+          context: .
           pull: true
           push: true
+          provenance: false
           no-cache: ${{ steps.config.outputs.no_cache }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           cache-to: type=inline
           target: builder
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ needs.check_ci_files.outputs.version }}
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ steps.config.outputs.version }}
       - name: Image digest
         if: steps.config.outputs.trigger == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
even when github.event_name != 'push', by moving run step to same job as build-push action.

Also set context path provided by checkout action to avoid future nonintuitive behavoir using default Git context, even when the checkout action appears to be being used.

- https://github.com/docker/build-push-action#git-context
- https://github.com/docker/build-push-action#path-context

Fixes:
- https://github.com/ros-planning/navigation2/pull/3494