### PR TITLE
Fixes for flaky WPF test

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -196,6 +196,11 @@ protected:
    */
   void populateErrorCode(typename std::shared_ptr<typename ActionT::Result> result);
 
+  /**
+   * @brief Setting BT error codes to success. Used to clean blackboard between different BT runs
+   */
+  void cleanErrorCodes();
+
   // Action name
   std::string action_name_;
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -284,6 +284,8 @@ void BtActionServer<ActionT>::executeCallback()
       action_server_->terminate_all(result);
       break;
   }
+
+  cleanErrorCodes();
 }
 
 template<class ActionT>
@@ -307,6 +309,14 @@ void BtActionServer<ActionT>::populateErrorCode(
 
   if (highest_priority_error_code != std::numeric_limits<int>::max()) {
     result->error_code = highest_priority_error_code;
+  }
+}
+
+template<class ActionT>
+void BtActionServer<ActionT>::cleanErrorCodes()
+{
+  for (const auto & error_code : error_code_names_) {
+    blackboard_->set<unsigned short>(error_code, 0);  //NOLINT
   }
 }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -230,6 +230,7 @@ void BtActionServer<ActionT>::executeCallback()
 {
   if (!on_goal_received_callback_(action_server_->get_current_goal())) {
     action_server_->terminate_current();
+    cleanErrorCodes();
     return;
   }
 

--- a/nav2_common/nav2_common/launch/rewritten_yaml.py
+++ b/nav2_common/nav2_common/launch/rewritten_yaml.py
@@ -87,6 +87,7 @@ class RewrittenYaml(launch.Substitution):
         param_rewrites, keys_rewrites = self.resolve_rewrites(context)
         data = yaml.safe_load(open(yaml_filename, 'r'))
         self.substitute_params(data, param_rewrites)
+        self.add_params(data, param_rewrites)
         self.substitute_keys(data, keys_rewrites)
         if self.__root_key is not None:
             root_key = launch.utilities.perform_substitutions(context, self.__root_key)
@@ -121,6 +122,15 @@ class RewrittenYaml(launch.Substitution):
                 yaml_keys = path.split('.')
                 yaml = self.updateYamlPathVals(yaml, yaml_keys, rewrite_val)
 
+    def add_params(self, yaml, param_rewrites):
+        # add new total path parameters
+        yaml_paths = self.pathify(yaml)
+        for path in param_rewrites:
+            if not path in yaml_paths:
+                new_val = self.convert(param_rewrites[path])
+                yaml_keys = path.split('.')
+                if 'ros__parameters' in yaml_keys:
+                    yaml = self.updateYamlPathVals(yaml, yaml_keys, new_val)
 
     def updateYamlPathVals(self, yaml, yaml_key_list, rewrite_val):
         for key in yaml_key_list:

--- a/nav2_system_tests/src/waypoint_follower/test_case_py.launch
+++ b/nav2_system_tests/src/waypoint_follower/test_case_py.launch
@@ -41,10 +41,13 @@ def generate_launch_description():
     params_file = os.path.join(bringup_dir, 'params/nav2_params.yaml')
 
     # Replace the `use_astar` setting on the params file
+    param_substitutions = {
+        'controller_server.ros__parameters.FollowPath.prune_distance': '1.0',
+        'controller_server.ros__parameters.FollowPath.forward_prune_distance': '1.0'}
     configured_params = RewrittenYaml(
         source_file=params_file,
         root_key='',
-        param_rewrites='',
+        param_rewrites=param_substitutions,
         convert_types=True)
 
     context = LaunchContext()

--- a/nav2_system_tests/src/waypoint_follower/tester.py
+++ b/nav2_system_tests/src/waypoint_follower/tester.py
@@ -236,9 +236,7 @@ def main(argv=sys.argv[1:]):
     # stop on failure test with bogous waypoint
     test.setStopFailureParam(True)
     bwps = [[-0.52, -0.54], [100.0, 100.0], [0.58, 0.52]]
-    starting_pose = [-2.0, -0.5]
     test.setWaypoints(bwps)
-    test.setInitialPose(starting_pose)
     result = test.run(True, False)
     assert not result
     result = not result

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -275,9 +275,7 @@ WaypointFollower::followWaypoints()
       }
     }
 
-    if (current_goal_status_.status != ActionStatus::PROCESSING &&
-      current_goal_status_.status != ActionStatus::UNKNOWN)
-    {
+    if (current_goal_status_.status != ActionStatus::PROCESSING) {
       // Update server state
       goal_index++;
       new_goal = true;

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -217,7 +217,10 @@ WaypointFollower::followWaypoints()
     feedback->current_waypoint = goal_index;
     action_server_->publish_feedback(feedback);
 
-    if (current_goal_status_.status == ActionStatus::FAILED) {
+    if (
+      current_goal_status_.status == ActionStatus::FAILED ||
+      current_goal_status_.status == ActionStatus::UNKNOWN)
+    {
       nav2_msgs::msg::MissedWaypoint missedWaypoint;
       missedWaypoint.index = goal_index;
       missedWaypoint.goal = goal->poses[goal_index];
@@ -324,6 +327,7 @@ WaypointFollower::resultCallback(
       current_goal_status_.status = ActionStatus::FAILED;
       return;
     default:
+      RCLCPP_ERROR(get_logger(), "Got unknown result from BT");
       current_goal_status_.status = ActionStatus::UNKNOWN;
       return;
   }

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -327,7 +327,7 @@ WaypointFollower::resultCallback(
       current_goal_status_.status = ActionStatus::FAILED;
       return;
     default:
-      RCLCPP_ERROR(get_logger(), "Got unknown result from BT");
+      RCLCPP_ERROR(get_logger(), "Received an UNKNOWN result code from navigation action!");
       current_goal_status_.status = ActionStatus::UNKNOWN;
       return;
   }


### PR DESCRIPTION
* New RewrittenYaml ability to add non-existing parameters
* Prune distance fix for WPF test
* Treat UNKNOWN status as error in WPF
* Clear error codes after BT run
* Remove unnecessary setInitialPose() from WPF test

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3765 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | colcon test |

---

## Description of contribution in a few bullet points

The following problems described in #3765, were fixed:

| Problem | Solution description |
| ------------- | ------------- |
| Problem1: No action | Return back BT action server timeout to 15 minutes: #3787 |
| Problem1: No action  | New RewrittenYaml ability to add non-existing parameters & prune distance fix for lower probability of recovery situations |
| Problem1: No action | Treat UNKNOWN status as error in WPF to avoid hangs when action goal was deleted |
| Problem2: Incorrect out-of-map status | Clear error codes after BT run |
| Problem3: Robot lost | Remove unnecessary setInitialPose() from testing |

## Verification status

Performed `colcon test` for `nav2_waypoint_follower`, `nav2_behavior_tree` and `nav2_system_tests` packages, touched in this PR. No regressions appear during the local testing.

## Description of documentation updates required from your changes

* Describe new ability of `RewrittenYaml` in Iron->Jazzy MG

---

## Future work that may be required in bullet points

* Remove Costmap Filter parameters YAML-s in favor of using new ability of RewrittenYaml to add new ROS-parameters. This will reduce boilerplate works to synchronize Costmap Filter parameters YAML-s with main one.
* Fix RCLCPP action 10-second timeout in either RCLCPP or make a workaround for Nav2

Both above items are subject of separate PR-s.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
