### PR TITLE
Add headless and use_rviz LaunchConfigurations to demo launch files

### DIFF
--- a/nav2_simple_commander/launch/assisted_teleop_example_launch.py
+++ b/nav2_simple_commander/launch/assisted_teleop_example_launch.py
@@ -18,8 +18,10 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -31,12 +33,28 @@ def generate_launch_description():
     map_yaml_file = os.path.join(warehouse_dir, 'maps', '005', 'map.yaml')
     world = os.path.join(python_commander_dir, 'warehouse.world')
 
+    # Launch configuration variables
+    use_rviz = LaunchConfiguration('use_rviz')
+    headless = LaunchConfiguration('headless')
+
+    # Declare the launch arguments
+    declare_use_rviz_cmd = DeclareLaunchArgument(
+        'use_rviz',
+        default_value='True',
+        description='Whether to start RVIZ')
+
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='True',
+        description='Whether to execute gzclient)')
+
     # start the simulation
     start_gazebo_server_cmd = ExecuteProcess(
         cmd=['gzserver', '-s', 'libgazebo_ros_factory.so', world],
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
+        condition=IfCondition(headless),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 
@@ -52,6 +70,7 @@ def generate_launch_description():
     rviz_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(nav2_bringup_dir, 'launch', 'rviz_launch.py')),
+        condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False'}.items())
 
@@ -69,6 +88,8 @@ def generate_launch_description():
         output='screen')
 
     ld = LaunchDescription()
+    ld.add_action(declare_use_rviz_cmd)
+    ld.add_action(declare_simulator_cmd)
     ld.add_action(start_gazebo_server_cmd)
     ld.add_action(start_gazebo_client_cmd)
     ld.add_action(start_robot_state_publisher_cmd)

--- a/nav2_simple_commander/launch/assisted_teleop_example_launch.py
+++ b/nav2_simple_commander/launch/assisted_teleop_example_launch.py
@@ -21,7 +21,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 
@@ -45,7 +45,7 @@ def generate_launch_description():
 
     declare_simulator_cmd = DeclareLaunchArgument(
         'headless',
-        default_value='True',
+        default_value='False',
         description='Whether to execute gzclient)')
 
     # start the simulation
@@ -54,7 +54,7 @@ def generate_launch_description():
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(headless),
+        condition=IfCondition(PythonExpression(['not ', headless])),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 

--- a/nav2_simple_commander/launch/follow_path_example_launch.py
+++ b/nav2_simple_commander/launch/follow_path_example_launch.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 
@@ -44,7 +44,7 @@ def generate_launch_description():
 
     declare_simulator_cmd = DeclareLaunchArgument(
         'headless',
-        default_value='True',
+        default_value='False',
         description='Whether to execute gzclient)')
 
     # start the simulation
@@ -53,7 +53,7 @@ def generate_launch_description():
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(headless),
+        condition=IfCondition(PythonExpression(['not ', headless])),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 

--- a/nav2_simple_commander/launch/follow_path_example_launch.py
+++ b/nav2_simple_commander/launch/follow_path_example_launch.py
@@ -17,8 +17,10 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -30,12 +32,28 @@ def generate_launch_description():
     map_yaml_file = os.path.join(warehouse_dir, 'maps', '005', 'map.yaml')
     world = os.path.join(python_commander_dir, 'warehouse.world')
 
+    # Launch configuration variables
+    use_rviz = LaunchConfiguration('use_rviz')
+    headless = LaunchConfiguration('headless')
+
+    # Declare the launch arguments
+    declare_use_rviz_cmd = DeclareLaunchArgument(
+        'use_rviz',
+        default_value='True',
+        description='Whether to start RVIZ')
+
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='True',
+        description='Whether to execute gzclient)')
+
     # start the simulation
     start_gazebo_server_cmd = ExecuteProcess(
         cmd=['gzserver', '-s', 'libgazebo_ros_factory.so', world],
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
+        condition=IfCondition(headless),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 
@@ -51,6 +69,7 @@ def generate_launch_description():
     rviz_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(nav2_bringup_dir, 'launch', 'rviz_launch.py')),
+        condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False'}.items())
 
@@ -68,6 +87,8 @@ def generate_launch_description():
         output='screen')
 
     ld = LaunchDescription()
+    ld.add_action(declare_use_rviz_cmd)
+    ld.add_action(declare_simulator_cmd)
     ld.add_action(start_gazebo_server_cmd)
     ld.add_action(start_gazebo_client_cmd)
     ld.add_action(start_robot_state_publisher_cmd)

--- a/nav2_simple_commander/launch/inspection_demo_launch.py
+++ b/nav2_simple_commander/launch/inspection_demo_launch.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 
@@ -44,7 +44,7 @@ def generate_launch_description():
 
     declare_simulator_cmd = DeclareLaunchArgument(
         'headless',
-        default_value='True',
+        default_value='False',
         description='Whether to execute gzclient)')
 
     # start the simulation
@@ -53,7 +53,7 @@ def generate_launch_description():
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(headless),
+        condition=IfCondition(PythonExpression(['not ', headless])),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 

--- a/nav2_simple_commander/launch/inspection_demo_launch.py
+++ b/nav2_simple_commander/launch/inspection_demo_launch.py
@@ -17,8 +17,10 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -30,12 +32,28 @@ def generate_launch_description():
     map_yaml_file = os.path.join(warehouse_dir, 'maps', '005', 'map.yaml')
     world = os.path.join(python_commander_dir, 'warehouse.world')
 
+    # Launch configuration variables
+    use_rviz = LaunchConfiguration('use_rviz')
+    headless = LaunchConfiguration('headless')
+
+    # Declare the launch arguments
+    declare_use_rviz_cmd = DeclareLaunchArgument(
+        'use_rviz',
+        default_value='True',
+        description='Whether to start RVIZ')
+
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='True',
+        description='Whether to execute gzclient)')
+
     # start the simulation
     start_gazebo_server_cmd = ExecuteProcess(
         cmd=['gzserver', '-s', 'libgazebo_ros_factory.so', world],
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
+        condition=IfCondition(headless),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 
@@ -51,6 +69,7 @@ def generate_launch_description():
     rviz_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(nav2_bringup_dir, 'launch', 'rviz_launch.py')),
+        condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False'}.items())
 
@@ -68,6 +87,8 @@ def generate_launch_description():
         output='screen')
 
     ld = LaunchDescription()
+    ld.add_action(declare_use_rviz_cmd)
+    ld.add_action(declare_simulator_cmd)
     ld.add_action(start_gazebo_server_cmd)
     ld.add_action(start_gazebo_client_cmd)
     ld.add_action(start_robot_state_publisher_cmd)

--- a/nav2_simple_commander/launch/nav_through_poses_example_launch.py
+++ b/nav2_simple_commander/launch/nav_through_poses_example_launch.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 
@@ -44,7 +44,7 @@ def generate_launch_description():
 
     declare_simulator_cmd = DeclareLaunchArgument(
         'headless',
-        default_value='True',
+        default_value='False',
         description='Whether to execute gzclient)')
 
     # start the simulation
@@ -53,7 +53,7 @@ def generate_launch_description():
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(headless),
+        condition=IfCondition(PythonExpression(['not ', headless])),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 

--- a/nav2_simple_commander/launch/nav_through_poses_example_launch.py
+++ b/nav2_simple_commander/launch/nav_through_poses_example_launch.py
@@ -17,8 +17,10 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -30,12 +32,28 @@ def generate_launch_description():
     map_yaml_file = os.path.join(warehouse_dir, 'maps', '005', 'map.yaml')
     world = os.path.join(python_commander_dir, 'warehouse.world')
 
+    # Launch configuration variables
+    use_rviz = LaunchConfiguration('use_rviz')
+    headless = LaunchConfiguration('headless')
+
+    # Declare the launch arguments
+    declare_use_rviz_cmd = DeclareLaunchArgument(
+        'use_rviz',
+        default_value='True',
+        description='Whether to start RVIZ')
+
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='True',
+        description='Whether to execute gzclient)')
+
     # start the simulation
     start_gazebo_server_cmd = ExecuteProcess(
         cmd=['gzserver', '-s', 'libgazebo_ros_factory.so', world],
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
+        condition=IfCondition(headless),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 
@@ -51,6 +69,7 @@ def generate_launch_description():
     rviz_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(nav2_bringup_dir, 'launch', 'rviz_launch.py')),
+        condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False'}.items())
 
@@ -68,6 +87,8 @@ def generate_launch_description():
         output='screen')
 
     ld = LaunchDescription()
+    ld.add_action(declare_use_rviz_cmd)
+    ld.add_action(declare_simulator_cmd)
     ld.add_action(start_gazebo_server_cmd)
     ld.add_action(start_gazebo_client_cmd)
     ld.add_action(start_robot_state_publisher_cmd)

--- a/nav2_simple_commander/launch/nav_to_pose_example_launch.py
+++ b/nav2_simple_commander/launch/nav_to_pose_example_launch.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 
@@ -44,7 +44,7 @@ def generate_launch_description():
 
     declare_simulator_cmd = DeclareLaunchArgument(
         'headless',
-        default_value='True',
+        default_value='False',
         description='Whether to execute gzclient)')
 
     # start the simulation
@@ -53,7 +53,7 @@ def generate_launch_description():
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(headless),
+        condition=IfCondition(PythonExpression(['not ', headless])),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 

--- a/nav2_simple_commander/launch/nav_to_pose_example_launch.py
+++ b/nav2_simple_commander/launch/nav_to_pose_example_launch.py
@@ -17,8 +17,10 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -30,12 +32,28 @@ def generate_launch_description():
     map_yaml_file = os.path.join(warehouse_dir, 'maps', '005', 'map.yaml')
     world = os.path.join(python_commander_dir, 'warehouse.world')
 
+    # Launch configuration variables
+    use_rviz = LaunchConfiguration('use_rviz')
+    headless = LaunchConfiguration('headless')
+
+    # Declare the launch arguments
+    declare_use_rviz_cmd = DeclareLaunchArgument(
+        'use_rviz',
+        default_value='True',
+        description='Whether to start RVIZ')
+
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='True',
+        description='Whether to execute gzclient)')
+
     # start the simulation
     start_gazebo_server_cmd = ExecuteProcess(
         cmd=['gzserver', '-s', 'libgazebo_ros_factory.so', world],
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
+        condition=IfCondition(headless),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 
@@ -51,6 +69,7 @@ def generate_launch_description():
     rviz_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(nav2_bringup_dir, 'launch', 'rviz_launch.py')),
+        condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False'}.items())
 
@@ -68,6 +87,8 @@ def generate_launch_description():
         output='screen')
 
     ld = LaunchDescription()
+    ld.add_action(declare_use_rviz_cmd)
+    ld.add_action(declare_simulator_cmd)
     ld.add_action(start_gazebo_server_cmd)
     ld.add_action(start_gazebo_client_cmd)
     ld.add_action(start_robot_state_publisher_cmd)

--- a/nav2_simple_commander/launch/picking_demo_launch.py
+++ b/nav2_simple_commander/launch/picking_demo_launch.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 
@@ -44,7 +44,7 @@ def generate_launch_description():
 
     declare_simulator_cmd = DeclareLaunchArgument(
         'headless',
-        default_value='True',
+        default_value='False',
         description='Whether to execute gzclient)')
 
     # start the simulation
@@ -53,7 +53,7 @@ def generate_launch_description():
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(headless),
+        condition=IfCondition(PythonExpression(['not ', headless])),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 

--- a/nav2_simple_commander/launch/picking_demo_launch.py
+++ b/nav2_simple_commander/launch/picking_demo_launch.py
@@ -17,8 +17,10 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -30,12 +32,28 @@ def generate_launch_description():
     map_yaml_file = os.path.join(warehouse_dir, 'maps', '005', 'map.yaml')
     world = os.path.join(python_commander_dir, 'warehouse.world')
 
+    # Launch configuration variables
+    use_rviz = LaunchConfiguration('use_rviz')
+    headless = LaunchConfiguration('headless')
+
+    # Declare the launch arguments
+    declare_use_rviz_cmd = DeclareLaunchArgument(
+        'use_rviz',
+        default_value='True',
+        description='Whether to start RVIZ')
+
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='True',
+        description='Whether to execute gzclient)')
+
     # start the simulation
     start_gazebo_server_cmd = ExecuteProcess(
         cmd=['gzserver', '-s', 'libgazebo_ros_factory.so', world],
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
+        condition=IfCondition(headless),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 
@@ -51,6 +69,7 @@ def generate_launch_description():
     rviz_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(nav2_bringup_dir, 'launch', 'rviz_launch.py')),
+        condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False'}.items())
 
@@ -68,6 +87,8 @@ def generate_launch_description():
         output='screen')
 
     ld = LaunchDescription()
+    ld.add_action(declare_use_rviz_cmd)
+    ld.add_action(declare_simulator_cmd)
     ld.add_action(start_gazebo_server_cmd)
     ld.add_action(start_gazebo_client_cmd)
     ld.add_action(start_robot_state_publisher_cmd)

--- a/nav2_simple_commander/launch/recoveries_example_launch.py
+++ b/nav2_simple_commander/launch/recoveries_example_launch.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 
@@ -44,7 +44,7 @@ def generate_launch_description():
 
     declare_simulator_cmd = DeclareLaunchArgument(
         'headless',
-        default_value='True',
+        default_value='False',
         description='Whether to execute gzclient)')
 
     # start the simulation
@@ -53,7 +53,7 @@ def generate_launch_description():
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(headless),
+        condition=IfCondition(PythonExpression(['not ', headless])),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 

--- a/nav2_simple_commander/launch/recoveries_example_launch.py
+++ b/nav2_simple_commander/launch/recoveries_example_launch.py
@@ -17,8 +17,10 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -30,12 +32,28 @@ def generate_launch_description():
     map_yaml_file = os.path.join(warehouse_dir, 'maps', '005', 'map.yaml')
     world = os.path.join(python_commander_dir, 'warehouse.world')
 
+    # Launch configuration variables
+    use_rviz = LaunchConfiguration('use_rviz')
+    headless = LaunchConfiguration('headless')
+
+    # Declare the launch arguments
+    declare_use_rviz_cmd = DeclareLaunchArgument(
+        'use_rviz',
+        default_value='True',
+        description='Whether to start RVIZ')
+
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='True',
+        description='Whether to execute gzclient)')
+
     # start the simulation
     start_gazebo_server_cmd = ExecuteProcess(
         cmd=['gzserver', '-s', 'libgazebo_ros_factory.so', world],
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
+        condition=IfCondition(headless),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 
@@ -51,6 +69,7 @@ def generate_launch_description():
     rviz_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(nav2_bringup_dir, 'launch', 'rviz_launch.py')),
+        condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False'}.items())
 
@@ -68,6 +87,8 @@ def generate_launch_description():
         output='screen')
 
     ld = LaunchDescription()
+    ld.add_action(declare_use_rviz_cmd)
+    ld.add_action(declare_simulator_cmd)
     ld.add_action(start_gazebo_server_cmd)
     ld.add_action(start_gazebo_client_cmd)
     ld.add_action(start_robot_state_publisher_cmd)

--- a/nav2_simple_commander/launch/security_demo_launch.py
+++ b/nav2_simple_commander/launch/security_demo_launch.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 
@@ -44,7 +44,7 @@ def generate_launch_description():
 
     declare_simulator_cmd = DeclareLaunchArgument(
         'headless',
-        default_value='True',
+        default_value='False',
         description='Whether to execute gzclient)')
 
     # start the simulation
@@ -53,7 +53,7 @@ def generate_launch_description():
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(headless),
+        condition=IfCondition(PythonExpression(['not ', headless])),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 

--- a/nav2_simple_commander/launch/security_demo_launch.py
+++ b/nav2_simple_commander/launch/security_demo_launch.py
@@ -17,8 +17,10 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -30,12 +32,28 @@ def generate_launch_description():
     map_yaml_file = os.path.join(warehouse_dir, 'maps', '005', 'map.yaml')
     world = os.path.join(python_commander_dir, 'warehouse.world')
 
+    # Launch configuration variables
+    use_rviz = LaunchConfiguration('use_rviz')
+    headless = LaunchConfiguration('headless')
+
+    # Declare the launch arguments
+    declare_use_rviz_cmd = DeclareLaunchArgument(
+        'use_rviz',
+        default_value='True',
+        description='Whether to start RVIZ')
+
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='True',
+        description='Whether to execute gzclient)')
+
     # start the simulation
     start_gazebo_server_cmd = ExecuteProcess(
         cmd=['gzserver', '-s', 'libgazebo_ros_factory.so', world],
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
+        condition=IfCondition(headless),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 
@@ -51,6 +69,7 @@ def generate_launch_description():
     rviz_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(nav2_bringup_dir, 'launch', 'rviz_launch.py')),
+        condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False'}.items())
 
@@ -68,6 +87,8 @@ def generate_launch_description():
         output='screen')
 
     ld = LaunchDescription()
+    ld.add_action(declare_use_rviz_cmd)
+    ld.add_action(declare_simulator_cmd)
     ld.add_action(start_gazebo_server_cmd)
     ld.add_action(start_gazebo_client_cmd)
     ld.add_action(start_robot_state_publisher_cmd)

--- a/nav2_simple_commander/launch/waypoint_follower_example_launch.py
+++ b/nav2_simple_commander/launch/waypoint_follower_example_launch.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 
@@ -44,7 +44,7 @@ def generate_launch_description():
 
     declare_simulator_cmd = DeclareLaunchArgument(
         'headless',
-        default_value='True',
+        default_value='False',
         description='Whether to execute gzclient)')
 
     # start the simulation
@@ -53,7 +53,7 @@ def generate_launch_description():
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
-        condition=IfCondition(headless),
+        condition=IfCondition(PythonExpression(['not ', headless])),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 

--- a/nav2_simple_commander/launch/waypoint_follower_example_launch.py
+++ b/nav2_simple_commander/launch/waypoint_follower_example_launch.py
@@ -17,8 +17,10 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -30,12 +32,28 @@ def generate_launch_description():
     map_yaml_file = os.path.join(warehouse_dir, 'maps', '005', 'map.yaml')
     world = os.path.join(python_commander_dir, 'warehouse.world')
 
+    # Launch configuration variables
+    use_rviz = LaunchConfiguration('use_rviz')
+    headless = LaunchConfiguration('headless')
+
+    # Declare the launch arguments
+    declare_use_rviz_cmd = DeclareLaunchArgument(
+        'use_rviz',
+        default_value='True',
+        description='Whether to start RVIZ')
+
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='True',
+        description='Whether to execute gzclient)')
+
     # start the simulation
     start_gazebo_server_cmd = ExecuteProcess(
         cmd=['gzserver', '-s', 'libgazebo_ros_factory.so', world],
         cwd=[warehouse_dir], output='screen')
 
     start_gazebo_client_cmd = ExecuteProcess(
+        condition=IfCondition(headless),
         cmd=['gzclient'],
         cwd=[warehouse_dir], output='screen')
 
@@ -51,6 +69,7 @@ def generate_launch_description():
     rviz_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(nav2_bringup_dir, 'launch', 'rviz_launch.py')),
+        condition=IfCondition(use_rviz),
         launch_arguments={'namespace': '',
                           'use_namespace': 'False'}.items())
 
@@ -68,6 +87,8 @@ def generate_launch_description():
         output='screen')
 
     ld = LaunchDescription()
+    ld.add_action(declare_use_rviz_cmd)
+    ld.add_action(declare_simulator_cmd)
     ld.add_action(start_gazebo_server_cmd)
     ld.add_action(start_gazebo_client_cmd)
     ld.add_action(start_robot_state_publisher_cmd)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3523 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points

Add headless and use_rviz LaunchConfigurations in nav2_simple_commander demo launch files, for whether to start rviz or gzclient, to simplify their use in headless environments:

- https://github.com/ros-planning/navigation2/pull/3523

## Description of documentation updates required from your changes

None, as the defaults maintain the existing launch file behavior.

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
