### PR TITLE
Fix uninitialized value

### DIFF
--- a/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
@@ -78,7 +78,7 @@ void CostmapFilter::onInitialize()
     // Get parameters
     node->get_parameter(name_ + "." + "enabled", enabled_);
     filter_info_topic_ = node->get_parameter(name_ + "." + "filter_info_topic").as_string();
-    double transform_tolerance;
+    double transform_tolerance {};
     node->get_parameter(name_ + "." + "transform_tolerance", transform_tolerance);
     transform_tolerance_ = tf2::durationFromSec(transform_tolerance);
 


### PR DESCRIPTION


## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |

| Primary OS tested on | Ubuntu 23 with gcc12 |

---

## Description of contribution in a few bullet points

In NAV2, this warning is treated as an error. Uninitialized doubles are bad, and the compiler can't guarantee anything before it's passed in to `get_parameter`. 


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
