### PR TITLE
Fix typo in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,8 +274,8 @@ _commands:
               then
                 TEST_PACKAGES=$(
                   colcon list \
-                    --names-only) \
-                    --packages-skip-regex << parameters.packages_skip_regex >>
+                    --names-only \
+                    --packages-skip-regex << parameters.packages_skip_regex >> )
               fi
               TEST_PACKAGES=$(
                 echo $TEST_PACKAGES \


### PR DESCRIPTION
from: https://github.com/ros-planning/navigation2/pull/3554