### PR TITLE
Install nav2_behavior_tree utils outside of BUILD_TESTING

### DIFF
--- a/nav2_behavior_tree/CMakeLists.txt
+++ b/nav2_behavior_tree/CMakeLists.txt
@@ -223,6 +223,10 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
+install(DIRECTORY test/utils/
+        DESTINATION include/utils/
+)
+
 install(FILES nav2_tree_nodes.xml DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)

--- a/nav2_behavior_tree/test/CMakeLists.txt
+++ b/nav2_behavior_tree/test/CMakeLists.txt
@@ -7,8 +7,3 @@ add_subdirectory(plugins/condition)
 add_subdirectory(plugins/decorator)
 add_subdirectory(plugins/control)
 add_subdirectory(plugins/action)
-
-install(DIRECTORY utils
-        DESTINATION include/)
-
-ament_export_include_directories(utils)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/3683 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Built with `--cmake-args "-DBUILD_TESTING=OFF"` and verified that `install/nav2_behavior_tree/include` contains the utils folder |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
- Moved nav2_behavior_tree/test/utils/ installs to be outside of BUILD_TESTING

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
