### PR TITLE
Collision Monitor fixups

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -27,7 +27,6 @@
 #include "tf2_ros/transform_listener.h"
 
 #include "nav2_util/lifecycle_node.hpp"
-#include "nav2_util/robot_utils.hpp"
 #include "nav2_msgs/msg/collision_monitor_state.hpp"
 
 #include "nav2_collision_monitor/types.hpp"

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -34,7 +34,7 @@ collision_monitor:
       type: "polygon"
       points: [0.5, 0.5, 0.5, -0.5, -0.5, -0.5, -0.5, 0.5]
       action_type: "limit"
-      max_points: 3
+      min_points: 4
       linear_limit: 0.4
       angular_limit: 0.5
       visualize: True

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -21,6 +21,7 @@
 #include "tf2_ros/create_timer_ros.h"
 
 #include "nav2_util/node_utils.hpp"
+#include "nav2_util/robot_utils.hpp"
 
 #include "nav2_collision_monitor/kinematics.hpp"
 

--- a/nav2_util/include/nav2_util/robot_utils.hpp
+++ b/nav2_util/include/nav2_util/robot_utils.hpp
@@ -60,18 +60,6 @@ bool transformPoseInTargetFrame(
   const double transform_timeout = 0.1);
 
 /**
- * @brief Obtains a transform from source_frame_id at source_time ->
- * to target_frame_id at target_time time
- * @param source_frame_id Source frame ID to convert from
- * @param source_time Source timestamp to convert from
- * @param target_frame_id Target frame ID to convert to
- * @param target_time Target time to interpolate to
- * @param transform_tolerance Transform tolerance
- * @param tf_transform Output source->target transform
- * @return True if got correct transform, otherwise false
- */
-
-/**
  * @brief Obtains a transform from source_frame_id -> to target_frame_id
  * @param source_frame_id Source frame ID to convert from
  * @param target_frame_id Target frame ID to convert to


### PR DESCRIPTION
Here are various fixes for CM, that have been detected recently during CM PR's review
* Fix `max_points` -> `min_points` in parameters
* Move `robot_utils.hpp` include to the source where it is actually using
* Remove double-description of `getTransform()` in header

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | `colcon test --packages-select nav2_collision_monitor` (no regressions) |

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
