### PR TITLE
nlamprian/controller server plugin handling

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -188,8 +188,11 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     }
   }
 
-  for (size_t i = 0; i != goal_checker_ids_.size(); i++) {
-    goal_checker_ids_concat_ += goal_checker_ids_[i] + std::string(" ");
+  for (size_t i = 0; i < goal_checker_ids_.size(); i++) {
+    goal_checker_ids_concat_ += goal_checker_ids_[i];
+    if (i < goal_checker_ids_.size() - 1) {
+      goal_checker_ids_concat_ += std::string(" ");
+    }
   }
 
   RCLCPP_INFO(
@@ -216,8 +219,11 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     }
   }
 
-  for (size_t i = 0; i != controller_ids_.size(); i++) {
-    controller_ids_concat_ += controller_ids_[i] + std::string(" ");
+  for (size_t i = 0; i < controller_ids_.size(); i++) {
+    controller_ids_concat_ += controller_ids_[i];
+    if (i < controller_ids_.size() - 1) {
+      controller_ids_concat_ += std::string(" ");
+    }
   }
 
   RCLCPP_INFO(
@@ -344,15 +350,15 @@ bool ControllerServer::findControllerId(
   std::string & current_controller)
 {
   if (controllers_.find(c_name) == controllers_.end()) {
-    if (controllers_.size() == 1 && c_name.empty()) {
-      RCLCPP_WARN_ONCE(
-        get_logger(), "No controller was specified in action call."
-        " Server will use only plugin loaded %s. "
-        "This warning will appear once.", controller_ids_concat_.c_str());
-      current_controller = controllers_.begin()->first;
+    if (c_name.empty()) {
+      current_controller = controller_ids_[0];
+      RCLCPP_INFO_ONCE(
+        get_logger(), "No controller_id specified in action goal. "
+        "Selected first available controller: %s. "
+        "This message will appear once.", current_controller.c_str());
     } else {
       RCLCPP_ERROR(
-        get_logger(), "FollowPath called with controller name %s, "
+        get_logger(), "Server called with controller name %s, "
         "which does not exist. Available controllers are: %s.",
         c_name.c_str(), controller_ids_concat_.c_str());
       return false;
@@ -370,16 +376,16 @@ bool ControllerServer::findGoalCheckerId(
   std::string & current_goal_checker)
 {
   if (goal_checkers_.find(c_name) == goal_checkers_.end()) {
-    if (goal_checkers_.size() == 1 && c_name.empty()) {
-      RCLCPP_WARN_ONCE(
-        get_logger(), "No goal checker was specified in parameter 'current_goal_checker'."
-        " Server will use only plugin loaded %s. "
-        "This warning will appear once.", goal_checker_ids_concat_.c_str());
-      current_goal_checker = goal_checkers_.begin()->first;
+    if (c_name.empty()) {
+      current_goal_checker = goal_checker_ids_[0];
+      RCLCPP_INFO_ONCE(
+        get_logger(), "No goal_checker_id specified in action goal. "
+        "Selected first available goal checker: %s. "
+        "This message will appear once.", current_goal_checker.c_str());
     } else {
       RCLCPP_ERROR(
-        get_logger(), "FollowPath called with goal_checker name %s in parameter"
-        " 'current_goal_checker', which does not exist. Available goal checkers are: %s.",
+        get_logger(), "Server called with goal checker name %s, "
+        "which does not exist. Available goal checkers are: %s.",
         c_name.c_str(), goal_checker_ids_concat_.c_str());
       return false;
     }


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of turtlebot3 |

---

## Description of contribution in a few bullet points

Take the goal_checker_id as an example. It's never set (at least within this project). This results in a warning always shown. Furthermore, if more than one plugin is configured, you are forced to specify which one you want to use. If you don't, nothing works. The logic here is kinda broken (in one case, an empty id is accepted, in another, it's not).

Ideally, the behavior I would have expected would be on par with the bt filenames. I believe choosing the first available id is the next best thing to having a default id parameter (which could also be done, of course).

## Description of documentation updates required from your changes

The normal behavior doesn't change. The extended behavior could be documented.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
