### PR TITLE
updating mppi's path angle critic for optional bidirectionality

### DIFF
--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -112,7 +112,6 @@ This process is then repeated a number of times and returns a converged solution
  | trajectory_point_step      | double | Default 4. Step of trajectory points to evaluate for path distance to reduce compute time. Between 1-10 is typically reasonable.   |
  | max_path_occupancy_ratio   | double | Default 0.07 (7%). Maximum proportion of the path that can be occupied before this critic is not considered to allow the obstacle and path follow critics to avoid obstacles while following the path's intent in presence of dynamic objects in the scene.  |
 
-
 #### Path Angle Critic
  | Parameter                 | Type   | Definition                                                                                                  |
  | ---------------           | ------ | ----------------------------------------------------------------------------------------------------------- |
@@ -121,6 +120,8 @@ This process is then repeated a number of times and returns a converged solution
  | threshold_to_consider     | double | Default 0.4. Distance between robot and goal above which path angle cost stops being considered             |
  | offset_from_furthest      | int    | Default 4. Number of path points after furthest one any trajectory achieves to compute path angle relative to.  |
  | max_angle_to_furthest     | double | Default 1.2. Angular distance between robot and goal above which path angle cost starts being considered           |
+ | forward_preference     | bool | Default true. Whether or not your robot has a preference for which way is forward in motion. Different from if reversing is generally allowed, but if you robot contains *no* particular preference one way or another.           |
+
 
 #### Path Follow Critic
  | Parameter             | Type   | Definition                                                                                                  |

--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -224,6 +224,7 @@ controller_server:
         offset_from_furthest: 4
         threshold_to_consider: 0.40
         max_angle_to_furthest: 1.0
+        forward_preference: true
       # TwirlingCritic:
       #   enabled: true
       #   twirling_cost_power: 1

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_angle_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_angle_critic.hpp
@@ -48,6 +48,8 @@ protected:
   float threshold_to_consider_{0};
 
   size_t offset_from_furthest_{0};
+  bool reversing_allowed_{true};
+  bool forward_preference_{true};
 
   unsigned int power_{0};
   float weight_{0};

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
@@ -416,15 +416,25 @@ inline void setPathCostsIfNotSet(
  * @param pose pose
  * @param point_x Point to find angle relative to X axis
  * @param point_y Point to find angle relative to Y axis
+ * @param forward_preference If reversing direction is valid
  * @return Angle between two points
  */
-inline double posePointAngle(const geometry_msgs::msg::Pose & pose, double point_x, double point_y)
+inline double posePointAngle(
+  const geometry_msgs::msg::Pose & pose, double point_x, double point_y, bool forward_preference)
 {
   double pose_x = pose.position.x;
   double pose_y = pose.position.y;
   double pose_yaw = tf2::getYaw(pose.orientation);
 
   double yaw = atan2(point_y - pose_y, point_x - pose_x);
+
+  // If no preference for forward, return smallest angle either in heading or 180 of heading
+  if (!forward_preference) {
+    return std::min(
+      abs(angles::shortest_angular_distance(yaw, pose_yaw)),
+      abs(angles::shortest_angular_distance(yaw, pose_yaw + M_PI)));
+  }
+
   return abs(angles::shortest_angular_distance(yaw, pose_yaw));
 }
 

--- a/nav2_mppi_controller/src/critics/constraint_critic.cpp
+++ b/nav2_mppi_controller/src/critics/constraint_critic.cpp
@@ -28,15 +28,14 @@ void ConstraintCritic::initialize()
     logger_, "ConstraintCritic instantiated with %d power and %f weight.",
     power_, weight_);
 
-  float vx_max, vy_max, vx_min, vy_min;
+  float vx_max, vy_max, vx_min;
   getParentParam(vx_max, "vx_max", 0.5);
   getParentParam(vy_max, "vy_max", 0.0);
   getParentParam(vx_min, "vx_min", -0.35);
-  getParentParam(vy_min, "vy_min", 0.0);
 
   const float min_sgn = vx_min > 0.0 ? 1.0 : -1.0;
   max_vel_ = std::sqrt(vx_max * vx_max + vy_max * vy_max);
-  min_vel_ = min_sgn * std::sqrt(vx_min * vx_min + vy_min * vy_min);
+  min_vel_ = min_sgn * std::sqrt(vx_min * vx_min + vy_max * vy_max);
 }
 
 void ConstraintCritic::score(CriticData & data)

--- a/nav2_mppi_controller/test/utils_test.cpp
+++ b/nav2_mppi_controller/test/utils_test.cpp
@@ -195,7 +195,14 @@ TEST(UtilsTests, AnglesTests)
   pose.position.y = 0.0;
   pose.orientation.w = 1.0;
   double point_x = 1.0, point_y = 0.0;
-  EXPECT_NEAR(posePointAngle(pose, point_x, point_y), 0.0, 1e-6);
+  bool forward_preference = true;
+  EXPECT_NEAR(posePointAngle(pose, point_x, point_y, forward_preference), 0.0, 1e-6);
+  forward_preference = false;
+  EXPECT_NEAR(posePointAngle(pose, point_x, point_y, forward_preference), 0.0, 1e-6);
+  point_x = -1.0;
+  EXPECT_NEAR(posePointAngle(pose, point_x, point_y, forward_preference), 0.0, 1e-6);
+  forward_preference = true;
+  EXPECT_NEAR(posePointAngle(pose, point_x, point_y, forward_preference), M_PI, 1e-6);
 }
 
 TEST(UtilsTests, FurthestAndClosestReachedPoint)


### PR DESCRIPTION
@doisyg please review

This adapts https://github.com/ros-planning/navigation2/pull/3454 for optionality and not using the path angles -- which might not be populated if not using the smac planners and/or including one of the optional Path Smoothers.

First step in path inversion work this week.

This method includes a check on if reversing is possible at all at the controller level. If not, uses only the forward values. It also has a new parameter (docs PR to match to be linked) if forward is preferred. That way, we consider using the inverted angle schema **only** when reversing is possible and that there genuinely is no preference one way or another. Otherwise, if there is a preference, we do penalize to encourage rotating to go forward.   

I also removed the use of the path point's orientations with the trajectory orientations. **Please check me on this.**

Also added a unit test for the utils function :-)

