### PR TITLE
Add ros2/geometry2 to underlay

### DIFF
--- a/tools/underlay.repos
+++ b/tools/underlay.repos
@@ -27,3 +27,7 @@ repositories:
   #   type: git
   #   url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
   #   version: ros2
+  ros2/geometry2:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: rolling


### PR DESCRIPTION
Add ros2/geometry2 to underlay in interim until next rolling sync.

Related:

- https://github.com/ros2/geometry2/pull/601