### PR TITLE
Publish collision monitor state

### DIFF
--- a/nav2_collision_monitor/CMakeLists.txt
+++ b/nav2_collision_monitor/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
+find_package(nav2_msgs REQUIRED)
 
 ### Header ###
 
@@ -35,6 +36,7 @@ set(dependencies
   tf2_geometry_msgs
   nav2_util
   nav2_costmap_2d
+  nav2_msgs
 )
 
 set(executable_name collision_monitor)

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -175,18 +175,12 @@ protected:
     Action & robot_action) const;
 
   /**
-   * @brief Prints robot action and polygon caused it (if it was)
-   * @param robot_action Robot action to print
+   * @brief Log and publish current robot action and polygon
+   * @param robot_action Robot action to notify
    * @param action_polygon Pointer to a polygon causing a selected action
    */
-  void printAction(
+  void notifyActionState(
     const Action & robot_action, const std::shared_ptr<Polygon> action_polygon) const;
-
-  /**
-   * @brief Publish current robot action and polygon name
-   * @param robot_action Robot action to publish
-   */
-  void publishActionState(const Action & robot_action) const;
 
   /**
    * @brief Polygons publishing routine. Made for visualization.

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -112,7 +112,7 @@ protected:
   bool getParameters(
     std::string & cmd_vel_in_topic,
     std::string & cmd_vel_out_topic,
-    std::string & collision_monitor_state_topic);
+    std::string & state_topic);
   /**
    * @brief Supporting routine creating and configuring all polygons
    * @param base_frame_id Robot base frame ID
@@ -208,7 +208,7 @@ protected:
 
   /// @brief CollisionMonitor state publisher
   rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::CollisionMonitorState>::SharedPtr
-    collision_monitor_state_pub_;
+    state_pub_;
 
   /// @brief Whether main routine is active
   bool process_active_;

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -27,6 +27,7 @@
 #include "tf2_ros/transform_listener.h"
 
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_msgs/msg/collision_monitor_state.hpp"
 
 #include "nav2_collision_monitor/types.hpp"
 #include "nav2_collision_monitor/polygon.hpp"
@@ -181,6 +182,12 @@ protected:
     const Action & robot_action, const std::shared_ptr<Polygon> action_polygon) const;
 
   /**
+   * @brief Publish current robot action and polygon name
+   * @param robot_action Robot action to publish
+   */
+  void publishActionState(const Action & robot_action) const;
+
+  /**
    * @brief Polygons publishing routine. Made for visualization.
    */
   void publishPolygons() const;
@@ -203,6 +210,10 @@ protected:
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_in_sub_;
   /// @brief Output cmd_vel publisher
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_out_pub_;
+
+  /// @brief CollisionMonitor state publisher
+  rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::CollisionMonitorState>::SharedPtr
+    collision_monitor_state_pub_;
 
   /// @brief Whether main routine is active
   bool process_active_;

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -111,7 +111,8 @@ protected:
    */
   bool getParameters(
     std::string & cmd_vel_in_topic,
-    std::string & cmd_vel_out_topic);
+    std::string & cmd_vel_out_topic,
+    std::string & collision_monitor_state_topic);
   /**
    * @brief Supporting routine creating and configuring all polygons
    * @param base_frame_id Robot base frame ID

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -15,6 +15,8 @@
 #ifndef NAV2_COLLISION_MONITOR__TYPES_HPP_
 #define NAV2_COLLISION_MONITOR__TYPES_HPP_
 
+#include <string>
+
 namespace nav2_collision_monitor
 {
 
@@ -73,6 +75,7 @@ struct Action
 {
   ActionType action_type;
   Velocity req_vel;
+  std::string polygon_name;
 };
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -68,7 +68,6 @@ enum ActionType
   STOP = 1,  // Stop the robot
   SLOWDOWN = 2,  // Slowdown in percentage from current operating speed
   APPROACH = 3,  // Keep constant time interval before collision
-  ACTION_UNKNOWN = 4 // Default for initializing action type
 };
 
 /// @brief Action for robot

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -67,7 +67,7 @@ enum ActionType
   DO_NOTHING = 0,  // No action
   STOP = 1,  // Stop the robot
   SLOWDOWN = 2,  // Slowdown in percentage from current operating speed
-  APPROACH = 3,  // Keep constant time interval before collision
+  APPROACH = 3  // Keep constant time interval before collision
 };
 
 /// @brief Action for robot

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -67,7 +67,8 @@ enum ActionType
   DO_NOTHING = 0,  // No action
   STOP = 1,  // Stop the robot
   SLOWDOWN = 2,  // Slowdown in percentage from current operating speed
-  APPROACH = 3  // Keep constant time interval before collision
+  APPROACH = 3,  // Keep constant time interval before collision
+  ACTION_UNKNOWN = 4 // Default for initializing action type
 };
 
 /// @brief Action for robot

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -64,11 +64,11 @@ struct Pose
 /// @brief Action type for robot
 enum ActionType
 {
-  DO_NOTHING = 0,  // No action
-  STOP = 1,  // Stop the robot
-  SLOWDOWN = 2,  // Slowdown in percentage from current operating speed
-  APPROACH = 3,  // Keep constant time interval before collision
-  ACTION_UNKNOWN = 4 // Default for initializing action type
+  ACTION_UNKNOWN = 0, // Default for initializing action type
+  DO_NOTHING = 1,  // No action
+  STOP = 2,  // Stop the robot
+  SLOWDOWN = 3,  // Slowdown in percentage from current operating speed
+  APPROACH = 4  // Keep constant time interval before collision
 };
 
 /// @brief Action for robot

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -64,11 +64,11 @@ struct Pose
 /// @brief Action type for robot
 enum ActionType
 {
-  ACTION_UNKNOWN = 0, // Default for initializing action type
-  DO_NOTHING = 1,  // No action
-  STOP = 2,  // Stop the robot
-  SLOWDOWN = 3,  // Slowdown in percentage from current operating speed
-  APPROACH = 4  // Keep constant time interval before collision
+  DO_NOTHING = 0,  // No action
+  STOP = 1,  // Stop the robot
+  SLOWDOWN = 2,  // Slowdown in percentage from current operating speed
+  APPROACH = 3,  // Keep constant time interval before collision
+  ACTION_UNKNOWN = 4 // Default for initializing action type
 };
 
 /// @brief Action for robot

--- a/nav2_collision_monitor/package.xml
+++ b/nav2_collision_monitor/package.xml
@@ -20,6 +20,7 @@
   <depend>nav2_common</depend>
   <depend>nav2_util</depend>
   <depend>nav2_costmap_2d</depend>
+  <depend>nav2_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -4,7 +4,7 @@ collision_monitor:
     odom_frame_id: "odom"
     cmd_vel_in_topic: "cmd_vel_raw"
     cmd_vel_out_topic: "cmd_vel"
-    collision_monitor_state_topic: "collision_monitor_state"
+    state_topic: "collision_monitor_state"
     transform_tolerance: 0.5
     source_timeout: 5.0
     base_shift_correction: True

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -4,6 +4,7 @@ collision_monitor:
     odom_frame_id: "odom"
     cmd_vel_in_topic: "cmd_vel_raw"
     cmd_vel_out_topic: "cmd_vel"
+    collision_monitor_state_topic: "collision_monitor_state"
     transform_tolerance: 0.5
     source_timeout: 5.0
     base_shift_correction: True

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -118,6 +118,7 @@ CollisionMonitor::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
 
   // Deactivating lifecycle publishers
   cmd_vel_out_pub_->on_deactivate();
+  collision_monitor_state_pub_->on_deactivate();
 
   // Destroying bond connection
   destroyBond();

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -29,7 +29,7 @@ namespace nav2_collision_monitor
 
 CollisionMonitor::CollisionMonitor(const rclcpp::NodeOptions & options)
 : nav2_util::LifecycleNode("collision_monitor", "", options),
-  process_active_(false), robot_action_prev_{ACTION_UNKNOWN, {-1.0, -1.0, -1.0}, ""},
+  process_active_(false), robot_action_prev_{DO_NOTHING, {-1.0, -1.0, -1.0}, ""},
   stop_stamp_{0, 0, get_clock()->get_clock_type()}, stop_pub_timeout_(1.0, 0.0)
 {
 }
@@ -109,7 +109,7 @@ CollisionMonitor::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   process_active_ = false;
 
   // Reset action type to default after worker deactivating
-  robot_action_prev_ = {ACTION_UNKNOWN, {-1.0, -1.0, -1.0}, ""};
+  robot_action_prev_ = {DO_NOTHING, {-1.0, -1.0, -1.0}, ""};
 
   // Deactivating polygons
   for (std::shared_ptr<Polygon> polygon : polygons_) {
@@ -387,9 +387,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
     }
   }
 
-  if (robot_action_prev_.action_type == ACTION_UNKNOWN ||
-    robot_action.polygon_name != robot_action_prev_.polygon_name)
-  {
+  if (robot_action.polygon_name != robot_action_prev_.polygon_name) {
     // Report changed robot behavior
     notifyActionState(robot_action, action_polygon);
   }

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -416,8 +416,8 @@ bool CollisionMonitor::processStopSlowdown(
 
   if (polygon->getPointsInside(collision_points) > polygon->getMaxPoints()) {
     if (polygon->getActionType() == STOP) {
-      robot_action.polygon_name = polygon->getName();
       // Setting up zero velocity for STOP model
+      robot_action.polygon_name = polygon->getName();
       robot_action.action_type = STOP;
       robot_action.req_vel.x = 0.0;
       robot_action.req_vel.y = 0.0;

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -82,7 +82,7 @@ CollisionMonitor::on_activate(const rclcpp_lifecycle::State & /*state*/)
 
   // Activating lifecycle publisher
   cmd_vel_out_pub_->on_activate();
-  if (state_pub_ != nullptr) {
+  if (state_pub_) {
     state_pub_->on_activate();
   }
 
@@ -122,7 +122,7 @@ CollisionMonitor::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
 
   // Deactivating lifecycle publishers
   cmd_vel_out_pub_->on_deactivate();
-  if (state_pub_ != nullptr) {
+  if (state_pub_) {
     state_pub_->on_deactivate();
   }
 
@@ -498,7 +498,7 @@ void CollisionMonitor::notifyActionState(
       "Robot to continue normal operation");
   }
 
-  if (state_pub_ != nullptr) {
+  if (state_pub_) {
     std::unique_ptr<nav2_msgs::msg::CollisionMonitorState> state_msg =
       std::make_unique<nav2_msgs::msg::CollisionMonitorState>();
     state_msg->polygon_name = robot_action.polygon_name;

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -391,8 +391,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
     robot_action.polygon_name != robot_action_prev_.polygon_name)
   {
     // Report changed robot behavior
-    printAction(robot_action, action_polygon);
-    publishActionState(robot_action);
+    notifyActionState(robot_action, action_polygon);
   }
 
   // Publish requred robot velocity
@@ -470,7 +469,7 @@ bool CollisionMonitor::processApproach(
   return false;
 }
 
-void CollisionMonitor::printAction(
+void CollisionMonitor::notifyActionState(
   const Action & robot_action, const std::shared_ptr<Polygon> action_polygon) const
 {
   if (robot_action.action_type == STOP) {
@@ -494,10 +493,7 @@ void CollisionMonitor::printAction(
       get_logger(),
       "Robot to continue normal operation");
   }
-}
 
-void CollisionMonitor::publishActionState(const Action & robot_action) const
-{
   std::unique_ptr<nav2_msgs::msg::CollisionMonitorState> collision_monitor_state_msg =
     std::make_unique<nav2_msgs::msg::CollisionMonitorState>();
   collision_monitor_state_msg->polygon_name = robot_action.polygon_name;

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -55,9 +55,10 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & /*state*/)
 
   std::string cmd_vel_in_topic;
   std::string cmd_vel_out_topic;
+  std::string collision_monitor_state_topic;
 
   // Obtaining ROS parameters
-  if (!getParameters(cmd_vel_in_topic, cmd_vel_out_topic)) {
+  if (!getParameters(cmd_vel_in_topic, cmd_vel_out_topic, collision_monitor_state_topic)) {
     return nav2_util::CallbackReturn::FAILURE;
   }
 
@@ -67,7 +68,7 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & /*state*/)
   cmd_vel_out_pub_ = this->create_publisher<geometry_msgs::msg::Twist>(
     cmd_vel_out_topic, 1);
   collision_monitor_state_pub_ = this->create_publisher<nav2_msgs::msg::CollisionMonitorState>(
-    "collision_monitor_state", 1);
+    collision_monitor_state_topic, 1);
 
   return nav2_util::CallbackReturn::SUCCESS;
 }
@@ -180,7 +181,8 @@ void CollisionMonitor::publishVelocity(const Action & robot_action)
 
 bool CollisionMonitor::getParameters(
   std::string & cmd_vel_in_topic,
-  std::string & cmd_vel_out_topic)
+  std::string & cmd_vel_out_topic,
+  std::string & collision_monitor_state_topic)
 {
   std::string base_frame_id, odom_frame_id;
   tf2::Duration transform_tolerance;
@@ -194,6 +196,9 @@ bool CollisionMonitor::getParameters(
   nav2_util::declare_parameter_if_not_declared(
     node, "cmd_vel_out_topic", rclcpp::ParameterValue("cmd_vel"));
   cmd_vel_out_topic = get_parameter("cmd_vel_out_topic").as_string();
+  nav2_util::declare_parameter_if_not_declared(
+    node, "collision_monitor_state_topic", rclcpp::ParameterValue("collision_monitor_state"));
+  collision_monitor_state_topic = get_parameter("collision_monitor_state_topic").as_string();
 
   nav2_util::declare_parameter_if_not_declared(
     node, "base_frame_id", rclcpp::ParameterValue("base_footprint"));

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -29,7 +29,7 @@ namespace nav2_collision_monitor
 
 CollisionMonitor::CollisionMonitor(const rclcpp::NodeOptions & options)
 : nav2_util::LifecycleNode("collision_monitor", "", options),
-  process_active_(false), robot_action_prev_{DO_NOTHING, {-1.0, -1.0, -1.0}, ""},
+  process_active_(false), robot_action_prev_{ACTION_UNKNOWN, {-1.0, -1.0, -1.0}, ""},
   stop_stamp_{0, 0, get_clock()->get_clock_type()}, stop_pub_timeout_(1.0, 0.0)
 {
 }
@@ -108,7 +108,7 @@ CollisionMonitor::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   process_active_ = false;
 
   // Reset action type to default after worker deactivating
-  robot_action_prev_ = {DO_NOTHING, {-1.0, -1.0, -1.0}, ""};
+  robot_action_prev_ = {ACTION_UNKNOWN, {-1.0, -1.0, -1.0}, ""};
 
   // Deactivating polygons
   for (std::shared_ptr<Polygon> polygon : polygons_) {
@@ -381,7 +381,9 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
     }
   }
 
-  if (robot_action.action_type != robot_action_prev_.action_type) {
+  if (robot_action_prev_.action_type == ACTION_UNKNOWN ||
+    robot_action.polygon_name != robot_action_prev_.polygon_name)
+  {
     // Report changed robot behavior
     printAction(robot_action, action_polygon);
     publishActionState(robot_action);

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -77,11 +77,11 @@ enum SourceType
 
 enum ActionType
 {
-  DO_NOTHING = 0,
-  STOP = 1,
-  SLOWDOWN = 2,
-  APPROACH = 3,
-  ACTION_UNKNOWN = 4
+  ACTION_UNKNOWN = 0,
+  DO_NOTHING = 1,
+  STOP = 2,
+  SLOWDOWN = 3,
+  APPROACH = 4
 };
 
 class CollisionMonitorWrapper : public nav2_collision_monitor::CollisionMonitor

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -81,7 +81,6 @@ enum ActionType
   STOP = 1,
   SLOWDOWN = 2,
   APPROACH = 3,
-  ACTION_UNKNOWN = 4
 };
 
 class CollisionMonitorWrapper : public nav2_collision_monitor::CollisionMonitor
@@ -602,8 +601,6 @@ TEST_F(Tester, testProcessStopSlowdown)
   ASSERT_NEAR(cmd_vel_out_->linear.x, 0.5, EPSILON);
   ASSERT_NEAR(cmd_vel_out_->linear.y, 0.2, EPSILON);
   ASSERT_NEAR(cmd_vel_out_->angular.z, 0.1, EPSILON);
-  ASSERT_EQ(action_state_->action_type, DO_NOTHING);
-  ASSERT_EQ(action_state_->polygon_name, "");
 
   // 2. Obstacle is in slowdown robot zone
   publishScan(1.5, curr_time);
@@ -667,8 +664,6 @@ TEST_F(Tester, testProcessApproach)
   ASSERT_NEAR(cmd_vel_out_->linear.x, 0.5, EPSILON);
   ASSERT_NEAR(cmd_vel_out_->linear.y, 0.2, EPSILON);
   ASSERT_NEAR(cmd_vel_out_->angular.z, 0.0, EPSILON);
-  ASSERT_EQ(action_state_->action_type, DO_NOTHING);
-  ASSERT_EQ(action_state_->polygon_name, "");
 
   // 2. Approaching obstacle (0.2 m ahead from robot footprint)
   publishScan(1.2, curr_time);
@@ -740,8 +735,6 @@ TEST_F(Tester, testProcessApproachRotation)
   ASSERT_NEAR(cmd_vel_out_->linear.x, 0.0, EPSILON);
   ASSERT_NEAR(cmd_vel_out_->linear.y, 0.0, EPSILON);
   ASSERT_NEAR(cmd_vel_out_->angular.z, M_PI / 4, EPSILON);
-  ASSERT_EQ(action_state_->action_type, DO_NOTHING);
-  ASSERT_EQ(action_state_->polygon_name, "");
 
   // 2. Approaching rotation to obstacle ( M_PI / 4 - M_PI / 20 ahead from robot)
   publishRange(1.4, curr_time);

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -77,11 +77,11 @@ enum SourceType
 
 enum ActionType
 {
-  ACTION_UNKNOWN = 0,
-  DO_NOTHING = 1,
-  STOP = 2,
-  SLOWDOWN = 3,
-  APPROACH = 4
+  DO_NOTHING = 0,
+  STOP = 1,
+  SLOWDOWN = 2,
+  APPROACH = 3,
+  ACTION_UNKNOWN = 4
 };
 
 class CollisionMonitorWrapper : public nav2_collision_monitor::CollisionMonitor

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -47,7 +47,7 @@ static const char SOURCE_FRAME_ID[]{"base_source"};
 static const char ODOM_FRAME_ID[]{"odom"};
 static const char CMD_VEL_IN_TOPIC[]{"cmd_vel_in"};
 static const char CMD_VEL_OUT_TOPIC[]{"cmd_vel_out"};
-static const char COLLISION_MONITOR_STATE_TOPIC[]{"collision_monitor_state"};
+static const char STATE_TOPIC[]{"collision_monitor_state"};
 static const char FOOTPRINT_TOPIC[]{"footprint"};
 static const char SCAN_NAME[]{"Scan"};
 static const char POINTCLOUD_NAME[]{"PointCloud"};
@@ -206,7 +206,7 @@ Tester::Tester()
     std::bind(&Tester::cmdVelOutCallback, this, std::placeholders::_1));
 
   action_state_sub_ = cm_->create_subscription<nav2_msgs::msg::CollisionMonitorState>(
-    COLLISION_MONITOR_STATE_TOPIC, rclcpp::SystemDefaultsQoS(),
+    STATE_TOPIC, rclcpp::SystemDefaultsQoS(),
     std::bind(&Tester::actionStateCallback, this, std::placeholders::_1));
 }
 
@@ -237,9 +237,9 @@ void Tester::setCommonParameters()
   cm_->set_parameter(
     rclcpp::Parameter("cmd_vel_out_topic", CMD_VEL_OUT_TOPIC));
   cm_->declare_parameter(
-    "collision_monitor_state_topic", rclcpp::ParameterValue(COLLISION_MONITOR_STATE_TOPIC));
+    "state_topic", rclcpp::ParameterValue(STATE_TOPIC));
   cm_->set_parameter(
-    rclcpp::Parameter("collision_monitor_state_topic", COLLISION_MONITOR_STATE_TOPIC));
+    rclcpp::Parameter("state_topic", STATE_TOPIC));
 
   cm_->declare_parameter(
     "base_frame_id", rclcpp::ParameterValue(BASE_FRAME_ID));

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -237,6 +237,10 @@ void Tester::setCommonParameters()
     "cmd_vel_out_topic", rclcpp::ParameterValue(CMD_VEL_OUT_TOPIC));
   cm_->set_parameter(
     rclcpp::Parameter("cmd_vel_out_topic", CMD_VEL_OUT_TOPIC));
+  cm_->declare_parameter(
+    "collision_monitor_state_topic", rclcpp::ParameterValue(COLLISION_MONITOR_STATE_TOPIC));
+  cm_->set_parameter(
+    rclcpp::Parameter("collision_monitor_state_topic", COLLISION_MONITOR_STATE_TOPIC));
 
   cm_->declare_parameter(
     "base_frame_id", rclcpp::ParameterValue(BASE_FRAME_ID));

--- a/nav2_msgs/CMakeLists.txt
+++ b/nav2_msgs/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(action_msgs REQUIRED)
 nav2_package()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/CollisionMonitorState.msg"
   "msg/Costmap.msg"
   "msg/CostmapMetaData.msg"
   "msg/CostmapFilterInfo.msg"

--- a/nav2_msgs/msg/CollisionMonitorState.msg
+++ b/nav2_msgs/msg/CollisionMonitorState.msg
@@ -1,0 +1,8 @@
+# Action type for robot in Collision Monitor
+# 0: DO_NOTHING - No action
+# 1: STOP - Stop the robot
+# 2: SLOWDOWN - Slowdown in percentage from current operating speed
+# 3: APPROACH - Keep constant time interval before collision
+uint8 action_type
+# Name of triggered polygon
+string polygon_name

--- a/nav2_msgs/msg/CollisionMonitorState.msg
+++ b/nav2_msgs/msg/CollisionMonitorState.msg
@@ -1,9 +1,9 @@
 # Action type for robot in Collision Monitor
-# 0: ACTION_UNKNOWN - Default for initializing action type
-# 1: DO_NOTHING - No action
-# 2: STOP - Stop the robot
-# 3: SLOWDOWN - Slowdown in percentage from current operating speed
-# 4: APPROACH - Keep constant time interval before collision
+# 0: DO_NOTHING - No action
+# 1: STOP - Stop the robot
+# 2: SLOWDOWN - Slowdown in percentage from current operating speed
+# 3: APPROACH - Keep constant time interval before collision
+# 4: ACTION_UNKNOWN - Default for initializing action type
 uint8 action_type
 # Name of triggered polygon
 string polygon_name

--- a/nav2_msgs/msg/CollisionMonitorState.msg
+++ b/nav2_msgs/msg/CollisionMonitorState.msg
@@ -1,8 +1,9 @@
 # Action type for robot in Collision Monitor
-# 0: DO_NOTHING - No action
-# 1: STOP - Stop the robot
-# 2: SLOWDOWN - Slowdown in percentage from current operating speed
-# 3: APPROACH - Keep constant time interval before collision
+uint8 DO_NOTHING=0 # No action
+uint8 STOP=1 # Stop the robot
+uint8 SLOWDOWN=2 # Slowdown in percentage from current operating speed
+uint8 APPROACH=3 # Keep constant time interval before collision
 uint8 action_type
+
 # Name of triggered polygon
 string polygon_name

--- a/nav2_msgs/msg/CollisionMonitorState.msg
+++ b/nav2_msgs/msg/CollisionMonitorState.msg
@@ -1,9 +1,9 @@
 # Action type for robot in Collision Monitor
-# 0: DO_NOTHING - No action
-# 1: STOP - Stop the robot
-# 2: SLOWDOWN - Slowdown in percentage from current operating speed
-# 3: APPROACH - Keep constant time interval before collision
-# 4: ACTION_UNKNOWN - Default for initializing action type
+# 0: ACTION_UNKNOWN - Default for initializing action type
+# 1: DO_NOTHING - No action
+# 2: STOP - Stop the robot
+# 3: SLOWDOWN - Slowdown in percentage from current operating speed
+# 4: APPROACH - Keep constant time interval before collision
 uint8 action_type
 # Name of triggered polygon
 string polygon_name

--- a/nav2_msgs/msg/CollisionMonitorState.msg
+++ b/nav2_msgs/msg/CollisionMonitorState.msg
@@ -3,7 +3,6 @@
 # 1: STOP - Stop the robot
 # 2: SLOWDOWN - Slowdown in percentage from current operating speed
 # 3: APPROACH - Keep constant time interval before collision
-# 4: ACTION_UNKNOWN - Default for initializing action type
 uint8 action_type
 # Name of triggered polygon
 string polygon_name

--- a/nav2_msgs/msg/CollisionMonitorState.msg
+++ b/nav2_msgs/msg/CollisionMonitorState.msg
@@ -3,6 +3,7 @@
 # 1: STOP - Stop the robot
 # 2: SLOWDOWN - Slowdown in percentage from current operating speed
 # 3: APPROACH - Keep constant time interval before collision
+# 4: ACTION_UNKNOWN - Default for initializing action type
 uint8 action_type
 # Name of triggered polygon
 string polygon_name


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3496  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory Simulation |

---

## Description of contribution in a few bullet points

* Added a new msg in `nav2_msgs` - `CollisionMonitorState.msg`
* Publish CollisionMonitor action state
* Also fixed that the first action will not be printed if it is `DO_NOTHING`
* Also updated the state change logic to check with `polygon_name` instead of `action_type` (To handle multiple `slowdown` polygons correctly)

## Description of documentation updates required from your changes

* Added new topic + param, so need to add that to default configs and documentation page


---

## Future work that may be required in bullet points

* This PR report the CM's action state change based on the input `cmd_vel`, but I think it will be very useful to publish the polygon state even when the robot is not moving too. Especially for cases like when the `stop` polygon is triggered(regardless of `cmd_vel` speed), or when there are points in `approach` polygon where the robot will not be able to move. (Probably similar requirement as mentioned [here](https://github.com/ros-planning/navigation2/pull/3500#issuecomment-1480890637))


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
