### PR TITLE
Fix broken symlink for gzweb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,7 +194,7 @@ RUN cd $GZWEB_WS && . /usr/share/gazebo/setup.sh && \
       -mindepth 1 -maxdepth 2 -type d -name "models" | paste -s -d: -) && \
     sed -i "s|var modelList =|var modelList = []; var oldModelList =|g" gz3d/src/gzgui.js && \
     xvfb-run -s "-screen 0 1280x1024x24" ./deploy.sh -m local && \
-    ln -s http/client/assets http/client/assets/models && \
+    ln -s $GZWEB_WS/http/client/assets http/client/assets/models && \
     ln -s $GZWEB_WS/http/client $ROOT_SRV/gzweb
 
 # patch gzsever


### PR DESCRIPTION
Typo from https://github.com/ros-planning/navigation2/pull/3576