### PR TITLE
add -Wnull-dereference and fix warnings

### DIFF
--- a/nav2_common/cmake/nav2_package.cmake
+++ b/nav2_common/cmake/nav2_package.cmake
@@ -37,7 +37,7 @@ macro(nav2_package)
   endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference)
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>")
   endif()
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/denoise/image_processing.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/denoise/image_processing.hpp
@@ -999,7 +999,10 @@ private:
     // The group of pixels labeled 0 corresponds to empty map cells.
     // Zero bin of the histogram is equal to the number of pixels in this group.
     // Because the values of empty map cells should not be changed, we will reset this bin
-    groups_sizes.front() = 0;  // don't change image background value
+    if (!groups_sizes.empty()) {
+      groups_sizes.front() = 0;  // don't change image background value
+    }
+
 
     // noise_labels_table[i] = true if group with label i is noise
     std::vector<bool> noise_labels_table(groups_sizes.size());

--- a/nav2_mppi_controller/test/critic_manager_test.cpp
+++ b/nav2_mppi_controller/test/critic_manager_test.cpp
@@ -65,12 +65,22 @@ public:
 
   bool getDummyCriticInitialized()
   {
-    return dynamic_cast<DummyCritic *>(critics_[0].get())->initialized_;
+    const auto critic = critics_[0].get();
+    if (critic == nullptr) {
+      return false;
+    }
+    const auto dummy_critic = dynamic_cast<DummyCritic *>(critic);
+    return dummy_critic == nullptr ? false : dummy_critic->initialized_;
   }
 
   bool getDummyCriticScored()
   {
-    return dynamic_cast<DummyCritic *>(critics_[0].get())->scored_;
+    const auto critic = critics_[0].get();
+    if (critic == nullptr) {
+      return false;
+    }
+    const auto dummy_critic = dynamic_cast<DummyCritic *>(critic);
+    return dummy_critic == nullptr ? false : dummy_critic->scored_;
   }
 };
 


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (None) |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | N/A |

---

## Description of contribution in a few bullet points
 Add Wnull-derefence warning  to compiler and fix it

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
