### PR TITLE
Only apply Wnon-virtual-dtor if the compile language is CXX

### DIFF
--- a/nav2_common/cmake/nav2_package.cmake
+++ b/nav2_common/cmake/nav2_package.cmake
@@ -37,7 +37,8 @@ macro(nav2_package)
   endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wnon-virtual-dtor)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC )
+    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>")
   endif()
 
   option(COVERAGE_ENABLED "Enable code coverage" FALSE)


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [(discovered here)](https://github.com/ros-planning/navigation2/pull/3609#issuecomment-1585120435) |
| Primary OS tested on | Ubuntu 22.04 |

---

## Description of contribution in a few bullet points

The recently added flag `Wnon-virtual-dtor` only applies to C++. It was applied to the whole build, rather than only the targets that are compiled with C++. Since `nav2_amcl` has C sources, this was failing on my computer.

Reference: https://stackoverflow.com/questions/25525047/cmake-generator-expression-differentiate-c-c-code

To test the generator is still applying the flag, I undid some of the changes earlier, such as adding the `virtual` keyword to destructor for `NavigatorBase`, and it failed to compile, as desired. 

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
