### PR TITLE
[MPPI] Enforce inversion MOD (NO TEST)

### DIFF
--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -89,14 +89,14 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  find_package(ament_cmake_gtest REQUIRED)
-  set(ament_cmake_copyright_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-  add_subdirectory(test)
-  # add_subdirectory(benchmark)
-endif()
+#if(BUILD_TESTING)
+#  find_package(ament_lint_auto REQUIRED)
+#  find_package(ament_cmake_gtest REQUIRED)
+#  set(ament_cmake_copyright_FOUND TRUE)
+#  ament_lint_auto_find_test_dependencies()
+#  add_subdirectory(test)
+#  # add_subdirectory(benchmark)
+#endif()
 
 ament_export_libraries(${libraries})
 ament_export_dependencies(${dependencies_pkgs})

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/path_handler.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/path_handler.hpp
@@ -88,6 +88,8 @@ public:
    */
   nav_msgs::msg::Path transformPath(const geometry_msgs::msg::PoseStamped & robot_pose);
 
+  bool isWithinInversionTolerances(const geometry_msgs::msg::PoseStamped & robot_pose);
+
 protected:
   /**
     * @brief Transform a pose to another frame
@@ -127,19 +129,25 @@ protected:
     * @brief Prune global path to only interesting portions
     * @param end Final path iterator
     */
-  void pruneGlobalPlan(const PathIterator end);
+  void prunePlan(nav_msgs::msg::Path & plan, const PathIterator end);
 
   std::string name_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   ParametersHandler * parameters_handler_;
 
+  nav_msgs::msg::Path global_plan_up_to_inversion_;
   nav_msgs::msg::Path global_plan_;
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
 
   double max_robot_pose_search_dist_{0};
   double prune_distance_{0};
   double transform_tolerance_{0};
+
+  bool enforce_inversion_{false};
+  bool inversion_remaining_{false};
+  double inversion_xy_tolerance_{0};
+  double inversion_yaw_tolerance{0};
 };
 }  // namespace mppi
 

--- a/nav2_mppi_controller/src/path_handler.cpp
+++ b/nav2_mppi_controller/src/path_handler.cpp
@@ -35,6 +35,11 @@ void PathHandler::initialize(
   getParam(max_robot_pose_search_dist_, "max_robot_pose_search_dist", getMaxCostmapDist());
   getParam(prune_distance_, "prune_distance", 1.5);
   getParam(transform_tolerance_, "transform_tolerance", 0.1);
+  getParam(enforce_inversion_, "enforce_inversion", false);
+  if (enforce_inversion_) {
+      getParam(inversion_xy_tolerance_, "inversion_xy_tolerance", 0.1);
+      getParam(inversion_yaw_tolerance, "inversion_yaw_tolerance", 0.1);
+  }
 }
 
 std::pair<nav_msgs::msg::Path, PathIterator>
@@ -43,12 +48,13 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
 {
   using nav2_util::geometry_utils::euclidean_distance;
 
-  auto begin = global_plan_.poses.begin();
+  auto begin = global_plan_up_to_inversion_.poses.begin();
 
   // Limit the search for the closest pose up to max_robot_pose_search_dist on the path
   auto closest_pose_upper_bound =
     nav2_util::geometry_utils::first_after_integrated_distance(
-    global_plan_.poses.begin(), global_plan_.poses.end(), max_robot_pose_search_dist_);
+    global_plan_up_to_inversion_.poses.begin(), global_plan_up_to_inversion_.poses.end(),
+    max_robot_pose_search_dist_);
 
   // Find closest point to the robot
   auto closest_point = nav2_util::geometry_utils::min_by(
@@ -63,7 +69,7 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
 
   auto pruned_plan_end =
     nav2_util::geometry_utils::first_after_integrated_distance(
-    closest_point, global_plan_.poses.end(), prune_distance_);
+    closest_point, global_plan_up_to_inversion_.poses.end(), prune_distance_);
 
   unsigned int mx, my;
   // Find the furthest relevent pose on the path to consider within costmap
@@ -95,12 +101,12 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
 geometry_msgs::msg::PoseStamped PathHandler::transformToGlobalPlanFrame(
   const geometry_msgs::msg::PoseStamped & pose)
 {
-  if (global_plan_.poses.empty()) {
+  if (global_plan_up_to_inversion_.poses.empty()) {
     throw nav2_core::InvalidPath("Received plan with zero length");
   }
 
   geometry_msgs::msg::PoseStamped robot_pose;
-  if (!transformPose(global_plan_.header.frame_id, pose, robot_pose)) {
+  if (!transformPose(global_plan_up_to_inversion_.header.frame_id, pose, robot_pose)) {
     throw nav2_core::ControllerTFError(
             "Unable to transform robot pose into global plan's frame");
   }
@@ -116,7 +122,15 @@ nav_msgs::msg::Path PathHandler::transformPath(
     transformToGlobalPlanFrame(robot_pose);
   auto [transformed_plan, lower_bound] = getGlobalPlanConsideringBoundsInCostmapFrame(global_pose);
 
-  pruneGlobalPlan(lower_bound);
+  prunePlan(global_plan_up_to_inversion_, lower_bound);
+
+  if (enforce_inversion_ && inversion_remaining_) {
+    if (isWithinInversionTolerances(global_pose)) {
+      prunePlan(global_plan_, utils::findFirstPathInversion(global_plan_));
+      global_plan_up_to_inversion_ = global_plan_;
+      inversion_remaining_ = utils::removePosesAfterFirstInversion(global_plan_);
+    }
+  }
 
   if (transformed_plan.poses.empty()) {
     throw nav2_core::InvalidPath("Resulting plan has 0 poses in it.");
@@ -156,13 +170,29 @@ double PathHandler::getMaxCostmapDist()
 void PathHandler::setPath(const nav_msgs::msg::Path & plan)
 {
   global_plan_ = plan;
+  global_plan_up_to_inversion_ = global_plan_;
+  inversion_remaining_ = utils::removePosesAfterFirstInversion(global_plan_up_to_inversion_);
 }
 
 nav_msgs::msg::Path & PathHandler::getPath() {return global_plan_;}
 
-void PathHandler::pruneGlobalPlan(const PathIterator end)
+void PathHandler::prunePlan(nav_msgs::msg::Path & plan, const PathIterator end)
 {
-  global_plan_.poses.erase(global_plan_.poses.begin(), end);
+  plan.poses.erase(plan.poses.begin(), end);
+}
+
+bool PathHandler::isWithinInversionTolerances(const geometry_msgs::msg::PoseStamped & robot_pose)
+{
+  // Keep full path if we are within tolerance of the inversion pose
+  double distance = std::hypot(
+    robot_pose.pose.position.x - global_plan_up_to_inversion_.poses.end()->pose.position.x,
+    robot_pose.pose.position.y - global_plan_up_to_inversion_.poses.end()->pose.position.y);
+
+  double angle_distance = angles::shortest_angular_distance(
+    tf2::getYaw(robot_pose.pose.orientation),
+    tf2::getYaw(global_plan_up_to_inversion_.poses.end()->pose.orientation));
+
+  return distance < inversion_xy_tolerance_ && fabs(angle_distance) < inversion_yaw_tolerance;
 }
 
 }  // namespace mppi

--- a/nav2_mppi_controller/test/path_handler_test.cpp
+++ b/nav2_mppi_controller/test/path_handler_test.cpp
@@ -38,9 +38,9 @@ public:
   PathHandlerWrapper()
   : PathHandler() {}
 
-  void pruneGlobalPlanWrapper(const PathIterator end)
+  void pruneGlobalPlanWrapper(nav_msgs::msg::Path & path, const PathIterator end)
   {
-    return pruneGlobalPlan(end);
+    return prunePlan(path, end);
   }
 
   double getMaxCostmapDistWrapper()
@@ -82,7 +82,7 @@ TEST(PathHandlerTests, GetAndPrunePath)
   EXPECT_EQ(path.poses.size(), rtn_path.poses.size());
 
   PathIterator it = rtn_path.poses.begin() + 5;
-  handler.pruneGlobalPlanWrapper(it);
+  handler.pruneGlobalPlanWrapper(path, it);
   auto rtn2_path = handler.getPath();
   EXPECT_EQ(rtn2_path.poses.size(), 6u);
 }
@@ -133,7 +133,7 @@ TEST(PathHandlerTests, TestBounds)
     handler.getGlobalPlanConsideringBoundsInCostmapFrameWrapper(robot_pose);
   auto & path_in = handler.getPath();
   EXPECT_EQ(closest - path_in.poses.begin(), 25);
-  handler.pruneGlobalPlanWrapper(closest);
+  handler.pruneGlobalPlanWrapper(path, closest);
   auto & path_pruned = handler.getPath();
   EXPECT_EQ(path_pruned.poses.size(), 75u);
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory robot |

---

## Description of contribution in a few bullet points

THIS IS A DRAFT
TESTS ARE DISABLED
Tested and used in production for a couple of months but doesn't necessarily work with all use cases.
Needs https://github.com/ros-planning/navigation2/pull/3454 to work properly.

This PR adds a mechanism to MPPI to enforce global path inversions: the part of the global path taken into account by the controller will be cropped to the closest orientation inversion found on the path until the robot is within the tolerances of the inversion pose.
This new behavior of the controller is controlled by the following new parameters:
```
      enforce_inversion (bool)
      inversion_xy_tolerance (double)
      inversion_yaw_tolerance (double)
```

Default behavior:

https://github.com/ros-planning/navigation2/assets/15727892/0f87d27b-55cd-43fc-8d1f-4a6db6680c33

With path inversion:

https://github.com/ros-planning/navigation2/assets/15727892/5fb50ade-e320-49ac-9947-d7a202acca1f




## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
