### PR TITLE
fix data race: addFilter() and resizeMap() can be executed concurrently

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
@@ -152,10 +152,8 @@ public:
   /**
    * @brief Add a new costmap filter plugin to the filters vector to process
    */
-  void addFilter(std::shared_ptr<Layer> filter)
-  {
-    filters_.push_back(filter);
-  }
+  void addFilter(std::shared_ptr<Layer> filter);
+
 
   /**
    * @brief Get if the size of the costmap is locked

--- a/nav2_costmap_2d/src/layered_costmap.cpp
+++ b/nav2_costmap_2d/src/layered_costmap.cpp
@@ -95,6 +95,12 @@ void LayeredCostmap::addPlugin(std::shared_ptr<Layer> plugin)
   plugins_.push_back(plugin);
 }
 
+void LayeredCostmap::addFilter(std::shared_ptr<Layer> filter)
+{
+  std::unique_lock<Costmap2D::mutex_t> lock(*(combined_costmap_.getMutex()));
+  filters_.push_back(filter);
+}
+
 void LayeredCostmap::resizeMap(
   unsigned int size_x, unsigned int size_y, double resolution,
   double origin_x,


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #2508 |
| Primary OS tested on | Ubuntu 22.04 & 20.04  |
| Robotic platform tested on | my hardware robot |

---

## Description of contribution in a few bullet points

addFilter() and resizeMap() can be executed concurrently.
std::vector is unsafe in multithreading.

PR #2512 has already addressed a part of the problem, but did not fix consider filters.


## Description of documentation updates required from your changes

---

## Future work that may be required in bullet points



#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
