### PR TITLE
Velocity smoother natural deadband

### DIFF
--- a/nav2_velocity_smoother/README.md
+++ b/nav2_velocity_smoother/README.md
@@ -54,6 +54,7 @@ velocity_smoother:
   	max_velocity: [0.5, 0.0, 2.5]  # Maximum velocities, ordered [Vx, Vy, Vw]
    	min_velocity: [-0.5, 0.0, -2.5]  # Minimum velocities, ordered [Vx, Vy, Vw]
    	deadband_velocity: [0.0, 0.0, 0.0]  # A deadband of velocities below which they should be zero-ed out for sending to the robot base controller, ordered [Vx, Vy, Vw]
+		natural_deadband_velocity: [0.0, 0.0, 0.0] # existing deadbands of the robot base controller, for intelligent closed loop smoothing
    	velocity_timeout: 1.0  # Time (s) after which if no new velocity commands are received to zero out and stop
    	max_accel: [2.5, 0.0, 3.2]  # Maximum acceleration, ordered [Ax, Ay, Aw]
    	max_decel: [-2.5, 0.0, -3.2]  # Maximum deceleration, ordered [Ax, Ay, Aw]
@@ -85,3 +86,5 @@ When in doubt, open-loop is a reasonable choice for most users.
 The minimum and maximum velocities for rotation (e.g. ``Vw``) represent left and right turns. While we make it possible to specify these separately, most users would be wise to set these values the same (but signed) for rotation. Additionally, the parameters are signed, so it is important to specify maximum deceleration with negative signs to represent deceleration. Minimum velocities with negatives when moving backward, so backward movement can be restricted by setting this to ``0``.
 
 Deadband velocities are minimum thresholds, below which we set its value to `0`. This can be useful when your robot's breaking torque from stand still is non-trivial so sending very small values will pull high amounts of current.
+
+The natural deadband velocities are to specify the minimum magnitude of velocity commands that will actually move the system. This is useful for closed loop control in systems that have inherent deadbands and will not move in response to small commands.

--- a/nav2_velocity_smoother/include/nav2_velocity_smoother/velocity_smoother.hpp
+++ b/nav2_velocity_smoother/include/nav2_velocity_smoother/velocity_smoother.hpp
@@ -150,6 +150,7 @@ protected:
   std::vector<double> max_accels_;
   std::vector<double> max_decels_;
   std::vector<double> deadband_velocities_;
+  std::vector<double> natural_deadband_velocities_;
   rclcpp::Duration velocity_timeout_{0, 0};
   rclcpp::Time last_command_time_;
 

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -612,6 +612,7 @@ TEST(VelocitySmootherTest, testDynamicParameter)
   std::vector<double> max_accel{10.0, 10.0, 10.0};
   std::vector<double> min_accel{0.0, 0.0, 0.0};
   std::vector<double> deadband{0.0, 0.0, 0.0};
+  std::vector<double> natural_deadband{0.0, 0.0, 0.0};
   std::vector<double> bad_test{0.0, 0.0};
 
   auto results = rec_param->set_parameters_atomically(
@@ -625,7 +626,8 @@ TEST(VelocitySmootherTest, testDynamicParameter)
       rclcpp::Parameter("odom_topic", std::string("TEST")),
       rclcpp::Parameter("odom_duration", 2.0),
       rclcpp::Parameter("velocity_timeout", 4.0),
-      rclcpp::Parameter("deadband_velocity", deadband)});
+      rclcpp::Parameter("deadband_velocity", deadband),
+      rclcpp::Parameter("natural_deadband_velocity", deadband)});
 
   rclcpp::spin_until_future_complete(
     smoother->get_node_base_interface(),
@@ -642,6 +644,7 @@ TEST(VelocitySmootherTest, testDynamicParameter)
   EXPECT_EQ(smoother->get_parameter("odom_duration").as_double(), 2.0);
   EXPECT_EQ(smoother->get_parameter("velocity_timeout").as_double(), 4.0);
   EXPECT_EQ(smoother->get_parameter("deadband_velocity").as_double_array(), deadband);
+  EXPECT_EQ(smoother->get_parameter("natural_deadband_velocity").as_double_array(), natural_deadband);
 
   // Test reverting
   results = rec_param->set_parameters_atomically(

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -627,7 +627,7 @@ TEST(VelocitySmootherTest, testDynamicParameter)
       rclcpp::Parameter("odom_duration", 2.0),
       rclcpp::Parameter("velocity_timeout", 4.0),
       rclcpp::Parameter("deadband_velocity", deadband),
-      rclcpp::Parameter("natural_deadband_velocity", deadband)});
+      rclcpp::Parameter("natural_deadband_velocity", natural_deadband)});
 
   rclcpp::spin_until_future_complete(
     smoother->get_node_base_interface(),
@@ -644,7 +644,9 @@ TEST(VelocitySmootherTest, testDynamicParameter)
   EXPECT_EQ(smoother->get_parameter("odom_duration").as_double(), 2.0);
   EXPECT_EQ(smoother->get_parameter("velocity_timeout").as_double(), 4.0);
   EXPECT_EQ(smoother->get_parameter("deadband_velocity").as_double_array(), deadband);
-  EXPECT_EQ(smoother->get_parameter("natural_deadband_velocity").as_double_array(), natural_deadband);
+  EXPECT_EQ(
+    smoother->get_parameter("natural_deadband_velocity").as_double_array(),
+    natural_deadband);
 
   // Test reverting
   results = rec_param->set_parameters_atomically(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3699 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Proprietary |

---

## Description of contribution in a few bullet points
This fixes the bug that specifying a non-zero deadband velocity on open loop mode makes it so you are stuck at 0 forever. This also adds a separate construct, the natural deadband velocity, which snaps up to that minimum value instead of snapping down like the existing deadband velocity. It's purpose is to fix trying to use closed loop mode on a system with an inherent deadband.

## Description of documentation updates required from your changes
Added new parameter `natural_deadband_velocities`

---

## Future work that may be required in bullet points
- maybe rename this new parameter

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
