### PR TITLE
Split nav2_system_tests into separate CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ _commands:
           type: string
         mixins:
           type: string
-        skip:
+        packages_skip:
           default: ""
           type: string
         restore:
@@ -200,7 +200,7 @@ _commands:
                     . << parameters.underlay >>/install/setup.sh
                     colcon build \
                       --packages-select ${BUILD_PACKAGES} \
-                      --packages-skip << parameters.skip >> \
+                      --packages-skip << parameters.packages_skip >> \
                       --mixin << parameters.mixins >>
               - ccache_stats:
                   workspace: << parameters.workspace >>
@@ -226,6 +226,9 @@ _commands:
           type: string
         cache_test:
           type: boolean
+        packages_skip:
+          type: string
+          default: ""
       steps:
         - run:
             name: Test Workspace | << parameters.workspace >>
@@ -294,6 +297,7 @@ _commands:
               set -o xtrace
               colcon test \
                 --packages-select ${TEST_PACKAGES}
+                --packages-skip << parameters.packages_skip >>
               colcon test-result \
                 --verbose
         - when:
@@ -380,14 +384,10 @@ _steps:
       underlay: /opt/underlay_ws
       workspace: /opt/overlay_ws
       mixins: ${OVERLAY_MIXINS}
-  setup_workspace_overlay_1: &setup_workspace_overlay_1
+  build_workspace_overlay: &build_workspace_overlay
     setup_workspace:
       <<: *setup_workspace_overlay
-      skip: nav2_system_tests
-  setup_workspace_overlay_2: &setup_workspace_overlay_2
-    setup_workspace:
-      <<: *setup_workspace_overlay
-      restore: false
+      packages_skip: << parameters.packages_skip >>
   restore_overlay_workspace: &restore_overlay_workspace
     setup_workspace:
       <<: *setup_workspace_overlay
@@ -397,6 +397,7 @@ _steps:
       key: overlay_ws
       workspace: /opt/overlay_ws
       cache_test: << parameters.cache_test >>
+      packages_skip: << parameters.packages_skip >>
   collect_overlay_coverage: &collect_overlay_coverage
     run:
       name: Collect Code Coverage
@@ -434,9 +435,11 @@ commands:
       - *install_overlay_dependencies
   build_source:
     description: "Build Source"
+    parameters:
+      packages_skip:
+        type: string
     steps:
-      - *setup_workspace_overlay_1
-      - *setup_workspace_overlay_2
+      - *build_workspace_overlay
   restore_build:
     description: "Restore Build"
     steps:
@@ -450,6 +453,8 @@ commands:
     parameters:
       cache_test:
         type: boolean
+      packages_skip:
+        type: string
     steps:
       - *test_overlay_workspace
   report_coverage:
@@ -485,8 +490,14 @@ executors:
       OVERLAY_MIXINS: "release ccache coverage-gcc lld"
 
 _jobs:
+  job_build: &job_build
+    parameters: &job_build_parameters
+      packages_skip:
+        type: string
+        default: ""
   job_test: &job_test
     parameters:
+      <<: *job_build_parameters
       cache_test:
         type: boolean
         default: false
@@ -499,11 +510,15 @@ _jobs:
 
 jobs:
   release_build: &release_build
+    <<: *job_build
     executor: release_exec
     steps:
       - checkout_source
       - setup_dependencies
-      - build_source
+      - build_source:
+          packages_skip: << parameters.packages_skip >>
+  system_build: &system_build
+    <<: *release_build
   release_test: &release_test
     <<: *job_test
     executor: release_exec
@@ -511,23 +526,49 @@ jobs:
       - restore_build
       - test_build:
           cache_test: << parameters.cache_test >>
+          packages_skip: << parameters.packages_skip >>
       - report_coverage
+  system_test: &system_test
+    <<: *release_test
 
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - release_build
+      - release_build:
+          packages_skip: "nav2_system_tests"
       - release_test:
           requires:
             - release_build
           cache_test: true
+          packages_skip: "nav2_system_tests"
+      - system_build:
+          requires:
+            - release_build
+      - system_test:
+          requires:
+            - system_build
+          cache_test: true
   nightly:
     jobs:
-      - release_build
+      - release_build:
+          packages_skip: "nav2_system_tests"
       - release_test:
           requires:
             - release_build
+          packages_skip: "nav2_system_tests"
+          matrix:
+            parameters:
+              rmw:
+                - rmw_connextdds
+                - rmw_cyclonedds_cpp
+                - rmw_fastrtps_cpp
+      - system_build:
+          requires:
+            - release_build
+      - system_test:
+          requires:
+            - system_build
           matrix:
             parameters:
               rmw:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,9 @@ _commands:
           type: string
         mixins:
           type: string
+        packages_select:
+          default: "*"
+          type: string
         packages_skip:
           default: ""
           type: string
@@ -185,6 +188,8 @@ _commands:
                       BUILD_PACKAGES=$(
                         colcon list \
                           --names-only \
+                          --packages-select-regex << parameters.packages_select >> \
+                          --packages-skip-regex << parameters.packages_skip >> \
                           --packages-above \
                             $BUILD_UNFINISHED \
                             $BUILD_FAILED \
@@ -200,7 +205,6 @@ _commands:
                     . << parameters.underlay >>/install/setup.sh
                     colcon build \
                       --packages-select ${BUILD_PACKAGES} \
-                      --packages-skip << parameters.packages_skip >> \
                       --mixin << parameters.mixins >>
               - ccache_stats:
                   workspace: << parameters.workspace >>
@@ -226,6 +230,9 @@ _commands:
           type: string
         cache_test:
           type: boolean
+        packages_select:
+          default: "*"
+          type: string
         packages_skip:
           type: string
           default: ""
@@ -264,6 +271,8 @@ _commands:
                 TEST_PACKAGES=$(
                   colcon list \
                     --names-only \
+                    --packages-select-regex << parameters.packages_select >> \
+                    --packages-skip-regex << parameters.packages_skip >> \
                     --packages-above \
                       $TEST_UNPASSED \
                       $TEST_FAILURES \
@@ -273,7 +282,9 @@ _commands:
               then
                 TEST_PACKAGES=$(
                   colcon list \
-                    --names-only)
+                    --names-only) \
+                    --packages-select-regex << parameters.packages_select >> \
+                    --packages-skip-regex << parameters.packages_skip >>
               fi
               TEST_PACKAGES=$(
                 echo $TEST_PACKAGES \
@@ -297,7 +308,6 @@ _commands:
               set -o xtrace
               colcon test \
                 --packages-select ${TEST_PACKAGES}
-                --packages-skip << parameters.packages_skip >>
               colcon test-result \
                 --verbose
         - when:
@@ -387,6 +397,7 @@ _steps:
   build_workspace_overlay: &build_workspace_overlay
     setup_workspace:
       <<: *setup_workspace_overlay
+      packages_select: << parameters.packages_select >>
       packages_skip: << parameters.packages_skip >>
   restore_overlay_workspace: &restore_overlay_workspace
     setup_workspace:
@@ -397,6 +408,7 @@ _steps:
       key: overlay_ws
       workspace: /opt/overlay_ws
       cache_test: << parameters.cache_test >>
+      packages_select: << parameters.packages_select >>
       packages_skip: << parameters.packages_skip >>
   collect_overlay_coverage: &collect_overlay_coverage
     run:
@@ -436,6 +448,8 @@ commands:
   build_source:
     description: "Build Source"
     parameters:
+      packages_select:
+        type: string
       packages_skip:
         type: string
     steps:
@@ -453,6 +467,8 @@ commands:
     parameters:
       cache_test:
         type: boolean
+      packages_select:
+        type: string
       packages_skip:
         type: string
     steps:
@@ -492,6 +508,9 @@ executors:
 _jobs:
   job_build: &job_build
     parameters: &job_build_parameters
+      packages_select:
+        type: string
+        default: "*"
       packages_skip:
         type: string
         default: ""
@@ -516,6 +535,7 @@ jobs:
       - checkout_source
       - setup_dependencies
       - build_source:
+          packages_select: << parameters.packages_select >>
           packages_skip: << parameters.packages_skip >>
   system_build: &system_build
     <<: *release_build
@@ -526,6 +546,7 @@ jobs:
       - restore_build
       - test_build:
           cache_test: << parameters.cache_test >>
+          packages_select: << parameters.packages_select >>
           packages_skip: << parameters.packages_skip >>
       - report_coverage
   system_test: &system_test
@@ -544,11 +565,12 @@ workflows:
           packages_skip: "nav2_system_tests"
       - system_build:
           requires:
-            - release_test
+            - release_build
+          packages_select: "nav2_system_tests"
       - system_test:
           requires:
             - system_build
-          cache_test: true
+          packages_select: "nav2_system_tests"
   nightly:
     jobs:
       - release_build:
@@ -556,7 +578,6 @@ workflows:
       - release_test:
           requires:
             - release_build
-          cache_test: true
           packages_skip: "nav2_system_tests"
           matrix:
             alias: release_test
@@ -567,10 +588,12 @@ workflows:
                 - rmw_fastrtps_cpp
       - system_build:
           requires:
-            - release_test
+            - release_build
+          packages_select: "nav2_system_tests"
       - system_test:
           requires:
             - system_build
+          packages_select: "nav2_system_tests"
           matrix:
             parameters:
               rmw:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,11 +571,12 @@ workflows:
           <<: *release_parameters
       - system_build:
           requires:
-            - release_build
+            - release_test
           <<: *system_parameters
       - system_test:
           requires:
             - system_build
+          cache_test: true
           <<: *system_parameters
   nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,10 +123,10 @@ _commands:
           type: string
         mixins:
           type: string
-        packages_select:
+        packages_select_regex:
           default: "*"
           type: string
-        packages_skip:
+        packages_skip_regex:
           default: ""
           type: string
         restore:
@@ -188,8 +188,8 @@ _commands:
                       BUILD_PACKAGES=$(
                         colcon list \
                           --names-only \
-                          --packages-select-regex << parameters.packages_select >> \
-                          --packages-skip-regex << parameters.packages_skip >> \
+                          --packages-select-regex << parameters.packages_select_regex >> \
+                          --packages-skip-regex << parameters.packages_skip_regex >> \
                           --packages-above \
                             $BUILD_UNFINISHED \
                             $BUILD_FAILED \
@@ -230,10 +230,10 @@ _commands:
           type: string
         cache_test:
           type: boolean
-        packages_select:
+        packages_select_regex:
           default: "*"
           type: string
-        packages_skip:
+        packages_skip_regex:
           type: string
           default: ""
       steps:
@@ -271,8 +271,8 @@ _commands:
                 TEST_PACKAGES=$(
                   colcon list \
                     --names-only \
-                    --packages-select-regex << parameters.packages_select >> \
-                    --packages-skip-regex << parameters.packages_skip >> \
+                    --packages-select-regex << parameters.packages_select_regex >> \
+                    --packages-skip-regex << parameters.packages_skip_regex >> \
                     --packages-above \
                       $TEST_UNPASSED \
                       $TEST_FAILURES \
@@ -283,8 +283,8 @@ _commands:
                 TEST_PACKAGES=$(
                   colcon list \
                     --names-only) \
-                    --packages-select-regex << parameters.packages_select >> \
-                    --packages-skip-regex << parameters.packages_skip >>
+                    --packages-select-regex << parameters.packages_select_regex >> \
+                    --packages-skip-regex << parameters.packages_skip_regex >>
               fi
               TEST_PACKAGES=$(
                 echo $TEST_PACKAGES \
@@ -397,8 +397,8 @@ _steps:
   build_workspace_overlay: &build_workspace_overlay
     setup_workspace:
       <<: *setup_workspace_overlay
-      packages_select: << parameters.packages_select >>
-      packages_skip: << parameters.packages_skip >>
+      packages_select_regex: << parameters.packages_select_regex >>
+      packages_skip_regex: << parameters.packages_skip_regex >>
   restore_overlay_workspace: &restore_overlay_workspace
     setup_workspace:
       <<: *setup_workspace_overlay
@@ -408,8 +408,8 @@ _steps:
       key: overlay_ws
       workspace: /opt/overlay_ws
       cache_test: << parameters.cache_test >>
-      packages_select: << parameters.packages_select >>
-      packages_skip: << parameters.packages_skip >>
+      packages_select_regex: << parameters.packages_select_regex >>
+      packages_skip_regex: << parameters.packages_skip_regex >>
   collect_overlay_coverage: &collect_overlay_coverage
     run:
       name: Collect Code Coverage
@@ -448,9 +448,9 @@ commands:
   build_source:
     description: "Build Source"
     parameters:
-      packages_select:
+      packages_select_regex:
         type: string
-      packages_skip:
+      packages_skip_regex:
         type: string
     steps:
       - *build_workspace_overlay
@@ -467,9 +467,9 @@ commands:
     parameters:
       cache_test:
         type: boolean
-      packages_select:
+      packages_select_regex:
         type: string
-      packages_skip:
+      packages_skip_regex:
         type: string
     steps:
       - *test_overlay_workspace
@@ -508,10 +508,10 @@ executors:
 _jobs:
   job_build: &job_build
     parameters: &job_build_parameters
-      packages_select:
+      packages_select_regex:
         type: string
         default: "*"
-      packages_skip:
+      packages_skip_regex:
         type: string
         default: ""
   job_test: &job_test
@@ -535,8 +535,8 @@ jobs:
       - checkout_source
       - setup_dependencies
       - build_source:
-          packages_select: << parameters.packages_select >>
-          packages_skip: << parameters.packages_skip >>
+          packages_select_regex: << parameters.packages_select_regex >>
+          packages_skip_regex: << parameters.packages_skip_regex >>
   system_build: &system_build
     <<: *release_build
   release_test: &release_test
@@ -546,17 +546,17 @@ jobs:
       - restore_build
       - test_build:
           cache_test: << parameters.cache_test >>
-          packages_select: << parameters.packages_select >>
-          packages_skip: << parameters.packages_skip >>
+          packages_select_regex: << parameters.packages_select_regex >>
+          packages_skip_regex: << parameters.packages_skip_regex >>
       - report_coverage
   system_test: &system_test
     <<: *release_test
 
 _parameters:
   release_parameters: &release_parameters
-    packages_skip: "nav2_system_tests"
+    packages_skip_regex: "nav2_system_tests"
   system_parameters: &system_parameters
-    packages_select: "nav2_system_tests"
+    packages_select_regex: "nav2_system_tests"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,6 +559,7 @@ workflows:
           cache_test: true
           packages_skip: "nav2_system_tests"
           matrix:
+            alias: release_test
             parameters:
               rmw:
                 - rmw_connextdds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,33 +552,39 @@ jobs:
   system_test: &system_test
     <<: *release_test
 
+_parameters:
+  release_parameters: &release_parameters
+    packages_skip: "nav2_system_tests"
+  system_parameters: &system_parameters
+    packages_select: "nav2_system_tests"
+
 workflows:
   version: 2
   build_and_test:
     jobs:
       - release_build:
-          packages_skip: "nav2_system_tests"
+          <<: *release_parameters
       - release_test:
           requires:
             - release_build
           cache_test: true
-          packages_skip: "nav2_system_tests"
+          <<: *release_parameters
       - system_build:
           requires:
             - release_build
-          packages_select: "nav2_system_tests"
+          <<: *system_parameters
       - system_test:
           requires:
             - system_build
-          packages_select: "nav2_system_tests"
+          <<: *system_parameters
   nightly:
     jobs:
       - release_build:
-          packages_skip: "nav2_system_tests"
+          <<: *release_parameters
       - release_test:
           requires:
             - release_build
-          packages_skip: "nav2_system_tests"
+          <<: *release_parameters
           matrix:
             alias: release_test
             parameters:
@@ -589,11 +595,11 @@ workflows:
       - system_build:
           requires:
             - release_build
-          packages_select: "nav2_system_tests"
+          <<: *system_parameters
       - system_test:
           requires:
             - system_build
-          packages_select: "nav2_system_tests"
+          <<: *system_parameters
           matrix:
             parameters:
               rmw:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,12 @@ _commands:
         - restore_cache:
             name: Restore Cache << parameters.key >>
             keys:
-              - "<< parameters.key >>-v13\
+              - "<< parameters.key >>-v14\
                 -{{ arch }}\
                 -{{ .Branch }}\
                 -{{ .Environment.CIRCLE_PR_NUMBER }}\
                 -{{ checksum  \"<< parameters.workspace >>/lockfile.txt\" }}"
-              - "<< parameters.key >>-v13\
+              - "<< parameters.key >>-v14\
                 -{{ arch }}\
                 -main\
                 -<no value>\
@@ -58,7 +58,7 @@ _commands:
       steps:
         - save_cache:
             name: Save Cache << parameters.key >>
-            key: "<< parameters.key >>-v13\
+            key: "<< parameters.key >>-v14\
               -{{ arch }}\
               -{{ .Branch }}\
               -{{ .Environment.CIRCLE_PR_NUMBER }}\

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -556,6 +556,7 @@ workflows:
       - release_test:
           requires:
             - release_build
+          cache_test: true
           packages_skip: "nav2_system_tests"
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,7 +544,7 @@ workflows:
           packages_skip: "nav2_system_tests"
       - system_build:
           requires:
-            - release_build
+            - release_test
       - system_test:
           requires:
             - system_build
@@ -565,7 +565,7 @@ workflows:
                 - rmw_fastrtps_cpp
       - system_build:
           requires:
-            - release_build
+            - release_test
       - system_test:
           requires:
             - system_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,9 +123,6 @@ _commands:
           type: string
         mixins:
           type: string
-        packages_select_regex:
-          default: "*"
-          type: string
         packages_skip_regex:
           default: ""
           type: string
@@ -188,7 +185,6 @@ _commands:
                       BUILD_PACKAGES=$(
                         colcon list \
                           --names-only \
-                          --packages-select-regex << parameters.packages_select_regex >> \
                           --packages-skip-regex << parameters.packages_skip_regex >> \
                           --packages-above \
                             $BUILD_UNFINISHED \
@@ -230,9 +226,6 @@ _commands:
           type: string
         cache_test:
           type: boolean
-        packages_select_regex:
-          default: "*"
-          type: string
         packages_skip_regex:
           type: string
           default: ""
@@ -271,7 +264,6 @@ _commands:
                 TEST_PACKAGES=$(
                   colcon list \
                     --names-only \
-                    --packages-select-regex << parameters.packages_select_regex >> \
                     --packages-skip-regex << parameters.packages_skip_regex >> \
                     --packages-above \
                       $TEST_UNPASSED \
@@ -283,7 +275,6 @@ _commands:
                 TEST_PACKAGES=$(
                   colcon list \
                     --names-only) \
-                    --packages-select-regex << parameters.packages_select_regex >> \
                     --packages-skip-regex << parameters.packages_skip_regex >>
               fi
               TEST_PACKAGES=$(
@@ -397,7 +388,6 @@ _steps:
   build_workspace_overlay: &build_workspace_overlay
     setup_workspace:
       <<: *setup_workspace_overlay
-      packages_select_regex: << parameters.packages_select_regex >>
       packages_skip_regex: << parameters.packages_skip_regex >>
   restore_overlay_workspace: &restore_overlay_workspace
     setup_workspace:
@@ -408,7 +398,6 @@ _steps:
       key: overlay_ws
       workspace: /opt/overlay_ws
       cache_test: << parameters.cache_test >>
-      packages_select_regex: << parameters.packages_select_regex >>
       packages_skip_regex: << parameters.packages_skip_regex >>
   collect_overlay_coverage: &collect_overlay_coverage
     run:
@@ -448,8 +437,6 @@ commands:
   build_source:
     description: "Build Source"
     parameters:
-      packages_select_regex:
-        type: string
       packages_skip_regex:
         type: string
     steps:
@@ -467,8 +454,6 @@ commands:
     parameters:
       cache_test:
         type: boolean
-      packages_select_regex:
-        type: string
       packages_skip_regex:
         type: string
     steps:
@@ -508,9 +493,6 @@ executors:
 _jobs:
   job_build: &job_build
     parameters: &job_build_parameters
-      packages_select_regex:
-        type: string
-        default: "*"
       packages_skip_regex:
         type: string
         default: ""
@@ -535,7 +517,6 @@ jobs:
       - checkout_source
       - setup_dependencies
       - build_source:
-          packages_select_regex: << parameters.packages_select_regex >>
           packages_skip_regex: << parameters.packages_skip_regex >>
   system_build: &system_build
     <<: *release_build
@@ -546,15 +527,12 @@ jobs:
       - restore_build
       - test_build:
           cache_test: << parameters.cache_test >>
-          packages_select_regex: << parameters.packages_select_regex >>
           packages_skip_regex: << parameters.packages_skip_regex >>
       - report_coverage
 
 _parameters:
   release_parameters: &release_parameters
     packages_skip_regex: "nav2_system_tests"
-  system_parameters: &system_parameters
-    packages_select_regex: "nav2_system_tests"
 
 workflows:
   version: 2
@@ -565,7 +543,6 @@ workflows:
       - system_build:
           requires:
             - release_build
-          <<: *system_parameters
       - release_test:
           requires:
             - system_build
@@ -577,7 +554,6 @@ workflows:
       - system_build:
           requires:
             - release_build
-          <<: *system_parameters
       - release_test:
           requires:
             - system_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -549,8 +549,6 @@ jobs:
           packages_select_regex: << parameters.packages_select_regex >>
           packages_skip_regex: << parameters.packages_skip_regex >>
       - report_coverage
-  system_test: &system_test
-    <<: *release_test
 
 _parameters:
   release_parameters: &release_parameters
@@ -564,44 +562,28 @@ workflows:
     jobs:
       - release_build:
           <<: *release_parameters
-      - release_test:
-          requires:
-            - release_build
-          cache_test: true
-          <<: *release_parameters
       - system_build:
           requires:
-            - release_test
+            - release_build
           <<: *system_parameters
-      - system_test:
+      - release_test:
           requires:
             - system_build
           cache_test: true
-          <<: *system_parameters
   nightly:
     jobs:
       - release_build:
           <<: *release_parameters
-      - release_test:
-          requires:
-            - release_build
-          <<: *release_parameters
-          matrix:
-            alias: release_test
-            parameters:
-              rmw:
-                - rmw_connextdds
-                - rmw_cyclonedds_cpp
-                - rmw_fastrtps_cpp
       - system_build:
           requires:
             - release_build
           <<: *system_parameters
-      - system_test:
+      - release_test:
           requires:
             - system_build
-          <<: *system_parameters
+          <<: *release_parameters
           matrix:
+            alias: release_test
             parameters:
               rmw:
                 - rmw_connextdds


### PR DESCRIPTION
to avoid CI timeout issues with CircleCI.

Related:

- https://github.com/ros-planning/navigation2/pull/3543