### PR TITLE
Fix for Message filter dropping message issue

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -445,7 +445,7 @@ Costmap2DROS::updateMap()
 
       auto footprint = std::make_unique<geometry_msgs::msg::PolygonStamped>();
       footprint->header.frame_id = global_frame_;
-      footprint->header.stamp = now();
+      footprint->header.stamp = rclcpp::Time();
       transformFootprint(x, y, yaw, padded_footprint_, *footprint);
 
       RCLCPP_DEBUG(get_logger(), "Publishing footprint");


### PR DESCRIPTION
rviz2 drop messages for published_footprint topic due to very high time stamp.
The code publishes footprint message with stamp of PC time which is very high
Fix is to either keep stamp to 0 or initialize to rclcpp::Time().
Original error: [rviz2-52] [INFO] [1684731771.953443812] [rviz2]: Message Filter dropping message: frame 'odom' at time 1684731769.924 for reason 'Unknown'


<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

<!--
* rviz2 drop messages for published_footprint topic due to very high time stamp.
* The code publishes footprint message with stamp of PC time which is very high
* Fix is to either keep stamp to 0 or initialize to rclcpp::Time().  This change will set to Time().
* Humble has stamp initialization removed keeping stamp to 0. but the fix was never ported back

Original error: [rviz2-52] [INFO] [1684731771.953443812] [rviz2]: Message Filter dropping message: frame 'odom' at time 1684731769.924 for reason 'Unknown'
-->

## Description of documentation updates required from your changes

<!--
* Bug fix.  No documentation change needed
-->

---

## Future work that may be required in bullet points

<!--
* Bug fix
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
