### PR TITLE
Fix costmap publisher test

### DIFF
--- a/nav2_costmap_2d/test/integration/test_costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_2d_publisher.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <future>
+#include <rclcpp/logging.hpp>
 
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_costmap_2d/costmap_subscriber.hpp"
@@ -156,24 +157,32 @@ protected:
 TEST_F(CostmapRosTestFixture, costmap_pub_test)
 {
   auto future = layer_subscriber_->layer_promise_.get_future();
+  std::cout << "Get future" << std::endl;
   auto status = future.wait_for(std::chrono::seconds(5));
-  EXPECT_TRUE(status == std::future_status::ready);
+  std::cout << "Waited for future" << std::endl;
+  ASSERT_TRUE(status == std::future_status::ready);
 
   auto costmap_raw = future.get();
+  std::cout << "Got future" << std::endl;
 
   // Check first 20 cells of the 10by10 map
+  std::cout << costmap_raw->data.size() << std::endl;
   unsigned int i = 0;
   for (; i < 7; ++i) {
-    EXPECT_EQ(costmap_raw->data[i], nav2_costmap_2d::FREE_SPACE);
+    std::cout << "i: " << i << std::endl;
+    EXPECT_EQ(costmap_raw->data.at(i), nav2_costmap_2d::FREE_SPACE);
   }
   for (; i < 10; ++i) {
-    EXPECT_EQ(costmap_raw->data[i], nav2_costmap_2d::LETHAL_OBSTACLE);
+    std::cout << "i: " << i << std::endl;
+    EXPECT_EQ(costmap_raw->data.at(i), nav2_costmap_2d::LETHAL_OBSTACLE);
   }
   for (; i < 17; ++i) {
-    EXPECT_EQ(costmap_raw->data[i], nav2_costmap_2d::FREE_SPACE);
+    std::cout << "i: " << i << std::endl;
+    EXPECT_EQ(costmap_raw->data.at(i), nav2_costmap_2d::FREE_SPACE);
   }
   for (; i < 20; ++i) {
-    EXPECT_EQ(costmap_raw->data[i], nav2_costmap_2d::LETHAL_OBSTACLE);
+    std::cout << "i: " << i << std::endl;
+    EXPECT_EQ(costmap_raw->data.at(i), nav2_costmap_2d::LETHAL_OBSTACLE);
   }
 
   SUCCEED();

--- a/nav2_costmap_2d/test/integration/test_costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_2d_publisher.cpp
@@ -15,7 +15,6 @@
 #include <gtest/gtest.h>
 
 #include <future>
-#include <rclcpp/logging.hpp>
 
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_costmap_2d/costmap_subscriber.hpp"
@@ -163,7 +162,8 @@ TEST_F(CostmapRosTestFixture, costmap_pub_test)
   auto costmap_raw = future.get();
 
   // Check first 20 cells of the 10by10 map
-  ASSERT_TRUE(costmap_raw->data.size() == 100); unsigned int i = 0;
+  ASSERT_TRUE(costmap_raw->data.size() == 100); 
+  unsigned int i = 0;
   for (; i < 7; ++i) {
     EXPECT_EQ(costmap_raw->data.at(i), nav2_costmap_2d::FREE_SPACE);
   }

--- a/nav2_costmap_2d/test/integration/test_costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_2d_publisher.cpp
@@ -162,7 +162,7 @@ TEST_F(CostmapRosTestFixture, costmap_pub_test)
   auto costmap_raw = future.get();
 
   // Check first 20 cells of the 10by10 map
-  ASSERT_TRUE(costmap_raw->data.size() == 100); 
+  ASSERT_TRUE(costmap_raw->data.size() == 100);
   unsigned int i = 0;
   for (; i < 7; ++i) {
     EXPECT_EQ(costmap_raw->data.at(i), nav2_costmap_2d::FREE_SPACE);

--- a/nav2_costmap_2d/test/integration/test_costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_2d_publisher.cpp
@@ -118,7 +118,7 @@ public:
 protected:
   void layerCallback(const nav2_msgs::msg::Costmap::SharedPtr layer)
   {
-    if (!callback_hit_) {
+    if (!callback_hit_ && (layer->data.size() == 100)) {
       layer_promise_.set_value(layer);
       callback_hit_ = true;
     }
@@ -157,31 +157,23 @@ protected:
 TEST_F(CostmapRosTestFixture, costmap_pub_test)
 {
   auto future = layer_subscriber_->layer_promise_.get_future();
-  std::cout << "Get future" << std::endl;
   auto status = future.wait_for(std::chrono::seconds(5));
-  std::cout << "Waited for future" << std::endl;
   ASSERT_TRUE(status == std::future_status::ready);
 
   auto costmap_raw = future.get();
-  std::cout << "Got future" << std::endl;
 
   // Check first 20 cells of the 10by10 map
-  std::cout << costmap_raw->data.size() << std::endl;
-  unsigned int i = 0;
+  ASSERT_TRUE(costmap_raw->data.size() == 100); unsigned int i = 0;
   for (; i < 7; ++i) {
-    std::cout << "i: " << i << std::endl;
     EXPECT_EQ(costmap_raw->data.at(i), nav2_costmap_2d::FREE_SPACE);
   }
   for (; i < 10; ++i) {
-    std::cout << "i: " << i << std::endl;
     EXPECT_EQ(costmap_raw->data.at(i), nav2_costmap_2d::LETHAL_OBSTACLE);
   }
   for (; i < 17; ++i) {
-    std::cout << "i: " << i << std::endl;
     EXPECT_EQ(costmap_raw->data.at(i), nav2_costmap_2d::FREE_SPACE);
   }
   for (; i < 20; ++i) {
-    std::cout << "i: " << i << std::endl;
     EXPECT_EQ(costmap_raw->data.at(i), nav2_costmap_2d::LETHAL_OBSTACLE);
   }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points
Sometimes the costmap data will be empty. Since the checks are assuming it be populated an index is accessed that is out of range. To resolve this, a check has been put in place to verify that costmap data has been correctly populated.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
