### PR TITLE
Declare param use_maximum on static _layer

### DIFF
--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -132,6 +132,7 @@ StaticLayer::getParameters()
   declareParameter("map_subscribe_transient_local", rclcpp::ParameterValue(true));
   declareParameter("transform_tolerance", rclcpp::ParameterValue(0.0));
   declareParameter("map_topic", rclcpp::ParameterValue(""));
+  declareParameter("use_maximum", rclcpp::ParameterValue(true));
 
   auto node = node_.lock();
   if (!node) {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (N/A |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | Currently tested on simulated robot|

---

## Description of contribution in a few bullet points


* I recover the "use_maximum" param declaration to use it in a similar way the "combination_method" is used in every layer as obstacle_layer. It is useful to use the enabled param dynamically and keep the maximum value from the data of the layers.  All the code was done, but the declaration was missing or broken. 


## Future work that may be required in bullet points

* Add the parameter to the official navigation web. 


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
