### PR TITLE
Added missing virtual destructor

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/critic_manager.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critic_manager.hpp
@@ -46,7 +46,7 @@ public:
     * @brief Constructor for mppi::CriticManager
     */
   CriticManager() = default;
-
+  ~CriticManager() = default;
 
   /**
     * @brief Virtual Destructor for mppi::CriticManager


### PR DESCRIPTION
## Basic Info

Added the missing empty virtual destructor which prevented package building of nav2_mppi_controller. 

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu 22.04 
| Robotic platform tested on | ROS2 Humble + simulation setup used -> NeoBotix sim mp400 robot

---
Added the missing empty virtual destructor which prevented package building of nav2_mppi_controller. 
A simple enough one-liner fix which allowed for the package to build

## Description of documentation updates required from your changes
No documentation update required

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
