### PR TITLE
[MPPI] empty path_follow_critic proper fix

### DIFF
--- a/nav2_mppi_controller/src/critics/path_follow_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_follow_critic.cpp
@@ -34,16 +34,15 @@ void PathFollowCritic::initialize()
 
 void PathFollowCritic::score(CriticData & data)
 {
-  const size_t path_size = data.path.x.shape(0) - 1;
-
-  if (!enabled_ || path_size == 0 ||
-    utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
+  if (!enabled_ || data.path.x.shape(0) < 2 ||
+      utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
   {
-    return;
+      return;
   }
 
   utils::setPathFurthestPointIfNotSet(data);
   utils::setPathCostsIfNotSet(data, costmap_ros_);
+  const size_t path_size = data.path.x.shape(0) - 1;
 
   auto offseted_idx = std::min(
     *data.furthest_reached_path_point + offset_from_furthest_, path_size);

--- a/nav2_mppi_controller/src/critics/path_follow_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_follow_critic.cpp
@@ -35,9 +35,9 @@ void PathFollowCritic::initialize()
 void PathFollowCritic::score(CriticData & data)
 {
   if (!enabled_ || data.path.x.shape(0) < 2 ||
-      utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
+    utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
   {
-      return;
+    return;
   }
 
   utils::setPathFurthestPointIfNotSet(data);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/3480 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory robot |

---

## Description of contribution in a few bullet points
Complementary as https://github.com/ros-planning/navigation2/pull/3484, as discussed a while ago, to be sure to protect against path of length 0 (though this should never happen)


## Future work that may be required in bullet points

Tests across all critics for path of length 0 and 1

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
