### PR TITLE
Fix bt_navigator crashes when restarted

### DIFF
--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -90,12 +90,12 @@ BtNavigator::BtNavigator(const rclcpp::NodeOptions & options)
   declare_parameter("global_frame", std::string("map"));
   declare_parameter("robot_base_frame", std::string("base_link"));
   declare_parameter("odom_topic", std::string("odom"));
-    
+
   // Navigator defaults
   const std::vector<std::string> default_navigator_ids = {
     "navigate_to_pose",
     "navigate_through_poses"
-  };    
+  };
   declare_parameter("navigators", default_navigator_ids);
 }
 

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -90,6 +90,13 @@ BtNavigator::BtNavigator(const rclcpp::NodeOptions & options)
   declare_parameter("global_frame", std::string("map"));
   declare_parameter("robot_base_frame", std::string("base_link"));
   declare_parameter("odom_topic", std::string("odom"));
+    
+  // Navigator defaults
+  const std::vector<std::string> default_navigator_ids = {
+    "navigate_to_pose",
+    "navigate_through_poses"
+  };    
+  declare_parameter("navigators", default_navigator_ids);
 }
 
 BtNavigator::~BtNavigator()
@@ -126,26 +133,9 @@ BtNavigator::on_configure(const rclcpp_lifecycle::State & /*state*/)
   auto node = shared_from_this();
   odom_smoother_ = std::make_shared<nav2_util::OdomSmoother>(node, 0.3, odom_topic_);
 
-  // Navigator defaults
-  const std::vector<std::string> default_navigator_ids = {
-    "navigate_to_pose",
-    "navigate_through_poses"
-  };
-  const std::vector<std::string> default_navigator_types = {
-    "nav2_bt_navigator/NavigateToPoseNavigator",
-    "nav2_bt_navigator/NavigateThroughPosesNavigator"
-  };
-
-  std::vector<std::string> navigator_ids;
-  declare_parameter("navigators", default_navigator_ids);
-  get_parameter("navigators", navigator_ids);
-  if (navigator_ids == default_navigator_ids) {
-    for (size_t i = 0; i < default_navigator_ids.size(); ++i) {
-      declare_parameter(default_navigator_ids[i] + ".plugin", default_navigator_types[i]);
-    }
-  }
-
   // Load navigator plugins
+  std::vector<std::string> navigator_ids;
+  get_parameter("navigators", navigator_ids);
   for (size_t i = 0; i != navigator_ids.size(); i++) {
     std::string navigator_type = nav2_util::get_plugin_type_param(node, navigator_ids[i]);
     try {


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3545 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation  |

---

## Description of contribution in a few bullet points

* move `declare_parameter("navigators")` in the constructor
* remove useless `default_navigator_types`


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
