### PR TITLE
Fix wrong usage of default params in python3 commander API

### DIFF
--- a/nav2_simple_commander/nav2_simple_commander/robot_navigator.py
+++ b/nav2_simple_commander/nav2_simple_commander/robot_navigator.py
@@ -353,7 +353,7 @@ class BasicNavigator(Node):
 
     def getPath(self, start, goal, planner_id='', use_start=False):
         """Send a `ComputePathToPose` action request."""
-        rtn = self._getPathImpl(start, goal, planner_id='', use_start=False)
+        rtn = self._getPathImpl(start, goal, planner_id, use_start)
         if not rtn:
             return None
         else:
@@ -426,7 +426,7 @@ class BasicNavigator(Node):
     def smoothPath(self, path, smoother_id='', max_duration=2.0, check_for_collision=False):
         """Send a `SmoothPath` action request."""
         rtn = self._smoothPathImpl(
-            self, path, smoother_id='', max_duration=2.0, check_for_collision=False)
+            self, path, smoother_id, max_duration, check_for_collision)
         if not rtn:
             return None
         else:


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3558 |
| Primary OS tested on | Ubuntu |
---

## Description of contribution in a few bullet points
Fixed #3558 for Humble branch as well

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
