### PR TITLE
Expose action server result timeout as a parameter in bt navigator servers

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -61,6 +61,9 @@ BtActionServer<ActionT>::BtActionServer(
   if (!node->has_parameter("default_server_timeout")) {
     node->declare_parameter("default_server_timeout", 20);
   }
+  if (!node->has_parameter("action_server_result_timeout")) {
+    node->declare_parameter("action_server_result_timeout", 900.0);
+  }
 
   std::vector<std::string> error_code_names = {
     "follow_path_error_code",
@@ -91,16 +94,6 @@ BtActionServer<ActionT>::BtActionServer(
       }
       RCLCPP_INFO_STREAM(logger_, "Error_code parameters were set to:" << error_codes_str);
     }
-  }
-
-  // Result timeout for the action server.
-  // In https://github.com/ros2/rcl/pull/1012 a change was introduced
-  // which makes action servers discard a goal handle if the result is not produced
-  // within 10 seconds. Since this may not be the case for all actions in
-  // Nav2, this timeout is exposed as a parameter and defaults to the previous
-  // expiration value of 15 minutes.
-  if (!node->has_parameter("action_server_result_timeout")) {
-    node->declare_parameter("action_server_result_timeout", 900.0);
   }
 }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -161,7 +161,7 @@ bool BtActionServer<ActionT>::on_configure()
   // Get parameters for BT timeouts
   int bt_loop_duration;
   node->get_parameter("bt_loop_duration", bt_loop_duration);
-  bt_loop_duration_ = std::chrono::milliseconds(timeout);
+  bt_loop_duration_ = std::chrono::milliseconds(bt_loop_duration);
   int default_server_timeout;
   node->get_parameter("default_server_timeout", default_server_timeout);
   default_server_timeout_ = std::chrono::milliseconds(default_server_timeout);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -99,7 +99,7 @@ BtActionServer<ActionT>::BtActionServer(
   // Nav2, this timeout is exposed as a parameter and defaults to the previous
   // expiration value of 15 minutes.
   if (!node->has_parameter("action_server_result_timeout")) {
-    node->declare_parameter("action_server_result_timeout", 15 * 60);
+    node->declare_parameter("action_server_result_timeout", 900.0);
   }
 }
 
@@ -139,10 +139,10 @@ bool BtActionServer<ActionT>::on_configure()
     "global_frame", node->get_parameter("global_frame").as_string());
 
   // set the timeout in seconds for the action server to discard goal handles if not finished
-  int timeout;
-  node->get_parameter("action_server_result_timeout", timeout);
+  double action_server_result_timeout;
+  node->get_parameter("action_server_result_timeout", action_server_result_timeout);
   rcl_action_server_options_t server_options = rcl_action_server_get_default_options();
-  server_options.result_timeout.nanoseconds = RCL_S_TO_NS(timeout);
+  server_options.result_timeout.nanoseconds = RCL_S_TO_NS(action_server_result_timeout);
 
   action_server_ = std::make_shared<ActionServer>(
     node->get_node_base_interface(),
@@ -153,10 +153,12 @@ bool BtActionServer<ActionT>::on_configure()
     nullptr, std::chrono::milliseconds(500), false, server_options);
 
   // Get parameters for BT timeouts
-  node->get_parameter("bt_loop_duration", timeout);
+  int bt_loop_duration;
+  node->get_parameter("bt_loop_duration", bt_loop_duration);
   bt_loop_duration_ = std::chrono::milliseconds(timeout);
-  node->get_parameter("default_server_timeout", timeout);
-  default_server_timeout_ = std::chrono::milliseconds(timeout);
+  int default_server_timeout;
+  node->get_parameter("default_server_timeout", default_server_timeout);
+  default_server_timeout_ = std::chrono::milliseconds(default_server_timeout);
 
   // Get error code id names to grab off of the blackboard
   error_code_names_ = node->get_parameter("error_code_names").as_string_array();

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -96,7 +96,7 @@ BtActionServer<ActionT>::BtActionServer(
   // In https://github.com/ros2/rcl/pull/1012 a change was introduced
   // which makes action servers discard a goal handle if the result is not produced
   // within 10 seconds. Since this may not be the case for all actions in
-  // Nav2, this timeout is exposed as a parameter and default to the previous
+  // Nav2, this timeout is exposed as a parameter and defaults to the previous
   // expiration value of 15 minutes.
   if (!node->has_parameter("action_server_result_timeout")) {
     node->declare_parameter("action_server_result_timeout", 15 * 60);
@@ -138,7 +138,7 @@ bool BtActionServer<ActionT>::on_configure()
   client_node_->declare_parameter(
     "global_frame", node->get_parameter("global_frame").as_string());
 
-  // set the timeout in seconds for the action server to discard goal handles
+  // set the timeout in seconds for the action server to discard goal handles if not finished
   int timeout;
   node->get_parameter("action_server_result_timeout", timeout);
   rcl_action_server_options_t server_options = rcl_action_server_get_default_options();

--- a/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
@@ -133,9 +133,25 @@ public:
     node->get_parameter("robot_base_frame", robot_base_frame_);
     node->get_parameter("transform_tolerance", transform_tolerance_);
 
+    // Result timeout for the action server.
+    // In https://github.com/ros2/rcl/pull/1012 a change was introduced
+    // which makes action servers discard a goal handle if the result is not produced
+    // within 10 seconds. Since this may not be the case for all actions in
+    // Nav2, this timeout is exposed as a parameter and defaults to the previous
+    // expiration value of 15 minutes.
+    if (!node->has_parameter("action_server_result_timeout")) {
+      node->declare_parameter("action_server_result_timeout", 900.0);
+    }
+
+    double action_server_result_timeout;
+    node->get_parameter("action_server_result_timeout", action_server_result_timeout);
+    rcl_action_server_options_t server_options = rcl_action_server_get_default_options();
+    server_options.result_timeout.nanoseconds = RCL_S_TO_NS(action_server_result_timeout);
+
     action_server_ = std::make_shared<ActionServer>(
       node, behavior_name_,
-      std::bind(&TimedBehavior::execute, this));
+      std::bind(&TimedBehavior::execute, this), nullptr, std::chrono::milliseconds(
+        500), false, server_options);
 
     local_collision_checker_ = local_collision_checker;
     global_collision_checker_ = global_collision_checker;

--- a/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
@@ -133,14 +133,8 @@ public:
     node->get_parameter("robot_base_frame", robot_base_frame_);
     node->get_parameter("transform_tolerance", transform_tolerance_);
 
-    // Result timeout for the action server.
-    // In https://github.com/ros2/rcl/pull/1012 a change was introduced
-    // which makes action servers discard a goal handle if the result is not produced
-    // within 10 seconds. Since this may not be the case for all actions in
-    // Nav2, this timeout is exposed as a parameter and defaults to the previous
-    // expiration value of 15 minutes.
     if (!node->has_parameter("action_server_result_timeout")) {
-      node->declare_parameter("action_server_result_timeout", 900.0);
+      node->declare_parameter("action_server_result_timeout", 10.0);
     }
 
     double action_server_result_timeout;

--- a/nav2_bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_1.yaml
@@ -45,8 +45,6 @@ bt_navigator:
     odom_topic: /odom
     bt_loop_duration: 10
     default_server_timeout: 20
-    # timeout [s] for action servers to discard goal handles if not completed, 
-    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
     action_server_result_timeout: 900.0
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
@@ -280,8 +278,6 @@ waypoint_follower:
   ros__parameters:
     loop_rate: 20
     stop_on_failure: false
-    # timeout [s] for action servers to discard goal handles if not completed, 
-    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
     action_server_result_timeout: 900.0
     waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:

--- a/nav2_bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_1.yaml
@@ -47,7 +47,7 @@ bt_navigator:
     default_server_timeout: 20
     # timeout [s] for action servers to discard goal handles if not completed, 
     # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
-    action_server_result_timeout: 900
+    action_server_result_timeout: 900.0
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
@@ -280,6 +280,9 @@ waypoint_follower:
   ros__parameters:
     loop_rate: 20
     stop_on_failure: false
+    # timeout [s] for action servers to discard goal handles if not completed, 
+    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900.0
     waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:
       plugin: "nav2_waypoint_follower::WaitAtWaypoint"

--- a/nav2_bringup/params/nav2_multirobot_params_1.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_1.yaml
@@ -45,6 +45,9 @@ bt_navigator:
     odom_topic: /odom
     bt_loop_duration: 10
     default_server_timeout: 20
+    # timeout [s] for action servers to discard goal handles if not completed, 
+    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"

--- a/nav2_bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_2.yaml
@@ -47,7 +47,7 @@ bt_navigator:
     default_server_timeout: 20
     # timeout [s] for action servers to discard goal handles if not completed, 
     # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
-    action_server_result_timeout: 900               # timeout for action servers to discard goal handles if not completed, 15 minutes previous de, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"

--- a/nav2_bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_2.yaml
@@ -45,6 +45,9 @@ bt_navigator:
     odom_topic: /odom
     bt_loop_duration: 10
     default_server_timeout: 20
+    # timeout [s] for action servers to discard goal handles if not completed, 
+    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900               # timeout for action servers to discard goal handles if not completed, 15 minutes previous de, see https://github.com/ros2/rcl/pull/1012
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"

--- a/nav2_bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_2.yaml
@@ -45,8 +45,6 @@ bt_navigator:
     odom_topic: /odom
     bt_loop_duration: 10
     default_server_timeout: 20
-    # timeout [s] for action servers to discard goal handles if not completed, 
-    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
     action_server_result_timeout: 900.0
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
@@ -279,8 +277,6 @@ waypoint_follower:
   ros__parameters:
     loop_rate: 20
     stop_on_failure: false
-    # timeout [s] for action servers to discard goal handles if not completed, 
-    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
     action_server_result_timeout: 900.0
     waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:

--- a/nav2_bringup/params/nav2_multirobot_params_2.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_2.yaml
@@ -47,7 +47,7 @@ bt_navigator:
     default_server_timeout: 20
     # timeout [s] for action servers to discard goal handles if not completed, 
     # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
-    action_server_result_timeout: 900
+    action_server_result_timeout: 900.0
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
@@ -279,6 +279,9 @@ waypoint_follower:
   ros__parameters:
     loop_rate: 20
     stop_on_failure: false
+    # timeout [s] for action servers to discard goal handles if not completed, 
+    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900.0
     waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:
       plugin: "nav2_waypoint_follower::WaitAtWaypoint"

--- a/nav2_bringup/params/nav2_multirobot_params_all.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_all.yaml
@@ -47,7 +47,7 @@ bt_navigator:
     default_server_timeout: 20
     # timeout [s] for action servers to discard goal handles if not completed, 
     # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
-    action_server_result_timeout: 900              # timeout for action servers to discard goal handles if not completed, 15 minutes previous de, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"

--- a/nav2_bringup/params/nav2_multirobot_params_all.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_all.yaml
@@ -45,6 +45,9 @@ bt_navigator:
     odom_topic: /odom
     bt_loop_duration: 10
     default_server_timeout: 20
+    # timeout [s] for action servers to discard goal handles if not completed, 
+    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900              # timeout for action servers to discard goal handles if not completed, 15 minutes previous de, see https://github.com/ros2/rcl/pull/1012
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"

--- a/nav2_bringup/params/nav2_multirobot_params_all.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_all.yaml
@@ -47,7 +47,7 @@ bt_navigator:
     default_server_timeout: 20
     # timeout [s] for action servers to discard goal handles if not completed, 
     # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
-    action_server_result_timeout: 900
+    action_server_result_timeout: 900.0
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
@@ -327,6 +327,9 @@ waypoint_follower:
   ros__parameters:
     loop_rate: 20
     stop_on_failure: false
+    # timeout [s] for action servers to discard goal handles if not completed, 
+    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900.0
     waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:
       plugin: "nav2_waypoint_follower::WaitAtWaypoint"

--- a/nav2_bringup/params/nav2_multirobot_params_all.yaml
+++ b/nav2_bringup/params/nav2_multirobot_params_all.yaml
@@ -45,8 +45,6 @@ bt_navigator:
     odom_topic: /odom
     bt_loop_duration: 10
     default_server_timeout: 20
-    # timeout [s] for action servers to discard goal handles if not completed, 
-    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
     action_server_result_timeout: 900.0
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
@@ -327,8 +325,6 @@ waypoint_follower:
   ros__parameters:
     loop_rate: 20
     stop_on_failure: false
-    # timeout [s] for action servers to discard goal handles if not completed, 
-    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
     action_server_result_timeout: 900.0
     waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -47,7 +47,7 @@ bt_navigator:
     default_server_timeout: 20
     # timeout [s] for action servers to discard goal handles if not completed, 
     # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
-    action_server_result_timeout: 900              # timeout for action servers to discard goal handles if not completed, 15 minutes previous de, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -45,6 +45,9 @@ bt_navigator:
     odom_topic: /odom
     bt_loop_duration: 10
     default_server_timeout: 20
+    # timeout [s] for action servers to discard goal handles if not completed, 
+    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900              # timeout for action servers to discard goal handles if not completed, 15 minutes previous de, see https://github.com/ros2/rcl/pull/1012
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -47,7 +47,7 @@ bt_navigator:
     default_server_timeout: 20
     # timeout [s] for action servers to discard goal handles if not completed, 
     # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
-    action_server_result_timeout: 900
+    action_server_result_timeout: 900.0
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
@@ -323,6 +323,9 @@ waypoint_follower:
   ros__parameters:
     loop_rate: 20
     stop_on_failure: false
+    # timeout [s] for action servers to discard goal handles if not completed, 
+    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
+    action_server_result_timeout: 900.0
     waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:
       plugin: "nav2_waypoint_follower::WaitAtWaypoint"

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -45,8 +45,6 @@ bt_navigator:
     odom_topic: /odom
     bt_loop_duration: 10
     default_server_timeout: 20
-    # timeout [s] for action servers to discard goal handles if not completed, 
-    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
     action_server_result_timeout: 900.0
     navigators: ["navigate_to_pose", "navigate_through_poses"]
     navigate_to_pose:
@@ -323,8 +321,6 @@ waypoint_follower:
   ros__parameters:
     loop_rate: 20
     stop_on_failure: false
-    # timeout [s] for action servers to discard goal handles if not completed, 
-    # 15 minutes previous default, see https://github.com/ros2/rcl/pull/1012
     action_server_result_timeout: 900.0
     waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -49,14 +49,8 @@ ControllerServer::ControllerServer(const rclcpp::NodeOptions & options)
   RCLCPP_INFO(get_logger(), "Creating controller server");
 
   declare_parameter("controller_frequency", 20.0);
-
-  // Result timeout for the action server.
-  // In https://github.com/ros2/rcl/pull/1012 a change was introduced
-  // which makes action servers discard a goal handle if the result is not produced
-  // within 10 seconds. Since this may not be the case for all actions in
-  // Nav2, this timeout is exposed as a parameter and defaults to the previous
-  // expiration value of 15 minutes.
-  declare_parameter("action_server_result_timeout", 900.0);
+  
+  declare_parameter("action_server_result_timeout", 10.0);
 
   declare_parameter("progress_checker_plugins", default_progress_checker_ids_);
   declare_parameter("goal_checker_plugins", default_goal_checker_ids_);

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -50,6 +50,14 @@ ControllerServer::ControllerServer(const rclcpp::NodeOptions & options)
 
   declare_parameter("controller_frequency", 20.0);
 
+  // Result timeout for the action server.
+  // In https://github.com/ros2/rcl/pull/1012 a change was introduced
+  // which makes action servers discard a goal handle if the result is not produced
+  // within 10 seconds. Since this may not be the case for all actions in
+  // Nav2, this timeout is exposed as a parameter and defaults to the previous
+  // expiration value of 15 minutes.
+  declare_parameter("action_server_result_timeout", 900.0);
+
   declare_parameter("progress_checker_plugins", default_progress_checker_ids_);
   declare_parameter("goal_checker_plugins", default_goal_checker_ids_);
   declare_parameter("controller_plugins", default_ids_);
@@ -227,6 +235,11 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
   odom_sub_ = std::make_unique<nav_2d_utils::OdomSubscriber>(node);
   vel_publisher_ = create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
 
+  double action_server_result_timeout;
+  get_parameter("action_server_result_timeout", action_server_result_timeout);
+  rcl_action_server_options_t server_options = rcl_action_server_get_default_options();
+  server_options.result_timeout.nanoseconds = RCL_S_TO_NS(action_server_result_timeout);
+
   // Create the action server that we implement with our followPath method
   action_server_ = std::make_unique<ActionServer>(
     shared_from_this(),
@@ -234,7 +247,7 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     std::bind(&ControllerServer::computeControl, this),
     nullptr,
     std::chrono::milliseconds(500),
-    true);
+    true, server_options);
 
   // Set subscribtion to the speed limiting topic
   speed_limit_sub_ = create_subscription<nav2_msgs::msg::SpeedLimit>(

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -49,7 +49,7 @@ ControllerServer::ControllerServer(const rclcpp::NodeOptions & options)
   RCLCPP_INFO(get_logger(), "Creating controller server");
 
   declare_parameter("controller_frequency", 20.0);
-  
+
   declare_parameter("action_server_result_timeout", 10.0);
 
   declare_parameter("progress_checker_plugins", default_progress_checker_ids_);

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -53,13 +53,7 @@ PlannerServer::PlannerServer(const rclcpp::NodeOptions & options)
   declare_parameter("planner_plugins", default_ids_);
   declare_parameter("expected_planner_frequency", 1.0);
 
-  // Result timeout for the action server.
-  // In https://github.com/ros2/rcl/pull/1012 a change was introduced
-  // which makes action servers discard a goal handle if the result is not produced
-  // within 10 seconds. Since this may not be the case for all actions in
-  // Nav2, this timeout is exposed as a parameter and defaults to the previous
-  // expiration value of 15 minutes.
-  declare_parameter("action_server_result_timeout", 900.0);
+  declare_parameter("action_server_result_timeout", 10.0);
 
   get_parameter("planner_plugins", planner_ids_);
   if (planner_ids_ == default_ids_) {

--- a/nav2_smoother/src/nav2_smoother.cpp
+++ b/nav2_smoother/src/nav2_smoother.cpp
@@ -54,13 +54,7 @@ SmootherServer::SmootherServer(const rclcpp::NodeOptions & options)
   declare_parameter("transform_tolerance", rclcpp::ParameterValue(0.1));
   declare_parameter("smoother_plugins", default_ids_);
 
-  // Result timeout for the action server.
-  // In https://github.com/ros2/rcl/pull/1012 a change was introduced
-  // which makes action servers discard a goal handle if the result is not produced
-  // within 10 seconds. Since this may not be the case for all actions in
-  // Nav2, this timeout is exposed as a parameter and defaults to the previous
-  // expiration value of 15 minutes.
-  declare_parameter("action_server_result_timeout", 900.0);
+  declare_parameter("action_server_result_timeout", 10.0);
 }
 
 SmootherServer::~SmootherServer()

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -36,6 +36,15 @@ WaypointFollower::WaypointFollower(const rclcpp::NodeOptions & options)
 
   declare_parameter("stop_on_failure", true);
   declare_parameter("loop_rate", 20);
+
+  // Result timeout for the action server.
+  // In https://github.com/ros2/rcl/pull/1012 a change was introduced
+  // which makes action servers discard a goal handle if the result is not produced
+  // within 10 seconds. Since this may not be the case for all actions in
+  // Nav2, this timeout is exposed as a parameter and defaults to the previous
+  // expiration value of 15 minutes.
+  declare_parameter("action_server_result_timeout", 900.0);
+
   nav2_util::declare_parameter_if_not_declared(
     this, std::string("waypoint_task_executor_plugin"),
     rclcpp::ParameterValue(std::string("wait_at_waypoint")));
@@ -71,12 +80,20 @@ WaypointFollower::on_configure(const rclcpp_lifecycle::State & /*state*/)
     get_node_waitables_interface(),
     "navigate_to_pose", callback_group_);
 
+  double action_server_result_timeout;
+  get_parameter("action_server_result_timeout", action_server_result_timeout);
+  rcl_action_server_options_t server_options = rcl_action_server_get_default_options();
+  server_options.result_timeout.nanoseconds = RCL_S_TO_NS(action_server_result_timeout);
+
   action_server_ = std::make_unique<ActionServer>(
     get_node_base_interface(),
     get_node_clock_interface(),
     get_node_logging_interface(),
     get_node_waitables_interface(),
-    "follow_waypoints", std::bind(&WaypointFollower::followWaypoints, this));
+    "follow_waypoints", std::bind(
+      &WaypointFollower::followWaypoints,
+      this), nullptr, std::chrono::milliseconds(
+      500), false, server_options);
 
   try {
     waypoint_task_executor_type_ = nav2_util::get_plugin_type_param(

--- a/nav2_waypoint_follower/src/waypoint_follower.cpp
+++ b/nav2_waypoint_follower/src/waypoint_follower.cpp
@@ -37,12 +37,6 @@ WaypointFollower::WaypointFollower(const rclcpp::NodeOptions & options)
   declare_parameter("stop_on_failure", true);
   declare_parameter("loop_rate", 20);
 
-  // Result timeout for the action server.
-  // In https://github.com/ros2/rcl/pull/1012 a change was introduced
-  // which makes action servers discard a goal handle if the result is not produced
-  // within 10 seconds. Since this may not be the case for all actions in
-  // Nav2, this timeout is exposed as a parameter and defaults to the previous
-  // expiration value of 15 minutes.
   declare_parameter("action_server_result_timeout", 900.0);
 
   nav2_util::declare_parameter_if_not_declared(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3765  |
| Primary OS tested on | Ubuntu 22.04 (docker) |
| Robotic platform tested on | gazebo turtlebot |

---

## Description of contribution in a few bullet points

* As described in #3765, the waypoint follower is getting `UNKNOWN` results if the call to `/navigate_to_pose` takes more than 10 seconds to complete. @AlexeyMerzlyakov traced this back the problem to https://github.com/ros2/rcl/pull/1012. I'm exposing the result timeout of the action server as a parameter in the `bt_navigator` node following @AlexeyMerzlyakov suggestion in #3765

## Description of documentation updates required from your changes

* Added the new parameter `action_server_result_timeout`, so need to add that to default configs and documentation page

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
