### PR TITLE
[velocity_smoother] Fix accel and deccel inverted for negative speeds

### DIFF
--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -206,9 +206,17 @@ double VelocitySmoother::applyConstraints(
   double v_component_max;
   double v_component_min;
 
-  if (abs(v_cmd) >= abs(v_curr)) {
-    v_component_max = accel / smoothing_frequency_;
-    v_component_min = -accel / smoothing_frequency_;
+  // Accelerating if magnitude of v_cmd is above magnitude of v_curr
+  // and if v_cmd and v_curr have the same sign (i.e. speed is NOT passing through 0.0)
+  // Deccelerating otherwise
+  if (v_curr * v_cmd >= 0.0) {
+    if (abs(v_cmd) >= abs(v_curr)) {
+      v_component_max = accel / smoothing_frequency_;
+      v_component_min = -accel / smoothing_frequency_;
+    } else {
+      v_component_max = -decel / smoothing_frequency_;
+      v_component_min = decel / smoothing_frequency_;
+    }
   } else {
     v_component_max = -decel / smoothing_frequency_;
     v_component_min = decel / smoothing_frequency_;

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -190,7 +190,7 @@ double VelocitySmoother::findEtaConstraint(
   // Accelerating if magnitude of v_cmd is above magnitude of v_curr
   // and if v_cmd and v_curr have the same sign (i.e. speed is NOT passing through 0.0)
   // Deccelerating otherwise
-  if ((abs(v_cmd) >= abs(v_curr)) && (v_curr * v_cmd >= 0.0)) {
+  if (abs(v_cmd) >= abs(v_curr) && v_curr * v_cmd >= 0.0) {
     v_component_max = accel / smoothing_frequency_;
     v_component_min = -accel / smoothing_frequency_;
   } else {

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -221,7 +221,7 @@ double VelocitySmoother::applyConstraints(
   // Accelerating if magnitude of v_cmd is above magnitude of v_curr
   // and if v_cmd and v_curr have the same sign (i.e. speed is NOT passing through 0.0)
   // Deccelerating otherwise
-  if ((abs(v_cmd) >= abs(v_curr)) && (v_curr * v_cmd >= 0.0)) {
+  if (abs(v_cmd) >= abs(v_curr) && v_curr * v_cmd >= 0.0) {
     v_component_max = accel / smoothing_frequency_;
     v_component_min = -accel / smoothing_frequency_;
   } else {

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -182,9 +182,21 @@ double VelocitySmoother::findEtaConstraint(
   const double v_curr, const double v_cmd, const double accel, const double decel)
 {
   // Exploiting vector scaling properties
-  const double v_component_max = accel / smoothing_frequency_;
-  const double v_component_min = decel / smoothing_frequency_;
-  const double dv = v_cmd - v_curr;
+  double dv = v_cmd - v_curr;
+
+  double v_component_max;
+  double v_component_min;
+
+  // Accelerating if magnitude of v_cmd is above magnitude of v_curr
+  // and if v_cmd and v_curr have the same sign (i.e. speed is NOT passing through 0.0)
+  // Deccelerating otherwise
+  if ((abs(v_cmd) >= abs(v_curr)) && (v_curr * v_cmd >= 0.0)) {
+    v_component_max = accel / smoothing_frequency_;
+    v_component_min = -accel / smoothing_frequency_;
+  } else {
+    v_component_max = -decel / smoothing_frequency_;
+    v_component_min = decel / smoothing_frequency_;
+  }
 
   if (dv > v_component_max) {
     return v_component_max / dv;

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -202,8 +202,18 @@ double VelocitySmoother::applyConstraints(
   const double accel, const double decel, const double eta)
 {
   double dv = v_cmd - v_curr;
-  const double v_component_max = accel / smoothing_frequency_;
-  const double v_component_min = decel / smoothing_frequency_;
+
+  double v_component_max;
+  double v_component_min;
+
+  if (abs(v_cmd) >= abs(v_curr)) {
+    v_component_max = accel / smoothing_frequency_;
+    v_component_min = -accel / smoothing_frequency_;
+  } else {
+    v_component_max = -decel / smoothing_frequency_;
+    v_component_min = decel / smoothing_frequency_;
+  }
+
   return v_curr + std::clamp(eta * dv, v_component_min, v_component_max);
 }
 

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -209,14 +209,9 @@ double VelocitySmoother::applyConstraints(
   // Accelerating if magnitude of v_cmd is above magnitude of v_curr
   // and if v_cmd and v_curr have the same sign (i.e. speed is NOT passing through 0.0)
   // Deccelerating otherwise
-  if (v_curr * v_cmd >= 0.0) {
-    if (abs(v_cmd) >= abs(v_curr)) {
-      v_component_max = accel / smoothing_frequency_;
-      v_component_min = -accel / smoothing_frequency_;
-    } else {
-      v_component_max = -decel / smoothing_frequency_;
-      v_component_min = decel / smoothing_frequency_;
-    }
+  if ((abs(v_cmd) >= abs(v_curr)) && (v_curr * v_cmd >= 0.0)) {
+    v_component_max = accel / smoothing_frequency_;
+    v_component_min = -accel / smoothing_frequency_;
   } else {
     v_component_max = -decel / smoothing_frequency_;
     v_component_min = decel / smoothing_frequency_;

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -189,7 +189,7 @@ double VelocitySmoother::findEtaConstraint(
 
   // Accelerating if magnitude of v_cmd is above magnitude of v_curr
   // and if v_cmd and v_curr have the same sign (i.e. speed is NOT passing through 0.0)
-  // Deccelerating otherwise
+  // Decelerating otherwise
   if (abs(v_cmd) >= abs(v_curr) && v_curr * v_cmd >= 0.0) {
     v_component_max = accel / smoothing_frequency_;
     v_component_min = -accel / smoothing_frequency_;
@@ -220,7 +220,7 @@ double VelocitySmoother::applyConstraints(
 
   // Accelerating if magnitude of v_cmd is above magnitude of v_curr
   // and if v_cmd and v_curr have the same sign (i.e. speed is NOT passing through 0.0)
-  // Deccelerating otherwise
+  // Decelerating otherwise
   if (abs(v_cmd) >= abs(v_curr) && v_curr * v_cmd >= 0.0) {
     v_component_max = accel / smoothing_frequency_;
     v_component_min = -accel / smoothing_frequency_;

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -179,17 +179,56 @@ TEST(VelocitySmootherTest, testfindEtaConstraint)
   // default frequency is 20.0
   smoother->configure(state);
 
-  // In range
-  EXPECT_EQ(smoother->findEtaConstraint(1.0, 1.0, 1.5, -2.0), -1);
-  EXPECT_EQ(smoother->findEtaConstraint(0.5, 0.55, 1.5, -2.0), -1);
-  EXPECT_EQ(smoother->findEtaConstraint(0.5, 0.45, 1.5, -2.0), -1);
-  // Too high
-  EXPECT_EQ(smoother->findEtaConstraint(1.0, 2.0, 1.5, -2.0), 0.075);
-  // Too low
-  EXPECT_EQ(smoother->findEtaConstraint(1.0, 0.0, 1.5, -2.0), 0.1);
+  double accel = 0.1; // dv 0.005
+  double deccel = -1.0; // dv 0.05
 
-  // In a more realistic situation accelerating linear axis
-  EXPECT_NEAR(smoother->findEtaConstraint(0.40, 0.50, 1.5, -2.0), 0.75, 0.001);
+  // In range
+  // Constant positive
+  EXPECT_EQ(smoother->findEtaConstraint(1.0, 1.0, accel, deccel), -1);
+  // Constant negative
+  EXPECT_EQ(smoother->findEtaConstraint(1.0, 1.0, accel, deccel), -1);
+  // Positive To Positive Accel
+  EXPECT_EQ(smoother->findEtaConstraint(0.5, 0.504, accel, deccel), -1);
+  // Positive To Positive Deccel
+  EXPECT_EQ(smoother->findEtaConstraint(0.5, 0.46, accel, deccel), -1);
+  // 0 To Positive Accel
+  EXPECT_EQ(smoother->findEtaConstraint(0.0, 0.004, accel, deccel), -1);
+  // Positive To 0 Deccel
+  EXPECT_EQ(smoother->findEtaConstraint(0.04, 0.0, accel, deccel), -1);
+  // Negative To Negative Accel
+  EXPECT_EQ(smoother->findEtaConstraint(-0.5, -0.504, accel, deccel), -1);
+  // Negative To Negative Deccel
+  EXPECT_EQ(smoother->findEtaConstraint(-0.5, -0.46, accel, deccel), -1);
+  // 0 To Negative Accel
+  EXPECT_EQ(smoother->findEtaConstraint(0.0, -0.004, accel, deccel), -1);
+  // Negative To 0 Deccel
+  EXPECT_EQ(smoother->findEtaConstraint(-0.04, 0.0, accel, deccel), -1);
+  // Negative to Positive
+  EXPECT_EQ(smoother->findEtaConstraint(-0.02, 0.02, accel, deccel), -1);
+  // Positive to Negative
+  EXPECT_EQ(smoother->findEtaConstraint(0.02, -0.02, accel, deccel), -1);
+
+  // Faster than limit
+  // Positive To Positive Accel
+  EXPECT_EQ(smoother->findEtaConstraint(0.5, 1.5, accel, deccel), 0.005);
+  // Positive To Positive Deccel
+  EXPECT_EQ(smoother->findEtaConstraint(1.5, 0.5, accel, deccel), 0.05);
+  // 0 To Positive Accel
+  EXPECT_EQ(smoother->findEtaConstraint(0.0, 1.0, accel, deccel), 0.005);
+  // Positive To 0 Deccel
+  EXPECT_EQ(smoother->findEtaConstraint(1.0, 0.0, accel, deccel), 0.05);
+  // Negative To Negative Accel
+  EXPECT_EQ(smoother->findEtaConstraint(-0.5, -1.5, accel, deccel), 0.005);
+  // Negative To Negative Deccel
+  EXPECT_EQ(smoother->findEtaConstraint(-1.5, -0.5, accel, deccel), 0.05);
+  // 0 To Negative Accel
+  EXPECT_EQ(smoother->findEtaConstraint(0.0, -1.0, accel, deccel), 0.005);
+  // Negative To 0 Deccel
+  EXPECT_EQ(smoother->findEtaConstraint(-1.0, 0.0, accel, deccel), 0.05);
+  // Negative to Positive
+  EXPECT_EQ(smoother->findEtaConstraint(-0.2, 0.8, accel, deccel), 0.05);
+  // Positive to Negative
+  EXPECT_EQ(smoother->findEtaConstraint(0.2, -0.8, accel, deccel), 0.05);
 }
 
 TEST(VelocitySmootherTest, testapplyConstraints)

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -550,7 +550,6 @@ TEST(VelocitySmootherTest, testapplyConstraintsNegativeToZeroDeccel)
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 
-
 TEST(VelocitySmootherTest, testCommandCallback)
 {
   auto smoother =

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -180,55 +180,55 @@ TEST(VelocitySmootherTest, testfindEtaConstraint)
   smoother->configure(state);
 
   double accel = 0.1;    // dv 0.005
-  double deccel = -1.0;  // dv 0.05
+  double decel = -1.0;  // dv 0.05
 
   // In range
   // Constant positive
-  EXPECT_EQ(smoother->findEtaConstraint(1.0, 1.0, accel, deccel), -1);
+  EXPECT_EQ(smoother->findEtaConstraint(1.0, 1.0, accel, decel), -1);
   // Constant negative
-  EXPECT_EQ(smoother->findEtaConstraint(1.0, 1.0, accel, deccel), -1);
+  EXPECT_EQ(smoother->findEtaConstraint(-1.0, -1.0, accel, decel), -1);
   // Positive To Positive Accel
-  EXPECT_EQ(smoother->findEtaConstraint(0.5, 0.504, accel, deccel), -1);
-  // Positive To Positive Deccel
-  EXPECT_EQ(smoother->findEtaConstraint(0.5, 0.46, accel, deccel), -1);
+  EXPECT_EQ(smoother->findEtaConstraint(0.5, 0.504, accel, decel), -1);
+  // Positive To Positive Decel
+  EXPECT_EQ(smoother->findEtaConstraint(0.5, 0.46, accel, decel), -1);
   // 0 To Positive Accel
-  EXPECT_EQ(smoother->findEtaConstraint(0.0, 0.004, accel, deccel), -1);
-  // Positive To 0 Deccel
-  EXPECT_EQ(smoother->findEtaConstraint(0.04, 0.0, accel, deccel), -1);
+  EXPECT_EQ(smoother->findEtaConstraint(0.0, 0.004, accel, decel), -1);
+  // Positive To 0 Decel
+  EXPECT_EQ(smoother->findEtaConstraint(0.04, 0.0, accel, decel), -1);
   // Negative To Negative Accel
-  EXPECT_EQ(smoother->findEtaConstraint(-0.5, -0.504, accel, deccel), -1);
-  // Negative To Negative Deccel
-  EXPECT_EQ(smoother->findEtaConstraint(-0.5, -0.46, accel, deccel), -1);
+  EXPECT_EQ(smoother->findEtaConstraint(-0.5, -0.504, accel, decel), -1);
+  // Negative To Negative Decel
+  EXPECT_EQ(smoother->findEtaConstraint(-0.5, -0.46, accel, decel), -1);
   // 0 To Negative Accel
-  EXPECT_EQ(smoother->findEtaConstraint(0.0, -0.004, accel, deccel), -1);
-  // Negative To 0 Deccel
-  EXPECT_EQ(smoother->findEtaConstraint(-0.04, 0.0, accel, deccel), -1);
+  EXPECT_EQ(smoother->findEtaConstraint(0.0, -0.004, accel, decel), -1);
+  // Negative To 0 Decel
+  EXPECT_EQ(smoother->findEtaConstraint(-0.04, 0.0, accel, decel), -1);
   // Negative to Positive
-  EXPECT_EQ(smoother->findEtaConstraint(-0.02, 0.02, accel, deccel), -1);
+  EXPECT_EQ(smoother->findEtaConstraint(-0.02, 0.02, accel, decel), -1);
   // Positive to Negative
-  EXPECT_EQ(smoother->findEtaConstraint(0.02, -0.02, accel, deccel), -1);
+  EXPECT_EQ(smoother->findEtaConstraint(0.02, -0.02, accel, decel), -1);
 
   // Faster than limit
   // Positive To Positive Accel
-  EXPECT_EQ(smoother->findEtaConstraint(0.5, 1.5, accel, deccel), 0.005);
-  // Positive To Positive Deccel
-  EXPECT_EQ(smoother->findEtaConstraint(1.5, 0.5, accel, deccel), 0.05);
+  EXPECT_EQ(smoother->findEtaConstraint(0.5, 1.5, accel, decel), 0.005);
+  // Positive To Positive Decel
+  EXPECT_EQ(smoother->findEtaConstraint(1.5, 0.5, accel, decel), 0.05);
   // 0 To Positive Accel
-  EXPECT_EQ(smoother->findEtaConstraint(0.0, 1.0, accel, deccel), 0.005);
-  // Positive To 0 Deccel
-  EXPECT_EQ(smoother->findEtaConstraint(1.0, 0.0, accel, deccel), 0.05);
+  EXPECT_EQ(smoother->findEtaConstraint(0.0, 1.0, accel, decel), 0.005);
+  // Positive To 0 Decel
+  EXPECT_EQ(smoother->findEtaConstraint(1.0, 0.0, accel, decel), 0.05);
   // Negative To Negative Accel
-  EXPECT_EQ(smoother->findEtaConstraint(-0.5, -1.5, accel, deccel), 0.005);
-  // Negative To Negative Deccel
-  EXPECT_EQ(smoother->findEtaConstraint(-1.5, -0.5, accel, deccel), 0.05);
+  EXPECT_EQ(smoother->findEtaConstraint(-0.5, -1.5, accel, decel), 0.005);
+  // Negative To Negative Decel
+  EXPECT_EQ(smoother->findEtaConstraint(-1.5, -0.5, accel, decel), 0.05);
   // 0 To Negative Accel
-  EXPECT_EQ(smoother->findEtaConstraint(0.0, -1.0, accel, deccel), 0.005);
-  // Negative To 0 Deccel
-  EXPECT_EQ(smoother->findEtaConstraint(-1.0, 0.0, accel, deccel), 0.05);
+  EXPECT_EQ(smoother->findEtaConstraint(0.0, -1.0, accel, decel), 0.005);
+  // Negative To 0 Decel
+  EXPECT_EQ(smoother->findEtaConstraint(-1.0, 0.0, accel, decel), 0.05);
   // Negative to Positive
-  EXPECT_EQ(smoother->findEtaConstraint(-0.2, 0.8, accel, deccel), 0.05);
+  EXPECT_EQ(smoother->findEtaConstraint(-0.2, 0.8, accel, decel), 0.05);
   // Positive to Negative
-  EXPECT_EQ(smoother->findEtaConstraint(0.2, -0.8, accel, deccel), 0.05);
+  EXPECT_EQ(smoother->findEtaConstraint(0.2, -0.8, accel, decel), 0.05);
 }
 
 TEST(VelocitySmootherTest, testapplyConstraints)
@@ -265,7 +265,7 @@ TEST(VelocitySmootherTest, testapplyConstraintsPositiveToPositiveAccel)
   smoother->configure(state);
   double no_eta = 1.0;
   double accel = 0.1;
-  double deccel = -1.0;
+  double decel = -1.0;
   double dv_accel = accel / 20.0;
   double init_vel, target_vel, v_curr;
   uint steps_to_target;
@@ -276,11 +276,11 @@ TEST(VelocitySmootherTest, testapplyConstraintsPositiveToPositiveAccel)
 
   v_curr = init_vel;
   for (size_t i = 1; i < steps_to_target + 1; i++) {
-    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
     EXPECT_NEAR(v_curr, init_vel + i * dv_accel, 0.001);
   }
   EXPECT_NEAR(v_curr, target_vel, 0.001);
-  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 
@@ -293,7 +293,7 @@ TEST(VelocitySmootherTest, testapplyConstraintsZeroToPositiveAccel)
   smoother->configure(state);
   double no_eta = 1.0;
   double accel = 0.1;
-  double deccel = -1.0;
+  double decel = -1.0;
   double dv_accel = accel / 20.0;
   double init_vel, target_vel, v_curr;
   uint steps_to_target;
@@ -304,15 +304,15 @@ TEST(VelocitySmootherTest, testapplyConstraintsZeroToPositiveAccel)
 
   v_curr = init_vel;
   for (size_t i = 1; i < steps_to_target + 1; i++) {
-    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
     EXPECT_NEAR(v_curr, init_vel + i * dv_accel, 0.001);
   }
   EXPECT_NEAR(v_curr, target_vel, 0.001);
-  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 
-TEST(VelocitySmootherTest, testapplyConstraintsNegativeToPositiveDeccelAccel)
+TEST(VelocitySmootherTest, testapplyConstraintsNegativeToPositiveDecelAccel)
 {
   auto smoother =
     std::make_shared<VelSmootherShim>();
@@ -321,28 +321,28 @@ TEST(VelocitySmootherTest, testapplyConstraintsNegativeToPositiveDeccelAccel)
   smoother->configure(state);
   double no_eta = 1.0;
   double accel = 0.1;
-  double deccel = -1.0;
+  double decel = -1.0;
   double dv_accel = accel / 20.0;
-  double dv_deccel = -deccel / 20.0;
+  double dv_decel = -decel / 20.0;
   double init_vel, target_vel, v_curr;
   uint steps_below_zero, steps_above_zero;
 
   init_vel = -1.0;
   target_vel = 2.0;
-  steps_below_zero = -init_vel / dv_deccel;
+  steps_below_zero = -init_vel / dv_decel;
   steps_above_zero = target_vel / dv_accel;
 
   v_curr = init_vel;
   for (size_t i = 1; i < steps_below_zero + steps_above_zero + 1; i++) {
-    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
     if (v_curr > 0) {
       EXPECT_NEAR(v_curr, (i - steps_below_zero) * dv_accel, 0.001);
     } else {
-      EXPECT_NEAR(v_curr, init_vel + i * dv_deccel, 0.001);
+      EXPECT_NEAR(v_curr, init_vel + i * dv_decel, 0.001);
     }
   }
   EXPECT_NEAR(v_curr, target_vel, 0.001);
-  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 
@@ -355,7 +355,7 @@ TEST(VelocitySmootherTest, testapplyConstraintsNegativeToNegativeAccel)
   smoother->configure(state);
   double no_eta = 1.0;
   double accel = 0.1;
-  double deccel = -1.0;
+  double decel = -1.0;
   double dv_accel = accel / 20.0;
   double init_vel, target_vel, v_curr;
   uint steps_to_target;
@@ -366,11 +366,11 @@ TEST(VelocitySmootherTest, testapplyConstraintsNegativeToNegativeAccel)
 
   v_curr = init_vel;
   for (size_t i = 1; i < steps_to_target + 1; i++) {
-    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
     EXPECT_NEAR(v_curr, init_vel - i * dv_accel, 0.001);
   }
   EXPECT_NEAR(v_curr, target_vel, 0.001);
-  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 
@@ -383,7 +383,7 @@ TEST(VelocitySmootherTest, testapplyConstraintsZeroToNegativeAccel)
   smoother->configure(state);
   double no_eta = 1.0;
   double accel = 0.1;
-  double deccel = -1.0;
+  double decel = -1.0;
   double dv_accel = accel / 20.0;
   double init_vel, target_vel, v_curr;
   uint steps_to_target;
@@ -394,15 +394,15 @@ TEST(VelocitySmootherTest, testapplyConstraintsZeroToNegativeAccel)
 
   v_curr = init_vel;
   for (size_t i = 1; i < steps_to_target + 1; i++) {
-    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
     EXPECT_NEAR(v_curr, init_vel - i * dv_accel, 0.001);
   }
   EXPECT_NEAR(v_curr, target_vel, 0.001);
-  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 
-TEST(VelocitySmootherTest, testapplyConstraintsPositiveToNegativeDeccelAccel)
+TEST(VelocitySmootherTest, testapplyConstraintsPositiveToNegativeDecelAccel)
 {
   auto smoother =
     std::make_shared<VelSmootherShim>();
@@ -411,32 +411,32 @@ TEST(VelocitySmootherTest, testapplyConstraintsPositiveToNegativeDeccelAccel)
   smoother->configure(state);
   double no_eta = 1.0;
   double accel = 0.1;
-  double deccel = -1.0;
+  double decel = -1.0;
   double dv_accel = accel / 20.0;
-  double dv_deccel = -deccel / 20.0;
+  double dv_decel = -decel / 20.0;
   double init_vel, target_vel, v_curr;
   uint steps_below_zero, steps_above_zero;
 
   init_vel = 1.0;
   target_vel = -2.0;
-  steps_above_zero = init_vel / dv_deccel;
+  steps_above_zero = init_vel / dv_decel;
   steps_below_zero = -target_vel / dv_accel;
 
   v_curr = init_vel;
   for (size_t i = 1; i < steps_below_zero + steps_above_zero + 1; i++) {
-    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
     if (v_curr < 0) {
       EXPECT_NEAR(v_curr, -static_cast<int>(i - steps_above_zero) * dv_accel, 0.001);
     } else {
-      EXPECT_NEAR(v_curr, init_vel - i * dv_deccel, 0.001);
+      EXPECT_NEAR(v_curr, init_vel - i * dv_decel, 0.001);
     }
   }
   EXPECT_NEAR(v_curr, target_vel, 0.001);
-  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 
-TEST(VelocitySmootherTest, testapplyConstraintsPositiveToPositiveDeccel)
+TEST(VelocitySmootherTest, testapplyConstraintsPositiveToPositiveDecel)
 {
   auto smoother =
     std::make_shared<VelSmootherShim>();
@@ -445,28 +445,28 @@ TEST(VelocitySmootherTest, testapplyConstraintsPositiveToPositiveDeccel)
   smoother->configure(state);
   double no_eta = 1.0;
 
-  // Test asymetric accel/deccel use cases
+  // Test asymetric accel/decel use cases
   double accel = 0.1;
-  double deccel = -1.0;
-  double dv_deccel = -deccel / 20.0;
+  double decel = -1.0;
+  double dv_decel = -decel / 20.0;
   double init_vel, target_vel, v_curr;
   uint steps_to_target;
 
   init_vel = 2.0;
   target_vel = 1.0;
-  steps_to_target = abs(target_vel - init_vel) / dv_deccel;
+  steps_to_target = abs(target_vel - init_vel) / dv_decel;
 
   v_curr = init_vel;
   for (size_t i = 1; i < steps_to_target + 1; i++) {
-    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
-    EXPECT_NEAR(v_curr, init_vel - i * dv_deccel, 0.001);
+    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
+    EXPECT_NEAR(v_curr, init_vel - i * dv_decel, 0.001);
   }
   EXPECT_NEAR(v_curr, target_vel, 0.001);
-  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 
-TEST(VelocitySmootherTest, testapplyConstraintsPositiveToZeroDeccel)
+TEST(VelocitySmootherTest, testapplyConstraintsPositiveToZeroDecel)
 {
   auto smoother =
     std::make_shared<VelSmootherShim>();
@@ -475,26 +475,26 @@ TEST(VelocitySmootherTest, testapplyConstraintsPositiveToZeroDeccel)
   smoother->configure(state);
   double no_eta = 1.0;
   double accel = 0.1;
-  double deccel = -1.0;
-  double dv_deccel = -deccel / 20.0;
+  double decel = -1.0;
+  double dv_decel = -decel / 20.0;
   double init_vel, target_vel, v_curr;
   uint steps_to_target;
 
   init_vel = 2.0;
   target_vel = 0.0;
-  steps_to_target = abs(target_vel - init_vel) / dv_deccel;
+  steps_to_target = abs(target_vel - init_vel) / dv_decel;
 
   v_curr = init_vel;
   for (size_t i = 1; i < steps_to_target + 1; i++) {
-    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
-    EXPECT_NEAR(v_curr, init_vel - i * dv_deccel, 0.001);
+    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
+    EXPECT_NEAR(v_curr, init_vel - i * dv_decel, 0.001);
   }
   EXPECT_NEAR(v_curr, target_vel, 0.001);
-  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 
-TEST(VelocitySmootherTest, testapplyConstraintsNegativeToNegativeDeccel)
+TEST(VelocitySmootherTest, testapplyConstraintsNegativeToNegativeDecel)
 {
   auto smoother =
     std::make_shared<VelSmootherShim>();
@@ -503,26 +503,26 @@ TEST(VelocitySmootherTest, testapplyConstraintsNegativeToNegativeDeccel)
   smoother->configure(state);
   double no_eta = 1.0;
   double accel = 0.1;
-  double deccel = -1.0;
-  double dv_deccel = -deccel / 20.0;
+  double decel = -1.0;
+  double dv_decel = -decel / 20.0;
   double init_vel, target_vel, v_curr;
   uint steps_to_target;
 
   init_vel = -2.0;
   target_vel = -1.0;
-  steps_to_target = abs(target_vel - init_vel) / dv_deccel;
+  steps_to_target = abs(target_vel - init_vel) / dv_decel;
 
   v_curr = init_vel;
   for (size_t i = 1; i < steps_to_target + 1; i++) {
-    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
-    EXPECT_NEAR(v_curr, init_vel + i * dv_deccel, 0.001);
+    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
+    EXPECT_NEAR(v_curr, init_vel + i * dv_decel, 0.001);
   }
   EXPECT_NEAR(v_curr, target_vel, 0.001);
-  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 
-TEST(VelocitySmootherTest, testapplyConstraintsNegativeToZeroDeccel)
+TEST(VelocitySmootherTest, testapplyConstraintsNegativeToZeroDecel)
 {
   auto smoother =
     std::make_shared<VelSmootherShim>();
@@ -531,22 +531,22 @@ TEST(VelocitySmootherTest, testapplyConstraintsNegativeToZeroDeccel)
   smoother->configure(state);
   double no_eta = 1.0;
   double accel = 0.1;
-  double deccel = -1.0;
-  double dv_deccel = -deccel / 20.0;
+  double decel = -1.0;
+  double dv_decel = -decel / 20.0;
   double init_vel, target_vel, v_curr;
   uint steps_to_target;
 
   init_vel = -2.0;
   target_vel = 0.0;
-  steps_to_target = abs(target_vel - init_vel) / dv_deccel;
+  steps_to_target = abs(target_vel - init_vel) / dv_decel;
 
   v_curr = init_vel;
   for (size_t i = 1; i < steps_to_target + 1; i++) {
-    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
-    EXPECT_NEAR(v_curr, init_vel + i * dv_deccel, 0.001);
+    v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
+    EXPECT_NEAR(v_curr, init_vel + i * dv_decel, 0.001);
   }
   EXPECT_NEAR(v_curr, target_vel, 0.001);
-  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
+  v_curr = smoother->applyConstraints(v_curr, target_vel, accel, decel, no_eta);
   EXPECT_NEAR(v_curr, target_vel, 0.001);
 }
 

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -387,7 +387,7 @@ TEST(VelocitySmootherTest, testapplyConstraintsPositiveToNegativeDeccelAccel)
   for (size_t i = 1; i < steps_below_zero + steps_above_zero + 1; i++) {
     v_curr = smoother->applyConstraints(v_curr, target_vel, accel, deccel, no_eta);
     if (v_curr < 0) {
-      EXPECT_NEAR(v_curr, -int(i - steps_above_zero) * dv_accel, 0.001);
+      EXPECT_NEAR(v_curr, -static_cast<int>(i - steps_above_zero) * dv_accel, 0.001);
     } else {
       EXPECT_NEAR(v_curr, init_vel - i * dv_deccel, 0.001);
     }
@@ -406,7 +406,7 @@ TEST(VelocitySmootherTest, testapplyConstraintsPositiveToPositiveDeccel)
   smoother->configure(state);
   double no_eta = 1.0;
 
-  //Test asymetric accel/deccel use cases
+  // Test asymetric accel/deccel use cases
   double accel = 0.1;
   double deccel = -1.0;
   double dv_deccel = -deccel / 20.0;

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -179,8 +179,8 @@ TEST(VelocitySmootherTest, testfindEtaConstraint)
   // default frequency is 20.0
   smoother->configure(state);
 
-  double accel = 0.1; // dv 0.005
-  double deccel = -1.0; // dv 0.05
+  double accel = 0.1;    // dv 0.005
+  double deccel = -1.0;  // dv 0.05
 
   // In range
   // Constant positive


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/3526 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory Sim |

---

## Description of contribution in a few bullet points

Fix https://github.com/ros-planning/navigation2/issues/3526

Tested only in sim, can test on real hardware next week. I would not mind a second pair of eyes / independent test on this one before merging as it is quite critical (in our system it is the last layer before the hardware commands). @richardw347 

With :

```
    velocity_smoother = Node(
        package='nav2_velocity_smoother',
        name='root_velocity_smoother',
        executable='velocity_smoother',
        parameters=[
            # {'use_sim_time': use_sim_time},
            {'smoothing_frequency': 20.0},
            {'scale_velocities': False},
            {'feedback': 'OPEN_LOOP'},
            {'max_velocity': [0.5, 0.0, 0.8]},
            {'min_velocity': [-0.5, 0.0, -0.8]},
            {'velocity_timeout': 0.5},
            {'max_accel': [0.1, 0.0, 0.2]},
            {'max_decel': [-0.5, 0.0, -1.2]},
            ],
        remappings=[
            ('cmd_vel', 'cmd_vel_protected'),
            ('cmd_vel_smoothed', 'cmd_vel')],
        output='screen')
```
![Screenshot from 2023-04-07 22-44-22](https://user-images.githubusercontent.com/15727892/230686427-0641d728-391f-4f48-832d-efcf52221ce7.png)
![Screenshot from 2023-04-07 22-44-53](https://user-images.githubusercontent.com/15727892/230686443-fc14e993-45ab-486e-bfd1-161e891e7243.png)
![Screenshot from 2023-04-07 23-06-32](https://user-images.githubusercontent.com/15727892/230686479-835528cf-6b22-4e73-839b-86c656e124f7.png)
![Screenshot from 2023-04-07 23-07-07](https://user-images.githubusercontent.com/15727892/230686478-525a97ce-5ac1-4203-bafc-da5fc77ea719.png)



#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
