### PR TITLE
Rename max_points to min_points polygon parameter

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -86,10 +86,10 @@ public:
    */
   ActionType getActionType() const;
   /**
-   * @brief Obtains polygon maximum points to enter inside polygon causing no action
-   * @return Maximum points to enter to current polygon and take no action
+   * @brief Obtains polygon minimum points to enter inside polygon causing the action
+   * @return Minimum number of data readings within a zone to trigger the action
    */
-  int getMaxPoints() const;
+  int getMinPoints() const;
   /**
    * @brief Obtains speed slowdown ratio for current polygon.
    * Applicable for SLOWDOWN model.
@@ -198,8 +198,8 @@ protected:
   std::string polygon_name_;
   /// @brief Action type for the polygon
   ActionType action_type_;
-  /// @brief Maximum number of data readings within a zone to not trigger the action
-  int max_points_;
+  /// @brief Minimum number of data readings within a zone to trigger the action
+  int min_points_;
   /// @brief Robot slowdown (share of its actual speed)
   double slowdown_ratio_;
   /// @brief Time before collision in seconds

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -18,14 +18,14 @@ collision_monitor:
       type: "polygon"
       points: [0.3, 0.3, 0.3, -0.3, 0.0, -0.3, 0.0, 0.3]
       action_type: "stop"
-      max_points: 3
+      min_points: 4
       visualize: True
       polygon_pub_topic: "polygon_stop"
     PolygonSlow:
       type: "polygon"
       points: [0.4, 0.4, 0.4, -0.4, -0.4, -0.4, -0.4, 0.4]
       action_type: "slowdown"
-      max_points: 3
+      min_points: 4
       slowdown_ratio: 0.3
       visualize: True
       polygon_pub_topic: "polygon_slowdown"
@@ -35,7 +35,7 @@ collision_monitor:
       footprint_topic: "/local_costmap/published_footprint"
       time_before_collision: 2.0
       simulation_time_step: 0.1
-      max_points: 5
+      min_points: 6
       visualize: False
     observation_sources: ["scan"]
     scan:

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -401,7 +401,7 @@ bool CollisionMonitor::processStopSlowdown(
     return false;
   }
 
-  if (polygon->getPointsInside(collision_points) > polygon->getMinPoints()) {
+  if (polygon->getPointsInside(collision_points) >= polygon->getMinPoints()) {
     if (polygon->getActionType() == STOP) {
       // Setting up zero velocity for STOP model
       robot_action.action_type = STOP;

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -401,7 +401,7 @@ bool CollisionMonitor::processStopSlowdown(
     return false;
   }
 
-  if (polygon->getPointsInside(collision_points) > polygon->getMaxPoints()) {
+  if (polygon->getPointsInside(collision_points) > polygon->getMinPoints()) {
     if (polygon->getActionType() == STOP) {
       // Setting up zero velocity for STOP model
       robot_action.action_type = STOP;

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -50,7 +50,7 @@ static const char FOOTPRINT_TOPIC[]{"footprint"};
 static const char SCAN_NAME[]{"Scan"};
 static const char POINTCLOUD_NAME[]{"PointCloud"};
 static const char RANGE_NAME[]{"Range"};
-static const int MAX_POINTS{1};
+static const int MIN_POINTS{2};
 static const double SLOWDOWN_RATIO{0.7};
 static const double TIME_BEFORE_COLLISION{1.0};
 static const double SIMULATION_TIME_STEP{0.01};
@@ -285,9 +285,9 @@ void Tester::addPolygon(
     rclcpp::Parameter(polygon_name + ".action_type", at));
 
   cm_->declare_parameter(
-    polygon_name + ".max_points", rclcpp::ParameterValue(MAX_POINTS));
+    polygon_name + ".min_points", rclcpp::ParameterValue(MIN_POINTS));
   cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + ".max_points", MAX_POINTS));
+    rclcpp::Parameter(polygon_name + ".min_points", MIN_POINTS));
 
   cm_->declare_parameter(
     polygon_name + ".slowdown_ratio", rclcpp::ParameterValue(SLOWDOWN_RATIO));


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3499 |
| Primary OS tested on | Ubuntu 22.04 w/ ROS2 Rolling built from source (from 20230110) |
| Robotic platform tested on | `colcon test --packages-select nav2_collision_monitor` |

---

## Description of contribution in a few bullet points

* `<polygon_name>.max_points` parameter was renamed to `<polygon_name>.min_points` to track its meaning
* Default value for this parameter was adjusted accordingly to not change default CM's behavior
* Old `<polygon_name>.max_points` is still used  (to be removed in the future releases), but now with deprecation warning, if parameter was set by developer
* New `testPolygonMaxPoints` testcase for `max_points` deprecated parameter

## Description of documentation updates required from your changes

* Update parameter description on CM parameters page
* Switch parameters on Tutorial page

---

## Future work that may be required in bullet points

* Remove the support of `<polygon_name>.max_points` parameter in the further releases

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
