### PR TITLE
Compile flags non-virtual-destructor

### DIFF
--- a/nav2_common/cmake/nav2_package.cmake
+++ b/nav2_common/cmake/nav2_package.cmake
@@ -39,12 +39,6 @@ macro(nav2_package)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Woverloaded-virtual -Wnon-virtual-dtor -Wcast-align -Wunused -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches)
   endif()
-  # Wold-style-cast used in Throttle
-  # Wconversion breaks alot of things
-  # Wuseless cast
-  # double promotation
-  # Wnull-dereference denosie layer
-
 
   option(COVERAGE_ENABLED "Enable code coverage" FALSE)
   if(COVERAGE_ENABLED)

--- a/nav2_common/cmake/nav2_package.cmake
+++ b/nav2_common/cmake/nav2_package.cmake
@@ -37,8 +37,14 @@ macro(nav2_package)
   endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Woverloaded-virtual -Wnon-virtual-dtor -Wcast-align -Wunused -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches)
   endif()
+  # Wold-style-cast used in Throttle
+  # Wconversion breaks alot of things
+  # Wuseless cast
+  # double promotation
+  # Wnull-dereference denosie layer
+
 
   option(COVERAGE_ENABLED "Enable code coverage" FALSE)
   if(COVERAGE_ENABLED)

--- a/nav2_common/cmake/nav2_package.cmake
+++ b/nav2_common/cmake/nav2_package.cmake
@@ -37,7 +37,7 @@ macro(nav2_package)
   endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Woverloaded-virtual -Wnon-virtual-dtor -Wcast-align -Wunused -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wnon-virtual-dtor)
   endif()
 
   option(COVERAGE_ENABLED "Enable code coverage" FALSE)

--- a/nav2_core/include/nav2_core/behavior_tree_navigator.hpp
+++ b/nav2_core/include/nav2_core/behavior_tree_navigator.hpp
@@ -117,7 +117,7 @@ class NavigatorBase
 {
 public:
   NavigatorBase() = default;
-  ~NavigatorBase() = default;
+  virtual ~NavigatorBase() = default;
 
   /**
    * @brief Configuration of the navigator's backend BT and actions

--- a/nav2_dwb_controller/costmap_queue/include/costmap_queue/map_based_queue.hpp
+++ b/nav2_dwb_controller/costmap_queue/include/costmap_queue/map_based_queue.hpp
@@ -69,7 +69,7 @@ public:
   {
     reset();
   }
-  
+
   /**
    * @brief Default virtual Destructor
    */

--- a/nav2_dwb_controller/costmap_queue/include/costmap_queue/map_based_queue.hpp
+++ b/nav2_dwb_controller/costmap_queue/include/costmap_queue/map_based_queue.hpp
@@ -69,6 +69,11 @@ public:
   {
     reset();
   }
+  
+  /**
+   * @brief Default virtual Destructor
+   */
+  virtual ~MapBasedQueue() = default;
 
   /**
    * @brief Clear the queue

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critic_manager.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critic_manager.hpp
@@ -47,6 +47,8 @@ public:
     */
   CriticManager() = default;
 
+  virtual ~CriticManager() = default;
+
   /**
     * @brief Configure critic manager on bringup and load plugins
     * @param parent WeakPtr to node
@@ -73,14 +75,13 @@ protected:
   /**
     * @brief Load the critic plugins
     */
-  virtual void loadCritics();
+  void loadCritics();
 
   /**
     * @brief Get full-name namespaced critic IDs
     */
   std::string getFullName(const std::string & name);
 
-protected:
   rclcpp_lifecycle::LifecycleNode::WeakPtr parent_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   std::string name_;

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critic_manager.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critic_manager.hpp
@@ -47,6 +47,10 @@ public:
     */
   CriticManager() = default;
 
+
+  /**
+    * @brief Virtual Destructor for mppi::CriticManager
+    */
   virtual ~CriticManager() = default;
 
   /**
@@ -75,13 +79,14 @@ protected:
   /**
     * @brief Load the critic plugins
     */
-  void loadCritics();
+  virtual void loadCritics();
 
   /**
     * @brief Get full-name namespaced critic IDs
     */
   std::string getFullName(const std::string & name);
 
+protected:
   rclcpp_lifecycle::LifecycleNode::WeakPtr parent_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   std::string name_;

--- a/nav2_mppi_controller/test/critic_manager_test.cpp
+++ b/nav2_mppi_controller/test/critic_manager_test.cpp
@@ -80,7 +80,7 @@ public:
   CriticManagerWrapperEnum()
   : CriticManager() {}
 
-  // virtual ~CriticManagerWrapperEnum() = default;
+  virtual ~CriticManagerWrapperEnum() = default;
 
   unsigned int getCriticNum()
   {

--- a/nav2_mppi_controller/test/critic_manager_test.cpp
+++ b/nav2_mppi_controller/test/critic_manager_test.cpp
@@ -46,6 +46,8 @@ public:
   CriticManagerWrapper()
   : CriticManager() {}
 
+  virtual ~CriticManagerWrapper() = default;
+
   virtual void loadCritics()
   {
     critics_.clear();
@@ -77,6 +79,8 @@ class CriticManagerWrapperEnum : public CriticManager
 public:
   CriticManagerWrapperEnum()
   : CriticManager() {}
+
+  // virtual ~CriticManagerWrapperEnum() = default;
 
   unsigned int getCriticNum()
   {

--- a/nav2_system_tests/src/behavior_tree/dummy_action_server.hpp
+++ b/nav2_system_tests/src/behavior_tree/dummy_action_server.hpp
@@ -55,6 +55,7 @@ public:
       std::bind(&DummyActionServer::handle_accepted, this, _1));
   }
 
+  virtual ~DummyActionServer() = default;
   void setFailureRanges(const Ranges & failureRanges)
   {
     failure_ranges_ = failureRanges;

--- a/nav2_system_tests/src/behavior_tree/dummy_service.hpp
+++ b/nav2_system_tests/src/behavior_tree/dummy_service.hpp
@@ -44,6 +44,8 @@ public:
       std::bind(&DummyService::handle_service, this, _1, _2, _3));
   }
 
+  virtual ~DummyService() = default;
+
   void disable()
   {
     service_.reset();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NONE |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | NONE |

---

## Description of contribution in a few bullet points
Added the flag non-virtual destructor to the compile flags. This flag warns the user if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points
Future compile flags could be added from https://github.com/cpp-best-practices/cppbestpractices/blob/master/02-Use_the_Tools_Available.md. 

Adding flags from this list might be a good first issue. 


<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
