### PR TITLE
Add an argument to select if the smoother server should be launched

### DIFF
--- a/nav2_bringup/launch/navigation_launch.py
+++ b/nav2_bringup/launch/navigation_launch.py
@@ -35,18 +35,21 @@ def generate_launch_description():
     autostart = LaunchConfiguration('autostart')
     params_file = LaunchConfiguration('params_file')
     use_composition = LaunchConfiguration('use_composition')
+    use_smooter_server = LaunchConfiguration('use_smooter_server')
     container_name = LaunchConfiguration('container_name')
     use_respawn = LaunchConfiguration('use_respawn')
     log_level = LaunchConfiguration('log_level')
 
-    lifecycle_nodes = ['controller_server',
-                       'smoother_server',
+    lifecycle_nodes = PythonExpression(["""['controller_server',
                        'planner_server',
                        'behavior_server',
                        'bt_navigator',
                        'waypoint_follower',
-                       'velocity_smoother']
-
+                       'velocity_smoother'] + (
+                        ['smoother_server'] if '""",
+                        use_smooter_server,
+                        "'.lower()=='true' else [])"])
+    
     # Map fully qualified names to relative ones so the node's namespace can be prepended.
     # In case of the transforms (tf), currently, there doesn't seem to be a better alternative
     # https://github.com/ros/geometry2/issues/32
@@ -93,6 +96,10 @@ def generate_launch_description():
         'use_composition', default_value='False',
         description='Use composed bringup if True')
 
+    declare_use_smooter_server_cmd = DeclareLaunchArgument(
+        'use_smooter_server', default_value='True',
+        description='Launch smooter server if True')
+
     declare_container_name_cmd = DeclareLaunchArgument(
         'container_name', default_value='nav2_container',
         description='the name of conatiner that nodes will load in if use composition')
@@ -118,6 +125,7 @@ def generate_launch_description():
                 arguments=['--ros-args', '--log-level', log_level],
                 remappings=remappings + [('cmd_vel', 'cmd_vel_nav')]),
             Node(
+                condition=IfCondition(use_smooter_server),
                 package='nav2_smoother',
                 executable='smoother_server',
                 name='smoother_server',
@@ -259,6 +267,7 @@ def generate_launch_description():
     ld.add_action(declare_params_file_cmd)
     ld.add_action(declare_autostart_cmd)
     ld.add_action(declare_use_composition_cmd)
+    ld.add_action(declare_use_smooter_server_cmd)
     ld.add_action(declare_container_name_cmd)
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)

--- a/nav2_bringup/launch/navigation_launch.py
+++ b/nav2_bringup/launch/navigation_launch.py
@@ -35,7 +35,7 @@ def generate_launch_description():
     autostart = LaunchConfiguration('autostart')
     params_file = LaunchConfiguration('params_file')
     use_composition = LaunchConfiguration('use_composition')
-    use_smooter_server = LaunchConfiguration('use_smooter_server')
+    use_smoother_server = LaunchConfiguration('use_smoother_server')
     container_name = LaunchConfiguration('container_name')
     use_respawn = LaunchConfiguration('use_respawn')
     log_level = LaunchConfiguration('log_level')
@@ -47,7 +47,7 @@ def generate_launch_description():
                        'waypoint_follower',
                        'velocity_smoother'] + (
                         ['smoother_server'] if '""",
-                        use_smooter_server,
+                        use_smoother_server,
                         "'.lower()=='true' else [])"])
     
     # Map fully qualified names to relative ones so the node's namespace can be prepended.
@@ -96,9 +96,9 @@ def generate_launch_description():
         'use_composition', default_value='False',
         description='Use composed bringup if True')
 
-    declare_use_smooter_server_cmd = DeclareLaunchArgument(
-        'use_smooter_server', default_value='True',
-        description='Launch smooter server if True')
+    declare_use_smoother_server_cmd = DeclareLaunchArgument(
+        'use_smoother_server', default_value='True',
+        description='Launch smoother server if True')
 
     declare_container_name_cmd = DeclareLaunchArgument(
         'container_name', default_value='nav2_container',
@@ -125,7 +125,7 @@ def generate_launch_description():
                 arguments=['--ros-args', '--log-level', log_level],
                 remappings=remappings + [('cmd_vel', 'cmd_vel_nav')]),
             Node(
-                condition=IfCondition(use_smooter_server),
+                condition=IfCondition(use_smoother_server),
                 package='nav2_smoother',
                 executable='smoother_server',
                 name='smoother_server',
@@ -267,7 +267,7 @@ def generate_launch_description():
     ld.add_action(declare_params_file_cmd)
     ld.add_action(declare_autostart_cmd)
     ld.add_action(declare_use_composition_cmd)
-    ld.add_action(declare_use_smooter_server_cmd)
+    ld.add_action(declare_use_smoother_server_cmd)
     ld.add_action(declare_container_name_cmd)
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)


### PR DESCRIPTION

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |
| Ros version tested on | Humble |

---

## Description of contribution in a few bullet points
I add an argument to the `navigation_launch.py` launch file to allow to select if the smoother server should be launched.

As some planner output are smooth enough to avoid  using a smoother and some  planner have an included smoother, the smoother server may be unnecessary. It may be interesting not to launch it to have one less node.

The argument default value is set to True to keep the actual behavior by default.

---

## Future work that may be required in bullet points

I wasn't able to add the condition to the smoother composed node as the composed does not have the condition argument. 

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
