### PR TITLE
Mount overlay workspace into Dev Container via volume

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,12 @@
 			"source": "ccache",
 			"target": "/tmp/.ccache",
 			"type": "volume"
-		}
+		},
+        {
+            "source": "overlay",
+            "target": "/opt/overlay_ws",
+            "type": "volume"
+        }
 	],
     "features": {
         // "ghcr.io/devcontainers/features/desktop-lite:1": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 {
     "name": "Nav2",
-	"build": {
-		"dockerfile": "../Dockerfile",
+    "build": {
+        "dockerfile": "../Dockerfile",
         "context": "..",
         "target": "dever",
         "cacheFrom": "ghcr.io/ros-planning/navigation2:main"
-	},
+    },
     "runArgs": [
         "--privileged",
         "--network=host"
@@ -20,17 +20,17 @@
         "CCACHE_DIR": "/tmp/.ccache"
     },
     "mounts": [
-		{
-			"source": "ccache-${devcontainerId}",
-			"target": "/tmp/.ccache",
-			"type": "volume"
-		},
+        {
+            "source": "ccache-${devcontainerId}",
+            "target": "/tmp/.ccache",
+            "type": "volume"
+        },
         {
             "source": "overlay-${devcontainerId}",
             "target": "/opt/overlay_ws",
             "type": "volume"
         }
-	],
+    ],
     "features": {
         // "ghcr.io/devcontainers/features/desktop-lite:1": {},
         "ghcr.io/devcontainers/features/github-cli:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,12 +21,12 @@
     },
     "mounts": [
 		{
-			"source": "ccache",
+			"source": "ccache-${devcontainerId}",
 			"target": "/tmp/.ccache",
 			"type": "volume"
 		},
         {
-            "source": "overlay",
+            "source": "overlay-${devcontainerId}",
             "target": "/opt/overlay_ws",
             "type": "volume"
         }

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -7,12 +7,6 @@ set -eo pipefail
 # set -x
 # env
 
-cd $OVERLAY_WS
-
 git config --global --add safe.directory "*"
-colcon cache lock
 
-. $UNDERLAY_WS/install/setup.sh
-colcon build \
-    --symlink-install \
-    --mixin $OVERLAY_MIXINS
+.devcontainer/update-content-command.sh

--- a/.devcontainer/update-content-command.sh
+++ b/.devcontainer/update-content-command.sh
@@ -49,9 +49,9 @@ then
 fi
 echo BUILD_PACKAGES: $BUILD_PACKAGES
 
-colcon clean packages --yes \
-    --packages-select ${BUILD_PACKAGES} \
-    --base-select install
+# colcon clean packages --yes \
+#     --packages-select ${BUILD_PACKAGES} \
+#     --base-select install
 
 . $UNDERLAY_WS/install/setup.sh
 colcon build \


### PR DESCRIPTION
This mounts the overlay workspace into a Dev Container via a volume, instead of relying on the write layers of the container.

This is an ergonomic improvement over previously storing workspace artifacts directly in the container file-system, as they are then inherently tied to the life-cycle of that particular container, and subsequently not persistent across Dev Container rebuilds. This can be a hassle when wanting to modify the Dev Container locally, a modification that would then necessitate rebuilding the entire Nav2 overlay workspace. While the existing use of ccache and it's own persistent volume help to lessen the compilation time, such re-compilation is often needless when modifying and testing dev container changes, such as those related to VS Code or development tools.

This is possible due to the use of propagation for bind mounts in docker. While named volumes can not propagate into existing bind mounts, the inverse is thankfully possible, where bind mounts can be propagated into named volumes. This allows for the `navigation2` source folder, or vscode workspace, to still seamlessly propagate on top of the named volume used to persist the `overlay_ws` directory, or colcon workspace.

- https://docs.docker.com/storage/volumes
- https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation
- https://github.com/docker/docs/pull/15725

Note: something that is not entirely obvious, as compared to how regular mounts work in Linux, is that empty volumes can be initialized using existing files from inside the container directory they are mounted to. So this PR would still work if we ever needed to go back to baking in a prebuilt colcon workspace in the docker image: allowing users to populate their own empty volumes upon the initial Dev Container build, but still persists their colcon workspace across local rebuilds of the Dev Container.  

- https://docs.docker.com/storage/#tips-for-using-bind-mounts-or-volumes
- https://github.com/moby/moby/issues/4361

This also appends the devcontainerId to all mounted volumes to avoid collision with other Dev Containers, while keeping the name stable across rebuilds. Users could rename these volumes, e.g. to include branch name or PR numbers, to further organize and switch between colcon workspaces for different environments.

Lastly this also simplifies the `.devcontainer` command scripts for better code reuse and avoids accidentally cleaning workspace packages. Although this is less hygienic than what our CI does, it's a bit closer to what a developer would expect from a native local development environment, where compiled artifacts are manually managed and not auto removed.