### PR TITLE
Add CostmapFilterInfoServer as a component

### DIFF
--- a/nav2_map_server/CMakeLists.txt
+++ b/nav2_map_server/CMakeLists.txt
@@ -125,6 +125,7 @@ if(WIN32)
     YAML_CPP_DLL)
 endif()
 
+rclcpp_components_register_nodes(${library_name} "nav2_map_server::CostmapFilterInfoServer")
 rclcpp_components_register_nodes(${library_name} "nav2_map_server::MapSaver")
 rclcpp_components_register_nodes(${library_name} "nav2_map_server::MapServer")
 

--- a/nav2_map_server/include/nav2_map_server/costmap_filter_info_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/costmap_filter_info_server.hpp
@@ -29,8 +29,10 @@ class CostmapFilterInfoServer : public nav2_util::LifecycleNode
 public:
   /**
    * @brief Constructor for the nav2_map_server::CostmapFilterInfoServer
+   * @param options Additional options to control creation of the node.
    */
-  CostmapFilterInfoServer();
+  explicit CostmapFilterInfoServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
   /**
    * @brief Destructor for the nav2_map_server::CostmapFilterInfoServer
    */

--- a/nav2_map_server/src/costmap_filter_info/costmap_filter_info_server.cpp
+++ b/nav2_map_server/src/costmap_filter_info/costmap_filter_info_server.cpp
@@ -24,8 +24,8 @@
 namespace nav2_map_server
 {
 
-CostmapFilterInfoServer::CostmapFilterInfoServer()
-: nav2_util::LifecycleNode("costmap_filter_info_server")
+CostmapFilterInfoServer::CostmapFilterInfoServer(const rclcpp::NodeOptions & options)
+: nav2_util::LifecycleNode("costmap_filter_info_server", "", options)
 {
   declare_parameter("filter_info_topic", "costmap_filter_info");
   declare_parameter("type", 0);
@@ -106,3 +106,10 @@ CostmapFilterInfoServer::on_shutdown(const rclcpp_lifecycle::State & /*state*/)
 }
 
 }  // namespace nav2_map_server
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(nav2_map_server::CostmapFilterInfoServer)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [Link to issue](https://github.com/ros-planning/navigation2/issues/3589) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (Turtlebot3 simulation) |

---

## Description of contribution in a few bullet points

<!--
* I added the CostampFilterInfoServer as a component.
-->

## Description of documentation updates required from your changes

<!--
* It is required to update the documentation so that people know they can use this as a component. 
-->

---

## Future work that may be required in bullet points

<!--
* Add an example to navigation_tutorials to use the keep out zone as a component. (I will be doing that also)
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
