### PR TITLE
moved error code enumerations to the result of action messages

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/assisted_teleop_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/assisted_teleop_action.hpp
@@ -30,7 +30,6 @@ namespace nav2_behavior_tree
 class AssistedTeleopAction : public BtActionNode<nav2_msgs::action::AssistedTeleop>
 {
   using Action = nav2_msgs::action::AssistedTeleop;
-  using ActionGoal = Action::Goal;
   using ActionResult = Action::Result;
 
 public:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_action.hpp
@@ -29,7 +29,6 @@ namespace nav2_behavior_tree
 class BackUpAction : public BtActionNode<nav2_msgs::action::BackUp>
 {
   using Action = nav2_msgs::action::BackUp;
-  using ActionGoal = Action::Goal;
   using ActionResult = Action::Result;
 
 public:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp
@@ -34,7 +34,6 @@ class ComputePathThroughPosesAction
 {
   using Action = nav2_msgs::action::ComputePathThroughPoses;
   using ActionResult = Action::Result;
-  using ActionGoal = Action::Goal;
 
 public:
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
@@ -31,7 +31,6 @@ class ComputePathToPoseAction : public BtActionNode<nav2_msgs::action::ComputePa
 {
   using Action = nav2_msgs::action::ComputePathToPose;
   using ActionResult = Action::Result;
-  using ActionGoal = Action::Goal;
 
 public:
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp
@@ -29,8 +29,7 @@ namespace nav2_behavior_tree
 class DriveOnHeadingAction : public BtActionNode<nav2_msgs::action::DriveOnHeading>
 {
   using Action = nav2_msgs::action::DriveOnHeading;
-  using ActionGoal = Action::Goal;
-  using ActionResult = Action::Goal;
+  using ActionResult = Action::Result;
 
 public:
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
@@ -31,7 +31,6 @@ class FollowPathAction : public BtActionNode<nav2_msgs::action::FollowPath>
 {
   using Action = nav2_msgs::action::FollowPath;
   using ActionResult = Action::Result;
-  using ActionGoal = Action::Goal;
 
 public:
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp
@@ -33,7 +33,6 @@ class NavigateThroughPosesAction : public BtActionNode<nav2_msgs::action::Naviga
 {
   using Action = nav2_msgs::action::NavigateThroughPoses;
   using ActionResult = Action::Result;
-  using ActionGoal = Action::Goal;
 
 public:
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp
@@ -32,7 +32,6 @@ class NavigateToPoseAction : public BtActionNode<nav2_msgs::action::NavigateToPo
 {
   using Action = nav2_msgs::action::NavigateToPose;
   using ActionResult = Action::Result;
-  using ActionGoal = Action::Goal;
 
 public:
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smooth_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smooth_path_action.hpp
@@ -32,7 +32,6 @@ class SmoothPathAction : public nav2_behavior_tree::BtActionNode<nav2_msgs::acti
 {
   using Action = nav2_msgs::action::SmoothPath;
   using ActionResult = Action::Result;
-  using ActionGoal = Action::Goal;
 
 public:
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/spin_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/spin_action.hpp
@@ -30,7 +30,6 @@ class SpinAction : public BtActionNode<nav2_msgs::action::Spin>
 {
   using Action = nav2_msgs::action::Spin;
   using ActionResult = Action::Result;
-  using ActionGoal = Action::Goal;
 
 public:
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.hpp
@@ -26,7 +26,7 @@ namespace nav2_behavior_tree
 class WouldAControllerRecoveryHelp : public AreErrorCodesPresent
 {
   using Action = nav2_msgs::action::FollowPath;
-  using ActionGoal = Action::Goal;
+  using ActionResult = Action::Result;
 
 public:
   WouldAControllerRecoveryHelp(

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.hpp
@@ -26,7 +26,7 @@ namespace nav2_behavior_tree
 class WouldAPlannerRecoveryHelp : public AreErrorCodesPresent
 {
   using Action = nav2_msgs::action::ComputePathToPose;
-  using ActionGoal = Action::Goal;
+  using ActionResult = Action::Result;
 
 public:
   WouldAPlannerRecoveryHelp(

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.hpp
@@ -27,7 +27,7 @@ namespace nav2_behavior_tree
 class WouldASmootherRecoveryHelp : public AreErrorCodesPresent
 {
   using Action = nav2_msgs::action::SmoothPath;
-  using ActionGoal = Action::Goal;
+  using ActionResult = Action::Result;
 
 public:
   WouldASmootherRecoveryHelp(

--- a/nav2_behavior_tree/plugins/action/assisted_teleop_action.cpp
+++ b/nav2_behavior_tree/plugins/action/assisted_teleop_action.cpp
@@ -43,7 +43,7 @@ void AssistedTeleopAction::on_tick()
 
 BT::NodeStatus AssistedTeleopAction::on_success()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -55,7 +55,7 @@ BT::NodeStatus AssistedTeleopAction::on_aborted()
 
 BT::NodeStatus AssistedTeleopAction::on_cancelled()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/action/back_up_action.cpp
+++ b/nav2_behavior_tree/plugins/action/back_up_action.cpp
@@ -48,7 +48,7 @@ void BackUpAction::on_tick()
 
 BT::NodeStatus BackUpAction::on_success()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -60,7 +60,7 @@ BT::NodeStatus BackUpAction::on_aborted()
 
 BT::NodeStatus BackUpAction::on_cancelled()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.cpp
@@ -42,7 +42,7 @@ BT::NodeStatus ComputePathThroughPosesAction::on_success()
 {
   setOutput("path", result_.result->path);
   // Set empty error code, action was successful
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -59,7 +59,7 @@ BT::NodeStatus ComputePathThroughPosesAction::on_cancelled()
   nav_msgs::msg::Path empty_path;
   setOutput("path", empty_path);
   // Set empty error code, action was cancelled
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
@@ -41,7 +41,7 @@ BT::NodeStatus ComputePathToPoseAction::on_success()
 {
   setOutput("path", result_.result->path);
   // Set empty error code, action was successful
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -58,7 +58,7 @@ BT::NodeStatus ComputePathToPoseAction::on_cancelled()
   nav_msgs::msg::Path empty_path;
   setOutput("path", empty_path);
   // Set empty error code, action was cancelled
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
+++ b/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
@@ -43,7 +43,7 @@ DriveOnHeadingAction::DriveOnHeadingAction(
 
 BT::NodeStatus DriveOnHeadingAction::on_success()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -55,7 +55,7 @@ BT::NodeStatus DriveOnHeadingAction::on_aborted()
 
 BT::NodeStatus DriveOnHeadingAction::on_cancelled()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/follow_path_action.cpp
@@ -38,7 +38,7 @@ void FollowPathAction::on_tick()
 
 BT::NodeStatus FollowPathAction::on_success()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -51,7 +51,7 @@ BT::NodeStatus FollowPathAction::on_aborted()
 BT::NodeStatus FollowPathAction::on_cancelled()
 {
   // Set empty error code, action was cancelled
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
@@ -41,7 +41,7 @@ void NavigateThroughPosesAction::on_tick()
 
 BT::NodeStatus NavigateThroughPosesAction::on_success()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -54,7 +54,7 @@ BT::NodeStatus NavigateThroughPosesAction::on_aborted()
 BT::NodeStatus NavigateThroughPosesAction::on_cancelled()
 {
   // Set empty error code, action was cancelled
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
@@ -40,7 +40,7 @@ void NavigateToPoseAction::on_tick()
 
 BT::NodeStatus NavigateToPoseAction::on_success()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -53,7 +53,7 @@ BT::NodeStatus NavigateToPoseAction::on_aborted()
 BT::NodeStatus NavigateToPoseAction::on_cancelled()
 {
   // Set empty error code, action was cancelled
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/action/smooth_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/smooth_path_action.cpp
@@ -45,7 +45,7 @@ BT::NodeStatus SmoothPathAction::on_success()
   setOutput("smoothing_duration", rclcpp::Duration(result_.result->smoothing_duration).seconds());
   setOutput("was_completed", result_.result->was_completed);
   // Set empty error code, action was successful
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -58,7 +58,7 @@ BT::NodeStatus SmoothPathAction::on_aborted()
 BT::NodeStatus SmoothPathAction::on_cancelled()
 {
   // Set empty error code, action was cancelled
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/action/spin_action.cpp
+++ b/nav2_behavior_tree/plugins/action/spin_action.cpp
@@ -43,7 +43,7 @@ void SpinAction::on_tick()
 
 BT::NodeStatus SpinAction::on_success()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -55,7 +55,7 @@ BT::NodeStatus SpinAction::on_aborted()
 
 BT::NodeStatus SpinAction::on_cancelled()
 {
-  setOutput("error_code_id", ActionGoal::NONE);
+  setOutput("error_code_id", ActionResult::NONE);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.cpp
@@ -24,10 +24,10 @@ WouldAControllerRecoveryHelp::WouldAControllerRecoveryHelp(
 : AreErrorCodesPresent(condition_name, conf)
 {
   error_codes_to_check_ = {
-    ActionGoal::UNKNOWN,
-    ActionGoal::PATIENCE_EXCEEDED,
-    ActionGoal::FAILED_TO_MAKE_PROGRESS,
-    ActionGoal::NO_VALID_CONTROL
+    ActionResult::UNKNOWN,
+    ActionResult::PATIENCE_EXCEEDED,
+    ActionResult::FAILED_TO_MAKE_PROGRESS,
+    ActionResult::NO_VALID_CONTROL
   };
 }
 

--- a/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.cpp
@@ -24,9 +24,9 @@ WouldAPlannerRecoveryHelp::WouldAPlannerRecoveryHelp(
 : AreErrorCodesPresent(condition_name, conf)
 {
   error_codes_to_check_ = {
-    ActionGoal::UNKNOWN,
-    ActionGoal::NO_VALID_PATH,
-    ActionGoal::TIMEOUT
+    ActionResult::UNKNOWN,
+    ActionResult::NO_VALID_PATH,
+    ActionResult::TIMEOUT
   };
 }
 

--- a/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.cpp
@@ -24,10 +24,10 @@ WouldASmootherRecoveryHelp::WouldASmootherRecoveryHelp(
 : AreErrorCodesPresent(condition_name, conf)
 {
   error_codes_to_check_ = {
-    ActionGoal::UNKNOWN,
-    ActionGoal::TIMEOUT,
-    ActionGoal::FAILED_TO_SMOOTH_PATH,
-    ActionGoal::SMOOTHED_PATH_IN_COLLISION
+    ActionResult::UNKNOWN,
+    ActionResult::TIMEOUT,
+    ActionResult::FAILED_TO_SMOOTH_PATH,
+    ActionResult::SMOOTHED_PATH_IN_COLLISION
   };
 }
 

--- a/nav2_behavior_tree/test/plugins/condition/test_are_error_codes_present.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_are_error_codes_present.cpp
@@ -24,11 +24,11 @@ class AreErrorCodesPresentFixture : public nav2_behavior_tree::BehaviorTreeTestF
 {
 public:
   using Action = nav2_msgs::action::FollowPath;
-  using ActionGoal = Action::Goal;
+  using ActionResult = Action::Result;
   void SetUp()
   {
-    uint16_t error_code = ActionGoal::NONE;
-    std::set<uint16_t> error_codes_to_check = {ActionGoal::UNKNOWN}; //NOLINT
+    uint16_t error_code = ActionResult::NONE;
+    std::set<uint16_t> error_codes_to_check = {ActionResult::UNKNOWN}; //NOLINT
     config_->blackboard->set("error_code", error_code);
     config_->blackboard->set("error_codes_to_check", error_codes_to_check);
 
@@ -59,8 +59,8 @@ std::shared_ptr<BT::Tree> AreErrorCodesPresentFixture::tree_ = nullptr;
 TEST_F(AreErrorCodesPresentFixture, test_condition)
 {
   std::map<uint16_t, BT::NodeStatus> error_to_status_map = {
-    {ActionGoal::NONE, BT::NodeStatus::FAILURE},
-    {ActionGoal::UNKNOWN, BT::NodeStatus::SUCCESS},
+    {ActionResult::NONE, BT::NodeStatus::FAILURE},
+    {ActionResult::UNKNOWN, BT::NodeStatus::SUCCESS},
   };
 
   for (const auto & error_to_status : error_to_status_map) {

--- a/nav2_behavior_tree/test/plugins/condition/test_would_a_controller_recovery_help.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_would_a_controller_recovery_help.cpp
@@ -24,10 +24,10 @@ class WouldAControllerRecoveryHelpFixture : public nav2_behavior_tree::BehaviorT
 {
 public:
   using Action = nav2_msgs::action::FollowPath;
-  using ActionGoal = Action::Goal;
+  using ActionResult = Action::Result;
   void SetUp()
   {
-    uint16_t error_code = ActionGoal::NONE;
+    uint16_t error_code = ActionResult::NONE;
     config_->blackboard->set("error_code", error_code);
 
     std::string xml_txt =
@@ -57,14 +57,14 @@ std::shared_ptr<BT::Tree> WouldAControllerRecoveryHelpFixture::tree_ = nullptr;
 TEST_F(WouldAControllerRecoveryHelpFixture, test_condition)
 {
   std::map<uint16_t, BT::NodeStatus> error_to_status_map = {
-    {ActionGoal::NONE, BT::NodeStatus::FAILURE},
-    {ActionGoal::UNKNOWN, BT::NodeStatus::SUCCESS},
-    {ActionGoal::INVALID_CONTROLLER, BT::NodeStatus::FAILURE},
-    {ActionGoal::TF_ERROR, BT::NodeStatus::FAILURE},
-    {ActionGoal::INVALID_PATH, BT::NodeStatus::FAILURE},
-    {ActionGoal::PATIENCE_EXCEEDED, BT::NodeStatus::SUCCESS},
-    {ActionGoal::FAILED_TO_MAKE_PROGRESS, BT::NodeStatus::SUCCESS},
-    {ActionGoal::NO_VALID_CONTROL, BT::NodeStatus::SUCCESS},
+    {ActionResult::NONE, BT::NodeStatus::FAILURE},
+    {ActionResult::UNKNOWN, BT::NodeStatus::SUCCESS},
+    {ActionResult::INVALID_CONTROLLER, BT::NodeStatus::FAILURE},
+    {ActionResult::TF_ERROR, BT::NodeStatus::FAILURE},
+    {ActionResult::INVALID_PATH, BT::NodeStatus::FAILURE},
+    {ActionResult::PATIENCE_EXCEEDED, BT::NodeStatus::SUCCESS},
+    {ActionResult::FAILED_TO_MAKE_PROGRESS, BT::NodeStatus::SUCCESS},
+    {ActionResult::NO_VALID_CONTROL, BT::NodeStatus::SUCCESS},
   };
 
   for (const auto & error_to_status : error_to_status_map) {

--- a/nav2_behavior_tree/test/plugins/condition/test_would_a_planner_recovery_help.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_would_a_planner_recovery_help.cpp
@@ -24,10 +24,10 @@ class WouldAPlannerRecoveryHelpFixture : public nav2_behavior_tree::BehaviorTree
 {
 public:
   using Action = nav2_msgs::action::ComputePathToPose;
-  using ActionGoal = Action::Goal;
+  using ActionResult = Action::Result;
   void SetUp()
   {
-    uint16_t error_code = ActionGoal::NONE;
+    uint16_t error_code = ActionResult::NONE;
     config_->blackboard->set("error_code", error_code);
 
     std::string xml_txt =
@@ -57,9 +57,9 @@ std::shared_ptr<BT::Tree> WouldAPlannerRecoveryHelpFixture::tree_ = nullptr;
 TEST_F(WouldAPlannerRecoveryHelpFixture, test_condition)
 {
   std::map<uint16_t, BT::NodeStatus> error_to_status_map = {
-    {ActionGoal::NONE, BT::NodeStatus::FAILURE},
-    {ActionGoal::UNKNOWN, BT::NodeStatus::SUCCESS},
-    {ActionGoal::NO_VALID_PATH, BT::NodeStatus::SUCCESS},
+    {ActionResult::NONE, BT::NodeStatus::FAILURE},
+    {ActionResult::UNKNOWN, BT::NodeStatus::SUCCESS},
+    {ActionResult::NO_VALID_PATH, BT::NodeStatus::SUCCESS},
   };
 
   for (const auto & error_to_status : error_to_status_map) {

--- a/nav2_behavior_tree/test/plugins/condition/test_would_a_smoother_recovery_help.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_would_a_smoother_recovery_help.cpp
@@ -24,7 +24,7 @@ class WouldASmootherRecoveryHelpFixture : public nav2_behavior_tree::BehaviorTre
 {
 public:
   using Action = nav2_msgs::action::SmoothPath;
-  using ActionGoal = Action::Goal;
+  using ActionGoal = Action::Result;
   void SetUp()
   {
     uint16_t error_code = ActionGoal::NONE;

--- a/nav2_behaviors/plugins/assisted_teleop.cpp
+++ b/nav2_behaviors/plugins/assisted_teleop.cpp
@@ -68,7 +68,7 @@ ResultStatus AssistedTeleop::onRun(const std::shared_ptr<const AssistedTeleopAct
   preempt_teleop_ = false;
   command_time_allowance_ = command->time_allowance;
   end_time_ = steady_clock_.now() + command_time_allowance_;
-  return ResultStatus{Status::SUCCEEDED, AssistedTeleopActionGoal::NONE};
+  return ResultStatus{Status::SUCCEEDED, AssistedTeleopActionResult::NONE};
 }
 
 void AssistedTeleop::onActionCompletion()
@@ -89,13 +89,13 @@ ResultStatus AssistedTeleop::onCycleUpdate()
       logger_,
       "Exceeded time allowance before reaching the " << behavior_name_.c_str() <<
         "goal - Exiting " << behavior_name_.c_str());
-    return ResultStatus{Status::FAILED, AssistedTeleopActionGoal::TIMEOUT};
+    return ResultStatus{Status::FAILED, AssistedTeleopActionResult::TIMEOUT};
   }
 
   // user states that teleop was successful
   if (preempt_teleop_) {
     stopRobot();
-    return ResultStatus{Status::SUCCEEDED, AssistedTeleopActionGoal::NONE};
+    return ResultStatus{Status::SUCCEEDED, AssistedTeleopActionResult::NONE};
   }
 
   geometry_msgs::msg::PoseStamped current_pose;
@@ -107,7 +107,7 @@ ResultStatus AssistedTeleop::onCycleUpdate()
       logger_,
       "Current robot pose is not available for " <<
         behavior_name_.c_str());
-    return ResultStatus{Status::FAILED, AssistedTeleopActionGoal::TF_ERROR};
+    return ResultStatus{Status::FAILED, AssistedTeleopActionResult::TF_ERROR};
   }
 
   geometry_msgs::msg::Pose2D projected_pose;
@@ -148,7 +148,7 @@ ResultStatus AssistedTeleop::onCycleUpdate()
   }
   vel_pub_->publish(std::move(scaled_twist));
 
-  return ResultStatus{Status::RUNNING, AssistedTeleopActionGoal::NONE};
+  return ResultStatus{Status::RUNNING, AssistedTeleopActionResult::NONE};
 }
 
 geometry_msgs::msg::Pose2D AssistedTeleop::projectPose(

--- a/nav2_behaviors/plugins/assisted_teleop.hpp
+++ b/nav2_behaviors/plugins/assisted_teleop.hpp
@@ -38,6 +38,7 @@ class AssistedTeleop : public TimedBehavior<AssistedTeleopAction>
 
 public:
   using AssistedTeleopActionGoal = AssistedTeleopAction::Goal;
+  using AssistedTeleopActionResult = AssistedTeleopAction::Result;
   AssistedTeleop();
 
   /**

--- a/nav2_behaviors/plugins/back_up.cpp
+++ b/nav2_behaviors/plugins/back_up.cpp
@@ -23,7 +23,7 @@ ResultStatus BackUp::onRun(const std::shared_ptr<const BackUpAction::Goal> comma
     RCLCPP_INFO(
       logger_,
       "Backing up in Y and Z not supported, will only move in X.");
-    return ResultStatus{Status::FAILED, BackUpActionGoal::INVALID_INPUT};
+    return ResultStatus{Status::FAILED, BackUpActionResult::INVALID_INPUT};
   }
 
   // Silently ensure that both the speed and direction are negative.
@@ -38,10 +38,10 @@ ResultStatus BackUp::onRun(const std::shared_ptr<const BackUpAction::Goal> comma
       transform_tolerance_))
   {
     RCLCPP_ERROR(logger_, "Initial robot pose is not available.");
-    return ResultStatus{Status::FAILED, BackUpActionGoal::TF_ERROR};
+    return ResultStatus{Status::FAILED, BackUpActionResult::TF_ERROR};
   }
 
-  return ResultStatus{Status::SUCCEEDED, BackUpActionGoal::NONE};
+  return ResultStatus{Status::SUCCEEDED, BackUpActionResult::NONE};
 }
 
 }  // namespace nav2_behaviors

--- a/nav2_behaviors/plugins/back_up.hpp
+++ b/nav2_behaviors/plugins/back_up.hpp
@@ -33,6 +33,7 @@ public:
 
   ResultStatus onRun(const std::shared_ptr<const BackUpActionGoal> command) override;
 };
-}
+
+}  // namespace nav2_behaviors
 
 #endif  // NAV2_BEHAVIORS__PLUGINS__BACK_UP_HPP_

--- a/nav2_behaviors/plugins/back_up.hpp
+++ b/nav2_behaviors/plugins/back_up.hpp
@@ -29,6 +29,7 @@ class BackUp : public DriveOnHeading<nav2_msgs::action::BackUp>
 {
 public:
   using BackUpActionGoal = BackUpAction::Goal;
+  using BackUpActionResult = BackUpAction::Result;
 
   ResultStatus onRun(const std::shared_ptr<const BackUpActionGoal> command) override;
 };

--- a/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -63,13 +63,13 @@ public:
       RCLCPP_INFO(
         this->logger_,
         "DrivingOnHeading in Y and Z not supported, will only move in X.");
-      return ResultStatus{Status::FAILED, ActionT::Goal::INVALID_INPUT};
+      return ResultStatus{Status::FAILED, ActionT::Result::INVALID_INPUT};
     }
 
     // Ensure that both the speed and direction have the same sign
     if (!((command->target.x > 0.0) == (command->speed > 0.0)) ) {
       RCLCPP_ERROR(this->logger_, "Speed and command sign did not match");
-      return ResultStatus{Status::FAILED, ActionT::Goal::INVALID_INPUT};
+      return ResultStatus{Status::FAILED, ActionT::Result::INVALID_INPUT};
     }
 
     command_x_ = command->target.x;
@@ -83,10 +83,10 @@ public:
         this->transform_tolerance_))
     {
       RCLCPP_ERROR(this->logger_, "Initial robot pose is not available.");
-      return ResultStatus{Status::FAILED, ActionT::Goal::TF_ERROR};
+      return ResultStatus{Status::FAILED, ActionT::Result::TF_ERROR};
     }
 
-    return ResultStatus{Status::SUCCEEDED, ActionT::Goal::NONE};
+    return ResultStatus{Status::SUCCEEDED, ActionT::Result::NONE};
   }
 
   /**
@@ -101,7 +101,7 @@ public:
       RCLCPP_WARN(
         this->logger_,
         "Exceeded time allowance before reaching the DriveOnHeading goal - Exiting DriveOnHeading");
-      return ResultStatus{Status::FAILED, ActionT::Goal::NONE};
+      return ResultStatus{Status::FAILED, ActionT::Result::NONE};
     }
 
     geometry_msgs::msg::PoseStamped current_pose;
@@ -110,7 +110,7 @@ public:
         this->transform_tolerance_))
     {
       RCLCPP_ERROR(this->logger_, "Current robot pose is not available.");
-      return ResultStatus{Status::FAILED, ActionT::Goal::TF_ERROR};
+      return ResultStatus{Status::FAILED, ActionT::Result::TF_ERROR};
     }
 
     double diff_x = initial_pose_.pose.position.x - current_pose.pose.position.x;
@@ -122,7 +122,7 @@ public:
 
     if (distance >= std::fabs(command_x_)) {
       this->stopRobot();
-      return ResultStatus{Status::SUCCEEDED, ActionT::Goal::NONE};
+      return ResultStatus{Status::SUCCEEDED, ActionT::Result::NONE};
     }
 
     auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>();
@@ -138,12 +138,12 @@ public:
     if (!isCollisionFree(distance, cmd_vel.get(), pose2d)) {
       this->stopRobot();
       RCLCPP_WARN(this->logger_, "Collision Ahead - Exiting DriveOnHeading");
-      return ResultStatus{Status::FAILED, ActionT::Goal::COLLISION_AHEAD};
+      return ResultStatus{Status::FAILED, ActionT::Result::COLLISION_AHEAD};
     }
 
     this->vel_pub_->publish(std::move(cmd_vel));
 
-    return ResultStatus{Status::RUNNING, ActionT::Goal::NONE};
+    return ResultStatus{Status::RUNNING, ActionT::Result::NONE};
   }
 
   /**

--- a/nav2_behaviors/plugins/spin.cpp
+++ b/nav2_behaviors/plugins/spin.cpp
@@ -79,7 +79,7 @@ ResultStatus Spin::onRun(const std::shared_ptr<const SpinActionGoal> command)
       transform_tolerance_))
   {
     RCLCPP_ERROR(logger_, "Current robot pose is not available.");
-    return ResultStatus{Status::FAILED, SpinActionGoal::TF_ERROR};
+    return ResultStatus{Status::FAILED, SpinActionResult::TF_ERROR};
   }
 
   prev_yaw_ = tf2::getYaw(current_pose.pose.orientation);
@@ -93,7 +93,7 @@ ResultStatus Spin::onRun(const std::shared_ptr<const SpinActionGoal> command)
   command_time_allowance_ = command->time_allowance;
   end_time_ = steady_clock_.now() + command_time_allowance_;
 
-  return ResultStatus{Status::SUCCEEDED, SpinActionGoal::NONE};
+  return ResultStatus{Status::SUCCEEDED, SpinActionResult::NONE};
 }
 
 ResultStatus Spin::onCycleUpdate()
@@ -104,7 +104,7 @@ ResultStatus Spin::onCycleUpdate()
     RCLCPP_WARN(
       logger_,
       "Exceeded time allowance before reaching the Spin goal - Exiting Spin");
-    return ResultStatus{Status::FAILED, SpinActionGoal::TIMEOUT};
+    return ResultStatus{Status::FAILED, SpinActionResult::TIMEOUT};
   }
 
   geometry_msgs::msg::PoseStamped current_pose;
@@ -113,7 +113,7 @@ ResultStatus Spin::onCycleUpdate()
       transform_tolerance_))
   {
     RCLCPP_ERROR(logger_, "Current robot pose is not available.");
-    return ResultStatus{Status::FAILED, SpinActionGoal::TF_ERROR};
+    return ResultStatus{Status::FAILED, SpinActionResult::TF_ERROR};
   }
 
   const double current_yaw = tf2::getYaw(current_pose.pose.orientation);
@@ -132,7 +132,7 @@ ResultStatus Spin::onCycleUpdate()
   double remaining_yaw = abs(cmd_yaw_) - abs(relative_yaw_);
   if (remaining_yaw < 1e-6) {
     stopRobot();
-    return ResultStatus{Status::SUCCEEDED, SpinActionGoal::NONE};
+    return ResultStatus{Status::SUCCEEDED, SpinActionResult::NONE};
   }
 
   double vel = sqrt(2 * rotational_acc_lim_ * remaining_yaw);
@@ -149,12 +149,12 @@ ResultStatus Spin::onCycleUpdate()
   if (!isCollisionFree(relative_yaw_, cmd_vel.get(), pose2d)) {
     stopRobot();
     RCLCPP_WARN(logger_, "Collision Ahead - Exiting Spin");
-    return ResultStatus{Status::FAILED, SpinActionGoal::COLLISION_AHEAD};
+    return ResultStatus{Status::FAILED, SpinActionResult::COLLISION_AHEAD};
   }
 
   vel_pub_->publish(std::move(cmd_vel));
 
-  return ResultStatus{Status::RUNNING, SpinActionGoal::NONE};
+  return ResultStatus{Status::RUNNING, SpinActionResult::NONE};
 }
 
 bool Spin::isCollisionFree(

--- a/nav2_behaviors/plugins/spin.hpp
+++ b/nav2_behaviors/plugins/spin.hpp
@@ -37,6 +37,7 @@ class Spin : public TimedBehavior<SpinAction>
 
 public:
   using SpinActionGoal = SpinAction::Goal;
+  using SpinActionResult = SpinAction::Result;
 
   /**
    * @brief A constructor for nav2_behaviors::Spin

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -491,56 +491,56 @@ void ControllerServer::computeControl()
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
     publishZeroVelocity();
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
-    result->error_code = Action::Goal::INVALID_CONTROLLER;
+    result->error_code = Action::Result::INVALID_CONTROLLER;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::ControllerTFError & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
     publishZeroVelocity();
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
-    result->error_code = Action::Goal::TF_ERROR;
+    result->error_code = Action::Result::TF_ERROR;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::NoValidControl & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
     publishZeroVelocity();
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
-    result->error_code = Action::Goal::NO_VALID_CONTROL;
+    result->error_code = Action::Result::NO_VALID_CONTROL;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::FailedToMakeProgress & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
     publishZeroVelocity();
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
-    result->error_code = Action::Goal::FAILED_TO_MAKE_PROGRESS;
+    result->error_code = Action::Result::FAILED_TO_MAKE_PROGRESS;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::PatienceExceeded & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
     publishZeroVelocity();
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
-    result->error_code = Action::Goal::PATIENCE_EXCEEDED;
+    result->error_code = Action::Result::PATIENCE_EXCEEDED;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::InvalidPath & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
     publishZeroVelocity();
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
-    result->error_code = Action::Goal::INVALID_PATH;
+    result->error_code = Action::Result::INVALID_PATH;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::ControllerException & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
     publishZeroVelocity();
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
-    result->error_code = Action::Goal::UNKNOWN;
+    result->error_code = Action::Result::UNKNOWN;
     action_server_->terminate_current(result);
     return;
   } catch (std::exception & e) {
     RCLCPP_ERROR(this->get_logger(), "%s", e.what());
     publishZeroVelocity();
     std::shared_ptr<Action::Result> result = std::make_shared<Action::Result>();
-    result->error_code = Action::Goal::UNKNOWN;
+    result->error_code = Action::Result::UNKNOWN;
     action_server_->terminate_current(result);
     return;
   }

--- a/nav2_msgs/action/AssistedTeleop.action
+++ b/nav2_msgs/action/AssistedTeleop.action
@@ -2,8 +2,9 @@
 builtin_interfaces/Duration time_allowance
 ---
 #result definition
-#error codes
-#note: The expected priority order of the error should match the message order
+
+# Error codes
+# Note: The expected priority order of the error should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=730
 uint16 TIMEOUT=731

--- a/nav2_msgs/action/AssistedTeleop.action
+++ b/nav2_msgs/action/AssistedTeleop.action
@@ -1,14 +1,14 @@
-# Error codes
-# Note: The expected priority order of the error should match the message order
+#goal definition
+builtin_interfaces/Duration time_allowance
+---
+#result definition
+#error codes
+#note: The expected priority order of the error should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=730
 uint16 TIMEOUT=731
 uint16 TF_ERROR=732
 
-#goal definition
-builtin_interfaces/Duration time_allowance
----
-#result definition
 builtin_interfaces/Duration total_elapsed_time
 uint16 error_code
 ---

--- a/nav2_msgs/action/BackUp.action
+++ b/nav2_msgs/action/BackUp.action
@@ -5,8 +5,9 @@ float32 speed
 builtin_interfaces/Duration time_allowance
 ---
 #result definition
-#error codes
-#note: The expected priority order of the error should match the message order
+
+# Error codes
+# Note: The expected priority order of the error should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=710
 uint16 TIMEOUT=711

--- a/nav2_msgs/action/BackUp.action
+++ b/nav2_msgs/action/BackUp.action
@@ -1,11 +1,3 @@
-# Error codes
-# Note: The expected priority order of the error should match the message order
-uint16 NONE=0
-uint16 UNKNOWN=710
-uint16 TIMEOUT=711
-uint16 TF_ERROR=712
-uint16 INVALID_INPUT=713
-uint16 COLLISION_AHEAD=714
 
 #goal definition
 geometry_msgs/Point target
@@ -13,6 +5,15 @@ float32 speed
 builtin_interfaces/Duration time_allowance
 ---
 #result definition
+#error codes
+#note: The expected priority order of the error should match the message order
+uint16 NONE=0
+uint16 UNKNOWN=710
+uint16 TIMEOUT=711
+uint16 TF_ERROR=712
+uint16 INVALID_INPUT=713
+uint16 COLLISION_AHEAD=714
+
 builtin_interfaces/Duration total_elapsed_time
 uint16 error_code
 ---

--- a/nav2_msgs/action/ComputePathThroughPoses.action
+++ b/nav2_msgs/action/ComputePathThroughPoses.action
@@ -1,5 +1,12 @@
-# Error codes
-# Note: The expected priority order of the errors should match the message order
+#goal definition
+geometry_msgs/PoseStamped[] goals
+geometry_msgs/PoseStamped start
+string planner_id
+bool use_start # If false, use current robot pose as path start, if true, use start above instead
+---
+#result definition
+#error codes
+#note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=300
 uint16 INVALID_PLANNER=301
@@ -12,13 +19,6 @@ uint16 TIMEOUT=3007
 uint16 NO_VALID_PATH=308
 uint16 NO_VIAPOINTS_GIVEN=309
 
-#goal definition
-geometry_msgs/PoseStamped[] goals
-geometry_msgs/PoseStamped start
-string planner_id
-bool use_start # If false, use current robot pose as path start, if true, use start above instead
----
-#result definition
 nav_msgs/Path path
 builtin_interfaces/Duration planning_time
 uint16 error_code

--- a/nav2_msgs/action/ComputePathThroughPoses.action
+++ b/nav2_msgs/action/ComputePathThroughPoses.action
@@ -5,8 +5,9 @@ string planner_id
 bool use_start # If false, use current robot pose as path start, if true, use start above instead
 ---
 #result definition
-#error codes
-#note: The expected priority order of the errors should match the message order
+
+# Error codes
+# Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=300
 uint16 INVALID_PLANNER=301

--- a/nav2_msgs/action/ComputePathToPose.action
+++ b/nav2_msgs/action/ComputePathToPose.action
@@ -5,8 +5,9 @@ string planner_id
 bool use_start # If false, use current robot pose as path start, if true, use start above instead
 ---
 #result definition
-#error codes
-#note: The expected priority order of the errors should match the message order
+
+# Error codes
+# Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=200
 uint16 INVALID_PLANNER=201

--- a/nav2_msgs/action/ComputePathToPose.action
+++ b/nav2_msgs/action/ComputePathToPose.action
@@ -1,5 +1,12 @@
-# Error codes
-# Note: The expected priority order of the errors should match the message order
+#goal definition
+geometry_msgs/PoseStamped goal
+geometry_msgs/PoseStamped start
+string planner_id
+bool use_start # If false, use current robot pose as path start, if true, use start above instead
+---
+#result definition
+#error codes
+#note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=200
 uint16 INVALID_PLANNER=201
@@ -11,13 +18,6 @@ uint16 GOAL_OCCUPIED=206
 uint16 TIMEOUT=207
 uint16 NO_VALID_PATH=208
 
-#goal definition
-geometry_msgs/PoseStamped goal
-geometry_msgs/PoseStamped start
-string planner_id
-bool use_start # If false, use current robot pose as path start, if true, use start above instead
----
-#result definition
 nav_msgs/Path path
 builtin_interfaces/Duration planning_time
 uint16 error_code

--- a/nav2_msgs/action/DriveOnHeading.action
+++ b/nav2_msgs/action/DriveOnHeading.action
@@ -1,11 +1,3 @@
-# Error codes
-# Note: The expected priority order of the error should match the message order
-uint16 NONE=0
-uint16 UNKNOWN=720
-uint16 TIMEOUT=721
-uint16 TF_ERROR=722
-uint16 COLLISION_AHEAD=723
-uint16 INVALID_INPUT=724
 
 #goal definition
 geometry_msgs/Point target
@@ -13,6 +5,15 @@ float32 speed
 builtin_interfaces/Duration time_allowance
 ---
 #result definition
+#error codes
+#note: The expected priority order of the error should match the message order
+uint16 NONE=0
+uint16 UNKNOWN=720
+uint16 TIMEOUT=721
+uint16 TF_ERROR=722
+uint16 COLLISION_AHEAD=723
+uint16 INVALID_INPUT=724
+
 builtin_interfaces/Duration total_elapsed_time
 uint16 error_code
 ---

--- a/nav2_msgs/action/DriveOnHeading.action
+++ b/nav2_msgs/action/DriveOnHeading.action
@@ -5,8 +5,9 @@ float32 speed
 builtin_interfaces/Duration time_allowance
 ---
 #result definition
-#error codes
-#note: The expected priority order of the error should match the message order
+
+# Error codes
+# Note: The expected priority order of the error should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=720
 uint16 TIMEOUT=721

--- a/nav2_msgs/action/FollowPath.action
+++ b/nav2_msgs/action/FollowPath.action
@@ -1,5 +1,12 @@
-# Error codes
-# Note: The expected priority order of the errors should match the message order
+#goal definition
+nav_msgs/Path path
+string controller_id
+string goal_checker_id
+string progress_checker_id
+---
+#result definition
+#error codes
+#note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=100
 uint16 INVALID_CONTROLLER=101
@@ -9,13 +16,6 @@ uint16 PATIENCE_EXCEEDED=104
 uint16 FAILED_TO_MAKE_PROGRESS=105
 uint16 NO_VALID_CONTROL=106
 
-#goal definition
-nav_msgs/Path path
-string controller_id
-string goal_checker_id
-string progress_checker_id
----
-#result definition
 std_msgs/Empty result
 uint16 error_code
 ---

--- a/nav2_msgs/action/FollowPath.action
+++ b/nav2_msgs/action/FollowPath.action
@@ -5,8 +5,9 @@ string goal_checker_id
 string progress_checker_id
 ---
 #result definition
-#error codes
-#note: The expected priority order of the errors should match the message order
+
+# Error codes
+# Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=100
 uint16 INVALID_CONTROLLER=101

--- a/nav2_msgs/action/FollowWaypoints.action
+++ b/nav2_msgs/action/FollowWaypoints.action
@@ -1,15 +1,15 @@
-# Error codes
-# Note: The expected priority order of the errors should match the message order
-uint16 NONE=0
-uint16 UNKNOWN=600
-uint16 TASK_EXECUTOR_FAILED=601
-
 #goal definition
 uint32 number_of_loops
 uint32 goal_index 0
 geometry_msgs/PoseStamped[] poses
 ---
 #result definition
+#error codes
+#note: The expected priority order of the errors should match the message order
+uint16 NONE=0
+uint16 UNKNOWN=600
+uint16 TASK_EXECUTOR_FAILED=601
+
 MissedWaypoint[] missed_waypoints
 ---
 #feedback definition

--- a/nav2_msgs/action/FollowWaypoints.action
+++ b/nav2_msgs/action/FollowWaypoints.action
@@ -4,8 +4,9 @@ uint32 goal_index 0
 geometry_msgs/PoseStamped[] poses
 ---
 #result definition
-#error codes
-#note: The expected priority order of the errors should match the message order
+
+# Error codes
+# Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=600
 uint16 TASK_EXECUTOR_FAILED=601

--- a/nav2_msgs/action/NavigateThroughPoses.action
+++ b/nav2_msgs/action/NavigateThroughPoses.action
@@ -4,8 +4,9 @@ geometry_msgs/PoseStamped[] poses
 string behavior_tree
 ---
 #result definition
-#error codes
-#note: The expected priority order of the errors should match the message order
+
+# Error codes
+# Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 
 uint16 error_code

--- a/nav2_msgs/action/NavigateThroughPoses.action
+++ b/nav2_msgs/action/NavigateThroughPoses.action
@@ -1,13 +1,13 @@
-# Error codes
-# Note: The expected priority order of the errors should match the message order
-uint16 NONE=0
 
 #goal definition
 geometry_msgs/PoseStamped[] poses
 string behavior_tree
 ---
 #result definition
-std_msgs/Empty result
+#error codes
+#note: The expected priority order of the errors should match the message order
+uint16 NONE=0
+
 uint16 error_code
 ---
 #feedback definition

--- a/nav2_msgs/action/NavigateToPose.action
+++ b/nav2_msgs/action/NavigateToPose.action
@@ -1,13 +1,12 @@
-# Error codes
-# Note: The expected priority order of the errors should match the message order
-uint16 NONE=0
-
 #goal definition
 geometry_msgs/PoseStamped pose
 string behavior_tree
 ---
 #result definition
-std_msgs/Empty result
+#error codes
+#note: The expected priority order of the errors should match the message order
+uint16 NONE=0
+
 uint16 error_code
 ---
 #feedback definition

--- a/nav2_msgs/action/NavigateToPose.action
+++ b/nav2_msgs/action/NavigateToPose.action
@@ -3,8 +3,9 @@ geometry_msgs/PoseStamped pose
 string behavior_tree
 ---
 #result definition
-#error codes
-#note: The expected priority order of the errors should match the message order
+
+# Error codes
+# Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 
 uint16 error_code

--- a/nav2_msgs/action/SmoothPath.action
+++ b/nav2_msgs/action/SmoothPath.action
@@ -1,5 +1,12 @@
-# Error codes
-# Note: The expected priority order of the errors should match the message order
+#goal definition
+nav_msgs/Path path
+string smoother_id
+builtin_interfaces/Duration max_smoothing_duration
+bool check_for_collisions
+---
+#result definition
+#error codes
+#note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=500
 uint16 INVALID_SMOOTHER=501
@@ -8,13 +15,6 @@ uint16 SMOOTHED_PATH_IN_COLLISION=503
 uint16 FAILED_TO_SMOOTH_PATH=504
 uint16 INVALID_PATH=505
 
-#goal definition
-nav_msgs/Path path
-string smoother_id
-builtin_interfaces/Duration max_smoothing_duration
-bool check_for_collisions
----
-#result definition
 nav_msgs/Path path
 builtin_interfaces/Duration smoothing_duration
 bool was_completed

--- a/nav2_msgs/action/SmoothPath.action
+++ b/nav2_msgs/action/SmoothPath.action
@@ -5,8 +5,9 @@ builtin_interfaces/Duration max_smoothing_duration
 bool check_for_collisions
 ---
 #result definition
-#error codes
-#note: The expected priority order of the errors should match the message order
+
+# Error codes
+# Note: The expected priority order of the errors should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=500
 uint16 INVALID_SMOOTHER=501

--- a/nav2_msgs/action/Spin.action
+++ b/nav2_msgs/action/Spin.action
@@ -1,16 +1,16 @@
-# Error codes
-# Note: The expected priority order of the error should match the message order
+#goal definition
+float32 target_yaw
+builtin_interfaces/Duration time_allowance
+---
+#result definition
+#error codes
+#note: The expected priority order of the error should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=700
 uint16 TIMEOUT=701
 uint16 TF_ERROR=702
 uint16 COLLISION_AHEAD=703
 
-#goal definition
-float32 target_yaw
-builtin_interfaces/Duration time_allowance
----
-#result definition
 builtin_interfaces/Duration total_elapsed_time
 uint16 error_code
 ---

--- a/nav2_msgs/action/Spin.action
+++ b/nav2_msgs/action/Spin.action
@@ -3,8 +3,9 @@ float32 target_yaw
 builtin_interfaces/Duration time_allowance
 ---
 #result definition
-#error codes
-#note: The expected priority order of the error should match the message order
+
+# Error codes
+# Note: The expected priority order of the error should match the message order
 uint16 NONE=0
 uint16 UNKNOWN=700
 uint16 TIMEOUT=701

--- a/nav2_planner/include/nav2_planner/planner_server.hpp
+++ b/nav2_planner/include/nav2_planner/planner_server.hpp
@@ -107,9 +107,9 @@ protected:
   nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
 
   using ActionToPose = nav2_msgs::action::ComputePathToPose;
-  using ActionToPoseGoal = ActionToPose::Goal;
+  using ActionToPoseResult = ActionToPose::Result;
   using ActionThroughPoses = nav2_msgs::action::ComputePathThroughPoses;
-  using ActionThroughPosesGoal = ActionThroughPoses::Goal;
+  using ActionThroughPosesResult = ActionThroughPoses::Result;
   using ActionServerToPose = nav2_util::SimpleActionServer<ActionToPose>;
   using ActionServerThroughPoses = nav2_util::SimpleActionServer<ActionThroughPoses>;
 

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -436,43 +436,43 @@ void PlannerServer::computePlanThroughPoses()
     action_server_poses_->succeeded_current(result);
   } catch (nav2_core::InvalidPlanner & ex) {
     exceptionWarning(curr_start, curr_goal, goal->planner_id, ex);
-    result->error_code = ActionToPoseGoal::INVALID_PLANNER;
+    result->error_code = ActionThroughPosesResult::INVALID_PLANNER;
     action_server_poses_->terminate_current(result);
   } catch (nav2_core::StartOccupied & ex) {
     exceptionWarning(curr_start, curr_goal, goal->planner_id, ex);
-    result->error_code = ActionThroughPosesGoal::START_OCCUPIED;
+    result->error_code = ActionThroughPosesResult::START_OCCUPIED;
     action_server_poses_->terminate_current(result);
   } catch (nav2_core::GoalOccupied & ex) {
     exceptionWarning(curr_start, curr_goal, goal->planner_id, ex);
-    result->error_code = ActionThroughPosesGoal::GOAL_OCCUPIED;
+    result->error_code = ActionThroughPosesResult::GOAL_OCCUPIED;
     action_server_poses_->terminate_current(result);
   } catch (nav2_core::NoValidPathCouldBeFound & ex) {
     exceptionWarning(curr_start, curr_goal, goal->planner_id, ex);
-    result->error_code = ActionThroughPosesGoal::NO_VALID_PATH;
+    result->error_code = ActionThroughPosesResult::NO_VALID_PATH;
     action_server_poses_->terminate_current(result);
   } catch (nav2_core::PlannerTimedOut & ex) {
     exceptionWarning(curr_start, curr_goal, goal->planner_id, ex);
-    result->error_code = ActionThroughPosesGoal::TIMEOUT;
+    result->error_code = ActionThroughPosesResult::TIMEOUT;
     action_server_poses_->terminate_current(result);
   } catch (nav2_core::StartOutsideMapBounds & ex) {
     exceptionWarning(curr_start, curr_goal, goal->planner_id, ex);
-    result->error_code = ActionThroughPosesGoal::START_OUTSIDE_MAP;
+    result->error_code = ActionThroughPosesResult::START_OUTSIDE_MAP;
     action_server_poses_->terminate_current(result);
   } catch (nav2_core::GoalOutsideMapBounds & ex) {
     exceptionWarning(curr_start, curr_goal, goal->planner_id, ex);
-    result->error_code = ActionThroughPosesGoal::GOAL_OUTSIDE_MAP;
+    result->error_code = ActionThroughPosesResult::GOAL_OUTSIDE_MAP;
     action_server_poses_->terminate_current(result);
   } catch (nav2_core::PlannerTFError & ex) {
     exceptionWarning(curr_start, curr_goal, goal->planner_id, ex);
-    result->error_code = ActionThroughPosesGoal::TF_ERROR;
+    result->error_code = ActionThroughPosesResult::TF_ERROR;
     action_server_poses_->terminate_current(result);
   } catch (nav2_core::NoViapointsGiven & ex) {
     exceptionWarning(curr_start, curr_goal, goal->planner_id, ex);
-    result->error_code = ActionThroughPosesGoal::NO_VIAPOINTS_GIVEN;
+    result->error_code = ActionThroughPosesResult::NO_VIAPOINTS_GIVEN;
     action_server_poses_->terminate_current(result);
   } catch (std::exception & ex) {
     exceptionWarning(curr_start, curr_goal, goal->planner_id, ex);
-    result->error_code = ActionThroughPosesGoal::UNKNOWN;
+    result->error_code = ActionThroughPosesResult::UNKNOWN;
     action_server_poses_->terminate_current(result);
   }
 }
@@ -531,39 +531,39 @@ PlannerServer::computePlan()
     action_server_pose_->succeeded_current(result);
   } catch (nav2_core::InvalidPlanner & ex) {
     exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = ActionToPoseGoal::INVALID_PLANNER;
+    result->error_code = ActionToPoseResult::INVALID_PLANNER;
     action_server_pose_->terminate_current(result);
   } catch (nav2_core::StartOccupied & ex) {
     exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = ActionToPoseGoal::START_OCCUPIED;
+    result->error_code = ActionToPoseResult::START_OCCUPIED;
     action_server_pose_->terminate_current(result);
   } catch (nav2_core::GoalOccupied & ex) {
     exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = ActionToPoseGoal::GOAL_OCCUPIED;
+    result->error_code = ActionToPoseResult::GOAL_OCCUPIED;
     action_server_pose_->terminate_current(result);
   } catch (nav2_core::NoValidPathCouldBeFound & ex) {
     exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = ActionToPoseGoal::NO_VALID_PATH;
+    result->error_code = ActionToPoseResult::NO_VALID_PATH;
     action_server_pose_->terminate_current(result);
   } catch (nav2_core::PlannerTimedOut & ex) {
     exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = ActionToPoseGoal::TIMEOUT;
+    result->error_code = ActionToPoseResult::TIMEOUT;
     action_server_pose_->terminate_current(result);
   } catch (nav2_core::StartOutsideMapBounds & ex) {
     exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = ActionToPoseGoal::START_OUTSIDE_MAP;
+    result->error_code = ActionToPoseResult::START_OUTSIDE_MAP;
     action_server_pose_->terminate_current(result);
   } catch (nav2_core::GoalOutsideMapBounds & ex) {
     exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = ActionToPoseGoal::GOAL_OUTSIDE_MAP;
+    result->error_code = ActionToPoseResult::GOAL_OUTSIDE_MAP;
     action_server_pose_->terminate_current(result);
   } catch (nav2_core::PlannerTFError & ex) {
     exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = ActionToPoseGoal::TF_ERROR;
+    result->error_code = ActionToPoseResult::TF_ERROR;
     action_server_pose_->terminate_current(result);
   } catch (std::exception & ex) {
     exceptionWarning(start, goal->goal, goal->planner_id, ex);
-    result->error_code = ActionToPoseGoal::UNKNOWN;
+    result->error_code = ActionToPoseResult::UNKNOWN;
     action_server_pose_->terminate_current(result);
   }
 }

--- a/nav2_smoother/include/nav2_smoother/nav2_smoother.hpp
+++ b/nav2_smoother/include/nav2_smoother/nav2_smoother.hpp
@@ -114,7 +114,7 @@ protected:
   nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
 
   using Action = nav2_msgs::action::SmoothPath;
-  using ActionGoal = Action::Goal;
+  using ActionResult = Action::Result;
   using ActionServer = nav2_util::SimpleActionServer<Action>;
 
   /**

--- a/nav2_smoother/src/nav2_smoother.cpp
+++ b/nav2_smoother/src/nav2_smoother.cpp
@@ -321,37 +321,37 @@ void SmootherServer::smoothPlan()
     action_server_->succeeded_current(result);
   } catch (nav2_core::InvalidSmoother & ex) {
     RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
-    result->error_code = ActionGoal::INVALID_SMOOTHER;
+    result->error_code = ActionResult::INVALID_SMOOTHER;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::SmootherTimedOut & ex) {
     RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
-    result->error_code = ActionGoal::TIMEOUT;
+    result->error_code = ActionResult::TIMEOUT;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::SmoothedPathInCollision & ex) {
     RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
-    result->error_code = ActionGoal::SMOOTHED_PATH_IN_COLLISION;
+    result->error_code = ActionResult::SMOOTHED_PATH_IN_COLLISION;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::FailedToSmoothPath & ex) {
     RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
-    result->error_code = ActionGoal::FAILED_TO_SMOOTH_PATH;
+    result->error_code = ActionResult::FAILED_TO_SMOOTH_PATH;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::InvalidPath & ex) {
     RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
-    result->error_code = ActionGoal::INVALID_PATH;
+    result->error_code = ActionResult::INVALID_PATH;
     action_server_->terminate_current(result);
     return;
   } catch (nav2_core::SmootherException & ex) {
     RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
-    result->error_code = ActionGoal::UNKNOWN;
+    result->error_code = ActionResult::UNKNOWN;
     action_server_->terminate_current(result);
     return;
   } catch (std::exception & ex) {
     RCLCPP_ERROR(this->get_logger(), "%s", ex.what());
-    result->error_code = ActionGoal::UNKNOWN;
+    result->error_code = ActionResult::UNKNOWN;
     action_server_->terminate_current(result);
     return;
   }

--- a/nav2_system_tests/src/behavior_tree/server_handler.hpp
+++ b/nav2_system_tests/src/behavior_tree/server_handler.hpp
@@ -74,7 +74,7 @@ protected:
     std::shared_ptr<nav2_msgs::action::ComputePathToPose::Result>
     & result) override
   {
-    result->error_code = nav2_msgs::action::ComputePathToPose::Goal::TIMEOUT;
+    result->error_code = nav2_msgs::action::ComputePathToPose::Result::TIMEOUT;
   }
 
 private:
@@ -92,7 +92,7 @@ protected:
     std::shared_ptr<nav2_msgs::action::FollowPath::Result>
     & result) override
   {
-    result->error_code = nav2_msgs::action::FollowPath::Goal::NO_VALID_CONTROL;
+    result->error_code = nav2_msgs::action::FollowPath::Result::NO_VALID_CONTROL;
   }
 };
 

--- a/nav2_system_tests/src/error_codes/test_error_codes.py
+++ b/nav2_system_tests/src/error_codes/test_error_codes.py
@@ -54,13 +54,13 @@ def main(argv=sys.argv[1:]):
 
     navigator._waitForNodeToActivate('controller_server')
     follow_path = {
-        'unknown': FollowPath.Goal().UNKNOWN,
-        'invalid_controller': FollowPath.Goal().INVALID_CONTROLLER,
-        'tf_error': FollowPath.Goal().TF_ERROR,
-        'invalid_path': FollowPath.Goal().INVALID_PATH,
-        'patience_exceeded': FollowPath.Goal().PATIENCE_EXCEEDED,
-        'failed_to_make_progress': FollowPath.Goal().FAILED_TO_MAKE_PROGRESS,
-        'no_valid_control': FollowPath.Goal().NO_VALID_CONTROL
+        'unknown': FollowPath.Result().UNKNOWN,
+        'invalid_controller': FollowPath.Result().INVALID_CONTROLLER,
+        'tf_error': FollowPath.Result().TF_ERROR,
+        'invalid_path': FollowPath.Result().INVALID_PATH,
+        'patience_exceeded': FollowPath.Result().PATIENCE_EXCEEDED,
+        'failed_to_make_progress': FollowPath.Result().FAILED_TO_MAKE_PROGRESS,
+        'no_valid_control': FollowPath.Result().NO_VALID_CONTROL
     }
 
     for controller, error_code in follow_path.items():
@@ -88,15 +88,15 @@ def main(argv=sys.argv[1:]):
 
     navigator._waitForNodeToActivate('planner_server')
     compute_path_to_pose = {
-        'unknown': ComputePathToPose.Goal().UNKNOWN,
-        'invalid_planner': ComputePathToPose.Goal().INVALID_PLANNER,
-        'tf_error': ComputePathToPose.Goal().TF_ERROR,
-        'start_outside_map': ComputePathToPose.Goal().START_OUTSIDE_MAP,
-        'goal_outside_map': ComputePathToPose.Goal().GOAL_OUTSIDE_MAP,
-        'start_occupied': ComputePathToPose.Goal().START_OCCUPIED,
-        'goal_occupied': ComputePathToPose.Goal().GOAL_OCCUPIED,
-        'timeout': ComputePathToPose.Goal().TIMEOUT,
-        'no_valid_path': ComputePathToPose.Goal().NO_VALID_PATH}
+        'unknown': ComputePathToPose.Result().UNKNOWN,
+        'invalid_planner': ComputePathToPose.Result().INVALID_PLANNER,
+        'tf_error': ComputePathToPose.Result().TF_ERROR,
+        'start_outside_map': ComputePathToPose.Result().START_OUTSIDE_MAP,
+        'goal_outside_map': ComputePathToPose.Result().GOAL_OUTSIDE_MAP,
+        'start_occupied': ComputePathToPose.Result().START_OCCUPIED,
+        'goal_occupied': ComputePathToPose.Result().GOAL_OCCUPIED,
+        'timeout': ComputePathToPose.Result().TIMEOUT,
+        'no_valid_path': ComputePathToPose.Result().NO_VALID_PATH}
 
     for planner, error_code in compute_path_to_pose.items():
         result = navigator._getPathImpl(initial_pose, goal_pose, planner)
@@ -107,16 +107,16 @@ def main(argv=sys.argv[1:]):
     goal_poses = [goal_pose, goal_pose1]
 
     compute_path_through_poses = {
-        'unknown': ComputePathThroughPoses.Goal().UNKNOWN,
-        'invalid_planner': ComputePathToPose.Goal().INVALID_PLANNER,
-        'tf_error': ComputePathThroughPoses.Goal().TF_ERROR,
-        'start_outside_map': ComputePathThroughPoses.Goal().START_OUTSIDE_MAP,
-        'goal_outside_map': ComputePathThroughPoses.Goal().GOAL_OUTSIDE_MAP,
-        'start_occupied': ComputePathThroughPoses.Goal().START_OCCUPIED,
-        'goal_occupied': ComputePathThroughPoses.Goal().GOAL_OCCUPIED,
-        'timeout': ComputePathThroughPoses.Goal().TIMEOUT,
-        'no_valid_path': ComputePathThroughPoses.Goal().NO_VALID_PATH,
-        'no_viapoints_given': ComputePathThroughPoses.Goal().NO_VIAPOINTS_GIVEN}
+        'unknown': ComputePathThroughPoses.Result().UNKNOWN,
+        'invalid_planner': ComputePathThroughPoses.Result().INVALID_PLANNER,
+        'tf_error': ComputePathThroughPoses.Result().TF_ERROR,
+        'start_outside_map': ComputePathThroughPoses.Result().START_OUTSIDE_MAP,
+        'goal_outside_map': ComputePathThroughPoses.Result().GOAL_OUTSIDE_MAP,
+        'start_occupied': ComputePathThroughPoses.Result().START_OCCUPIED,
+        'goal_occupied': ComputePathThroughPoses.Result().GOAL_OCCUPIED,
+        'timeout': ComputePathThroughPoses.Result().TIMEOUT,
+        'no_valid_path': ComputePathThroughPoses.Result().NO_VALID_PATH,
+        'no_viapoints_given': ComputePathThroughPoses.Result().NO_VIAPOINTS_GIVEN}
 
     for planner, error_code in compute_path_through_poses.items():
         result = navigator._getPathThroughPosesImpl(initial_pose, goal_poses, planner)
@@ -141,12 +141,12 @@ def main(argv=sys.argv[1:]):
 
     navigator._waitForNodeToActivate('smoother_server')
     smoother = {
-        'invalid_smoother': SmoothPath.Goal().INVALID_SMOOTHER,
-        'unknown': SmoothPath.Goal().UNKNOWN,
-        'timeout': SmoothPath.Goal().TIMEOUT,
-        'smoothed_path_in_collision': SmoothPath.Goal().SMOOTHED_PATH_IN_COLLISION,
-        'failed_to_smooth_path': SmoothPath.Goal().FAILED_TO_SMOOTH_PATH,
-        'invalid_path': SmoothPath.Goal().INVALID_PATH
+        'invalid_smoother': SmoothPath.Result().INVALID_SMOOTHER,
+        'unknown': SmoothPath.Result().UNKNOWN,
+        'timeout': SmoothPath.Result().TIMEOUT,
+        'smoothed_path_in_collision': SmoothPath.Result().SMOOTHED_PATH_IN_COLLISION,
+        'failed_to_smooth_path': SmoothPath.Result().FAILED_TO_SMOOTH_PATH,
+        'invalid_path': SmoothPath.Result().INVALID_PATH
     }
 
     for smoother, error_code in smoother.items():

--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -231,7 +231,7 @@ def main(argv=sys.argv[1:]):
     assert not result
     result = not result
     assert test.action_result.missed_waypoints[0].error_code == \
-           ComputePathToPose.Goal().GOAL_OUTSIDE_MAP
+           ComputePathToPose.Result().GOAL_OUTSIDE_MAP
 
     # stop on failure test with bogous waypoint
     test.setStopFailureParam(True)

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -251,7 +251,7 @@ WaypointFollower::followWaypoints()
         nav2_msgs::msg::MissedWaypoint missedWaypoint;
         missedWaypoint.index = goal_index;
         missedWaypoint.goal = goal->poses[goal_index];
-        missedWaypoint.error_code = nav2_msgs::action::FollowWaypoints::Goal::TASK_EXECUTOR_FAILED;
+        missedWaypoint.error_code = nav2_msgs::action::FollowWaypoints::Result::TASK_EXECUTOR_FAILED;
         result->missed_waypoints.push_back(missedWaypoint);
       }
       // if task execution was failed and stop_on_failure_ is on , terminate action

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -251,7 +251,8 @@ WaypointFollower::followWaypoints()
         nav2_msgs::msg::MissedWaypoint missedWaypoint;
         missedWaypoint.index = goal_index;
         missedWaypoint.goal = goal->poses[goal_index];
-        missedWaypoint.error_code = nav2_msgs::action::FollowWaypoints::Result::TASK_EXECUTOR_FAILED;
+        missedWaypoint.error_code =
+          nav2_msgs::action::FollowWaypoints::Result::TASK_EXECUTOR_FAILED;
         result->missed_waypoints.push_back(missedWaypoint);
       }
       // if task execution was failed and stop_on_failure_ is on , terminate action


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo |

---

## Description of contribution in a few bullet points
Previously, the error code enumerations were define in the goal section of the action message. This was incorrect because the the error code is a result. This pr moves the error code enumerations for the actions to the result section.  

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
