### PR TITLE
Option for ObstacleLayer to not override StaticLayer's unknown parts

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/cost_values.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/cost_values.hpp
@@ -39,6 +39,34 @@
 /** Provides a mapping for often used cost values */
 namespace nav2_costmap_2d
 {
+
+/**
+ * @enum nav2_costmap_2d::CombinationMethod
+ * @brief Describes the method used to add data to master costmap, default to maximum.
+ */
+enum class CombinationMethod : int
+{
+  /**
+   * Overwrite means every valid value from this layer
+   * is written into the master grid (does not copy NO_INFORMATION)
+   */
+  Overwrite = 0,
+  /**
+   * Sets the new value to the maximum of the master_grid's value
+   * and this layer's value. If the master value is NO_INFORMATION,
+   * it is overwritten. If the layer's value is NO_INFORMATION,
+   * the master value does not change
+   */
+  Max = 1,
+  /**
+   * Sets the new value to the maximum of the master_grid's value
+   * and this layer's value. If the master value is NO_INFORMATION,
+   * it is NOT overwritten. If the layer's value is NO_INFORMATION,
+   * the master value does not change.
+   */
+  MaxWithoutUnknownOverwrite = 2
+};
+
 static constexpr unsigned char NO_INFORMATION = 255;
 static constexpr unsigned char LETHAL_OBSTACLE = 254;
 static constexpr unsigned char INSCRIBED_INFLATED_OBSTACLE = 253;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
@@ -132,6 +132,19 @@ protected:
    * Updates the master_grid within the specified
    * bounding box using this layer's values.
    *
+   * Sets the new value to the maximum of the master_grid's value
+   * and this layer's value. If the master value is NO_INFORMATION,
+   * it is NOT overwritten. If the layer's value is NO_INFORMATION,
+   * the master value does not change.
+   */
+  void updateWithMaxWithoutUnknownOverride(
+    nav2_costmap_2d::Costmap2D & master_grid, int min_i, int min_j, int max_i,
+    int max_j);
+
+  /*
+   * Updates the master_grid within the specified
+   * bounding box using this layer's values.
+   *
    * Sets the new value to the sum of the master grid's value
    * and this layer's value. If the master value is NO_INFORMATION,
    * it is overwritten with the layer's value. If the layer's value

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
@@ -185,6 +185,13 @@ protected:
   void useExtraBounds(double * min_x, double * min_y, double * max_x, double * max_y);
   bool has_extra_bounds_;
 
+    /**
+   * @brief Converts an integer to a CombinationMethod enum and logs on failure
+   * @param value The integer to convert
+   * @param function_name The name of the function calling this conversion (for logging)
+   */
+  CombinationMethod combination_method_from_int (const int value);
+
 private:
   double extra_min_x_, extra_max_x_, extra_min_y_, extra_max_y_;
 };

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
@@ -137,7 +137,7 @@ protected:
    * it is NOT overwritten. If the layer's value is NO_INFORMATION,
    * the master value does not change.
    */
-  void updateWithMaxWithoutUnknownOverride(
+  void updateWithMaxWithoutUnknownOverwrite(
     nav2_costmap_2d::Costmap2D & master_grid, int min_i, int min_j, int max_i,
     int max_j);
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_layer.hpp
@@ -185,12 +185,12 @@ protected:
   void useExtraBounds(double * min_x, double * min_y, double * max_x, double * max_y);
   bool has_extra_bounds_;
 
-    /**
-   * @brief Converts an integer to a CombinationMethod enum and logs on failure
-   * @param value The integer to convert
-   * @param function_name The name of the function calling this conversion (for logging)
-   */
-  CombinationMethod combination_method_from_int (const int value);
+  /**
+ * @brief Converts an integer to a CombinationMethod enum and logs on failure
+ * @param value The integer to convert
+ * @param function_name The name of the function calling this conversion (for logging)
+ */
+  CombinationMethod combination_method_from_int(const int value);
 
 private:
   double extra_min_x_, extra_max_x_, extra_min_y_, extra_max_y_;

--- a/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
@@ -62,39 +62,6 @@ namespace nav2_costmap_2d
 {
 
 /**
- * @enum nav2_costmap_2d::CombinationMethod
- * @brief Describes the method used to add data to master costmap, default to maximum.
- */
-enum class CombinationMethod : int
-{
-  /**
-   * Overwrite means every valid value from this layer
-   * is written into the master grid (does not copy NO_INFORMATION)
-   */
-  Overwrite = 0,
-  /**
-   * Sets the new value to the maximum of the master_grid's value
-   * and this layer's value. If the master value is NO_INFORMATION,
-   * it is overwritten. If the layer's value is NO_INFORMATION,
-   * the master value does not change
-   */
-  Max = 1,
-  /**
-   * Sets the new value to the maximum of the master_grid's value
-   * and this layer's value. If the master value is NO_INFORMATION,
-   * it is NOT overwritten. If the layer's value is NO_INFORMATION,
-   * the master value does not change.
-   */
-  MaxWithoutUnknownOverwrite = 2
-};
-  /**
-   * @brief Converts an integer to a CombinationMethod enum and logs on failure
-   * @param value The integer to convert
-   * @param function_name The name of the function calling this conversion (for logging)
-   */
-CombinationMethod combination_method_from_int (const int value, const std::string function_name);
-
-/**
  * @class ObstacleLayer
  * @brief Takes in laser and pointcloud data to populate into 2D costmap
  */

--- a/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
@@ -62,6 +62,37 @@ namespace nav2_costmap_2d
 {
 
 /**
+ * @enum nav2_costmap_2d::CombinationMethod
+ * @brief Describes the method used to add data to master costmap, default to maximum.
+ */
+enum class CombinationMethod : int
+{
+  /**
+   * Overwrite means every valid value from this layer
+   * is written into the master grid (does not copy NO_INFORMATION)
+   */
+  Overwrite = 0,
+  /**
+   * Sets the new value to the maximum of the master_grid's value
+   * and this layer's value. If the master value is NO_INFORMATION,
+   * it is overwritten. If the layer's value is NO_INFORMATION,
+   * the master value does not change
+   */
+  Max = 1,
+  /**
+   * Sets the new value to the maximum of the master_grid's value
+   * and this layer's value. If the master value is NO_INFORMATION,
+   * it is NOT overwritten. If the layer's value is NO_INFORMATION,
+   * the master value does not change.
+   */
+  MaxWithoutUnknownOverride = 2
+};
+  /**
+   * @brief Converts an integer to a CombinationMethod enum and logs on failure
+   */
+CombinationMethod combination_method_from_int (const int value, const std::string function_name);
+
+/**
  * @class ObstacleLayer
  * @brief Takes in laser and pointcloud data to populate into 2D costmap
  */
@@ -252,7 +283,7 @@ protected:
 
   bool rolling_window_;
   bool was_reset_;
-  int combination_method_;
+  nav2_costmap_2d::CombinationMethod combination_method_;
 };
 
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
@@ -85,7 +85,7 @@ enum class CombinationMethod : int
    * it is NOT overwritten. If the layer's value is NO_INFORMATION,
    * the master value does not change.
    */
-  MaxWithoutUnknownOverride = 2
+  MaxWithoutUnknownOverwrite = 2
 };
   /**
    * @brief Converts an integer to a CombinationMethod enum and logs on failure

--- a/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/obstacle_layer.hpp
@@ -89,6 +89,8 @@ enum class CombinationMethod : int
 };
   /**
    * @brief Converts an integer to a CombinationMethod enum and logs on failure
+   * @param value The integer to convert
+   * @param function_name The name of the function calling this conversion (for logging)
    */
 CombinationMethod combination_method_from_int (const int value, const std::string function_name);
 

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -546,6 +546,8 @@ ObstacleLayer::updateCosts(
     case 1:  // Maximum
       updateWithMax(master_grid, min_i, min_j, max_i, max_j);
       break;
+    case 2: // Maximum without overwrite if unknown
+      updateWithMaxWithoutUnknownOverride(master_grid, min_i, min_j, max_i, max_j);
     default:  // Nothing
       break;
   }

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -551,8 +551,8 @@ ObstacleLayer::updateCosts(
     case CombinationMethod::Max:
       updateWithMax(master_grid, min_i, min_j, max_i, max_j);
       break;
-    case CombinationMethod::MaxWithoutUnknownOverride:
-      updateWithMaxWithoutUnknownOverride(master_grid, min_i, min_j, max_i, max_j);
+    case CombinationMethod::MaxWithoutUnknownOverwrite:
+      updateWithMaxWithoutUnknownOverwrite(master_grid, min_i, min_j, max_i, max_j);
       break;
     default:  // Nothing
       break;
@@ -775,7 +775,7 @@ CombinationMethod combination_method_from_int (const int value, const std::strin
     case 1:
       return CombinationMethod::Max;
     case 2:
-      return CombinationMethod::MaxWithoutUnknownOverride;
+      return CombinationMethod::MaxWithoutUnknownOverwrite;
     default:
       RCLCPP_WARN(
         rclcpp::get_logger("nav2_costmap_2d"),

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -98,8 +98,7 @@ void ObstacleLayer::onInitialize()
 
   int combination_method_param{};
   node->get_parameter(name_ + "." + "combination_method", combination_method_param);
-  combination_method_ = combination_method_from_int(combination_method_param,
-    "ObstacleLayer::onInitialize()");
+  combination_method_ = combination_method_from_int(combination_method_param);
 
   dyn_params_handler_ = node->add_on_set_parameters_callback(
     std::bind(
@@ -315,8 +314,7 @@ ObstacleLayer::dynamicParametersCallback(
       }
     } else if (param_type == ParameterType::PARAMETER_INTEGER) {
       if (param_name == name_ + "." + "combination_method") {
-        combination_method_ = combination_method_from_int(parameter.as_int(), "ObstacleLayer::"
-          "dynamicParametersCallback()");
+        combination_method_ = combination_method_from_int(parameter.as_int());
       }
     }
   }
@@ -765,24 +763,6 @@ ObstacleLayer::resetBuffersLastUpdated()
     if (observation_buffers_[i]) {
       observation_buffers_[i]->resetLastUpdated();
     }
-  }
-}
-
-CombinationMethod combination_method_from_int (const int value, const std::string function_name){
-    switch(value){
-    case 0:
-      return CombinationMethod::Overwrite;
-    case 1:
-      return CombinationMethod::Max;
-    case 2:
-      return CombinationMethod::MaxWithoutUnknownOverwrite;
-    default:
-      RCLCPP_WARN(
-        rclcpp::get_logger("nav2_costmap_2d"),
-        (function_name + ": param combination_method: %i. Possible values are  0 (Overwrite) or 1 (Maximum) or "
-        "2 (Maximum without overwriting the master's NO_INFORMATION values)."
-        "The default value 1 will be used").c_str(), value);
-      return CombinationMethod::Max;
   }
 }
 

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -548,6 +548,7 @@ ObstacleLayer::updateCosts(
       break;
     case 2: // Maximum without overwrite if unknown
       updateWithMaxWithoutUnknownOverride(master_grid, min_i, min_j, max_i, max_j);
+      break;
     default:  // Nothing
       break;
   }

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -90,8 +90,7 @@ void VoxelLayer::onInitialize()
 
   int combination_method_param{};
   node->get_parameter(name_ + "." + "combination_method", combination_method_param);
-  combination_method_ = combination_method_from_int(combination_method_param,
-    "VoxelLayer::onInitialize()");
+  combination_method_ = combination_method_from_int(combination_method_param);
 
   auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();
 
@@ -526,8 +525,7 @@ VoxelLayer::dynamicParametersCallback(
       } else if (param_name == name_ + "." + "mark_threshold") {
         mark_threshold_ = parameter.as_int();
       } else if (param_name == name_ + "." + "combination_method") {
-        combination_method_ = combination_method_from_int(parameter.as_int(), "VoxelLayer::"
-          "dynamicParametersCallback()");
+        combination_method_ = combination_method_from_int(parameter.as_int());
       }
     }
   }

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -86,8 +86,12 @@ void VoxelLayer::onInitialize()
   node->get_parameter(name_ + "." + "z_resolution", z_resolution_);
   node->get_parameter(name_ + "." + "unknown_threshold", unknown_threshold_);
   node->get_parameter(name_ + "." + "mark_threshold", mark_threshold_);
-  node->get_parameter(name_ + "." + "combination_method", combination_method_);
   node->get_parameter(name_ + "." + "publish_voxel_map", publish_voxel_);
+
+  int combination_method_param{};
+  node->get_parameter(name_ + "." + "combination_method", combination_method_param);
+  combination_method_ = combination_method_from_int(combination_method_param,
+    "VoxelLayer::onInitialize()");
 
   auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();
 
@@ -522,7 +526,8 @@ VoxelLayer::dynamicParametersCallback(
       } else if (param_name == name_ + "." + "mark_threshold") {
         mark_threshold_ = parameter.as_int();
       } else if (param_name == name_ + "." + "combination_method") {
-        combination_method_ = parameter.as_int();
+        combination_method_ = combination_method_from_int(parameter.as_int(), "VoxelLayer::"
+          "dynamicParametersCallback()");
       }
     }
   }

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -245,4 +245,22 @@ void CostmapLayer::updateWithAddition(
     }
   }
 }
+
+CombinationMethod CostmapLayer::combination_method_from_int (const int value){
+    switch(value){
+    case 0:
+      return CombinationMethod::Overwrite;
+    case 1:
+      return CombinationMethod::Max;
+    case 2:
+      return CombinationMethod::MaxWithoutUnknownOverwrite;
+    default:
+      RCLCPP_WARN(
+        rclcpp::get_logger("nav2_costmap_2d"),
+        "Param combination_method: %i. Possible values are  0 (Overwrite) or 1 (Maximum) or "
+        "2 (Maximum without overwriting the master's NO_INFORMATION values)."
+        "The default value 1 will be used", value);
+      return CombinationMethod::Max;
+  }
+}
 }  // namespace nav2_costmap_2d

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -256,7 +256,7 @@ CombinationMethod CostmapLayer::combination_method_from_int (const int value){
       return CombinationMethod::MaxWithoutUnknownOverwrite;
     default:
       RCLCPP_WARN(
-        rclcpp::get_logger("nav2_costmap_2d"),
+        logger_,
         "Param combination_method: %i. Possible values are  0 (Overwrite) or 1 (Maximum) or "
         "2 (Maximum without overwriting the master's NO_INFORMATION values)."
         "The default value 1 will be used", value);

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -246,8 +246,9 @@ void CostmapLayer::updateWithAddition(
   }
 }
 
-CombinationMethod CostmapLayer::combination_method_from_int (const int value){
-    switch(value){
+CombinationMethod CostmapLayer::combination_method_from_int(const int value)
+{
+  switch (value) {
     case 0:
       return CombinationMethod::Overwrite;
     case 1:

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -157,7 +157,7 @@ void CostmapLayer::updateWithMaxWithoutUnknownOverride(
       }
 
       unsigned char old_cost = master_array[it];
-      if (old_cost < costmap_[it]) {
+      if (old_cost != NO_INFORMATION && old_cost < costmap_[it]) {
         master_array[it] = costmap_[it];
       }
       it++;

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -136,6 +136,35 @@ void CostmapLayer::updateWithMax(
   }
 }
 
+void CostmapLayer::updateWithMaxWithoutUnknownOverride(
+  nav2_costmap_2d::Costmap2D & master_grid, int min_i, int min_j,
+  int max_i,
+  int max_j)
+{
+  if (!enabled_) {
+    return;
+  }
+
+  unsigned char * master_array = master_grid.getCharMap();
+  unsigned int span = master_grid.getSizeInCellsX();
+
+  for (int j = min_j; j < max_j; j++) {
+    unsigned int it = j * span + min_i;
+    for (int i = min_i; i < max_i; i++) {
+      if (costmap_[it] == NO_INFORMATION) {
+        it++;
+        continue;
+      }
+
+      unsigned char old_cost = master_array[it];
+      if (old_cost < costmap_[it]) {
+        master_array[it] = costmap_[it];
+      }
+      it++;
+    }
+  }
+}
+
 void CostmapLayer::updateWithTrueOverwrite(
   nav2_costmap_2d::Costmap2D & master_grid, int min_i,
   int min_j,

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -136,7 +136,7 @@ void CostmapLayer::updateWithMax(
   }
 }
 
-void CostmapLayer::updateWithMaxWithoutUnknownOverride(
+void CostmapLayer::updateWithMaxWithoutUnknownOverwrite(
   nav2_costmap_2d::Costmap2D & master_grid, int min_i, int min_j,
   int max_i,
   int max_j)

--- a/nav2_costmap_2d/test/integration/obstacle_tests.cpp
+++ b/nav2_costmap_2d/test/integration/obstacle_tests.cpp
@@ -554,3 +554,50 @@ TEST_F(TestNode, testDynParamsSetStatic)
   costmap->on_cleanup(rclcpp_lifecycle::State());
   costmap->on_shutdown(rclcpp_lifecycle::State());
 }
+
+
+class TestNodeWithoutUnknownOverwrite : public ::testing::Test
+{
+public:
+  TestNodeWithoutUnknownOverwrite()
+  {
+    node_ = std::make_shared<TestLifecycleNode>("obstacle_test_node");
+    node_->declare_parameter("track_unknown_space", rclcpp::ParameterValue(true));
+    node_->declare_parameter("lethal_cost_threshold", rclcpp::ParameterValue(100));
+    node_->declare_parameter("trinary_costmap", rclcpp::ParameterValue(true));
+    node_->declare_parameter("transform_tolerance", rclcpp::ParameterValue(0.3));
+    node_->declare_parameter("observation_sources", rclcpp::ParameterValue(std::string("")));
+    // MaxWithoutUnknownOverwrite
+    node_->declare_parameter("obstacles.combination_method", rclcpp::ParameterValue(2));
+  }
+
+  ~TestNodeWithoutUnknownOverwrite() {}
+
+protected:
+  std::shared_ptr<TestLifecycleNode> node_;
+};
+
+/**
+ * Test CombinationMethod::MaxWithoutUnknownOverwrite in ObstacleLayer.
+ */
+TEST_F(TestNodeWithoutUnknownOverwrite, testMaxWithoutUnknownOverwriteCombinationMethod) {
+  tf2_ros::Buffer tf(node_->get_clock());
+
+  // Create a costmap with full unknown space
+  nav2_costmap_2d::LayeredCostmap layers("frame", false, true);
+  layers.resizeMap(10, 10, 1, 0, 0);
+
+  std::shared_ptr<nav2_costmap_2d::ObstacleLayer> olayer = nullptr;
+  addObstacleLayer(layers, tf, node_, olayer);
+
+  addObservation(olayer, 0.0, 0.0, MAX_Z / 2, 0, 0, MAX_Z / 2);
+
+  // The observation tries to set the cost of the cell to 254, but since it is unknown, it should
+  // remain unknown.
+  layers.updateMap(0, 0, 0);  // 0, 0, 0 is robot pose
+  // printMap(*(layers.getCostmap()));
+
+  int unknown_count = countValues(*(layers.getCostmap()), nav2_costmap_2d::NO_INFORMATION);
+
+  ASSERT_EQ(unknown_count, 100);
+}

--- a/nav2_costmap_2d/test/integration/obstacle_tests.cpp
+++ b/nav2_costmap_2d/test/integration/obstacle_tests.cpp
@@ -556,6 +556,30 @@ TEST_F(TestNode, testDynParamsSetStatic)
 }
 
 
+/**
+ * Test CombinationMethod::Max overwrites unknown value in ObstacleLayer.
+ */
+TEST_F(TestNode, testMaxCombinationMethod) {
+  tf2_ros::Buffer tf(node_->get_clock());
+
+  // Create a costmap with full unknown space
+  nav2_costmap_2d::LayeredCostmap layers("frame", false, true);
+  layers.resizeMap(10, 10, 1, 0, 0);
+
+  std::shared_ptr<nav2_costmap_2d::ObstacleLayer> olayer = nullptr;
+  addObstacleLayer(layers, tf, node_, olayer);
+
+  addObservation(olayer, 0.0, 0.0, MAX_Z / 2, 0, 0, MAX_Z / 2);
+
+  // The observation sets the cost of the cell to 254
+  layers.updateMap(0, 0, 0);  // 0, 0, 0 is robot pose
+  // printMap(*(layers.getCostmap()));
+
+  int unknown_count = countValues(*(layers.getCostmap()), nav2_costmap_2d::NO_INFORMATION);
+
+  ASSERT_EQ(unknown_count, 99);
+}
+
 class TestNodeWithoutUnknownOverwrite : public ::testing::Test
 {
 public:


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [#3603](https://github.com/ros-planning/navigation2/issues/3603) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points


* I added an updateWithMaxWithoutUnknownOverride method to the CostmapLayer
* I added an value option to the ObstacleLayer's  combination_method parameter that uses the previous method.
<!--
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes


* Added new parameter value, so need to add that to the documentation page
* <!--
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
