### PR TITLE
Fix zig-zaggin in smac planner due to discrete angular bin quantizations

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
@@ -110,7 +110,7 @@ public:
    */
   bool createPath(
     CoordinateVector & path, int & num_iterations, const float & tolerance,
-    std::vector<std::tuple<float, float>> * expansions_log = nullptr);
+    std::vector<std::tuple<float, float, float>> * expansions_log = nullptr);
 
   /**
    * @brief Sets the collision checker to use
@@ -239,6 +239,14 @@ protected:
    * @brief Clear graph of nodes searched
    */
   inline void clearGraph();
+
+  /**
+   * @brief Populate a debug log of expansions for Hybrid-A* for visualization
+   * @param node Node expanded
+   * @param expansions_log Log to add not expanded to
+   */
+  inline void populateExpansionsLog(const NodePtr & node,
+  std::vector<std::tuple<float, float, float>> * expansions_log);
 
   int _timing_interval = 5000;
 

--- a/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
@@ -245,8 +245,8 @@ protected:
    * @param node Node expanded
    * @param expansions_log Log to add not expanded to
    */
-  inline void populateExpansionsLog(const NodePtr & node,
-  std::vector<std::tuple<float, float, float>> * expansions_log);
+  inline void populateExpansionsLog(
+    const NodePtr & node, std::vector<std::tuple<float, float, float>> * expansions_log);
 
   int _timing_interval = 5000;
 

--- a/nav2_smac_planner/include/nav2_smac_planner/node_basic.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_basic.hpp
@@ -76,6 +76,7 @@ public:
   MotionPrimitive * prim_ptr;  // Used by NodeLattice
   unsigned int index, motion_index;
   bool backward;
+  TurnDirection turn_dir;
 };
 
 }  // namespace nav2_smac_planner

--- a/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
@@ -122,10 +122,13 @@ struct HybridMotionTable
   float cost_penalty;
   float reverse_penalty;
   float travel_distance_reward;
+  bool downsample_obstacle_heuristic;
+  bool use_quadratic_cost_penalty;
   ompl::base::StateSpacePtr state_space;
   std::vector<std::vector<double>> delta_xs;
   std::vector<std::vector<double>> delta_ys;
   std::vector<TrigValues> trig_values;
+  std::vector<float> travel_costs;
 };
 
 /**

--- a/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
@@ -232,9 +232,10 @@ public:
    * @brief Sets the motion primitive index used to achieve node in search
    * @param reference to motion primitive idx
    */
-  inline void setMotionPrimitiveIndex(const unsigned int & idx)
+  inline void setMotionPrimitiveIndex(const unsigned int & idx, const TurnDirection & turn_dir)
   {
     _motion_primitive_index = idx;
+    _turn_dir = turn_dir;
   }
 
   /**
@@ -244,6 +245,15 @@ public:
   inline unsigned int & getMotionPrimitiveIndex()
   {
     return _motion_primitive_index;
+  }
+
+  /**
+   * @brief Gets the motion primitive turning direction used to achieve node in search
+   * @return reference to motion primitive turning direction
+   */
+  inline TurnDirection & getTurnDirection()
+  {
+    return _turn_dir;
   }
 
   /**
@@ -460,6 +470,7 @@ private:
   unsigned int _index;
   bool _was_visited;
   unsigned int _motion_primitive_index;
+  TurnDirection _turn_dir;
 };
 
 }  // namespace nav2_smac_planner

--- a/nav2_smac_planner/include/nav2_smac_planner/types.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/types.hpp
@@ -103,6 +103,21 @@ struct SmootherParams
 };
 
 /**
+ * @struct nav2_smac_planner::TurnDirection
+ * @brief A struct with the motion primitive's direction embedded
+ */
+enum struct TurnDirection
+{
+  UNKNOWN = 0,
+  FORWARD = 1,
+  LEFT = 2,
+  RIGHT = 3,
+  REVERSE = 4,
+  REV_LEFT = 5,
+  REV_RIGHT = 6
+};
+
+/**
  * @struct nav2_smac_planner::MotionPose
  * @brief A struct for poses in motion primitives
  */
@@ -118,19 +133,22 @@ struct MotionPose
    * @param x X pose
    * @param y Y pose
    * @param theta Angle of pose
+   * @param TurnDirection Direction of the primitive's turn
    */
-  MotionPose(const float & x, const float & y, const float & theta)
-  : _x(x), _y(y), _theta(theta)
+  MotionPose(const float & x, const float & y, const float & theta, const TurnDirection & turn_dir)
+  : _x(x), _y(y), _theta(theta), _turn_dir(turn_dir)
   {}
 
   MotionPose operator-(const MotionPose & p2)
   {
-    return MotionPose(this->_x - p2._x, this->_y - p2._y, this->_theta - p2._theta);
+    return MotionPose(
+      this->_x - p2._x, this->_y - p2._y, this->_theta - p2._theta, TurnDirection::UNKNOWN);
   }
 
   float _x;
   float _y;
   float _theta;
+  TurnDirection _turn_dir;
 };
 
 typedef std::vector<MotionPose> MotionPoses;

--- a/nav2_smac_planner/include/nav2_smac_planner/types.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/types.hpp
@@ -34,19 +34,19 @@ typedef std::pair<float, unsigned int> NodeHeuristicPair;
  */
 struct SearchInfo
 {
-  float minimum_turning_radius;
-  float non_straight_penalty;
-  float change_penalty;
-  float reverse_penalty;
-  float cost_penalty;
-  float retrospective_penalty;
-  float rotation_penalty;
-  float analytic_expansion_ratio;
-  float analytic_expansion_max_length;
+  float minimum_turning_radius{8.0};
+  float non_straight_penalty{1.05};
+  float change_penalty{0.0};
+  float reverse_penalty{2.0};
+  float cost_penalty{2.0};
+  float retrospective_penalty{0.015};
+  float rotation_penalty{5.0};
+  float analytic_expansion_ratio{3.5};
+  float analytic_expansion_max_length{60.0};
   std::string lattice_filepath;
-  bool cache_obstacle_heuristic;
-  bool allow_reverse_expansion;
-  bool allow_primitive_interpolation;
+  bool cache_obstacle_heuristic{false};
+  bool allow_reverse_expansion{false};
+  bool allow_primitive_interpolation{false};
 };
 
 /**

--- a/nav2_smac_planner/include/nav2_smac_planner/types.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/types.hpp
@@ -46,6 +46,7 @@ struct SearchInfo
   std::string lattice_filepath;
   bool cache_obstacle_heuristic;
   bool allow_reverse_expansion;
+  bool allow_primitive_interpolation;
 };
 
 /**

--- a/nav2_smac_planner/include/nav2_smac_planner/types.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/types.hpp
@@ -47,6 +47,8 @@ struct SearchInfo
   bool cache_obstacle_heuristic{false};
   bool allow_reverse_expansion{false};
   bool allow_primitive_interpolation{false};
+  bool downsample_obstacle_heuristic{true};
+  bool use_quadratic_cost_penalty{false};
 };
 
 /**

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -152,15 +152,15 @@ void AStarAlgorithm<NodeT>::setStart(
 }
 
 template<>
-void AStarAlgorithm<NodeHybrid>::populateExpansionsLog(
+void AStarAlgorithm<Node2D>::populateExpansionsLog(
   const NodePtr & node,
   std::vector<std::tuple<float, float, float>> * expansions_log)
 {
-  NodeHybrid::Coordinates coords = node->pose;
+  Node2D::Coordinates coords = node->getCoords(node->getIndex());
   expansions_log->emplace_back(
     _costmap->getOriginX() + ((coords.x + 0.5) * _costmap->getResolution()),
     _costmap->getOriginY() + ((coords.y + 0.5) * _costmap->getResolution()),
-    NodeHybrid::motion_table.getAngleFromBin(coords.theta));
+    0.0);
 }
 
 template<typename NodeT>
@@ -168,7 +168,11 @@ void AStarAlgorithm<NodeT>::populateExpansionsLog(
   const NodePtr & node,
   std::vector<std::tuple<float, float, float>> * expansions_log)
 {
-  return;
+  typename NodeT::Coordinates coords = node->pose;
+  expansions_log->emplace_back(
+    _costmap->getOriginX() + ((coords.x + 0.5) * _costmap->getResolution()),
+    _costmap->getOriginY() + ((coords.y + 0.5) * _costmap->getResolution()),
+    NodeT::motion_table.getAngleFromBin(coords.theta));
 }
 
 template<>

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -160,7 +160,7 @@ void AStarAlgorithm<NodeHybrid>::populateExpansionsLog(
   expansions_log->emplace_back(
     _costmap->getOriginX() + ((coords.x + 0.5) * _costmap->getResolution()),
     _costmap->getOriginY() + ((coords.y + 0.5) * _costmap->getResolution()),
-    coords.theta);
+    NodeHybrid::motion_table.getAngleFromBin(coords.theta));
 }
 
 template<typename NodeT>

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -152,6 +152,26 @@ void AStarAlgorithm<NodeT>::setStart(
 }
 
 template<>
+void AStarAlgorithm<NodeHybrid>::populateExpansionsLog(
+  const NodePtr & node,
+  std::vector<std::tuple<float, float, float>> * expansions_log)
+{
+  NodeHybrid::Coordinates coords = node->pose;
+  expansions_log->emplace_back(
+    _costmap->getOriginX() + ((coords.x + 0.5) * _costmap->getResolution()),
+    _costmap->getOriginY() + ((coords.y + 0.5) * _costmap->getResolution()),
+    coords.theta);
+}
+
+template<typename NodeT>
+void AStarAlgorithm<NodeT>::populateExpansionsLog(
+  const NodePtr & node,
+  std::vector<std::tuple<float, float, float>> * expansions_log)
+{
+  return;
+}
+
+template<>
 void AStarAlgorithm<Node2D>::setGoal(
   const unsigned int & mx,
   const unsigned int & my,
@@ -222,7 +242,7 @@ template<typename NodeT>
 bool AStarAlgorithm<NodeT>::createPath(
   CoordinateVector & path, int & iterations,
   const float & tolerance,
-  std::vector<std::tuple<float, float>> * expansions_log)
+  std::vector<std::tuple<float, float, float>> * expansions_log)
 {
   steady_clock::time_point start_time = steady_clock::now();
   _tolerance = tolerance;
@@ -276,13 +296,7 @@ bool AStarAlgorithm<NodeT>::createPath(
 
     // Save current node coordinates for debug
     if (expansions_log) {
-      Coordinates coords = current_node->getCoords(
-        current_node->getIndex(), getSizeX(), getSizeDim3());
-      expansions_log->push_back(
-        std::make_tuple<float, float>(
-          _costmap->getOriginX() + (coords.x * _costmap->getResolution()),
-          _costmap->getOriginY() + (coords.y * _costmap->getResolution()))
-      );
+      populateExpansionsLog(current_node, expansions_log);
     }
 
     // We allow for nodes to be queued multiple times in case

--- a/nav2_smac_planner/src/node_basic.cpp
+++ b/nav2_smac_planner/src/node_basic.cpp
@@ -30,7 +30,7 @@ void NodeBasic<NodeHybrid>::processSearchNode()
   // a new branch is overriding one of lower cost already visited.
   if (!this->graph_node_ptr->wasVisited()) {
     this->graph_node_ptr->pose = this->pose;
-    this->graph_node_ptr->setMotionPrimitiveIndex(this->motion_index);
+    this->graph_node_ptr->setMotionPrimitiveIndex(this->motion_index, this->turn_dir);
   }
 }
 
@@ -59,6 +59,7 @@ void NodeBasic<NodeHybrid>::populateSearchNode(NodeHybrid * & node)
   this->pose = node->pose;
   this->graph_node_ptr = node;
   this->motion_index = node->getMotionPrimitiveIndex();
+  this->turn_dir = node->getTurnDirection();
 }
 
 template<>

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -50,6 +50,12 @@ ObstacleHeuristicQueue NodeHybrid::obstacle_heuristic_queue;
 // cell. Though this could be later modified to project a certain
 // amount of time or particular distance forward.
 
+// TODO i
+  // Document: new change, reduce resolution, 72 no longer needed. new param guide + migration
+  // Visualize to validate correct
+  // test preformance
+
+
 // http://planning.cs.uiuc.edu/node821.html
 // Model for ackermann style vehicle with minimum radius restriction
 void HybridMotionTable::initDubin(
@@ -116,6 +122,21 @@ void HybridMotionTable::initDubin(
   projections.emplace_back(hypotf(delta_x, delta_y), 0.0, 0.0);  // Forward
   projections.emplace_back(delta_x, delta_y, increments);  // Left
   projections.emplace_back(delta_x, -delta_y, -increments);  // Right
+
+  if (search_info.allow_primitive_interpolation && increments != 1.0f) {
+    // Create primitives that are +/- N to fill in search space to use all set angular quantizations
+    // Allows us to create N many primitives so that each search iteration can expand into any angle
+    // bin possible with the minimum turning radius constraint, not just the most extreme turns.
+    projections.reserve(3 + (2 * (increments - 1)));
+    for (unsigned int i = 1; i < static_cast<unsigned int>(increments); i++) {
+      const float angle_n = static_cast<float>(i) * bin_size;
+      const float turning_rad_n = sqrt(2.0f) / (2.0f * sin(angle_n / 2.0f));
+      const float delta_x_n = turning_rad_n * sin(angle_n);
+      const float delta_y_n = turning_rad_n - (turning_rad_n * cos(angle_n));
+      projections.emplace_back(delta_x_n, delta_y_n, i);  // Left
+      projections.emplace_back(delta_x_n, -delta_y_n, -i);  // Right
+    }
+  }
 
   // Create the correct OMPL state space
   state_space = std::make_unique<ompl::base::DubinsStateSpace>(min_turning_radius);
@@ -193,6 +214,23 @@ void HybridMotionTable::initReedsShepp(
   projections.emplace_back(-hypotf(delta_x, delta_y), 0.0, 0.0);  // Backward
   projections.emplace_back(-delta_x, delta_y, -increments);  // Backward + Left
   projections.emplace_back(-delta_x, -delta_y, increments);  // Backward + Right
+
+  if (search_info.allow_primitive_interpolation && increments != 1.0f) {
+    // Create primitives that are +/- N to fill in search space to use all set angular quantizations
+    // Allows us to create N many primitives so that each search iteration can expand into any angle
+    // bin possible with the minimum turning radius constraint, not just the most extreme turns.
+    projections.reserve(6 + (4 * (increments - 1)));
+    for (unsigned int i = 1; i < static_cast<unsigned int>(increments); i++) {
+      const float angle_n = static_cast<float>(i) * bin_size;
+      const float turning_rad_n = sqrt(2.0f) / (2.0f * sin(angle_n / 2.0f));
+      const float delta_x_n = turning_rad_n * sin(angle_n);
+      const float delta_y_n = turning_rad_n - (turning_rad_n * cos(angle_n));
+      projections.emplace_back(delta_x_n, delta_y_n, i);  // Forward + Left
+      projections.emplace_back(delta_x_n, -delta_y_n, -i);  // Forward + Right
+      projections.emplace_back(-delta_x_n, delta_y_n, -i);  // Backward + Left
+      projections.emplace_back(-delta_x_n, -delta_y_n, i);  // Backward + Right
+    }
+  }
 
   // Create the correct OMPL state space
   state_space = std::make_unique<ompl::base::ReedsSheppStateSpace>(min_turning_radius);

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -50,12 +50,6 @@ ObstacleHeuristicQueue NodeHybrid::obstacle_heuristic_queue;
 // cell. Though this could be later modified to project a certain
 // amount of time or particular distance forward.
 
-// TODO i
-  // Document: new change, reduce resolution, 72 no longer needed. new param guide + migration
-  // Visualize to validate correct
-  // test preformance
-
-
 // http://planning.cs.uiuc.edu/node821.html
 // Model for ackermann style vehicle with minimum radius restriction
 void HybridMotionTable::initDubin(

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -65,6 +65,8 @@ void HybridMotionTable::initDubin(
   cost_penalty = search_info.cost_penalty;
   reverse_penalty = search_info.reverse_penalty;
   travel_distance_reward = 1.0f - search_info.retrospective_penalty;
+  downsample_obstacle_heuristic = search_info.downsample_obstacle_heuristic;
+  use_quadratic_cost_penalty = search_info.use_quadratic_cost_penalty;
 
   // if nothing changed, no need to re-compute primitives
   if (num_angle_quantization_in == num_angle_quantization &&
@@ -159,6 +161,20 @@ void HybridMotionTable::initDubin(
       delta_ys[i][j] = projections[i]._x * sin_theta + projections[i]._y * cos_theta;
     }
   }
+
+  // Precompute travel costs for each motion primitive
+  travel_costs.resize(projections.size());
+  for (unsigned int i = 0; i != projections.size(); i++) {
+    const TurnDirection turn_dir = projections[i]._turn_dir;
+    if (turn_dir != TurnDirection::FORWARD && turn_dir != TurnDirection::REVERSE) {
+      // Turning, so length is the arc length
+      const float angle = projections[i]._theta * bin_size;
+      const float turning_rad = delta_dist / (2.0f * sin(angle / 2.0f));
+      travel_costs[i] = turning_rad * angle;
+    } else {
+      travel_costs[i] = delta_dist;
+    }
+  }
 }
 
 // http://planning.cs.uiuc.edu/node822.html
@@ -176,6 +192,8 @@ void HybridMotionTable::initReedsShepp(
   cost_penalty = search_info.cost_penalty;
   reverse_penalty = search_info.reverse_penalty;
   travel_distance_reward = 1.0f - search_info.retrospective_penalty;
+  downsample_obstacle_heuristic = search_info.downsample_obstacle_heuristic;
+  use_quadratic_cost_penalty = search_info.use_quadratic_cost_penalty;
 
   // if nothing changed, no need to re-compute primitives
   if (num_angle_quantization_in == num_angle_quantization &&
@@ -264,6 +282,20 @@ void HybridMotionTable::initReedsShepp(
       delta_ys[i][j] = projections[i]._x * sin_theta + projections[i]._y * cos_theta;
     }
   }
+
+  // Precompute travel costs for each motion primitive
+  travel_costs.resize(projections.size());
+  for (unsigned int i = 0; i != projections.size(); i++) {
+    const TurnDirection turn_dir = projections[i]._turn_dir;
+    if (turn_dir != TurnDirection::FORWARD && turn_dir != TurnDirection::REVERSE) {
+      // Turning, so length is the arc length
+      const float angle = projections[i]._theta * bin_size;
+      const float turning_rad = delta_dist / (2.0f * sin(angle / 2.0f));
+      travel_costs[i] = turning_rad * angle;
+    } else {
+      travel_costs[i] = delta_dist;
+    }
+  }
 }
 
 MotionPoses HybridMotionTable::getProjections(const NodeHybrid * node)
@@ -349,7 +381,7 @@ bool NodeHybrid::isNodeValid(
 
 float NodeHybrid::getTraversalCost(const NodePtr & child)
 {
-  const float normalized_cost = child->getCost() / 252.0;
+  const float normalized_cost = child->getCost() / 252.0f;
   if (std::isnan(normalized_cost)) {
     throw std::runtime_error(
             "Node attempted to get traversal "
@@ -362,10 +394,17 @@ float NodeHybrid::getTraversalCost(const NodePtr & child)
   }
 
   const TurnDirection & child_turn_dir = child->getTurnDirection();
+  float travel_cost_raw = motion_table.travel_costs[child->getMotionPrimitiveIndex()];
   float travel_cost = 0.0;
-  float travel_cost_raw =
-    NodeHybrid::travel_distance_cost *
-    (motion_table.travel_distance_reward + motion_table.cost_penalty * normalized_cost);
+
+  if (motion_table.use_quadratic_cost_penalty) {
+    travel_cost_raw *=
+      (motion_table.travel_distance_reward +
+        (motion_table.cost_penalty * normalized_cost * normalized_cost));
+  } else {
+    travel_cost_raw *=
+      (motion_table.travel_distance_reward + motion_table.cost_penalty * normalized_cost);
+  }
 
   if (child_turn_dir == TurnDirection::FORWARD || child_turn_dir == TurnDirection::REVERSE) {
     // New motion is a straight motion, no additional costs to be applied
@@ -446,10 +485,13 @@ void NodeHybrid::resetObstacleHeuristic(
   // the planner considerably to search through 75% less cells with no detectable
   // erosion of path quality after even modest smoothing. The error would be no more
   // than 0.05 * normalized cost. Since this is just a search prior, there's no loss in generality
-  std::weak_ptr<nav2_util::LifecycleNode> ptr;
-  downsampler.on_configure(ptr, "fake_frame", "fake_topic", costmap, 2.0, true);
-  downsampler.on_activate();
-  sampled_costmap = downsampler.downsample(2.0);
+  sampled_costmap = costmap;
+  if (motion_table.downsample_obstacle_heuristic) {
+    std::weak_ptr<nav2_util::LifecycleNode> ptr;
+    downsampler.on_configure(ptr, "fake_frame", "fake_topic", costmap, 2.0, true);
+    downsampler.on_activate();
+    sampled_costmap = downsampler.downsample(2.0);
+  }
 
   // Clear lookup table
   unsigned int size = sampled_costmap->getSizeInCellsX() * sampled_costmap->getSizeInCellsY();
@@ -472,7 +514,13 @@ void NodeHybrid::resetObstacleHeuristic(
 
   // Set initial goal point to queue from. Divided by 2 due to downsampled costmap.
   const unsigned int size_x = sampled_costmap->getSizeInCellsX();
-  const unsigned int goal_index = floor(goal_y / 2.0) * size_x + floor(goal_x / 2.0);
+  unsigned int goal_index;
+  if (motion_table.downsample_obstacle_heuristic) {
+    goal_index = floor(goal_y / 2.0f) * size_x + floor(goal_x / 2.0f);
+  } else {
+    goal_index = floor(goal_y) * size_x + floor(goal_x);
+  }
+
   obstacle_heuristic_queue.emplace_back(
     distanceHeuristic2D(goal_index, size_x, start_x, start_y), goal_index);
 
@@ -488,14 +536,23 @@ float NodeHybrid::getObstacleHeuristic(
 {
   // If already expanded, return the cost
   const unsigned int size_x = sampled_costmap->getSizeInCellsX();
+
   // Divided by 2 due to downsampled costmap.
-  const unsigned int start_y = floor(node_coords.y / 2.0);
-  const unsigned int start_x = floor(node_coords.x / 2.0);
+  unsigned int start_y, start_x;
+  const bool & downsample_H = motion_table.downsample_obstacle_heuristic;
+  if (downsample_H) {
+    start_y = floor(node_coords.y / 2.0f);
+    start_x = floor(node_coords.x / 2.0f);
+  } else {
+    start_y = floor(node_coords.y);
+    start_x = floor(node_coords.x);
+  }
+
   const unsigned int start_index = start_y * size_x + start_x;
   const float & requested_node_cost = obstacle_heuristic_lookup_table[start_index];
   if (requested_node_cost > 0.0f) {
     // costs are doubled due to downsampling
-    return 2.0f * requested_node_cost;
+    return downsample_H ? 2.0f * requested_node_cost : requested_node_cost;
   }
 
   // If not, expand until it is included. This dynamic programming ensures that
@@ -516,9 +573,9 @@ float NodeHybrid::getObstacleHeuristic(
 
   const int size_x_int = static_cast<int>(size_x);
   const unsigned int size_y = sampled_costmap->getSizeInCellsY();
-  const float sqrt_2 = sqrt(2);
+  const float sqrt2 = sqrt(2.0f);
   float c_cost, cost, travel_cost, new_cost, existing_cost;
-  unsigned int idx, mx, my, mx_idx, my_idx;
+  unsigned int idx, mx, my;
   unsigned int new_idx = 0;
 
   const std::vector<int> neighborhood = {1, -1,  // left right
@@ -541,9 +598,6 @@ float NodeHybrid::getObstacleHeuristic(
     c_cost = -c_cost;
     obstacle_heuristic_lookup_table[idx] = c_cost;  // set a positive value to close the cell
 
-    my_idx = idx / size_x;
-    mx_idx = idx - (my_idx * size_x);
-
     // find neighbors
     for (unsigned int i = 0; i != neighborhood.size(); i++) {
       new_idx = static_cast<unsigned int>(static_cast<int>(idx) + neighborhood[i]);
@@ -558,17 +612,23 @@ float NodeHybrid::getObstacleHeuristic(
         my = new_idx / size_x;
         mx = new_idx - (my * size_x);
 
-        if (mx == 0 && mx_idx >= size_x - 1 || mx >= size_x - 1 && mx_idx == 0) {
+        if (mx >= size_x - 3 || mx <= 3) {
           continue;
         }
-        if (my == 0 && my_idx >= size_y - 1 || my >= size_y - 1 && my_idx == 0) {
+        if (my >= size_y - 3 || my <= 3) {
           continue;
         }
 
         existing_cost = obstacle_heuristic_lookup_table[new_idx];
         if (existing_cost <= 0.0f) {
-          travel_cost =
-            ((i <= 3) ? 1.0f : sqrt_2) * (1.0f + (cost_penalty * cost / 252.0f));
+          if (motion_table.use_quadratic_cost_penalty) {
+            travel_cost =
+              (i <= 3 ? 1.0f : sqrt2) * (1.0f + (cost_penalty * cost * cost / 64516.0f));  // 254^2
+          } else {
+            travel_cost =
+              ((i <= 3) ? 1.0f : sqrt2) * (1.0f + (cost_penalty * cost / 254.0f));
+          }
+
           new_cost = c_cost + travel_cost;
           if (existing_cost == 0.0f || -existing_cost > new_cost) {
             // the negative value means the cell is in the open set
@@ -588,9 +648,26 @@ float NodeHybrid::getObstacleHeuristic(
     }
   }
 
+  // #include "nav_msgs/msg/occupancy_grid.hpp"
+  // static auto node = std::make_shared<rclcpp::Node>("test");
+  // static auto pub = node->create_publisher<nav_msgs::msg::OccupancyGrid>("test", 1);
+  // nav_msgs::msg::OccupancyGrid msg;
+  // msg.info.height = size_y;
+  // msg.info.width = size_x;
+  // msg.info.origin.position.x = -33.6;
+  // msg.info.origin.position.y = -26;
+  // msg.info.resolution = 0.05;
+  // msg.header.frame_id = "map";
+  // msg.header.stamp = node->now();
+  // msg.data.resize(size_x * size_y, 0);
+  // for (unsigned int i = 0; i != size_y * size_x; i++) {
+  //   msg.data.at(i) = obstacle_heuristic_lookup_table[i] / 10.0;
+  // }
+  // pub->publish(std::move(msg));
+
   // return requested_node_cost which has been updated by the search
   // costs are doubled due to downsampling
-  return 2.0f * requested_node_cost;
+  return downsample_H ? 2.0f * requested_node_cost : requested_node_cost;
 }
 
 float NodeHybrid::getDistanceHeuristic(

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -361,7 +361,6 @@ float NodeHybrid::getTraversalCost(const NodePtr & child)
   }
 
   const TurnDirection & child_turn_dir = child->getTurnDirection();
-  const unsigned int & child_motion_prim = child->getMotionPrimitiveIndex();
   float travel_cost = 0.0;
   float travel_cost_raw =
     NodeHybrid::travel_distance_cost *

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020, Samsung Research America
 // Copyright (c) 2020, Applied Electric Vehicles Pty Ltd
+// Copyright (c) 2023, Open Navigation LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -494,7 +495,7 @@ float NodeHybrid::getObstacleHeuristic(
   const float & requested_node_cost = obstacle_heuristic_lookup_table[start_index];
   if (requested_node_cost > 0.0f) {
     // costs are doubled due to downsampling
-    return 2.0 * requested_node_cost;
+    return 2.0f * requested_node_cost;
   }
 
   // If not, expand until it is included. This dynamic programming ensures that
@@ -589,7 +590,7 @@ float NodeHybrid::getObstacleHeuristic(
 
   // return requested_node_cost which has been updated by the search
   // costs are doubled due to downsampling
-  return 2.0 * requested_node_cost;
+  return 2.0f * requested_node_cost;
 }
 
 float NodeHybrid::getDistanceHeuristic(

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -123,7 +123,7 @@ void HybridMotionTable::initDubin(
   projections.emplace_back(delta_x, delta_y, increments);  // Left
   projections.emplace_back(delta_x, -delta_y, -increments);  // Right
 
-  if (search_info.allow_primitive_interpolation && increments != 1.0f) {
+  if (search_info.allow_primitive_interpolation && increments > 1.0f) {
     // Create primitives that are +/- N to fill in search space to use all set angular quantizations
     // Allows us to create N many primitives so that each search iteration can expand into any angle
     // bin possible with the minimum turning radius constraint, not just the most extreme turns.
@@ -133,8 +133,8 @@ void HybridMotionTable::initDubin(
       const float turning_rad_n = sqrt(2.0f) / (2.0f * sin(angle_n / 2.0f));
       const float delta_x_n = turning_rad_n * sin(angle_n);
       const float delta_y_n = turning_rad_n - (turning_rad_n * cos(angle_n));
-      projections.emplace_back(delta_x_n, delta_y_n, i);  // Left
-      projections.emplace_back(delta_x_n, -delta_y_n, -i);  // Right
+      projections.emplace_back(delta_x_n, delta_y_n, static_cast<float>(i));  // Left
+      projections.emplace_back(delta_x_n, -delta_y_n, -static_cast<float>(i));  // Right
     }
   }
 
@@ -215,7 +215,7 @@ void HybridMotionTable::initReedsShepp(
   projections.emplace_back(-delta_x, delta_y, -increments);  // Backward + Left
   projections.emplace_back(-delta_x, -delta_y, increments);  // Backward + Right
 
-  if (search_info.allow_primitive_interpolation && increments != 1.0f) {
+  if (search_info.allow_primitive_interpolation && increments > 1.0f) {
     // Create primitives that are +/- N to fill in search space to use all set angular quantizations
     // Allows us to create N many primitives so that each search iteration can expand into any angle
     // bin possible with the minimum turning radius constraint, not just the most extreme turns.
@@ -225,10 +225,10 @@ void HybridMotionTable::initReedsShepp(
       const float turning_rad_n = sqrt(2.0f) / (2.0f * sin(angle_n / 2.0f));
       const float delta_x_n = turning_rad_n * sin(angle_n);
       const float delta_y_n = turning_rad_n - (turning_rad_n * cos(angle_n));
-      projections.emplace_back(delta_x_n, delta_y_n, i);  // Forward + Left
-      projections.emplace_back(delta_x_n, -delta_y_n, -i);  // Forward + Right
-      projections.emplace_back(-delta_x_n, delta_y_n, -i);  // Backward + Left
-      projections.emplace_back(-delta_x_n, -delta_y_n, i);  // Backward + Right
+      projections.emplace_back(delta_x_n, delta_y_n, static_cast<float>(i));  // Forward + Left
+      projections.emplace_back(delta_x_n, -delta_y_n, -static_cast<float>(i));  // Forward + Right
+      projections.emplace_back(-delta_x_n, delta_y_n, -static_cast<float>(i));  // Backward + Left
+      projections.emplace_back(-delta_x_n, -delta_y_n, static_cast<float>(i));  // Backward + Right
     }
   }
 

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -106,14 +106,15 @@ void HybridMotionTable::initDubin(
   // find deflections
   // If we make a right triangle out of the chord in circle of radius
   // min turning angle, we can see that delta X = R * sin (angle)
-  float delta_x = min_turning_radius * sin(angle);
+  const float delta_x = min_turning_radius * sin(angle);
   // Using that same right triangle, we can see that the complement
   // to delta Y is R * cos (angle). If we subtract R, we get the actual value
-  float delta_y = min_turning_radius - (min_turning_radius * cos(angle));
+  const float delta_y = min_turning_radius - (min_turning_radius * cos(angle));
+  const float delta_dist = hypotf(delta_x, delta_y);
 
   projections.clear();
   projections.reserve(3);
-  projections.emplace_back(hypotf(delta_x, delta_y), 0.0, 0.0);  // Forward
+  projections.emplace_back(delta_dist, 0.0, 0.0);  // Forward
   projections.emplace_back(delta_x, delta_y, increments);  // Left
   projections.emplace_back(delta_x, -delta_y, -increments);  // Right
 
@@ -124,7 +125,7 @@ void HybridMotionTable::initDubin(
     projections.reserve(3 + (2 * (increments - 1)));
     for (unsigned int i = 1; i < static_cast<unsigned int>(increments); i++) {
       const float angle_n = static_cast<float>(i) * bin_size;
-      const float turning_rad_n = sqrt(2.0f) / (2.0f * sin(angle_n / 2.0f));
+      const float turning_rad_n = delta_dist / (2.0f * sin(angle_n / 2.0f));
       const float delta_x_n = turning_rad_n * sin(angle_n);
       const float delta_y_n = turning_rad_n - (turning_rad_n * cos(angle_n));
       projections.emplace_back(delta_x_n, delta_y_n, static_cast<float>(i));  // Left
@@ -197,15 +198,16 @@ void HybridMotionTable::initReedsShepp(
   }
   angle = increments * bin_size;
 
-  float delta_x = min_turning_radius * sin(angle);
-  float delta_y = min_turning_radius - (min_turning_radius * cos(angle));
+  const float delta_x = min_turning_radius * sin(angle);
+  const float delta_y = min_turning_radius - (min_turning_radius * cos(angle));
+  const float delta_dist = hypotf(delta_x, delta_y);
 
   projections.clear();
   projections.reserve(6);
-  projections.emplace_back(hypotf(delta_x, delta_y), 0.0, 0.0);  // Forward
+  projections.emplace_back(delta_dist, 0.0, 0.0);  // Forward
   projections.emplace_back(delta_x, delta_y, increments);  // Forward + Left
   projections.emplace_back(delta_x, -delta_y, -increments);  // Forward + Right
-  projections.emplace_back(-hypotf(delta_x, delta_y), 0.0, 0.0);  // Backward
+  projections.emplace_back(-delta_dist, 0.0, 0.0);  // Backward
   projections.emplace_back(-delta_x, delta_y, -increments);  // Backward + Left
   projections.emplace_back(-delta_x, -delta_y, increments);  // Backward + Right
 
@@ -216,7 +218,7 @@ void HybridMotionTable::initReedsShepp(
     projections.reserve(6 + (4 * (increments - 1)));
     for (unsigned int i = 1; i < static_cast<unsigned int>(increments); i++) {
       const float angle_n = static_cast<float>(i) * bin_size;
-      const float turning_rad_n = sqrt(2.0f) / (2.0f * sin(angle_n / 2.0f));
+      const float turning_rad_n = delta_dist / (2.0f * sin(angle_n / 2.0f));
       const float delta_x_n = turning_rad_n * sin(angle_n);
       const float delta_y_n = turning_rad_n - (turning_rad_n * cos(angle_n));
       projections.emplace_back(delta_x_n, delta_y_n, static_cast<float>(i));  // Forward + Left

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -400,7 +400,7 @@ float NodeHybrid::getTraversalCost(const NodePtr & child)
   if (motion_table.use_quadratic_cost_penalty) {
     travel_cost_raw *=
       (motion_table.travel_distance_reward +
-        (motion_table.cost_penalty * normalized_cost * normalized_cost));
+      (motion_table.cost_penalty * normalized_cost * normalized_cost));
   } else {
     travel_cost_raw *=
       (motion_table.travel_distance_reward + motion_table.cost_penalty * normalized_cost);

--- a/nav2_smac_planner/src/node_lattice.cpp
+++ b/nav2_smac_planner/src/node_lattice.cpp
@@ -225,7 +225,8 @@ bool NodeLattice::isNodeValid(
   if (motion_primitive) {
     const float & grid_resolution = motion_table.lattice_metadata.grid_resolution;
     const float & resolution_diag_sq = 2.0 * grid_resolution * grid_resolution;
-    MotionPose last_pose(1e9, 1e9, 1e9), pose_dist(0.0, 0.0, 0.0);
+    MotionPose last_pose(1e9, 1e9, 1e9, TurnDirection::UNKNOWN);
+    MotionPose pose_dist(0.0, 0.0, 0.0, TurnDirection::UNKNOWN);
 
     // Back out the initial node starting point to move motion primitive relative to
     MotionPose initial_pose, prim_pose;

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -102,7 +102,8 @@ void SmacPlannerHybrid::configure(
   node->get_parameter(name + ".minimum_turning_radius", _minimum_turning_radius_global_coords);
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".allow_primitive_interpolation", rclcpp::ParameterValue(false));
-  node->get_parameter(name + ".allow_primitive_interpolation", _search_info.allow_primitive_interpolation);
+  node->get_parameter(
+    name + ".allow_primitive_interpolation", _search_info.allow_primitive_interpolation);
   nav2_util::declare_parameter_if_not_declared(
     node, name + ".cache_obstacle_heuristic", rclcpp::ParameterValue(false));
   node->get_parameter(name + ".cache_obstacle_heuristic", _search_info.cache_obstacle_heuristic);

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -496,6 +496,13 @@ SmacPlannerHybrid::dynamicParametersCallback(std::vector<rclcpp::Parameter> para
         if (_smoother) {
           reinit_smoother = true;
         }
+
+        if (parameter.as_double() < _costmap->getResolution() * _downsampling_factor) {
+          RCLCPP_ERROR(
+            _logger, "Min turning radius cannot be less than the search grid cell resolution!");
+          result.successful = false;
+        }
+
         _minimum_turning_radius_global_coords = static_cast<float>(parameter.as_double());
       } else if (name == _name + ".reverse_penalty") {
         reinit_a_star = true;
@@ -527,6 +534,9 @@ SmacPlannerHybrid::dynamicParametersCallback(std::vector<rclcpp::Parameter> para
       } else if (name == _name + ".cache_obstacle_heuristic") {
         reinit_a_star = true;
         _search_info.cache_obstacle_heuristic = parameter.as_bool();
+      } else if (name == _name + ".allow_primitive_interpolation") {
+        _search_info.allow_primitive_interpolation = parameter.as_bool();
+        reinit_a_star = true;
       } else if (name == _name + ".smooth_path") {
         if (parameter.as_bool()) {
           reinit_smoother = true;

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -155,17 +155,23 @@ void SmacPlannerHybrid::configure(
   }
 
   if (_max_on_approach_iterations <= 0) {
-    RCLCPP_INFO(
+    RCLCPP_WARN(
       _logger, "On approach iteration selected as <= 0, "
       "disabling tolerance and on approach iterations.");
     _max_on_approach_iterations = std::numeric_limits<int>::max();
   }
 
   if (_max_iterations <= 0) {
-    RCLCPP_INFO(
+    RCLCPP_WARN(
       _logger, "maximum iteration selected as <= 0, "
       "disabling maximum iterations.");
     _max_iterations = std::numeric_limits<int>::max();
+  }
+
+  if (_minimum_turning_radius_global_coords < _costmap->getResolution() * _downsampling_factor) {
+    RCLCPP_WARN(
+      _logger, "Min turning radius cannot be less than the search grid cell resolution!");
+    _minimum_turning_radius_global_coords = _costmap->getResolution() * _downsampling_factor;
   }
 
   // convert to grid coordinates

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -385,8 +385,7 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
       for (auto & e : *expansions) {
         msg_pose.position.x = std::get<0>(e);
         msg_pose.position.y = std::get<1>(e);
-        msg_pose.orientation = getWorldOrientation(
-          NodeHybrid::motion_table.getAngleFromBin(std::get<2>(e)));
+        msg_pose.orientation = getWorldOrientation(std::get<2>(e));
         msg.poses.push_back(msg_pose);
       }
       _expansions_publisher->publish(msg);
@@ -420,8 +419,7 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
     for (auto & e : *expansions) {
       msg_pose.position.x = std::get<0>(e);
       msg_pose.position.y = std::get<1>(e);
-      msg_pose.orientation = getWorldOrientation(
-        NodeHybrid::motion_table.getAngleFromBin(std::get<2>(e)));
+      msg_pose.orientation = getWorldOrientation(std::get<2>(e));
       msg.poses.push_back(msg_pose);
     }
     _expansions_publisher->publish(msg);

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -126,6 +126,15 @@ void SmacPlannerHybrid::configure(
     node, name + ".analytic_expansion_ratio", rclcpp::ParameterValue(3.5));
   node->get_parameter(name + ".analytic_expansion_ratio", _search_info.analytic_expansion_ratio);
   nav2_util::declare_parameter_if_not_declared(
+    node, name + ".use_quadratic_cost_penalty", rclcpp::ParameterValue(false));
+  node->get_parameter(
+    name + ".use_quadratic_cost_penalty", _search_info.use_quadratic_cost_penalty);
+  nav2_util::declare_parameter_if_not_declared(
+    node, name + ".downsample_obstacle_heuristic", rclcpp::ParameterValue(true));
+  node->get_parameter(
+    name + ".downsample_obstacle_heuristic", _search_info.downsample_obstacle_heuristic);
+
+  nav2_util::declare_parameter_if_not_declared(
     node, name + ".analytic_expansion_max_length", rclcpp::ParameterValue(3.0));
   node->get_parameter(name + ".analytic_expansion_max_length", analytic_expansion_max_length_m);
   _search_info.analytic_expansion_max_length =

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -101,6 +101,9 @@ void SmacPlannerHybrid::configure(
     node, name + ".minimum_turning_radius", rclcpp::ParameterValue(0.4));
   node->get_parameter(name + ".minimum_turning_radius", _minimum_turning_radius_global_coords);
   nav2_util::declare_parameter_if_not_declared(
+    node, name + ".allow_primitive_interpolation", rclcpp::ParameterValue(false));
+  node->get_parameter(name + ".allow_primitive_interpolation", _search_info.allow_primitive_interpolation);
+  nav2_util::declare_parameter_if_not_declared(
     node, name + ".cache_obstacle_heuristic", rclcpp::ParameterValue(false));
   node->get_parameter(name + ".cache_obstacle_heuristic", _search_info.cache_obstacle_heuristic);
   nav2_util::declare_parameter_if_not_declared(

--- a/nav2_smac_planner/test/test_a_star.cpp
+++ b/nav2_smac_planner/test/test_a_star.cpp
@@ -162,7 +162,10 @@ TEST(AStarTest, test_a_star_se2)
   a_star.setStart(10u, 10u, 0u);
   a_star.setGoal(80u, 80u, 40u);
   nav2_smac_planner::NodeHybrid::CoordinateVector path;
-  EXPECT_TRUE(a_star.createPath(path, num_it, tolerance));
+  std::unique_ptr<std::vector<std::tuple<float, float, float>>> expansions = nullptr;
+  expansions = std::make_unique<std::vector<std::tuple<float, float, float>>>();
+
+  EXPECT_TRUE(a_star.createPath(path, num_it, tolerance, expansions.get()));
 
   // check path is the right size and collision free
   EXPECT_EQ(num_it, 3222);
@@ -174,6 +177,9 @@ TEST(AStarTest, test_a_star_se2)
   for (unsigned int i = 1; i != path.size(); i++) {
     EXPECT_LT(hypotf(path[i].x - path[i - 1].x, path[i].y - path[i - 1].y), 2.1f);
   }
+
+  // Expansions properly recorded
+  EXPECT_GT(expansions->size(), 5u);
 
   delete costmapA;
 }

--- a/nav2_smac_planner/test/test_a_star.cpp
+++ b/nav2_smac_planner/test/test_a_star.cpp
@@ -168,8 +168,8 @@ TEST(AStarTest, test_a_star_se2)
   EXPECT_TRUE(a_star.createPath(path, num_it, tolerance, expansions.get()));
 
   // check path is the right size and collision free
-  EXPECT_EQ(num_it, 7413);
-  EXPECT_EQ(path.size(), 63u);
+  EXPECT_EQ(num_it, 8427);
+  EXPECT_EQ(path.size(), 62u);
   for (unsigned int i = 0; i != path.size(); i++) {
     EXPECT_EQ(costmapA->getCost(path[i].x, path[i].y), 0);
   }

--- a/nav2_smac_planner/test/test_a_star.cpp
+++ b/nav2_smac_planner/test/test_a_star.cpp
@@ -168,8 +168,8 @@ TEST(AStarTest, test_a_star_se2)
   EXPECT_TRUE(a_star.createPath(path, num_it, tolerance, expansions.get()));
 
   // check path is the right size and collision free
-  EXPECT_EQ(num_it, 3222);
-  EXPECT_EQ(path.size(), 63u);
+  EXPECT_EQ(num_it, 3186);
+  EXPECT_EQ(path.size(), 64u);
   for (unsigned int i = 0; i != path.size(); i++) {
     EXPECT_EQ(costmapA->getCost(path[i].x, path[i].y), 0);
   }
@@ -233,7 +233,7 @@ TEST(AStarTest, test_a_star_lattice)
   EXPECT_TRUE(a_star.createPath(path, num_it, tolerance));
 
   // check path is the right size and collision free
-  EXPECT_EQ(num_it, 21);
+  EXPECT_EQ(num_it, 26);
   EXPECT_GT(path.size(), 47u);
   for (unsigned int i = 0; i != path.size(); i++) {
     EXPECT_EQ(costmapA->getCost(path[i].x, path[i].y), 0);

--- a/nav2_smac_planner/test/test_a_star.cpp
+++ b/nav2_smac_planner/test/test_a_star.cpp
@@ -168,8 +168,8 @@ TEST(AStarTest, test_a_star_se2)
   EXPECT_TRUE(a_star.createPath(path, num_it, tolerance, expansions.get()));
 
   // check path is the right size and collision free
-  EXPECT_EQ(num_it, 8427);
-  EXPECT_EQ(path.size(), 62u);
+  EXPECT_EQ(num_it, 3222);
+  EXPECT_EQ(path.size(), 63u);
   for (unsigned int i = 0; i != path.size(); i++) {
     EXPECT_EQ(costmapA->getCost(path[i].x, path[i].y), 0);
   }

--- a/nav2_smac_planner/test/test_a_star.cpp
+++ b/nav2_smac_planner/test/test_a_star.cpp
@@ -168,7 +168,7 @@ TEST(AStarTest, test_a_star_se2)
   EXPECT_TRUE(a_star.createPath(path, num_it, tolerance, expansions.get()));
 
   // check path is the right size and collision free
-  EXPECT_EQ(num_it, 3222);
+  EXPECT_EQ(num_it, 7413);
   EXPECT_EQ(path.size(), 63u);
   for (unsigned int i = 0; i != path.size(); i++) {
     EXPECT_EQ(costmapA->getCost(path[i].x, path[i].y), 0);

--- a/nav2_smac_planner/test/test_nodehybrid.cpp
+++ b/nav2_smac_planner/test/test_nodehybrid.cpp
@@ -238,7 +238,7 @@ TEST(NodeHybridTest, test_node_debin_neighbors)
     nav2_smac_planner::MotionModel::DUBIN, size_x, size_y, size_theta, info);
 
   // test neighborhood computation
-  EXPECT_EQ(nav2_smac_planner::NodeHybrid::motion_table.projections.size(), 11u);
+  EXPECT_EQ(nav2_smac_planner::NodeHybrid::motion_table.projections.size(), 3u);
   EXPECT_NEAR(nav2_smac_planner::NodeHybrid::motion_table.projections[0]._x, 1.731517, 0.01);
   EXPECT_NEAR(nav2_smac_planner::NodeHybrid::motion_table.projections[0]._y, 0, 0.01);
   EXPECT_NEAR(nav2_smac_planner::NodeHybrid::motion_table.projections[0]._theta, 0, 0.01);
@@ -250,6 +250,48 @@ TEST(NodeHybridTest, test_node_debin_neighbors)
   EXPECT_NEAR(nav2_smac_planner::NodeHybrid::motion_table.projections[2]._x, 1.69047, 0.01);
   EXPECT_NEAR(nav2_smac_planner::NodeHybrid::motion_table.projections[2]._y, -0.3747, 0.01);
   EXPECT_NEAR(nav2_smac_planner::NodeHybrid::motion_table.projections[2]._theta, -5, 0.01);
+}
+
+TEST(NodeHybridTest, test_interpolation_prims)
+{
+  unsigned int size_x = 100;
+  unsigned int size_y = 100;
+  unsigned int size_theta = 64;
+
+  nav2_smac_planner::SearchInfo info;
+  info.change_penalty = 1.2;
+  info.non_straight_penalty = 1.4;
+  info.reverse_penalty = 2.1;
+  info.minimum_turning_radius = 8;  // 0.4 in grid coordinates
+  info.retrospective_penalty = 0.0;
+
+  // Test to make sure the right num. of prims are generated when interpolation is on
+  info.allow_primitive_interpolation = true;
+  nav2_smac_planner::NodeHybrid::initMotionModel(
+    nav2_smac_planner::MotionModel::DUBIN, size_x, size_y, size_theta, info);
+
+  EXPECT_EQ(nav2_smac_planner::NodeHybrid::motion_table.projections.size(), 5u);
+}
+
+TEST(NodeHybridTest, test_interpolation_prims2)
+{
+  unsigned int size_x = 100;
+  unsigned int size_y = 100;
+  unsigned int size_theta = 72;
+
+  nav2_smac_planner::SearchInfo info;
+  info.change_penalty = 1.2;
+  info.non_straight_penalty = 1.4;
+  info.reverse_penalty = 2.1;
+  info.minimum_turning_radius = 8;  // 0.4 in grid coordinates
+  info.retrospective_penalty = 0.0;
+
+  // Test to make sure the right num. of prims are generated when interpolation is on
+  info.allow_primitive_interpolation = true;
+  nav2_smac_planner::NodeHybrid::initMotionModel(
+    nav2_smac_planner::MotionModel::DUBIN, size_x, size_y, size_theta, info);
+
+  EXPECT_EQ(nav2_smac_planner::NodeHybrid::motion_table.projections.size(), 7u);
 }
 
 TEST(NodeHybridTest, test_node_reeds_neighbors)

--- a/nav2_smac_planner/test/test_nodehybrid.cpp
+++ b/nav2_smac_planner/test/test_nodehybrid.cpp
@@ -231,7 +231,7 @@ TEST(NodeHybridTest, test_node_debin_neighbors)
     nav2_smac_planner::MotionModel::DUBIN, size_x, size_y, size_theta, info);
 
   // test neighborhood computation
-  EXPECT_EQ(nav2_smac_planner::NodeHybrid::motion_table.projections.size(), 3u);
+  EXPECT_EQ(nav2_smac_planner::NodeHybrid::motion_table.projections.size(), 11u);
   EXPECT_NEAR(nav2_smac_planner::NodeHybrid::motion_table.projections[0]._x, 1.731517, 0.01);
   EXPECT_NEAR(nav2_smac_planner::NodeHybrid::motion_table.projections[0]._y, 0, 0.01);
   EXPECT_NEAR(nav2_smac_planner::NodeHybrid::motion_table.projections[0]._theta, 0, 0.01);

--- a/nav2_smac_planner/test/test_nodehybrid.cpp
+++ b/nav2_smac_planner/test/test_nodehybrid.cpp
@@ -90,25 +90,25 @@ TEST(NodeHybridTest, test_node_hybrid)
   // but now reduced by retrospective penalty (10%)
   testB.setMotionPrimitiveIndex(1, nav2_smac_planner::TurnDirection::LEFT);
   testA.setMotionPrimitiveIndex(0, nav2_smac_planner::TurnDirection::FORWARD);
-  EXPECT_NEAR(testB.getTraversalCost(&testA), 2.088 * 0.9, 0.1);
+  EXPECT_NEAR(testB.getTraversalCost(&testA), 2.088f * 0.9, 0.1);
   // same direction as parent, testB
   testA.setMotionPrimitiveIndex(1, nav2_smac_planner::TurnDirection::LEFT);
-  EXPECT_NEAR(testB.getTraversalCost(&testA), 2.297f * 0.9, 0.01);
+  EXPECT_NEAR(testB.getTraversalCost(&testA), 2.294f * 0.9, 0.01);
   // opposite direction as parent, testB
   testA.setMotionPrimitiveIndex(2, nav2_smac_planner::TurnDirection::RIGHT);
   EXPECT_NEAR(testB.getTraversalCost(&testA), 2.506f * 0.9, 0.01);
   // reverse direction as parent, testB
-  testA.setMotionPrimitiveIndex(3, nav2_smac_planner::TurnDirection::REV_RIGHT);
-  EXPECT_NEAR(testB.getTraversalCost(&testA), 2.506f * 0.9 * 2.0, 0.01);
+  testA.setMotionPrimitiveIndex(1, nav2_smac_planner::TurnDirection::REV_RIGHT);
+  EXPECT_NEAR(testB.getTraversalCost(&testA), 2.513f * 0.9 * 2.0, 0.01);
   // reverse direction as parent, testB
-  testA.setMotionPrimitiveIndex(4, nav2_smac_planner::TurnDirection::REV_LEFT);
-  EXPECT_NEAR(testB.getTraversalCost(&testA), 2.506f * 0.9 * 2.0, 0.01);
+  testA.setMotionPrimitiveIndex(2, nav2_smac_planner::TurnDirection::REV_LEFT);
+  EXPECT_NEAR(testB.getTraversalCost(&testA), 2.513f * 0.9 * 2.0, 0.01);
 
   // will throw because never collision checked testB
   EXPECT_THROW(testA.getTraversalCost(&testB), std::runtime_error);
 
   // check motion primitives
-  EXPECT_EQ(testA.getMotionPrimitiveIndex(), 4u);
+  EXPECT_EQ(testA.getMotionPrimitiveIndex(), 2u);
 
   // check operator== works on index
   nav2_smac_planner::NodeHybrid testC(49);

--- a/nav2_smac_planner/test/test_nodehybrid.cpp
+++ b/nav2_smac_planner/test/test_nodehybrid.cpp
@@ -24,6 +24,7 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_smac_planner/node_hybrid.hpp"
 #include "nav2_smac_planner/collision_checker.hpp"
+#include "nav2_smac_planner/types.hpp"
 
 class RclCppFixture
 {
@@ -87,21 +88,27 @@ TEST(NodeHybridTest, test_node_hybrid)
   EXPECT_NEAR(testB.getTraversalCost(&testA), 2.088, 0.1);
   // now with straight motion, cost is 0, so will be neutral as well
   // but now reduced by retrospective penalty (10%)
-  testB.setMotionPrimitiveIndex(1);
-  testA.setMotionPrimitiveIndex(0);
+  testB.setMotionPrimitiveIndex(1, nav2_smac_planner::TurnDirection::LEFT);
+  testA.setMotionPrimitiveIndex(0, nav2_smac_planner::TurnDirection::FORWARD);
   EXPECT_NEAR(testB.getTraversalCost(&testA), 2.088 * 0.9, 0.1);
   // same direction as parent, testB
-  testA.setMotionPrimitiveIndex(1);
+  testA.setMotionPrimitiveIndex(1, nav2_smac_planner::TurnDirection::LEFT);
   EXPECT_NEAR(testB.getTraversalCost(&testA), 2.297f * 0.9, 0.01);
   // opposite direction as parent, testB
-  testA.setMotionPrimitiveIndex(2);
+  testA.setMotionPrimitiveIndex(2, nav2_smac_planner::TurnDirection::RIGHT);
   EXPECT_NEAR(testB.getTraversalCost(&testA), 2.506f * 0.9, 0.01);
+  // reverse direction as parent, testB
+  testA.setMotionPrimitiveIndex(3, nav2_smac_planner::TurnDirection::REV_RIGHT);
+  EXPECT_NEAR(testB.getTraversalCost(&testA), 2.506f * 0.9 * 2.0, 0.01);
+  // reverse direction as parent, testB
+  testA.setMotionPrimitiveIndex(4, nav2_smac_planner::TurnDirection::REV_LEFT);
+  EXPECT_NEAR(testB.getTraversalCost(&testA), 2.506f * 0.9 * 2.0, 0.01);
 
   // will throw because never collision checked testB
   EXPECT_THROW(testA.getTraversalCost(&testB), std::runtime_error);
 
   // check motion primitives
-  EXPECT_EQ(testA.getMotionPrimitiveIndex(), 2u);
+  EXPECT_EQ(testA.getMotionPrimitiveIndex(), 4u);
 
   // check operator== works on index
   nav2_smac_planner::NodeHybrid testC(49);

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -134,7 +134,7 @@ TEST(SmootherTest, test_full_smoother)
   // Test smoother, should succeed with same number of points
   // and shorter overall length, while still being collision free.
   auto path_size_in = plan.poses.size();
-  EXPECT_TRUE(smoother->smooth(plan, costmap, maxtime));
+  smoother->smooth(plan, costmap, maxtime);
   EXPECT_EQ(plan.poses.size(), path_size_in);  // Should have same number of poses
   double length = 0.0;
   x_m = plan.poses[0].pose.position.x;

--- a/nav2_smac_planner/test/test_smoother.cpp
+++ b/nav2_smac_planner/test/test_smoother.cpp
@@ -134,7 +134,7 @@ TEST(SmootherTest, test_full_smoother)
   // Test smoother, should succeed with same number of points
   // and shorter overall length, while still being collision free.
   auto path_size_in = plan.poses.size();
-  smoother->smooth(plan, costmap, maxtime);
+  EXPECT_TRUE(smoother->smooth(plan, costmap, maxtime));
   EXPECT_EQ(plan.poses.size(), path_size_in);  // Should have same number of poses
   double length = 0.0;
   x_m = plan.poses[0].pose.position.x;

--- a/tools/planner_benchmarking/README.md
+++ b/tools/planner_benchmarking/README.md
@@ -8,7 +8,6 @@ To use, modify the Nav2 bringup parameters to include the planners of interest:
 planner_server:
   ros__parameters:
     expected_planner_frequency: 20.0
-    use_sim_time: True
     planner_plugins: ["SmacHybrid", "Smac2d", "SmacLattice", "Navfn", "ThetaStar"]
     SmacHybrid:
       plugin: "nav2_smac_planner/SmacPlannerHybrid"


### PR DESCRIPTION
Per https://github.com/ros-planning/navigation2/issues/3172, we sometimes see zig-zagging behavior due to the discrete increments of angular quanitizations not fully utilizing the requested angular resolution. This issue is written out in detail in this comment: https://github.com/ros-planning/navigation2/issues/3172#issuecomment-1672249118

This solves that by creating additional motion primitives to fill in the angular space for each expansion to hit every angular bin possible. As a result, keeping angular bin densities of 64/72 as previously utilized will create **many** more new primitives for certain configurations than previously. It may be wise to reduce your resolution to not create additional primitives that your application does not require.

TODO
- [x]  performance testing across reeds-shepp, dubin, various turning rads (0.05, 0.1, 0.4, 0.5, 1.0, 2.0, 10.0), and non-circular robots for path quality and runtime. 
- [x] Unit testing of new methods like populateExpansionsLog
- [x] Traversal cost for primitives of turns
- [x] Dynamic parameter support
- [x] Document change: reduce resolution (72 no longer needed), new param in guide + migration guide. Post on Discourse about this major change for folks to update their config files https://github.com/ros-planning/navigation.ros.org/pull/459
- [x] Find new best practice resolution to use (e.g. 16, 32, 64, 72, ...) with rationale. More bins = more prims; lower $R_t$ = more prims
- [ ] test on realistic maps, not just benchmarking scripts -- why don't I see more change between the paths with various turning radii? Shouldn't the curves be very different? Need to look into that manually, something doesn't seem quite right (as if the static members are being shared between them?) or does the cost-awareness generally just guide it into the center so they have similar influences? I need to plot some turns. Or has to do with the number of smaller primitives available?
