### PR TITLE
use ros clock for wait

### DIFF
--- a/nav2_behaviors/include/nav2_behaviors/plugins/wait.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/wait.hpp
@@ -63,7 +63,7 @@ public:
   CostmapInfoType getResourceInfo() override {return CostmapInfoType::LOCAL;}
 
 protected:
-  std::chrono::time_point<std::chrono::steady_clock> wait_end_;
+  rclcpp::Time wait_end_;
   WaitAction::Feedback::SharedPtr feedback_;
 };
 

--- a/nav2_behaviors/plugins/wait.cpp
+++ b/nav2_behaviors/plugins/wait.cpp
@@ -30,22 +30,20 @@ Wait::~Wait() = default;
 
 ResultStatus Wait::onRun(const std::shared_ptr<const WaitAction::Goal> command)
 {
-  wait_end_ = std::chrono::steady_clock::now() +
-    rclcpp::Duration(command->time).to_chrono<std::chrono::nanoseconds>();
-  return ResultStatus{Status::SUCCEEDED};
+  wait_end_ = node_.lock()->now() + rclcpp::Duration(command->time);
+  return Status::SUCCEEDED;
 }
 
 ResultStatus Wait::onCycleUpdate()
 {
-  auto current_point = std::chrono::steady_clock::now();
-  auto time_left =
-    std::chrono::duration_cast<std::chrono::nanoseconds>(wait_end_ - current_point).count();
+  auto current_point = node_.lock()->now();
+  auto time_left = wait_end_ - current_point;
 
-  feedback_->time_left = rclcpp::Duration(rclcpp::Duration::from_nanoseconds(time_left));
+  feedback_->time_left = time_left;
   action_server_->publish_feedback(feedback_);
 
-  if (time_left > 0) {
-    return ResultStatus{Status::RUNNING};
+  if (time_left.nanoseconds() > 0) {
+    return Status::RUNNING;
   } else {
     return ResultStatus{Status::SUCCEEDED};
   }

--- a/nav2_behaviors/plugins/wait.cpp
+++ b/nav2_behaviors/plugins/wait.cpp
@@ -31,7 +31,7 @@ Wait::~Wait() = default;
 ResultStatus Wait::onRun(const std::shared_ptr<const WaitAction::Goal> command)
 {
   wait_end_ = node_.lock()->now() + rclcpp::Duration(command->time);
-  return Status::SUCCEEDED;
+  return ResultStatus{Status::SUCCEEDED};
 }
 
 ResultStatus Wait::onCycleUpdate()
@@ -43,7 +43,7 @@ ResultStatus Wait::onCycleUpdate()
   action_server_->publish_feedback(feedback_);
 
   if (time_left.nanoseconds() > 0) {
-    return Status::RUNNING;
+    return ResultStatus{Status::RUNNING};
   } else {
     return ResultStatus{Status::SUCCEEDED};
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/3780 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory Simulation |

---

## Description of contribution in a few bullet points
Use ros time that automatically uses simulation time if `use_sim_time = true` so waiting time is coherent with simulation time

## Description of documentation updates required from your changes

Migration guide ?

---

## Future work that may be required in bullet points

Solve all cases listed here: https://github.com/ros-planning/navigation2/issues/3303

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
