### PR TITLE
CI test fixing for BT.CPP (paired with BehaviorTree.CPP/579)

### DIFF
--- a/nav2_behavior_tree/test/plugins/decorator/test_single_trigger_node.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_single_trigger_node.cpp
@@ -28,8 +28,9 @@ using namespace std::chrono_literals;  // NOLINT
 class ShimNode : public nav2_behavior_tree::SingleTrigger
 {
 public:
-  ShimNode(const std::string & name,
-  const BT::NodeConfiguration & confi)
+  ShimNode(
+    const std::string & name,
+    const BT::NodeConfiguration & confi)
   : SingleTrigger(name, confi)
   {}
   ~ShimNode() {}

--- a/nav2_behavior_tree/test/plugins/decorator/test_single_trigger_node.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_single_trigger_node.cpp
@@ -24,13 +24,24 @@
 using namespace std::chrono;  // NOLINT
 using namespace std::chrono_literals;  // NOLINT
 
+// Shim BT node to access protected resetStatus method
+class ShimNode : public nav2_behavior_tree::SingleTrigger
+{
+public:
+  ShimNode(const std::string & name,
+  const BT::NodeConfiguration & confi)
+  : SingleTrigger(name, confi)
+  {}
+  ~ShimNode() {}
+  void changeStatus() {resetStatus();}
+};
+
 class SingleTriggerTestFixture : public nav2_behavior_tree::BehaviorTreeTestFixture
 {
 public:
   void SetUp()
   {
-    bt_node_ = std::make_shared<nav2_behavior_tree::SingleTrigger>(
-      "single_trigger", *config_);
+    bt_node_ = std::make_shared<ShimNode>("single_trigger", *config_);
     dummy_node_ = std::make_shared<nav2_behavior_tree::DummyNode>();
     bt_node_->setChild(dummy_node_.get());
   }
@@ -42,11 +53,11 @@ public:
   }
 
 protected:
-  static std::shared_ptr<nav2_behavior_tree::SingleTrigger> bt_node_;
+  static std::shared_ptr<ShimNode> bt_node_;
   static std::shared_ptr<nav2_behavior_tree::DummyNode> dummy_node_;
 };
 
-std::shared_ptr<nav2_behavior_tree::SingleTrigger>
+std::shared_ptr<ShimNode>
 SingleTriggerTestFixture::bt_node_ = nullptr;
 std::shared_ptr<nav2_behavior_tree::DummyNode>
 SingleTriggerTestFixture::dummy_node_ = nullptr;
@@ -71,6 +82,7 @@ TEST_F(SingleTriggerTestFixture, test_behavior)
   // halt BT for a new execution run, should work when dummy node is running
   // and once when dummy node returns success and then fail
   bt_node_->halt();
+  bt_node_->changeStatus();  // BTv3.8+ doesn't reset root node automatically
   dummy_node_->changeStatus(BT::NodeStatus::RUNNING);
   EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::RUNNING);
   dummy_node_->changeStatus(BT::NodeStatus::SUCCESS);

--- a/nav2_smoother/test/test_smoother_server.cpp
+++ b/nav2_smoother/test/test_smoother_server.cpp
@@ -223,21 +223,16 @@ public:
 };
 
 // Define a test class to hold the context for the tests
-
-class SmootherConfigTest : public ::testing::Test
-{
-};
-
 class SmootherTest : public ::testing::Test
 {
-protected:
-  SmootherTest() {SetUp();}
+public:
+  SmootherTest() {}
   ~SmootherTest() {}
 
-  void SetUp()
+  void SetUp() override
   {
-    node_lifecycle_ =
-      std::make_shared<rclcpp_lifecycle::LifecycleNode>(
+    node_ =
+      std::make_shared<rclcpp::Node>(
       "LifecycleSmootherTestNode", rclcpp::NodeOptions());
 
     smoother_server_ = std::make_shared<DummySmootherServer>();
@@ -252,10 +247,10 @@ protected:
     smoother_server_->activate();
 
     client_ = rclcpp_action::create_client<SmoothAction>(
-      node_lifecycle_->get_node_base_interface(),
-      node_lifecycle_->get_node_graph_interface(),
-      node_lifecycle_->get_node_logging_interface(),
-      node_lifecycle_->get_node_waitables_interface(), "smooth_path");
+      node_->get_node_base_interface(),
+      node_->get_node_graph_interface(),
+      node_->get_node_logging_interface(),
+      node_->get_node_waitables_interface(), "smooth_path");
     std::cout << "Setup complete." << std::endl;
   }
 
@@ -264,6 +259,9 @@ protected:
     smoother_server_->deactivate();
     smoother_server_->cleanup();
     smoother_server_->shutdown();
+    smoother_server_.reset();
+    client_.reset();
+    node_.reset();
   }
 
   bool sendGoal(
@@ -291,7 +289,7 @@ protected:
 
     auto future_goal = client_->async_send_goal(goal);
 
-    if (rclcpp::spin_until_future_complete(node_lifecycle_, future_goal) !=
+    if (rclcpp::spin_until_future_complete(node_, future_goal) !=
       rclcpp::FutureReturnCode::SUCCESS)
     {
       std::cout << "failed sending goal" << std::endl;
@@ -315,12 +313,12 @@ protected:
     std::cout << "Getting async result..." << std::endl;
     auto future_result = client_->async_get_result(goal_handle_);
     std::cout << "Waiting on future..." << std::endl;
-    rclcpp::spin_until_future_complete(node_lifecycle_, future_result);
+    rclcpp::spin_until_future_complete(node_, future_result);
     std::cout << "future received!" << std::endl;
     return future_result.get();
   }
 
-  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node_lifecycle_;
+  std::shared_ptr<rclcpp::Node> node_;
   std::shared_ptr<DummySmootherServer> smoother_server_;
   std::shared_ptr<rclcpp_action::Client<SmoothAction>> client_;
   std::shared_ptr<rclcpp_action::ClientGoalHandle<SmoothAction>> goal_handle_;
@@ -387,7 +385,7 @@ TEST_F(SmootherTest, testingCollisionCheckDisabled)
   SUCCEED();
 }
 
-TEST_F(SmootherConfigTest, testingConfigureSuccessWithValidSmootherPlugin)
+TEST(SmootherConfigTest, testingConfigureSuccessWithValidSmootherPlugin)
 {
   auto smoother_server = std::make_shared<DummySmootherServer>();
   smoother_server->set_parameter(
@@ -402,7 +400,7 @@ TEST_F(SmootherConfigTest, testingConfigureSuccessWithValidSmootherPlugin)
   SUCCEED();
 }
 
-TEST_F(SmootherConfigTest, testingConfigureFailureWithInvalidSmootherPlugin)
+TEST(SmootherConfigTest, testingConfigureFailureWithInvalidSmootherPlugin)
 {
   auto smoother_server = std::make_shared<DummySmootherServer>();
   smoother_server->set_parameter(
@@ -417,7 +415,7 @@ TEST_F(SmootherConfigTest, testingConfigureFailureWithInvalidSmootherPlugin)
   SUCCEED();
 }
 
-TEST_F(SmootherConfigTest, testingConfigureSuccessWithDefaultPlugin)
+TEST(SmootherConfigTest, testingConfigureSuccessWithDefaultPlugin)
 {
   auto smoother_server = std::make_shared<DummySmootherServer>();
   auto state = smoother_server->configure();


### PR DESCRIPTION
Requires https://github.com/BehaviorTree/BehaviorTree.CPP/pull/579 to be merged + released to build but resolves https://github.com/ros-planning/navigation2/issues/3310

Fixes 
- CI failures related to BT.CPP unit tests
- CI failures related to the smoother server