### PR TITLE
Fix CERES failing build from compilation warnings

### DIFF
--- a/nav2_constrained_smoother/CMakeLists.txt
+++ b/nav2_constrained_smoother/CMakeLists.txt
@@ -27,7 +27,6 @@ set(library_name nav2_constrained_smoother)
 
 include_directories(
   include
-  ${CERES_INCLUDES}
 )
 
 set(dependencies
@@ -42,7 +41,7 @@ set(dependencies
 )
 
 add_library(${library_name} SHARED src/constrained_smoother.cpp)
-target_link_libraries(${library_name} ${CERES_LIBRARIES})
+target_link_libraries(${library_name} Ceres::ceres)
 # prevent pluginlib from using boost
 target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 ament_target_dependencies(${library_name} ${dependencies})


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu 23 with GCC12 |

---

## Description of contribution in a few bullet points

* Ceres has compiler warnings that fail nav2 build with werr
* This treats them as SYSTEM includes so we can ignore them

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
