### PR TITLE
Verify tb3 exists at launch time

### DIFF
--- a/nav2_bringup/launch/tb3_simulation_launch.py
+++ b/nav2_bringup/launch/tb3_simulation_launch.py
@@ -30,6 +30,8 @@ def generate_launch_description():
     # Get the launch directory
     bringup_dir = get_package_share_directory('nav2_bringup')
     launch_dir = os.path.join(bringup_dir, 'launch')
+    # This checks during launch that tb3 exists
+    _ = get_package_share_directory('turtlebot3_gazebo')
 
     # Create the launch configuration variables
     slam = LaunchConfiguration('slam')

--- a/nav2_bringup/launch/tb3_simulation_launch.py
+++ b/nav2_bringup/launch/tb3_simulation_launch.py
@@ -30,7 +30,7 @@ def generate_launch_description():
     # Get the launch directory
     bringup_dir = get_package_share_directory('nav2_bringup')
     launch_dir = os.path.join(bringup_dir, 'launch')
-    # This checks during launch that tb3 exists
+    # This checks that tb3 exists needed for the URDF. If not using TB3, its safe to remove.
     _ = get_package_share_directory('turtlebot3_gazebo')
 
     # Create the launch configuration variables

--- a/nav2_bringup/package.xml
+++ b/nav2_bringup/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>navigation2</exec_depend>
   <exec_depend>nav2_common</exec_depend>
   <exec_depend>slam_toolbox</exec_depend>
+  <exec_depend>turtlebot3_gazebo</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | TB3 Simulation |

---

## Description of contribution in a few bullet points

* I added support at launch time to verify the necessary turtlebot3_gazebo package is installed, preventing a cryptic runtime failure if you forget to install the dependnecy
* I added a dependency in the package.xml on the tb3 model, which is smaller than the suggested method: `sudo apt install ros-<ros2-distro>-turtlebot3*`


## Change in behavior
before, the launch continues despite errors. Errors are in white and hard to notice. Gazebo launches but is empty. 
```
[spawn_entity.py-3] [ERROR] [1682316083.368866917] [spawn_entity]: Service %s/spawn_entity unavailable. Was Gazebo started with GazeboRosFactory?
[spawn_entity.py-3] [ERROR] [1682316083.369139584] [spawn_entity]: Spawn service failed. Exiting.
[ERROR] [spawn_entity.py-3]: process has died [pid 79161, exit code 1, cmd '/opt/ros/humble/lib/gazebo_ros/spawn_entity.py -entity turtlebot3_waffle -file /home/ryan/Development/nav2_ws/install/nav2_bringup/share/nav2_bringup/worlds/waffle.model -robot_namespace -x -2.00 -y -0.50 -z 0.01 -R 0.00 -P 0.00 -Y 0.00 --ros-args'].
[gzserver-1] Error Code 12 Msg: Unable to find uri[model://turtlebot3_world]
```

after, the error is descriptive the package is missing, it aborts the launch. 
```
ryan@ryan-B650:~/Development/nav2_ws$ ros2 launch nav2_bringup tb3_simulation_launch.py headless:=False
[INFO] [launch]: All log files can be found below /home/ryan/.ros/log/2023-05-03-09-20-07-551915-ryan-B650-52304
[INFO] [launch]: Default logging verbosity is set to INFO
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught exception when trying to load file of format [py]: "package 'turtlebot3_gazebo' not found, searching: ['/home/ryan/Development/nav2_ws/install/nav2_system_tests', '/home/ryan/Development/nav2_ws/install/nav2_bringup', '/home/ryan/Development/nav2_ws/install/navigation2', '/home/ryan/Development/nav2_ws/install/nav2_smoother', '/home/ryan/Development/nav2_ws/install/nav2_dwb_controller', '/home/ryan/Development/nav2_ws/install/nav2_controller', '/home/ryan/Development/nav2_ws/install/dwb_plugins', '/home/ryan/Development/nav2_ws/install/dwb_critics', '/home/ryan/Development/nav2_ws/install/dwb_core', '/home/ryan/Development/nav2_ws/install/nav_2d_utils', '/home/ryan/Development/nav2_ws/install/dwb_msgs', '/home/ryan/Development/nav2_ws/install/nav_2d_msgs', '/home/ryan/Development/nav2_ws/install/nav2_waypoint_follower', '/home/ryan/Development/nav2_ws/install/nav2_theta_star_planner', '/home/ryan/Development/nav2_ws/install/nav2_smac_planner', '/home/ryan/Development/nav2_ws/install/nav2_rotation_shim_controller', '/home/ryan/Development/nav2_ws/install/nav2_regulated_pure_pursuit_controller', '/home/ryan/Development/nav2_ws/install/nav2_planner', '/home/ryan/Development/nav2_ws/install/nav2_navfn_planner', '/home/ryan/Development/nav2_ws/install/nav2_mppi_controller', '/home/ryan/Development/nav2_ws/install/nav2_constrained_smoother', '/home/ryan/Development/nav2_ws/install/nav2_bt_navigator', '/home/ryan/Development/nav2_ws/install/nav2_behaviors', '/home/ryan/Development/nav2_ws/install/nav2_core', '/home/ryan/Development/nav2_ws/install/nav2_collision_monitor', '/home/ryan/Development/nav2_ws/install/costmap_queue', '/home/ryan/Development/nav2_ws/install/nav2_costmap_2d', '/home/ryan/Development/nav2_ws/install/nav2_voxel_grid', '/home/ryan/Development/nav2_ws/install/nav2_velocity_smoother', '/home/ryan/Development/nav2_ws/install/nav2_rviz_plugins', '/home/ryan/Development/nav2_ws/install/nav2_map_server', '/home/ryan/Development/nav2_ws/install/nav2_lifecycle_manager', '/home/ryan/Development/nav2_ws/install/nav2_behavior_tree', '/home/ryan/Development/nav2_ws/install/nav2_amcl', '/home/ryan/Development/nav2_ws/install/nav2_util', '/home/ryan/Development/nav2_ws/install/nav2_simple_commander', '/home/ryan/Development/nav2_ws/install/nav2_msgs', '/home/ryan/Development/nav2_ws/install/nav2_common', '/opt/ros/humble']"
```

This increases the size of the nav2 dependencies by 1225 kB. There was a concern about forcing this increase on users when downloading all of the tb3 assets, however, by using the specific dependency, I don't think this concern is as strong. 
```
ryan@ryan-B650:~/Development/nav2_ws/src$ apt show ros-humble-turtlebot3-gazebo 
Package: ros-humble-turtlebot3-gazebo
Version: 2.2.5-3jammy.20230426.110059
Priority: optional
Section: misc
Maintainer: Will Son <willson@robotis.com>
Installed-Size: 1,225 kB
Depends: libc6 (>= 2.34), libgcc-s1 (>= 3.3.1), libstdc++6 (>= 11), ros-humble-gazebo-ros-pkgs, ros-humble-geometry-msgs, ros-humble-nav-msgs, ros-humble-rclcpp, ros-humble-sensor-msgs, ros-humble-tf2, ros-humble-ros-workspace
Homepage: http://turtlebot3.robotis.com
Download-Size: 167 kB
APT-Sources: http://packages.ros.org/ros2/ubuntu jammy/main amd64 Packages
Description: Gazebo simulation package for the TurtleBot3
```

## Future work that may be required in bullet points

* Docs will be updated in a follow up PR

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
