### PR TITLE
Rpp dubins constraint

### DIFF
--- a/nav2_msgs/CMakeLists.txt
+++ b/nav2_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Costmap.msg"
   "msg/CostmapMetaData.msg"
   "msg/CostmapFilterInfo.msg"
+  "msg/CrossTrackError.msg"
   "msg/SpeedLimit.msg"
   "msg/VoxelGrid.msg"
   "msg/BehaviorTreeStatusChange.msg"

--- a/nav2_msgs/msg/CrossTrackError.msg
+++ b/nav2_msgs/msg/CrossTrackError.msg
@@ -1,0 +1,2 @@
+float64 position_error
+float64 heading_error

--- a/nav2_msgs/msg/CrossTrackError.msg
+++ b/nav2_msgs/msg/CrossTrackError.msg
@@ -1,2 +1,4 @@
+std_msgs/Header header
+
 float64 position_error
 float64 heading_error

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
@@ -59,6 +59,8 @@ struct Parameters
   bool use_interpolation;
   bool use_collision_detection;
   double transform_tolerance;
+  bool use_dubins_min_lookahead_dist;
+  double dubins_min_turning_radius;
 };
 
 /**

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
@@ -76,7 +76,10 @@ public:
     const geometry_msgs::msg::PoseStamped & in_pose,
     geometry_msgs::msg::PoseStamped & out_pose) const;
 
-  void setPlan(const nav_msgs::msg::Path & path) {global_plan_ = path;}
+  void setPlan(const nav_msgs::msg::Path & path) {
+    global_plan_ = path;
+    path_progress_cursor_ = global_plan_.poses.begin();
+  }
 
   nav_msgs::msg::Path getPlan() {return global_plan_;}
 
@@ -92,6 +95,7 @@ protected:
   std::shared_ptr<tf2_ros::Buffer> tf_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   nav_msgs::msg::Path global_plan_;
+  std::vector<geometry_msgs::msg::PoseStamped>::iterator path_progress_cursor_;
 };
 
 }  // namespace nav2_regulated_pure_pursuit_controller

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
@@ -84,6 +84,8 @@ public:
 
   nav_msgs::msg::Path getPlan() {return global_plan_;}
 
+  nav_msgs::msg::Path & getPlan() {return global_plan_;}
+
   std::vector<geometry_msgs::msg::PoseStamped>::iterator getCurrentPose()
   {
     return path_progress_cursor_;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
@@ -84,8 +84,6 @@ public:
 
   nav_msgs::msg::Path getPlan() {return global_plan_;}
 
-  nav_msgs::msg::Path & getPlan() {return global_plan_;}
-
   std::vector<geometry_msgs::msg::PoseStamped>::iterator getCurrentPose()
   {
     return path_progress_cursor_;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
@@ -76,12 +76,18 @@ public:
     const geometry_msgs::msg::PoseStamped & in_pose,
     geometry_msgs::msg::PoseStamped & out_pose) const;
 
-  void setPlan(const nav_msgs::msg::Path & path) {
+  void setPlan(const nav_msgs::msg::Path & path)
+  {
     global_plan_ = path;
     path_progress_cursor_ = global_plan_.poses.begin();
   }
 
   nav_msgs::msg::Path getPlan() {return global_plan_;}
+
+  std::vector<geometry_msgs::msg::PoseStamped>::iterator getCurrentPose()
+  {
+    return path_progress_cursor_;
+  }
 
 protected:
   /**

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -117,7 +117,9 @@ protected:
    * @param cmd the current speed to use to compute lookahead point
    * @return lookahead distance
    */
-  double getLookAheadDistance(const geometry_msgs::msg::Twist &);
+  double getLookAheadDistance(const geometry_msgs::msg::Twist &,
+    const nav_msgs::msg::Path & path,
+    const geometry_msgs::msg::PoseStamped & pose);
 
   /**
    * @brief Creates a PointStamped message for visualization
@@ -195,6 +197,10 @@ protected:
    * @return robot distance from the cusp
    */
   double findVelocitySignChange(const nav_msgs::msg::Path & transformed_plan);
+
+  double getDubinsMinLookAheadDistance(
+    const nav_msgs::msg::Path & path,
+    const geometry_msgs::msg::PoseStamped & pose);
 
   rclcpp_lifecycle::LifecycleNode::WeakPtr node_;
   std::shared_ptr<tf2_ros::Buffer> tf_;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -23,6 +23,7 @@
 #include <mutex>
 
 #include "nav2_core/controller.hpp"
+#include "nav2_msgs/msg/cross_track_error.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "pluginlib/class_loader.hpp"
 #include "pluginlib/class_list_macros.hpp"
@@ -117,9 +118,9 @@ protected:
    * @param cmd the current speed to use to compute lookahead point
    * @return lookahead distance
    */
-  double getLookAheadDistance(const geometry_msgs::msg::Twist &,
-    const nav_msgs::msg::Path & path,
-    const geometry_msgs::msg::PoseStamped & pose);
+  double getLookAheadDistance(
+    const geometry_msgs::msg::Twist &,
+    const nav2_msgs::msg::CrossTrackError & cross_track_error);
 
   /**
    * @brief Creates a PointStamped message for visualization
@@ -198,9 +199,10 @@ protected:
    */
   double findVelocitySignChange(const nav_msgs::msg::Path & transformed_plan);
 
-  double getDubinsMinLookAheadDistance(
-    const nav_msgs::msg::Path & path,
-    const geometry_msgs::msg::PoseStamped & pose);
+  double getDubinsMinLookAheadDistance(const nav2_msgs::msg::CrossTrackError & cross_track_error);
+
+  nav2_msgs::msg::CrossTrackError getCrossTrackError(
+    const nav_msgs::msg::Path & transformed_plan);
 
   rclcpp_lifecycle::LifecycleNode::WeakPtr node_;
   std::shared_ptr<tf2_ros::Buffer> tf_;
@@ -217,6 +219,11 @@ protected:
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PointStamped>>
   carrot_pub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> carrot_arc_pub_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PoseStamped>>
+  projected_pose_pub_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::CrossTrackError>>
+  cross_track_error_pub_;
+
   std::unique_ptr<nav2_regulated_pure_pursuit_controller::PathHandler> path_handler_;
   std::unique_ptr<nav2_regulated_pure_pursuit_controller::ParameterHandler> param_handler_;
   std::unique_ptr<nav2_regulated_pure_pursuit_controller::CollisionChecker> collision_checker_;

--- a/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
@@ -166,7 +166,8 @@ ParameterHandler::ParameterHandler(
       " every point on path for the closest value.");
     params_.max_robot_pose_search_dist = std::numeric_limits<double>::max();
   }
-  node->get_parameter(plugin_name_ + ".use_dubins_min_lookahead_dist",
+  node->get_parameter(
+    plugin_name_ + ".use_dubins_min_lookahead_dist",
     params_.use_dubins_min_lookahead_dist);
   node->get_parameter(
     plugin_name_ + ".dubins_min_turning_radius",

--- a/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
@@ -96,6 +96,11 @@ ParameterHandler::ParameterHandler(
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".use_collision_detection",
     rclcpp::ParameterValue(true));
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".use_dubins_min_lookahead_dist",
+    rclcpp::ParameterValue(false));
+  declare_parameter_if_not_declared(
+    node, plugin_name_ + ".dubins_min_turning_radius", rclcpp::ParameterValue(1.0));
 
   node->get_parameter(plugin_name_ + ".desired_linear_vel", params_.desired_linear_vel);
   params_.base_desired_linear_vel = params_.desired_linear_vel;
@@ -161,6 +166,11 @@ ParameterHandler::ParameterHandler(
       " every point on path for the closest value.");
     params_.max_robot_pose_search_dist = std::numeric_limits<double>::max();
   }
+  node->get_parameter(plugin_name_ + ".use_dubins_min_lookahead_dist",
+    params_.use_dubins_min_lookahead_dist);
+  node->get_parameter(
+    plugin_name_ + ".dubins_min_turning_radius",
+    params_.dubins_min_turning_radius);
 
   node->get_parameter(
     plugin_name_ + ".use_interpolation",
@@ -243,6 +253,8 @@ ParameterHandler::dynamicParametersCallback(
         params_.max_angular_accel = parameter.as_double();
       } else if (name == plugin_name_ + ".rotate_to_heading_min_angle") {
         params_.rotate_to_heading_min_angle = parameter.as_double();
+      } else if (name == plugin_name_ + ".dubins_min_turning_radius") {
+        params_.dubins_min_turning_radius = parameter.as_double();
       }
     } else if (type == ParameterType::PARAMETER_BOOL) {
       if (name == plugin_name_ + ".use_velocity_scaled_lookahead_dist") {
@@ -271,6 +283,8 @@ ParameterHandler::dynamicParametersCallback(
           continue;
         }
         params_.allow_reversing = parameter.as_bool();
+      } else if (name == plugin_name_ + ".use_dubins_min_lookahead_dist") {
+        params_.use_dubins_min_lookahead_dist = parameter.as_bool();
       }
     }
   }

--- a/nav2_regulated_pure_pursuit_controller/src/path_handler.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/path_handler.cpp
@@ -49,12 +49,8 @@ nav_msgs::msg::Path PathHandler::transformGlobalPlan(
   const geometry_msgs::msg::PoseStamped & pose,
   double max_robot_pose_search_dist)
 {
-  if (global_plan_.poses.empty()) {
+  if (global_plan_.poses.empty() || path_progress_cursor_ == global_plan_.poses.end()) {
     throw nav2_core::InvalidPath("Received plan with zero length");
-  }
-
-  if (path_progress_cursor_ == global_plan_.poses.end()) {
-    throw nav2_core::PlannerException("No more poses to transform");
   }
 
   // let's get the pose of the robot in the frame of the plan

--- a/nav2_regulated_pure_pursuit_controller/src/path_handler.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/path_handler.cpp
@@ -53,6 +53,10 @@ nav_msgs::msg::Path PathHandler::transformGlobalPlan(
     throw nav2_core::InvalidPath("Received plan with zero length");
   }
 
+  if (path_progress_cursor_ == global_plan_.poses.end()) {
+    throw nav2_core::PlannerException("No more poses to transform");
+  }
+
   // let's get the pose of the robot in the frame of the plan
   geometry_msgs::msg::PoseStamped robot_pose;
   if (!transformPose(global_plan_.header.frame_id, pose, robot_pose)) {
@@ -61,14 +65,14 @@ nav_msgs::msg::Path PathHandler::transformGlobalPlan(
 
   auto closest_pose_upper_bound =
     nav2_util::geometry_utils::first_after_integrated_distance(
-    global_plan_.poses.begin(), global_plan_.poses.end(), max_robot_pose_search_dist);
+    path_progress_cursor_, global_plan_.poses.end(), max_robot_pose_search_dist);
 
   // First find the closest pose on the path to the robot
   // bounded by when the path turns around (if it does) so we don't get a pose from a later
   // portion of the path
   auto transformation_begin =
     nav2_util::geometry_utils::min_by(
-    global_plan_.poses.begin(), closest_pose_upper_bound,
+    path_progress_cursor_, closest_pose_upper_bound,
     [&robot_pose](const geometry_msgs::msg::PoseStamped & ps) {
       return euclidean_distance(robot_pose, ps);
     });
@@ -103,9 +107,9 @@ nav_msgs::msg::Path PathHandler::transformGlobalPlan(
   transformed_plan.header.frame_id = costmap_ros_->getBaseFrameID();
   transformed_plan.header.stamp = robot_pose.header.stamp;
 
-  // Remove the portion of the global plan that we've already passed so we don't
+  // Mark the portion of the global plan that we've already passed so we don't
   // process it on the next iteration (this is called path pruning)
-  global_plan_.poses.erase(begin(global_plan_.poses), transformation_begin);
+  path_progress_cursor_ = transformation_begin;
 
   if (transformed_plan.poses.empty()) {
     throw nav2_core::InvalidPath("Resulting plan has 0 poses in it.");

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -143,7 +143,9 @@ double RegulatedPurePursuitController::getLookAheadDistance(
   }
 
   if (params_->use_dubins_min_lookahead_dist) {
-    double dubins_min_lookahead_dist = std::min(getDubinsMinLookAheadDistance(cross_track_error), params_->max_lookahead_dist);
+    double dubins_min_lookahead_dist = std::min(
+      getDubinsMinLookAheadDistance(
+        cross_track_error), params_->max_lookahead_dist);
     lookahead_dist = std::max(lookahead_dist, dubins_min_lookahead_dist);
   }
 
@@ -176,7 +178,10 @@ double RegulatedPurePursuitController::getDubinsMinLookAheadDistance(
   // symmetrical arcs of `arc_length` radians to reach the path.
   // These serve to give us a reasonable bound on the lookahead
   // without generating full dubins curves
-  double arc_length = std::acos(1.0 - cross_track_error.position_error / (2.0 * params_->dubins_min_turning_radius));
+  double arc_length =
+    std::acos(
+    1.0 - cross_track_error.position_error /
+    (2.0 * params_->dubins_min_turning_radius));
   return 2 * params_->dubins_min_turning_radius * std::sin(arc_length);
 }
 

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -75,7 +75,8 @@ void RegulatedPurePursuitController::configure(
   node->get_parameter(
     plugin_name_ + ".use_interpolation",
     use_interpolation_);
-  node->get_parameter(plugin_name_ + ".use_dubins_min_lookahead_dist",
+  node->get_parameter(
+    plugin_name_ + ".use_dubins_min_lookahead_dist",
     use_dubins_min_lookahead_dist_);
   node->get_parameter(
     plugin_name_ + ".dubins_min_turning_radius",
@@ -212,7 +213,7 @@ nav2_msgs::msg::CrossTrackError RegulatedPurePursuitController::getCrossTrackErr
   geometry_msgs::msg::PoseStamped previous_pose, transformed_previous_pose;
   previous_pose.header.frame_id = global_plan_.header.frame_id;
   previous_pose.header.stamp = transformed_plan.header.stamp;
-  previous_pose.pose = std::prev(path_progress_cursor_)->pose;
+  previous_pose.pose = std::prev(path_handler_->getCurrentPose())->pose;
   transformPose(costmap_ros_->getBaseFrameID(), previous_pose, transformed_previous_pose);
   smooth_path.poses.insert(smooth_path.poses.begin(), transformed_previous_pose);
 

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -88,6 +88,11 @@ void RegulatedPurePursuitController::configure(
   global_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("received_global_plan", 1);
   carrot_pub_ = node->create_publisher<geometry_msgs::msg::PointStamped>("lookahead_point", 1);
   carrot_arc_pub_ = node->create_publisher<nav_msgs::msg::Path>("lookahead_collision_arc", 1);
+  projected_pose_pub_ =
+    node->create_publisher<geometry_msgs::msg::PoseStamped>("projected_pose", 1);
+  cross_track_error_pub_ = node->create_publisher<nav2_msgs::msg::CrossTrackError>(
+    "cross_track_error", 1);
+
 
   // initialize collision checker and set costmap
   collision_checker_ = std::make_unique<nav2_costmap_2d::
@@ -104,6 +109,8 @@ void RegulatedPurePursuitController::cleanup()
     plugin_name_.c_str());
   global_path_pub_.reset();
   carrot_pub_.reset();
+  projected_pose_pub_.reset();
+  cross_track_error_pub_.reset();
 }
 
 void RegulatedPurePursuitController::activate()
@@ -115,6 +122,8 @@ void RegulatedPurePursuitController::activate()
     plugin_name_.c_str());
   global_path_pub_->on_activate();
   carrot_pub_->on_activate();
+  projected_pose_pub_->on_activate();
+  cross_track_error_pub_->on_activate();
 }
 
 void RegulatedPurePursuitController::deactivate()
@@ -126,6 +135,8 @@ void RegulatedPurePursuitController::deactivate()
     plugin_name_.c_str());
   global_path_pub_->on_deactivate();
   carrot_pub_->on_deactivate();
+  projected_pose_pub_->on_deactivate();
+  cross_track_error_pub_->on_deactivate();
 }
 
 std::unique_ptr<geometry_msgs::msg::PointStamped> RegulatedPurePursuitController::createCarrotMsg(

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -57,7 +57,7 @@ public:
 
   double getLookAheadDistanceWrapper(const geometry_msgs::msg::Twist & twist)
   {
-    return getLookAheadDistance(twist);
+    return getLookAheadDistance(twist, nav2_msgs::msg::CrossTrackError());
   }
 
   static geometry_msgs::msg::Point circleSegmentIntersectionWrapper(

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -120,6 +120,44 @@ inline double euclidean_distance(
 }
 
 /**
+ * @brief Get the squared euclidean distance between 2 geometry_msgs::Poses
+ * @param pos1 First pose
+ * @param pos1 Second pose
+ * @param is_3d True if a true 3D distance is desired (default false)
+ * @return double squared euclidean distance
+ */
+inline double squared_euclidean_distance(
+  const geometry_msgs::msg::Pose & pos1,
+  const geometry_msgs::msg::Pose & pos2,
+  const bool is_3d = false)
+{
+  double dx = pos1.position.x - pos2.position.x;
+  double dy = pos1.position.y - pos2.position.y;
+
+  if (is_3d) {
+    double dz = pos1.position.z - pos2.position.z;
+    return dx * dx + dy * dy + dz * dz;
+  }
+
+  return dx * dx + dy * dy;
+}
+
+/**
+ * @brief Get the squared L2 distance between 2 geometry_msgs::PoseStamped
+ * @param pos1 First pose
+ * @param pos1 Second pose
+ * @param is_3d True if a true squared L2 distance is desired (default false)
+ * @return double squared L2 distance
+ */
+inline double squared_euclidean_distance(
+  const geometry_msgs::msg::PoseStamped & pos1,
+  const geometry_msgs::msg::PoseStamped & pos2,
+  const bool is_3d = false)
+{
+  return squared_euclidean_distance(pos1.pose, pos2.pose, is_3d);
+}
+
+/**
  * Find element in iterator with the minimum calculated value
  */
 template<typename Iter, typename Getter>
@@ -177,6 +215,63 @@ inline double calculate_path_length(const nav_msgs::msg::Path & path, size_t sta
     path_length += euclidean_distance(path.poses[idx].pose, path.poses[idx + 1].pose);
   }
   return path_length;
+}
+
+std::pair<geometry_msgs::msg::PoseStamped, geometry_msgs::msg::PoseStamped>
+find_closest_path_segment(const nav_msgs::msg::Path & path, const geometry_msgs::msg::PoseStamped & pose)
+{
+  std::vector<double> distances(path.poses.size());
+  std::transform(
+    path.poses.begin(),
+    path.poses.end(),
+    distances.begin(),
+    [&pose](const auto & path_pose) {
+      return squared_euclidean_distance(path_pose, pose);
+    }
+  );
+  auto closest_distance_it = std::min_element(
+    distances.begin(),
+    distances.end()
+  );
+
+  auto next_closest_distance_it = distances.end();
+
+  if (std::next(closest_distance_it) == distances.end()) {
+    next_closest_distance_it = std::prev(closest_distance_it);
+  } else if (closest_distance_it == distances.begin()) {
+    next_closest_distance_it = std::next(closest_distance_it);
+  } else if (*std::prev(closest_distance_it) < *std::next(closest_distance_it)) {
+    next_closest_distance_it = std::prev(closest_distance_it);
+  } else {
+    next_closest_distance_it = std::next(closest_distance_it);
+  }
+
+  size_t closest_pose_index = std::distance(distances.begin(), closest_distance_it);
+  size_t next_closest_pose_index = std::distance(distances.begin(), next_closest_distance_it);
+
+  return std::make_pair(path.poses.at(closest_pose_index), path.poses.at(next_closest_pose_index));
+}
+
+double cross_track_error(const nav_msgs::msg::Path & path, const geometry_msgs::msg::PoseStamped & pose)
+{
+  // http://paulbourke.net/geometry/pointlineplane/
+
+  // Even if the target pose is "off the end" of this line segment, the projected point
+  // exists as if the segment was extended out.
+  const auto & [pose1, pose2] = find_closest_path_segment(path, pose);
+  const double x1 = pose1.pose.position.x;
+  const double y1 = pose1.pose.position.y;
+  const double x2 = pose2.pose.position.x;
+  const double y2 = pose2.pose.position.y;
+  const double x3 = pose.pose.position.x;
+  const double y3 = pose.pose.position.y;
+
+  const double u = ((x3 - x1) * (x2 - x1) + (y3 - y1) * (y2 - y1)) / ((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
+
+  const double x = x1 + u * (x2 - x1);
+  const double y = y1 + u * (y2 - y1);
+
+  return std::sqrt((x - x3) * (x - x3) + (y - y3) * (y - y3));
 }
 
 }  // namespace geometry_utils

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -219,7 +219,7 @@ inline double calculate_path_length(const nav_msgs::msg::Path & path, size_t sta
   return path_length;
 }
 
-std::pair<geometry_msgs::msg::PoseStamped, geometry_msgs::msg::PoseStamped>
+inline std::pair<geometry_msgs::msg::PoseStamped, geometry_msgs::msg::PoseStamped>
 find_closest_path_segment(
   const nav_msgs::msg::Path & path,
   const geometry_msgs::msg::PoseStamped & pose)
@@ -276,7 +276,7 @@ find_closest_path_segment(
  * Assuming the robot is at the origin of the frame the path is in,
  * find the closest pose on the path to the robot, interpolated in both position and orientation.
 */
-geometry_msgs::msg::PoseStamped project_robot_onto_path(const nav_msgs::msg::Path & path)
+inline geometry_msgs::msg::PoseStamped project_robot_onto_path(const nav_msgs::msg::Path & path)
 {
   // http://paulbourke.net/geometry/pointlineplane/
 
@@ -322,7 +322,7 @@ geometry_msgs::msg::PoseStamped project_robot_onto_path(const nav_msgs::msg::Pat
   return projected_pose;
 }
 
-nav2_msgs::msg::CrossTrackError calculate_cross_track_error(
+inline nav2_msgs::msg::CrossTrackError calculate_cross_track_error(
   geometry_msgs::msg::PoseStamped projected_pose)
 {
   nav2_msgs::msg::CrossTrackError error;

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -314,6 +314,7 @@ inline geometry_msgs::msg::PoseStamped project_robot_onto_path(const nav_msgs::m
 
   geometry_msgs::msg::PoseStamped projected_pose;
   projected_pose.header.frame_id = pose1.header.frame_id;
+  projected_pose.header.stamp = pose1.header.stamp;
   projected_pose.pose.position.x = x;
   projected_pose.pose.position.y = y;
   projected_pose.pose.position.z = pose1.pose.position.z;
@@ -326,6 +327,8 @@ inline nav2_msgs::msg::CrossTrackError calculate_cross_track_error(
   geometry_msgs::msg::PoseStamped projected_pose)
 {
   nav2_msgs::msg::CrossTrackError error;
+  error.header.frame_id = projected_pose.frame_id;
+  error.header.stamp = projected_pose.stamp;
   error.position_error = std::hypot(projected_pose.pose.position.x, projected_pose.pose.position.y);
   tf2::Quaternion error_orientation;
   tf2::fromMsg(projected_pose.pose.orientation, error_orientation);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A ||
| Primary OS tested on | Ubuntu ||
| Robotic platform tested on | Custom sim |

---

## Description of contribution in a few bullet points
In ackermann vehicles, if the lookahead point is too short when the vehicle gets significantly off the planned path, it oscillates around the lookahead point since it is trying to reach a point that it cannot reach and straighten out.

This adds the capability to add a lower bound to the lookahead distance based on the minimum turning radius of the vehicle, and how much cross-track error there is. For the sake of simplicity, this doesn't actually generate the dubins curve, but instead just assumes that if the robot is parallel to a path, then the minimum lookahead distance it can reach the path and still be on the correct heading is `2*R*sin(a)`, where `R` is the minimum turning radius, and `a` is the arc length of two symmetric arcs of a dubins curve.

So far, this has helped a lot on my robot.

## Description of documentation updates required from your changes
Added new parameters:
- `use_dubins_min_lookahead_dist`
- `dubins_min_turning_radius`
---

## Future work that may be required in bullet points
The cross track error may be useful to break out and use for all controllers as a heuristic to track for performance.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
