### PR TITLE
Fix flaky costmap filters tests

### DIFF
--- a/nav2_system_tests/src/costmap_filters/keepout_params.yaml
+++ b/nav2_system_tests/src/costmap_filters/keepout_params.yaml
@@ -119,6 +119,7 @@ controller_server:
       plugin: "dwb_core::DWBLocalPlanner"
       debug_trajectory_details: True
       prune_distance: 1.0
+      forward_prune_distance: 1.0
       min_vel_x: 0.0
       min_vel_y: 0.0
       max_vel_x: 0.26

--- a/nav2_system_tests/src/costmap_filters/test_keepout_launch.py
+++ b/nav2_system_tests/src/costmap_filters/test_keepout_launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
     param_substitutions = {
         'planner_server.ros__parameters.GridBased.use_astar': os.getenv('ASTAR'),
         'filter_mask_server.ros__parameters.yaml_filename': filter_mask_file,
-        'yaml_filename': filter_mask_file}
+        'map_server.ros__parameters.yaml_filename': map_yaml_file}
     configured_params = RewrittenYaml(
         source_file=params_file,
         root_key='',

--- a/nav2_system_tests/src/costmap_filters/test_speed_launch.py
+++ b/nav2_system_tests/src/costmap_filters/test_speed_launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
     param_substitutions = {
         'planner_server.ros__parameters.GridBased.use_astar': os.getenv('ASTAR'),
         'filter_mask_server.ros__parameters.yaml_filename': filter_mask_file,
-        'yaml_filename': filter_mask_file}
+        'map_server.ros__parameters.yaml_filename': map_yaml_file}
     configured_params = RewrittenYaml(
         source_file=params_file,
         root_key='',


### PR DESCRIPTION
1. Set forward_prune_distance to `1.0` to robot not getting lost during keepout zone avoidance
2. Correct map name for costmap filter tests

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | local and `navigation2:main` docker colcon tests |

---

## Description of contribution in a few bullet points

Fixes for Costmap Filter keepout and speed flaky system tests. The following issues were resolved:

### Issue1: Incorrect map causing robot mislocalization and speed filter test failure

Incorrect map, passed through ROS-parameters gave lack of sensor points for AMCL to synchronize on:
![localization_problem](https://github.com/ros-planning/navigation2/assets/60094858/32dc09d3-933f-4477-b355-16a7cf009d18)

This caused loosing of localization accuracy and robot "twitching" on the map, that sometimes gave incorrect number of speed area entries in speed filter system tests, that could be confirmed by the following logs:
```
[tester_node-18] [INFO] [1690857935.497620380] [nav2_tester]: Goal accepted
[tester_node-18] [INFO] [1690857935.498106541] [nav2_tester]: Waiting for 'NavigateToPose' action to complete
[controller_server-10] [INFO] [1690857935.517831450] [controller_server]: Received a goal, begin computing control effort.
[controller_server-10] [WARN] [1690857935.517887210] [controller_server]: No goal checker was specified in parameter 'current_goal_checker'. Server will use only plugin loaded goal_checker . This warning will appear once.
[controller_server-10] [WARN] [1690857935.517903675] [controller_server]: No progress checker was specified in parameter 'current_progress_checker'. Server will use only plugin loaded progress_checker . This warning will appear once.
[controller_server-10] [INFO] [1690857936.568124126] [controller_server]: Passing new path to controller.
[tester_node-18] [INFO] [1690857936.814635994] [nav2_tester]: Received amcl_pose
[controller_server-10] [INFO] [1690857937.618128835] [controller_server]: Passing new path to controller.
[tester_node-18] [INFO] [1690857937.782155017] [nav2_tester]: Received amcl_pose
[controller_server-10] [INFO] [1690857938.618131785] [controller_server]: Passing new path to controller.
[tester_node-18] [INFO] [1690857938.646635378] [nav2_tester]: Received speed limit: 50.0
<- Robot is entering speed limit zone: everything is correct

[tester_node-18] [INFO] [1690857938.846981755] [nav2_tester]: Received speed limit: 0.0
<- After it, suddenly leaves speed limit zone

[tester_node-18] [INFO] [1690857938.982200947] [nav2_tester]: Received amcl_pose
[tester_node-18] [INFO] [1690857939.046789310] [nav2_tester]: Received speed limit: 50.0
<- And soon returned back. This is incorrect behavior caused by robot shaking/twitching on the map

[tester_node-18] [ERROR] [1690857939.047206631] [nav2_tester]: Got excess speed limit
<- Second entrance into speed area: testcase defines this situation as failure

[controller_server-10] [INFO] [1690857939.668130632] [controller_server]: Passing new path to controller.
[controller_server-10] [INFO] [1690857940.668122891] [controller_server]: Passing new path to controller.
[tester_node-18] [INFO] [1690857940.986499344] [nav2_tester]: Received amcl_pose
[controller_server-10] [INFO] [1690857941.718128812] [controller_server]: Passing new path to controller.
[controller_server-10] [INFO] [1690857942.768132606] [controller_server]: Passing new path to controller.
[tester_node-18] [INFO] [1690857943.191380905] [nav2_tester]: Received amcl_pose
[tester_node-18] [INFO] [1690857943.247161526] [nav2_tester]: Received speed limit: 0.0
<- Normal speed area exitting

[tester_node-18] [ERROR] [1690857943.247846851] [nav2_tester]: Got excess speed limit
[controller_server-10] [INFO] [1690857943.768127124] [controller_server]: Passing new path to controller.
[tester_node-18] [INFO] [1690857944.406945426] [nav2_tester]: Received amcl_pose
[controller_server-10] [INFO] [1690857944.818131328] [controller_server]: Passing new path to controller.
[tester_node-18] [INFO] [1690857945.596909621] [nav2_tester]: Received amcl_pose
[controller_server-10] [INFO] [1690857945.818129002] [controller_server]: Passing new path to controller.
[controller_server-10] [INFO] [1690857945.972374709] [controller_server]: Reached the goal!
[bt_navigator-14] [INFO] [1690857946.007176582] [bt_navigator]: Goal succeeded
[tester_node-18] [INFO] [1690857946.008504667] [nav2_tester]: Goal succeeded!
[tester_node-18] [INFO] [1690857946.009112104] [nav2_tester]: Setting goal pose
[bt_navigator-14] [INFO] [1690857946.009900886] [bt_navigator]: Begin navigating from current location (-0.21, -0.59) to (0.00, -0.50)
[tester_node-18] [INFO] [1690857946.009931408] [nav2_tester]: Waiting 60 seconds for robot to reach goal
[tester_node-18] [INFO] [1690857946.010768094] [nav2_tester]: Distance from goal is: 0.24604320282810566
[tester_node-18] [INFO] [1690857946.011335055] [nav2_tester]: *** GOAL REACHED ***
[tester_node-18] [ERROR] [1690857946.011845001] [nav2_tester]: Test FAILED
```

After giving correct map name to map server, robot became to operate flawlessly and the problem disappears:
![after_fix](https://github.com/ros-planning/navigation2/assets/60094858/398bf11e-5b23-4783-a769-57d3c006ff20)

### Issue 2. Untuned usage of `forward_prune_distance` for the keepout test

Initial problem was described as "Problem 2" in #3098 and fixed in #3120: `prune_distance` was decreased from 2.0 -> to 1.0. However, after c09bbcdcf0c433ecec07fe252e654ab3e7569aa2 new `forward_prune_distance` parameter appeared, which causing the same as described in #3098 -> Problem 2, behavior in keepout system test.

This issue is fixing by setting `forward_prune_distance` to `1.0`, as well.

## Verification results
* Local test run of `test_speed_filter_local` and `test_keepout_filter` each on 20 times in a row - no failures
* Using `ghcr.io/ros-planning/navigation2:main` Docker container for testing (same as CircleCI). Running all `test_keepout_filter`/`test_speed_filter_global`/`test_speed_filter_local` tests 30 times in a row - no fails.
* Stress testing script is being attached to current PR, for the reference:
[run_stress.sh.txt](https://github.com/ros-planning/navigation2/files/12321284/run_stress.sh.txt)

## Description of documentation updates required from your changes

No doc updates are required

---

## Future work that may be required in bullet points

* Refuse constant boilerplate works with keeping up to date of `nav2_system_tests/src/costmap_filters/keepout_params.yaml` `nav2_system_tests/src/costmap_filters/speed_global_params.yaml` and `nav2_system_tests/src/costmap_filters/speed_local_params.yaml` files. Instead of it use `nav2_bringup/params/nav2_params.yaml` base YAML and add all new required ROS-parameters on the top of it (not sure, whether the `RewrittenYaml` can do this). Anyway, this is the subject of talk for separate ticket/PR.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
