### PR TITLE
Same orientation of coordinate frames in rviz ang gazebo

### DIFF
--- a/nav2_bringup/rviz/nav2_default_view.rviz
+++ b/nav2_bringup/rviz/nav2_default_view.rviz
@@ -560,7 +560,7 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Angle: -1.6150002479553223
+      Angle: 0
       Class: rviz_default_plugins/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
@@ -570,11 +570,11 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Scale: 127.88431549072266
+      Scale: 160
       Target Frame: <Fixed Frame>
       Value: TopDownOrtho (rviz_default_plugins)
-      X: -0.044467076659202576
-      Y: -0.38726311922073364
+      X: 0
+      Y: 0
     Saved: ~
 Window Geometry:
   Displays:

--- a/nav2_bringup/rviz/nav2_default_view.rviz
+++ b/nav2_bringup/rviz/nav2_default_view.rviz
@@ -560,7 +560,7 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Angle: 0
+      Angle: -1.5708
       Class: rviz_default_plugins/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549

--- a/nav2_bringup/rviz/nav2_namespaced_view.rviz
+++ b/nav2_bringup/rviz/nav2_namespaced_view.rviz
@@ -342,7 +342,7 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Angle: -1.5700000524520874
+      Angle: 0
       Class: rviz_default_plugins/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
@@ -352,11 +352,11 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Scale: 134.638427734375
+      Scale: 160
       Target Frame: <Fixed Frame>
       Value: TopDownOrtho (rviz_default_plugins)
-      X: -0.032615214586257935
-      Y: -0.0801941454410553
+      X: 0
+      Y: 0
     Saved: ~
 Window Geometry:
   Displays:

--- a/nav2_bringup/rviz/nav2_namespaced_view.rviz
+++ b/nav2_bringup/rviz/nav2_namespaced_view.rviz
@@ -342,7 +342,7 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Angle: 0
+      Angle: -1.5708
       Class: rviz_default_plugins/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549

--- a/nav2_bringup/worlds/world_only.model
+++ b/nav2_bringup/worlds/world_only.model
@@ -16,7 +16,7 @@
 
     <gui fullscreen='0'>
       <camera name='user_camera'>
-        <pose frame=''>0.319654 -0.235002 9.29441 0 1.5138 0.009599</pose>
+        <pose frame=''>0 0 10 0 1.570796 1.570796</pose>
         <view_controller>orbit</view_controller>
         <projection_type>perspective</projection_type>
       </camera>

--- a/nav2_bringup/worlds/world_only.model
+++ b/nav2_bringup/worlds/world_only.model
@@ -16,7 +16,7 @@
 
     <gui fullscreen='0'>
       <camera name='user_camera'>
-        <pose frame=''>0 0 10 0 1.570796 1.570796</pose>
+        <pose frame=''>0 0 10 0 1.570796 0</pose>
         <view_controller>orbit</view_controller>
         <projection_type>perspective</projection_type>
       </camera>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo |

---

## Description of contribution in a few bullet points

* The coordinate frames in rviz and gazebo are oriented such that the positive x-axis points right
* This could simplify things for beginner users.
![rviz](https://github.com/ros-planning/navigation2/assets/6976069/ac488ed5-21fb-4208-9ff5-b8b0fc8fc439)
![gazebo](https://github.com/ros-planning/navigation2/assets/6976069/998ff0f1-cec6-406d-ae1a-4332ec89e4f1)

## Description of documentation updates required from your changes

Is there maybe some tutorial that references this?

---

## Future work that may be required in bullet points

None

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
