### PR TITLE
Add docker compose support to devcontainer to allow using iron and hu…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,24 +1,17 @@
 {
     "name": "Nav2",
-    "build": {
-        "dockerfile": "../Dockerfile",
-        "context": "..",
-        "target": "visualizer",
-        "cacheFrom": "ghcr.io/ros-planning/navigation2:main"
-    },
-    "runArgs": [
-        // "--cap-add=SYS_PTRACE", // enable debugging, e.g. gdb
-        // "--ipc=host", // shared memory transport with host, e.g. rviz GUIs
-        // "--network=host", // network access to host interfaces, e.g. eth0
-        // "--pid=host", // DDS discovery with host, without --network=host
-        // "--privileged", // device access to host peripherals, e.g. USB
-        // "--security-opt=seccomp=unconfined", // enable debugging, e.g. gdb
+    "dockerComposeFile": [
+        "docker-compose.yaml"
     ],
+    "service": "rolling",
+    // Only run the desired, otherwise VSCode builds all of them.
+    // https://stackoverflow.com/questions/64069256/building-only-required-docker-compose-yaml-services-with-vs-code-dev-container
+    "runServices": ["rolling"],
     "workspaceFolder": "/opt/overlay_ws/src/navigation2",
-    "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind",
-    "onCreateCommand": ".devcontainer/on-create-command.sh",
-    "updateContentCommand": ".devcontainer/update-content-command.sh",
-    "postCreateCommand": ".devcontainer/post-create-command.sh",
+    // "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind",
+    // "onCreateCommand": ".devcontainer/on-create-command.sh",
+    // "updateContentCommand": ".devcontainer/update-content-command.sh",
+    // "postCreateCommand": ".devcontainer/post-create-command.sh",
     "remoteEnv": {
         "OVERLAY_MIXINS": "release ccache lld",
         "CCACHE_DIR": "/tmp/.ccache"

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,28 @@
+services:
+  rolling:
+    build:
+      args:
+        FROM_IMAGE: ros:rolling
+      context: ..
+      cache_from: 
+        - ghcr.io/ros-planning/navigation2:main
+      target: visualizer
+    container_name: nav2-rolling
+  iron:
+    build:
+      args:
+        FROM_IMAGE: ros:iron
+      context: ..
+      cache_from: 
+        - ghcr.io/ros-planning/navigation2:iron
+      target: visualizer
+    container_name: nav2-iron
+  humble:
+    build:
+      args:
+        FROM_IMAGE: ros:humble
+      context: ..
+      cache_from: 
+        - ghcr.io/ros-planning/navigation2:humble
+      target: visualizer
+    container_name: nav2-humble


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3790  |
| Primary OS tested on | Ubuntu 23 |
| Robotic platform tested on | None |

---

## Description of contribution in a few bullet points

* Added a docker compose file with support for rolling, iron, and humble like so:
  * `docker compose -f .devcontainer/docker-compose.yaml build rolling`
  * `docker compose -f .devcontainer/docker-compose.yaml build iron`
  * `docker compose -f .devcontainer/docker-compose.yaml build humble`
* Updated the caching to cache from the right branch, instead of humble trying to cache from `main`
* Used the compose file in the devcontainer instead of raw docker build arguments

## Description of documentation updates required from your changes

* TODO update docs on how to use it. Most things happen under the hood.

## Current Problem with the PR

Currently, the devcontainer is able to build, but it fails to start. Using the compose file directly works fine. Any ideas @ruffsl ?
```
[2023-09-01T16:13:26.799Z] [+] Running 1/1
 ✔ Container nav2-rolling  Started                                         0.2s 
[2023-09-01T16:13:26.801Z] Stop (20118 ms): Run: docker events --format {{json .}} --filter event=start
[2023-09-01T16:13:26.802Z] Stop (266 ms): Run: docker compose --project-name navigation2_devcontainer -f /home/ryan/Development/nav2_ws/src/navigation2/.devcontainer/docker-compose.yaml -f /tmp/devcontainercli-ryan/docker-compose/docker-compose.devcontainer.build-1693584790409.yml -f /tmp/devcontainercli-ryan/docker-compose/docker-compose.devcontainer.containerFeatures-1693584806536.yml up -d rolling
[2023-09-01T16:13:26.802Z] Start: Run: docker ps -q -a --filter label=com.docker.compose.project=navigation2_devcontainer --filter label=com.docker.compose.service=rolling
[2023-09-01T16:13:26.810Z] Stop (8 ms): Run: docker ps -q -a --filter label=com.docker.compose.project=navigation2_devcontainer --filter label=com.docker.compose.service=rolling
[2023-09-01T16:13:26.810Z] Start: Run: docker inspect --type container fb166d25ff96
[2023-09-01T16:13:26.820Z] Stop (10 ms): Run: docker inspect --type container fb166d25ff96
[2023-09-01T16:13:26.821Z] Start: Inspecting container
[2023-09-01T16:13:26.821Z] Start: Run: docker inspect --type container fb166d25ff96ea97a4701daeda20a10171b7164fc4398122f7819883af6ca7d5
[2023-09-01T16:13:26.829Z] Stop (8 ms): Run: docker inspect --type container fb166d25ff96ea97a4701daeda20a10171b7164fc4398122f7819883af6ca7d5
[2023-09-01T16:13:26.829Z] Stop (8 ms): Inspecting container
[2023-09-01T16:13:26.829Z] Start: Run in container: /bin/sh
[2023-09-01T16:13:26.833Z] Start: Run in container: uname -m
[2023-09-01T16:13:26.901Z] Stop (72 ms): Run in container: /bin/sh
[2023-09-01T16:13:27.492Z] Shell server terminated (code: 126, signal: null)
[2023-09-01T16:13:27.492Z] OCI runtime exec failed: exec failed: unable to start container process: error writing config to pipe: write init-p: broken pipe: unknown

[2023-09-01T16:13:26.901Z] Start: Run in container: getent passwd root
[2023-09-01T16:13:26.901Z] Stdin closed!
[2023-09-01T16:13:27.492Z] Error: An error occurred setting up the container.
[2023-09-01T16:13:27.492Z]     at $$ (/home/ryan/.vscode-remote-containers/dist/dev-containers-cli-0.304.0/dist/spec-node/devContainersSpecCLI.js:409:3567)
[2023-09-01T16:13:27.492Z]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
[2023-09-01T16:13:27.492Z]     at async mAA (/home/ryan/.vscode-remote-containers/dist/dev-containers-cli-0.304.0/dist/spec-node/devContainersSpecCLI.js:479:3833)
[2023-09-01T16:13:27.492Z]     at async LC (/home/ryan/.vscode-remote-containers/dist/dev-containers-cli-0.304.0/dist/spec-node/devContainersSpecCLI.js:479:4775)
[2023-09-01T16:13:27.492Z]     at async jeA (/home/ryan/.vscode-remote-containers/dist/dev-containers-cli-0.304.0/dist/spec-node/devContainersSpecCLI.js:611:12219)
[2023-09-01T16:13:27.492Z]     at async _eA (/home/ryan/.vscode-remote-containers/dist/dev-containers-cli-0.304.0/dist/spec-node/devContainersSpecCLI.js:611:11960)
[2023-09-01T16:13:27.493Z] Stop (21141 ms): Run in Host: /home/ryan/.vscode-server/bin/6c3e3dba23e8fadc360aed75ce363ba185c49794/node /home/ryan/.vscode-remote-containers/dist/dev-containers-cli-0.304.0/dist/spec-node/devContainersSpecCLI.js up --container-session-data-folder /tmp/devcontainers-deb26e8f-2472-45b9-9c26-ad671afe2f0e1693584772285 --workspace-folder /home/ryan/Development/nav2_ws/src/navigation2 --workspace-mount-consistency cached --id-label devcontainer.local_folder=/home/ryan/Development/nav2_ws/src/navigation2 --id-label devcontainer.config_file=/home/ryan/Development/nav2_ws/src/navigation2/.devcontainer/devcontainer.json --log-level debug --log-format json --config /home/ryan/Development/nav2_ws/src/navigation2/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --remove-existing-container --mount type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root true
[2023-09-01T16:13:27.493Z] Exit code 1
[2023-09-01T16:13:27.494Z] Command failed: /home/ryan/.vscode-server/bin/6c3e3dba23e8fadc360aed75ce363ba185c49794/node /home/ryan/.vscode-remote-containers/dist/dev-containers-cli-0.304.0/dist/spec-node/devContainersSpecCLI.js up --container-session-data-folder /tmp/devcontainers-deb26e8f-2472-45b9-9c26-ad671afe2f0e1693584772285 --workspace-folder /home/ryan/Development/nav2_ws/src/navigation2 --workspace-mount-consistency cached --id-label devcontainer.local_folder=/home/ryan/Development/nav2_ws/src/navigation2 --id-label devcontainer.config_file=/home/ryan/Development/nav2_ws/src/navigation2/.devcontainer/devcontainer.json --log-level debug --log-format json --config /home/ryan/Development/nav2_ws/src/navigation2/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --remove-existing-container --mount type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root true
[2023-09-01T16:13:27.494Z] Exit code 1
```

## Future work that may be required in bullet points

* When backporting to iron and humble, change the devcontainer service names to iron and humble respectively


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
