### PR TITLE
Refactor sim_time and composable node usage in Collision Monitor

### DIFF
--- a/nav2_collision_monitor/launch/collision_monitor_node.launch.py
+++ b/nav2_collision_monitor/launch/collision_monitor_node.launch.py
@@ -19,10 +19,12 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.actions import DeclareLaunchArgument, GroupAction
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch_ros.actions import LoadComposableNodes, SetParameter
 from launch_ros.actions import Node
-from nav2_common.launch import RewrittenYaml
+from launch_ros.descriptions import ComposableNode
 
 
 def generate_launch_description():
@@ -38,6 +40,9 @@ def generate_launch_description():
     namespace = LaunchConfiguration('namespace')
     use_sim_time = LaunchConfiguration('use_sim_time')
     params_file = LaunchConfiguration('params_file')
+    use_composition = LaunchConfiguration('use_composition')
+    container_name = LaunchConfiguration('container_name')
+    container_name_full = (namespace, '/', container_name)
 
     # 2. Declare the launch arguments
     declare_namespace_cmd = DeclareLaunchArgument(
@@ -55,33 +60,57 @@ def generate_launch_description():
         default_value=os.path.join(package_dir, 'params', 'collision_monitor_params.yaml'),
         description='Full path to the ROS2 parameters file to use for all launched nodes')
 
-    # Create our own temporary YAML files that include substitutions
-    param_substitutions = {
-        'use_sim_time': use_sim_time}
+    declare_use_composition_cmd = DeclareLaunchArgument(
+        'use_composition', default_value='True',
+        description='Use composed bringup if True')
 
-    configured_params = RewrittenYaml(
-        source_file=params_file,
-        root_key=namespace,
-        param_rewrites=param_substitutions,
-        convert_types=True)
+    declare_container_name_cmd = DeclareLaunchArgument(
+        'container_name', default_value='nav2_container',
+        description='the name of conatiner that nodes will load in if use composition')
 
-    # Nodes launching commands
-    start_lifecycle_manager_cmd = Node(
-            package='nav2_lifecycle_manager',
-            executable='lifecycle_manager',
-            name='lifecycle_manager',
-            output='screen',
-            emulate_tty=True,  # https://github.com/ros2/launch/issues/188
-            parameters=[{'use_sim_time': use_sim_time},
-                        {'autostart': autostart},
-                        {'node_names': lifecycle_nodes}])
+    load_nodes = GroupAction(
+        condition=IfCondition(PythonExpression(['not ', use_composition])),
+        actions=[
+            SetParameter('use_sim_time', use_sim_time),
+            Node(
+                package='nav2_lifecycle_manager',
+                executable='lifecycle_manager',
+                name='lifecycle_manager_collision_monitor',
+                output='screen',
+                emulate_tty=True,  # https://github.com/ros2/launch/issues/188
+                parameters=[{'autostart': autostart},
+                            {'node_names': lifecycle_nodes}]),
+            Node(
+                package='nav2_collision_monitor',
+                executable='collision_monitor',
+                output='screen',
+                emulate_tty=True,  # https://github.com/ros2/launch/issues/188
+                parameters=[params_file])
+        ]
+    )
 
-    start_collision_monitor_cmd = Node(
-            package='nav2_collision_monitor',
-            executable='collision_monitor',
-            output='screen',
-            emulate_tty=True,  # https://github.com/ros2/launch/issues/188
-            parameters=[configured_params])
+    load_composable_nodes = GroupAction(
+        condition=IfCondition(use_composition),
+        actions=[
+            SetParameter('use_sim_time', use_sim_time),
+            LoadComposableNodes(
+                target_container=container_name_full,
+                composable_node_descriptions=[
+                    ComposableNode(
+                        package='nav2_lifecycle_manager',
+                        plugin='nav2_lifecycle_manager::LifecycleManager',
+                        name='lifecycle_manager_collision_monitor',
+                        parameters=[{'autostart': autostart},
+                                    {'node_names': lifecycle_nodes}]),
+                    ComposableNode(
+                        package='nav2_collision_monitor',
+                        plugin='nav2_collision_monitor::CollisionMonitor',
+                        name='collision_monitor',
+                        parameters=[params_file]),
+                ],
+            )
+        ]
+    )
 
     ld = LaunchDescription()
 
@@ -89,9 +118,11 @@ def generate_launch_description():
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_params_file_cmd)
+    ld.add_action(declare_use_composition_cmd)
+    ld.add_action(declare_container_name_cmd)
 
     # Node launching commands
-    ld.add_action(start_lifecycle_manager_cmd)
-    ld.add_action(start_collision_monitor_cmd)
+    ld.add_action(load_nodes)
+    ld.add_action(load_composable_nodes)
 
     return ld

--- a/nav2_collision_monitor/launch/collision_monitor_node.launch.py
+++ b/nav2_collision_monitor/launch/collision_monitor_node.launch.py
@@ -79,7 +79,7 @@ def generate_launch_description():
         param_rewrites={},
         convert_types=True)
 
-    # Declare launch commands
+    # Declare node launching commands
     load_nodes = GroupAction(
         condition=IfCondition(PythonExpression(['not ', use_composition])),
         actions=[

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -50,7 +50,7 @@ collision_monitor:
     observation_sources: ["scan"]
     scan:
       type: "scan"
-      topic: "/scan"
+      topic: "scan"
     pointcloud:
       type: "pointcloud"
       topic: "/intel_realsense_r200_depth/points"


### PR DESCRIPTION
This PR fixes Collision Monitor launch-script with:
* Apply to the CM the refactor of `sim_time` usage, introduced in 7703c816a11368fb1a48663dc92e4e93affb637e
* Adding the ability to launch CM as composable node in the container. Enabling this option by-default.
* Adding the support of non-empty root namespace

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3131, #2750|
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | standard Gazebo TB3 simulation |

---

## Description of documentation updates required from your changes

* No documentation updates required for sim time refactoring.
* Collision Monitor launch-file by-default also launch CM and CM's lifecycle manager in composable container, so all previously described in tutorial commands will remain correct and untouched. Please, let me know, if there an additional notice or sentence about that we have an ability to run w/ and w/o composable container, in tutorial is required.

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
