### PR TITLE
Remove mapToWorld() in navfn_planner.cpp

### DIFF
--- a/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
+++ b/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
@@ -167,15 +167,6 @@ protected:
   bool worldToMap(double wx, double wy, unsigned int & mx, unsigned int & my);
 
   /**
-   * @brief Transform a point from map to world frame
-   * @param mx double of map X coordinate
-   * @param my double of map Y coordinate
-   * @param wx double of world X coordinate
-   * @param wy double of world Y coordinate
-   */
-  void mapToWorld(double mx, double my, double & wx, double & wy);
-
-  /**
    * @brief Set the corresponding cell cost to be free space
    * @param mx int of map X coordinate
    * @param my int of map Y coordinate

--- a/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
+++ b/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
@@ -157,16 +157,6 @@ protected:
   }
 
   /**
-   * @brief Transform a point from world to map frame
-   * @param wx double of world X coordinate
-   * @param wy double of world Y coordinate
-   * @param mx int of map X coordinate
-   * @param my int of map Y coordinate
-   * @return true if can transform
-   */
-  bool worldToMap(double wx, double wy, unsigned int & mx, unsigned int & my);
-
-  /**
    * @brief Set the corresponding cell cost to be free space
    * @param mx int of map X coordinate
    * @param my int of map Y coordinate

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -417,7 +417,7 @@ NavfnPlanner::getPlanFromPotential(
   for (int i = len - 1; i >= 0; --i) {
     // convert the plan to world coordinates
     double world_x, world_y;
-    this->costmap_->mapToWorld(x[i], y[i], world_x, world_y);
+    costmap_->mapToWorld(x[i], y[i], world_x, world_y);
 
     geometry_msgs::msg::PoseStamped pose;
     pose.pose.position.x = world_x;

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -238,7 +238,7 @@ NavfnPlanner::makePlan(
     start.position.x, start.position.y, goal.position.x, goal.position.y);
 
   unsigned int mx, my;
-  if(!costmap_->worldToMap(wx, wy, mx, my)){
+  if (!costmap_->worldToMap(wx, wy, mx, my)){
     RCLCPP_ERROR(
       logger_,
       "worldToMap failed: mx,my: %d,%d, size_x,size_y: %d,%d", mx, my,
@@ -267,7 +267,7 @@ NavfnPlanner::makePlan(
   wx = goal.position.x;
   wy = goal.position.y;
 
-  if(!costmap_->worldToMap(wx, wy, mx, my)){
+  if (!costmap_->worldToMap(wx, wy, mx, my)){
     RCLCPP_ERROR(
       logger_,
       "worldToMap failed: mx,my: %d,%d, size_x,size_y: %d,%d", mx, my,
@@ -399,7 +399,7 @@ NavfnPlanner::getPlanFromPotential(
 
   // the potential has already been computed, so we won't update our copy of the costmap
   unsigned int mx, my;
-  if(!costmap_->worldToMap(wx, wy, mx, my)){
+  if (!costmap_->worldToMap(wx, wy, mx, my)){
     RCLCPP_ERROR(
       logger_,
       "worldToMap failed: mx,my: %d,%d, size_x,size_y: %d,%d", mx, my,

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -417,7 +417,7 @@ NavfnPlanner::getPlanFromPotential(
   for (int i = len - 1; i >= 0; --i) {
     // convert the plan to world coordinates
     double world_x, world_y;
-    mapToWorld(x[i], y[i], world_x, world_y);
+    this->costmap_->mapToWorld(x[i], y[i], world_x, world_y);
 
     geometry_msgs::msg::PoseStamped pose;
     pose.pose.position.x = world_x;
@@ -504,13 +504,6 @@ NavfnPlanner::worldToMap(double wx, double wy, unsigned int & mx, unsigned int &
     costmap_->getSizeInCellsX(), costmap_->getSizeInCellsY());
 
   return false;
-}
-
-void
-NavfnPlanner::mapToWorld(double mx, double my, double & wx, double & wy)
-{
-  wx = costmap_->getOriginX() + mx * costmap_->getResolution();
-  wy = costmap_->getOriginY() + my * costmap_->getResolution();
 }
 
 void

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -238,7 +238,13 @@ NavfnPlanner::makePlan(
     start.position.x, start.position.y, goal.position.x, goal.position.y);
 
   unsigned int mx, my;
-  worldToMap(wx, wy, mx, my);
+  if(!costmap_->worldToMap(wx, wy, mx, my)){
+    RCLCPP_ERROR(
+      logger_,
+      "worldToMap failed: mx,my: %d,%d, size_x,size_y: %d,%d", mx, my,
+      costmap_->getSizeInCellsX(), costmap_->getSizeInCellsY());
+  }
+
 
   // clear the starting cell within the costmap because we know it can't be an obstacle
   clearRobotCell(mx, my);
@@ -261,7 +267,12 @@ NavfnPlanner::makePlan(
   wx = goal.position.x;
   wy = goal.position.y;
 
-  worldToMap(wx, wy, mx, my);
+  if(!costmap_->worldToMap(wx, wy, mx, my)){
+    RCLCPP_ERROR(
+      logger_,
+      "worldToMap failed: mx,my: %d,%d, size_x,size_y: %d,%d", mx, my,
+      costmap_->getSizeInCellsX(), costmap_->getSizeInCellsY());
+  }
   int map_goal[2];
   map_goal[0] = mx;
   map_goal[1] = my;
@@ -388,7 +399,12 @@ NavfnPlanner::getPlanFromPotential(
 
   // the potential has already been computed, so we won't update our copy of the costmap
   unsigned int mx, my;
-  worldToMap(wx, wy, mx, my);
+  if(!costmap_->worldToMap(wx, wy, mx, my)){
+    RCLCPP_ERROR(
+      logger_,
+      "worldToMap failed: mx,my: %d,%d, size_x,size_y: %d,%d", mx, my,
+      costmap_->getSizeInCellsX(), costmap_->getSizeInCellsY());
+  }
 
   int map_goal[2];
   map_goal[0] = mx;
@@ -437,7 +453,7 @@ double
 NavfnPlanner::getPointPotential(const geometry_msgs::msg::Point & world_point)
 {
   unsigned int mx, my;
-  if (!worldToMap(world_point.x, world_point.y, mx, my)) {
+  if (!costmap_->worldToMap(world_point.x, world_point.y, mx, my)) {
     return std::numeric_limits<double>::max();
   }
 
@@ -481,30 +497,6 @@ NavfnPlanner::getPointPotential(const geometry_msgs::msg::Point & world_point)
 
 //   return false;
 // }
-
-bool
-NavfnPlanner::worldToMap(double wx, double wy, unsigned int & mx, unsigned int & my)
-{
-  if (wx < costmap_->getOriginX() || wy < costmap_->getOriginY()) {
-    return false;
-  }
-
-  mx = static_cast<int>(
-    std::round((wx - costmap_->getOriginX()) / costmap_->getResolution()));
-  my = static_cast<int>(
-    std::round((wy - costmap_->getOriginY()) / costmap_->getResolution()));
-
-  if (mx < costmap_->getSizeInCellsX() && my < costmap_->getSizeInCellsY()) {
-    return true;
-  }
-
-  RCLCPP_ERROR(
-    logger_,
-    "worldToMap failed: mx,my: %d,%d, size_x,size_y: %d,%d", mx, my,
-    costmap_->getSizeInCellsX(), costmap_->getSizeInCellsY());
-
-  return false;
-}
 
 void
 NavfnPlanner::clearRobotCell(unsigned int mx, unsigned int my)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (https://github.com/ros-planning/navigation2/issues/3669) |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points
* replace mapToWorld() by using the mapToWorld() in costmap_2d
* replace worldToMap() by using the worldToMap() in costmap_2d

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
