### PR TITLE
Let Navigators have different error codes

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -285,7 +285,7 @@ void BtActionServer<ActionT>::populateErrorCode(
         highest_priority_error_code = current_error_code;
       }
     } catch (...) {
-      RCLCPP_ERROR(
+      RCLCPP_DEBUG(
         logger_,
         "Failed to get error code: %s from blackboard",
         error_code.c_str());

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -88,9 +88,7 @@ BtActionServer<ActionT>::BtActionServer(
       for (const auto & error_code : error_code_names) {
         error_codes_str += "\n" + error_code;
       }
-      RCLCPP_INFO_STREAM(
-        logger_, "Error_code parameters were set to: "
-          << error_codes_str);
+      RCLCPP_INFO_STREAM(logger_, "Error_code parameters were set to: " << error_codes_str);
     }
   }
 }

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -73,10 +73,10 @@ BtActionServer<ActionT>::BtActionServer(
     if (value.get_type() == rclcpp::PARAMETER_NOT_SET) {
       std::string error_codes_str;
       for (const auto & error_code : error_code_names) {
-        error_codes_str += "\n" + error_code;
+        error_codes_str += " " + error_code;
       }
       RCLCPP_WARN_STREAM(
-        logger_, "Error_code parameters were not set. Using default values of: "
+        logger_, "Error_code parameters were not set. Using default values of:"
           << error_codes_str + "\n"
           << "Make sure these match your BT and there are not other sources of error codes you"
           "reported to your application");
@@ -86,9 +86,9 @@ BtActionServer<ActionT>::BtActionServer(
       error_code_names = value.get<std::vector<std::string>>();
       std::string error_codes_str;
       for (const auto & error_code : error_code_names) {
-        error_codes_str += "\n" + error_code;
+        error_codes_str += " " + error_code;
       }
-      RCLCPP_INFO_STREAM(logger_, "Error_code parameters were set to: " << error_codes_str);
+      RCLCPP_INFO_STREAM(logger_, "Error_code parameters were set to:" << error_codes_str);
     }
   }
 }

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -82,6 +82,15 @@ BtActionServer<ActionT>::BtActionServer(
           "reported to your application");
       rclcpp::Parameter error_code_names_param("error_code_names", error_code_names);
       node->set_parameter(error_code_names_param);
+    } else {
+      error_code_names = value.get<std::vector<std::string>>();
+      std::string error_codes_str;
+      for (const auto & error_code : error_code_names) {
+        error_codes_str += "\n" + error_code;
+      }
+      RCLCPP_INFO_STREAM(
+        logger_, "Error_code parameters were set to: "
+          << error_codes_str);
     }
   }
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [#3633](https://github.com/ros-planning/navigation2/issues/3633) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points


* Change "Failed to get error code: %s from blackboard" log from ERROR to DEBUG
* Add INFO log on initialization about which errors codes are being used to help debug
<!--
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

* <!--
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
