### PR TITLE
Fix dynamic polygons vertices not updated for different frame

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -238,12 +238,12 @@ protected:
   // Visualization
   /// @brief Whether to publish the polygon
   bool visualize_;
-  /// @brief Polygon stored for later publishing
+  /// @brief Polygon, used for: 1. visualization; 2. storing latest dynamic polygon message
   geometry_msgs::msg::PolygonStamped polygon_;
   /// @brief Polygon publisher for visualization purposes
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PolygonStamped>::SharedPtr polygon_pub_;
 
-  /// @brief Polygon points (vertices)
+  /// @brief Polygon points (vertices) in a base_frame_id_
   std::vector<Point> poly_;
 };  // class Polygon
 

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -379,6 +379,9 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
       break;
     }
 
+    // Update polygon coordinates, when it necessary
+    polygon->updatePolygon();
+
     const ActionType at = polygon->getActionType();
     if (at == STOP || at == SLOWDOWN || at == LIMIT) {
       // Process STOP/SLOWDOWN for the selected polygon
@@ -468,8 +471,6 @@ bool CollisionMonitor::processApproach(
   const Velocity & velocity,
   Action & robot_action) const
 {
-  polygon->updatePolygon();
-
   if (!polygon->isShapeSet()) {
     return false;
   }

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -379,7 +379,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
       break;
     }
 
-    // Update polygon coordinates, when it necessary
+    // Update polygon coordinates
     polygon->updatePolygon();
 
     const ActionType at = polygon->getActionType();

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -188,6 +188,30 @@ void Polygon::updatePolygon()
       p_s.y = footprint_vec[i].y;
       polygon_.polygon.points[i] = p_s;
     }
+  } else if (!polygon_.header.frame_id.empty() && polygon_.header.frame_id != base_frame_id_) {
+    // Polygon is published in another frame: correct poly_ vertices to the latest frame state
+    std::size_t new_size = polygon_.polygon.points.size();
+
+    // Get the transform from PolygonStamped frame to base_frame_id_
+    tf2::Transform tf_transform;
+    if (
+      !nav2_util::getTransform(
+        polygon_.header.frame_id, base_frame_id_,
+        transform_tolerance_, tf_buffer_, tf_transform))
+    {
+      return;
+    }
+
+    // Correct main poly_ vertices
+    poly_.resize(new_size);
+    for (std::size_t i = 0; i < new_size; i++) {
+      // Transform point coordinates from PolygonStamped frame -> to base frame
+      tf2::Vector3 p_v3_s(polygon_.polygon.points[i].x, polygon_.polygon.points[i].y, 0.0);
+      tf2::Vector3 p_v3_b = tf_transform * p_v3_s;
+
+      // Fill poly_ array
+      poly_[i] = {p_v3_b.x(), p_v3_b.y()};
+    }
   }
 }
 
@@ -443,7 +467,7 @@ void Polygon::updatePolygon(geometry_msgs::msg::PolygonStamped::ConstSharedPtr m
     return;
   }
 
-  // Set main polygon vertices
+  // Set main poly_ vertices first time
   poly_.resize(new_size);
   for (std::size_t i = 0; i < new_size; i++) {
     // Transform point coordinates from PolygonStamped frame -> to base frame
@@ -454,10 +478,9 @@ void Polygon::updatePolygon(geometry_msgs::msg::PolygonStamped::ConstSharedPtr m
     poly_[i] = {p_v3_b.x(), p_v3_b.y()};
   }
 
-  if (visualize_) {
-    // Store polygon_ for visualization
-    polygon_ = *msg;
-  }
+  // Store incoming polygon for further (possible) poly_ vertices corrections
+  // from PolygonStamped frame -> to base frame
+  polygon_ = *msg;
 }
 
 void Polygon::polygonCallback(geometry_msgs::msg::PolygonStamped::ConstSharedPtr msg)


### PR DESCRIPTION
This is the fix for #3590 issue: Collision Monitor to correct polygon vertices to the actual TF state, for the case when this polygon was obtained from another than `base_link` frame. 

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3590|
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | TB3 simulation, `colcon test --packages-select nav2_collision_monitor`, code coverage |

---

Fix dynamic polygons vertices not updated for different frame
* In `updatePolygon()`, correct `poly_` vertice coordinates to the latest frame state, when polygon is published in another (than `base_frame_id_`) frame
* Re-use `geometry_msgs::msg::PolygonStamped polygon_` to preserve latest dynamic polygon message for this correction
* Call `updatePolygon()` for all cases, but not only for the footprint approaches in the main `CollisionMonitorNode` loop
* Added the testcase on the written in the issue situation

## Description of documentation updates required from your changes

No documentation updates is required for this bugfix.

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
