### PR TITLE
adapting goal critic for speed to goal

### DIFF
--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -183,17 +183,17 @@ controller_server:
         enabled: true
         cost_power: 1
         cost_weight: 5.0
-        threshold_to_consider: 1.0
+        threshold_to_consider: 1.4
       GoalAngleCritic:
         enabled: true
         cost_power: 1
         cost_weight: 3.0
-        threshold_to_consider: 0.4
+        threshold_to_consider: 0.5
       PreferForwardCritic:
         enabled: true
         cost_power: 1
         cost_weight: 5.0
-        threshold_to_consider: 0.4
+        threshold_to_consider: 0.5
       ObstaclesCritic:
         enabled: true
         cost_power: 1
@@ -209,20 +209,20 @@ controller_server:
         cost_weight: 14.0
         max_path_occupancy_ratio: 0.05
         trajectory_point_step: 3
-        threshold_to_consider: 0.40
+        threshold_to_consider: 0.5
         offset_from_furthest: 20
       PathFollowCritic:
         enabled: true
         cost_power: 1
         cost_weight: 5.0
         offset_from_furthest: 5
-        threshold_to_consider: 0.6
+        threshold_to_consider: 1.4
       PathAngleCritic:
         enabled: true
         cost_power: 1
         cost_weight: 2.0
         offset_from_furthest: 4
-        threshold_to_consider: 0.40
+        threshold_to_consider: 0.5
         max_angle_to_furthest: 1.0
         forward_preference: true
       # TwirlingCritic:

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/goal_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/goal_critic.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+// Copyright (c) 2023 Open Navigation LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_follow_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_follow_critic.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+// Copyright (c) 2023 Open Navigation LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nav2_mppi_controller/src/critics/goal_angle_critic.cpp
+++ b/nav2_mppi_controller/src/critics/goal_angle_critic.cpp
@@ -24,7 +24,7 @@ void GoalAngleCritic::initialize()
   getParam(power_, "cost_power", 1);
   getParam(weight_, "cost_weight", 3.0);
 
-  getParam(threshold_to_consider_, "threshold_to_consider", 0.40);
+  getParam(threshold_to_consider_, "threshold_to_consider", 0.5);
 
   RCLCPP_INFO(
     logger_,

--- a/nav2_mppi_controller/src/critics/goal_critic.cpp
+++ b/nav2_mppi_controller/src/critics/goal_critic.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+// Copyright (c) 2023 Open Navigation LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +26,7 @@ void GoalCritic::initialize()
 
   getParam(power_, "cost_power", 1);
   getParam(weight_, "cost_weight", 5.0);
-  getParam(threshold_to_consider_, "threshold_to_consider", 1.0);
+  getParam(threshold_to_consider_, "threshold_to_consider", 1.4);
 
   RCLCPP_INFO(
     logger_, "GoalCritic instantiated with %d power and %f weight.",

--- a/nav2_mppi_controller/src/critics/goal_critic.cpp
+++ b/nav2_mppi_controller/src/critics/goal_critic.cpp
@@ -17,6 +17,8 @@
 namespace mppi::critics
 {
 
+using xt::evaluation_strategy::immediate;
+
 void GoalCritic::initialize()
 {
   auto getParam = parameters_handler_->getParamGetter(name_);
@@ -47,14 +49,14 @@ void GoalCritic::score(CriticData & data)
   const auto goal_x = data.path.x(goal_idx);
   const auto goal_y = data.path.y(goal_idx);
 
-  const auto last_x = xt::view(data.trajectories.x, xt::all(), -1);
-  const auto last_y = xt::view(data.trajectories.y, xt::all(), -1);
+  const auto traj_x = xt::view(data.trajectories.x, xt::all(), xt::all());
+  const auto traj_y = xt::view(data.trajectories.y, xt::all(), xt::all());
 
   auto dists = xt::sqrt(
-    xt::pow(last_x - goal_x, 2) +
-    xt::pow(last_y - goal_y, 2));
+    xt::pow(traj_x - goal_x, 2) +
+    xt::pow(traj_y - goal_y, 2));
 
-  data.costs += xt::pow(std::move(dists) * weight_, power_);
+  data.costs += xt::pow(xt::mean(dists, {1}) * weight_, power_);
 }
 
 }  // namespace mppi::critics

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -34,7 +34,7 @@ void PathAlignCritic::initialize()
   getParam(trajectory_point_step_, "trajectory_point_step", 4);
   getParam(
     threshold_to_consider_,
-    "threshold_to_consider", 0.40f);
+    "threshold_to_consider", 0.5);
 
   RCLCPP_INFO(
     logger_,

--- a/nav2_mppi_controller/src/critics/path_angle_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_angle_critic.cpp
@@ -37,7 +37,7 @@ void PathAngleCritic::initialize()
   getParam(weight_, "cost_weight", 2.0);
   getParam(
     threshold_to_consider_,
-    "threshold_to_consider", 0.40f);
+    "threshold_to_consider", 0.5);
   getParam(
     max_angle_to_furthest_,
     "max_angle_to_furthest", 1.2);

--- a/nav2_mppi_controller/src/critics/path_follow_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_follow_critic.cpp
@@ -26,7 +26,7 @@ void PathFollowCritic::initialize()
 
   getParam(
     threshold_to_consider_,
-    "threshold_to_consider", 0.40f);
+    "threshold_to_consider", 1.4);
   getParam(offset_from_furthest_, "offset_from_furthest", 6);
   getParam(power_, "cost_power", 1);
   getParam(weight_, "cost_weight", 5.0);

--- a/nav2_mppi_controller/src/critics/prefer_forward_critic.cpp
+++ b/nav2_mppi_controller/src/critics/prefer_forward_critic.cpp
@@ -24,7 +24,7 @@ void PreferForwardCritic::initialize()
   getParam(weight_, "cost_weight", 5.0);
   getParam(
     threshold_to_consider_,
-    "threshold_to_consider", 0.40f);
+    "threshold_to_consider", 0.5);
 
   RCLCPP_INFO(
     logger_, "PreferForwardCritic instantiated with %d power and %f weight.", power_, weight_);

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -417,9 +417,9 @@ TEST(CriticTests, PathFollowCritic)
   // Scoring testing
 
   // provide state poses and path close within positional tolerances
-  state.pose.pose.position.x = 1.0;
+  state.pose.pose.position.x = 2.0;
   path.reset(6);
-  path.x(5) = 0.85;
+  path.x(5) = 1.7;
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
 


### PR DESCRIPTION
CC @doisyg for testing

If this works
- [x] update defaults for threshold to consider for `time_steps * model_dt * vx_max`
- [x] Add README commentary about this behavior on approach to goal and if you see plateau how to set it (see eq. above)
- [x] Adapt the Path Follow critic too to use the same formulation? Retune path follow + goal critics to account for
- [x] migration guide commentary on changes
