### PR TITLE
Add velocity based polygon

### DIFF
--- a/nav2_collision_monitor/CMakeLists.txt
+++ b/nav2_collision_monitor/CMakeLists.txt
@@ -45,6 +45,7 @@ set(library_name ${executable_name}_core)
 add_library(${library_name} SHARED
   src/collision_monitor_node.cpp
   src/polygon.cpp
+  src/polygon_velocity.cpp
   src/circle.cpp
   src/source.cpp
   src/scan.cpp

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -28,6 +28,7 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_costmap_2d/footprint_subscriber.hpp"
 
+#include "nav2_collision_monitor/polygon_velocity.hpp"
 #include "nav2_collision_monitor/types.hpp"
 
 namespace nav2_collision_monitor
@@ -126,6 +127,16 @@ public:
    * Othewise, prints a warning and returns false.
    */
   virtual bool isShapeSet();
+
+  /**
+   * @brief Returns true if using velocity based polygon
+   */
+  bool isUsingPolygonVelocitySelector();
+
+  /**
+   * @brief Updates polygon by velocity (if any)
+   */
+  void updatePolygonByVelocity(const Velocity & cmd_vel_in);
 
   /**
    * @brief Updates polygon from footprint subscriber (if any)
@@ -242,6 +253,9 @@ protected:
   geometry_msgs::msg::PolygonStamped polygon_;
   /// @brief Polygon publisher for visualization purposes
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PolygonStamped>::SharedPtr polygon_pub_;
+
+  /// @brief Polygon velocity (if any)
+  std::vector<std::shared_ptr<PolygonVelocity>> polygon_velocity_;
 
   /// @brief Polygon points (vertices) in a base_frame_id_
   std::vector<Point> poly_;

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon_velocity.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon_velocity.hpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2022 Samsung R&D Institute Russia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_COLLISION_MONITOR__POLYGON_VELOCITY_HPP_
+#define NAV2_COLLISION_MONITOR__POLYGON_VELOCITY_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "nav2_collision_monitor/types.hpp"
+
+namespace nav2_collision_monitor
+{
+
+/**
+ * @brief Polygon velocity class.
+ * This class contains all the points of the polygon and
+ * the expected condition of the velocity based polygon.
+ */
+class PolygonVelocity
+{
+public:
+  /**
+   * @brief PolygonVelocity constructor
+   * @param poly Points of the polygon
+   * @param polygon_name Name of polygon
+   * @param linear_max Maximum twist linear velocity
+   * @param linear_min Minimum twist linear velocity
+   * @param direction_max Maximum twist direction angle
+   * @param direction_min Minimum twist direction angle
+   * @param theta_max Maximum twist rotational speed
+   * @param theta_min Minimum twist rotational speed
+   */
+  PolygonVelocity(
+    const std::vector<Point> & poly,
+    const std::string & polygon_name,
+    const double & linear_max,
+    const double & linear_min,
+    const double & direction_max,
+    const double & direction_min,
+    const double & theta_max,
+    const double & theta_min);
+  /**
+   * @brief PolygonVelocity destructor
+   */
+  virtual ~PolygonVelocity();
+
+  /**
+   * @brief Check if the velocities and direction is in expected range.
+   * @param cmd_vel_in Robot twist command input
+   * @return True if speed and direction is within the condition
+   */
+  bool isInRange(const Velocity & cmd_vel_in);
+
+  /**
+   * @brief Check if the velocities and direction is in expected range.
+   * @param cmd_vel_in Robot twist command input
+   * @return True if speed and direction is within the condition
+   */
+  std::vector<Point> getPolygon();
+
+protected:
+  // ----- Variables -----
+
+  /// @brief Collision monitor node logger stored for further usage
+  rclcpp::Logger logger_{rclcpp::get_logger("collision_monitor")};
+
+  // Basic parameters
+  /// @brief Points of the polygon
+  std::vector<Point> poly_;
+  /// @brief Name of polygon
+  std::string polygon_name_;
+  /// @brief Maximum twist linear velocity
+  double linear_max_;
+  /// @brief Minimum twist linear velocity
+  double linear_min_;
+  /// @brief Maximum twist direction angle
+  double direction_max_;
+  /// @brief Minimum twist direction angle
+  double direction_min_;
+  /// @brief Maximum twist rotational speed
+  double theta_max_;
+  /// @brief Minimum twist rotational speed
+  double theta_min_;
+};  // class PolygonVelocity
+
+}  // namespace nav2_collision_monitor
+
+#endif  // NAV2_COLLISION_MONITOR__POLYGON_VELOCITY_HPP_

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -42,11 +42,45 @@ collision_monitor:
     FootprintApproach:
       type: "polygon"
       action_type: "approach"
-      footprint_topic: "/local_costmap/published_footprint"
+      # footprint_topic: "/local_costmap/published_footprint"
       time_before_collision: 2.0
       simulation_time_step: 0.1
       min_points: 6
-      visualize: False
+      visualize: True
+      polygon_pub_topic: "polygon_approach"
+      polygon_velocity: ["stop", "rotation", "translation_forward", "translation_backward"] # third priority
+      stop:
+        points: [0.25, 0.25, 0.25, -0.25, -0.25, -0.25, -0.25, 0.25]
+        linear_min: 0.0
+        linear_max: 0.01
+        direction_min: -3.14159
+        direction_max: 3.14159
+        theta_min: 0.0
+        theta_max: 0.01
+      rotation:
+        points: [0.3, 0.3, 0.3, -0.3, -0.3, -0.3, -0.3, 0.3]
+        linear_min: 0.0
+        linear_max: 0.05
+        direction_min: -3.14159
+        direction_max: 3.14159
+        theta_min: -1.0
+        theta_max: 1.0
+      translation_forward:
+        points: [0.35, 0.3, 0.35, -0.3, -0.2, -0.3, -0.2, 0.3]
+        linear_min: 0.0
+        linear_max: 1.0
+        direction_min: -1.5708
+        direction_max: 1.5708
+        theta_min: -1.0
+        theta_max: 1.0
+      translation_backward:
+        points: [0.2, 0.3, 0.2, -0.3, -0.35, -0.3, -0.35, 0.3]
+        linear_min: 0.0
+        linear_max: 1.0
+        direction_min: 1.5708
+        direction_max: -1.5708
+        theta_min: -1.0
+        theta_max: 1.0
     observation_sources: ["scan"]
     scan:
       type: "scan"

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -423,6 +423,10 @@ bool CollisionMonitor::processStopSlowdownLimit(
   const Velocity & velocity,
   Action & robot_action) const
 {
+  if (polygon->isUsingPolygonVelocitySelector()) {
+    polygon->updatePolygonByVelocity(velocity);
+  }
+
   if (!polygon->isShapeSet()) {
     return false;
   }
@@ -478,6 +482,10 @@ bool CollisionMonitor::processApproach(
   const Velocity & velocity,
   Action & robot_action) const
 {
+  if (polygon->isUsingPolygonVelocitySelector()) {
+    polygon->updatePolygonByVelocity(velocity);
+  }
+
   if (!polygon->isShapeSet()) {
     return false;
   }

--- a/nav2_collision_monitor/src/polygon_velocity.cpp
+++ b/nav2_collision_monitor/src/polygon_velocity.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 Samsung R&D Institute Russia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_collision_monitor/polygon_velocity.hpp"
+
+#include "nav2_util/node_utils.hpp"
+#include "nav2_util/robot_utils.hpp"
+
+
+namespace nav2_collision_monitor
+{
+
+PolygonVelocity::PolygonVelocity(
+  const std::vector<Point> & poly,
+  const std::string & polygon_name,
+  const double & linear_max,
+  const double & linear_min,
+  const double & direction_max,
+  const double & direction_min,
+  const double & theta_max,
+  const double & theta_min)
+: poly_(poly), polygon_name_(polygon_name), linear_max_(linear_max), linear_min_(linear_min),
+  direction_max_(direction_max), direction_min_(direction_min),
+  theta_max_(theta_max), theta_min_(theta_min)
+{
+  RCLCPP_INFO(logger_, "[%s]: Creating PolygonVelocity", polygon_name_.c_str());
+}
+
+
+PolygonVelocity::~PolygonVelocity()
+{
+  RCLCPP_INFO(logger_, "[%s]: Destroying PolygonVelocity", polygon_name_.c_str());
+  poly_.clear();
+}
+
+bool PolygonVelocity::isInRange(const Velocity & cmd_vel_in)
+{
+  const double twist_linear = std::hypot(cmd_vel_in.x, cmd_vel_in.y);
+
+  // check if direction in angle range(min -> max)
+  double direction = std::atan2(cmd_vel_in.y, cmd_vel_in.x);
+  bool direction_in_range;
+  if (direction_min_ <= direction_max_) {
+    direction_in_range = (direction >= direction_min_ && direction <= direction_max_);
+  } else {
+    direction_in_range = (direction >= direction_min_ || direction <= direction_max_);
+  }
+
+  return twist_linear <= linear_max_ &&
+         twist_linear >= linear_min_ &&
+         direction_in_range &&
+         cmd_vel_in.tw <= theta_max_ &&
+         cmd_vel_in.tw >= theta_min_;
+}
+
+
+std::vector<Point> PolygonVelocity::getPolygon()
+{
+  return poly_;
+}
+
+
+}  // namespace nav2_collision_monitor


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  #3313  |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | Nav2 TB3 gazebo simulation |

---

## Description of contribution in a few bullet points

* Adds velocity based polygon as the third priority in Collision Monitor

## Description of documentation updates required from your changes

* Added new parameter - `polygon_velocity`, so need to add that to default configs and documentation page


---

## Future work that may be required in bullet points

* Add odom speed condition check (linear, direction + theta too) for speed based polygon. (Better control on when to switch based on actual speed)


## Pending 
* Full range velocity coverage check(linear, direction, theta)

## Test
1. Use `tb3_simulation_launch.py`
2. Update collision_monitor [config](https://github.com/ros-planning/navigation2/blob/main/nav2_collision_monitor/params/collision_monitor_params.yaml#L17) to use `FootprintApproach`
3. Use `rqt_robot_steering` for convenient bi-directional testing

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
