### PR TITLE
mppi: return NO_INFORMATION when the checked point is outside the costmap

### DIFF
--- a/nav2_mppi_controller/src/critics/obstacles_critic.cpp
+++ b/nav2_mppi_controller/src/critics/obstacles_critic.cpp
@@ -191,7 +191,10 @@ CollisionCost ObstaclesCritic::costAtPose(float x, float y, float theta)
   float & cost = collision_cost.cost;
   collision_cost.using_footprint = false;
   unsigned int x_i, y_i;
-  collision_checker_.worldToMap(x, y, x_i, y_i);
+  if (!collision_checker_.worldToMap(x, y, x_i, y_i)) {
+    cost = nav2_costmap_2d::NO_INFORMATION;
+    return collision_cost;
+  }
   cost = collision_checker_.pointCost(x_i, y_i);
 
   if (consider_footprint_ && (cost >= possibly_inscribed_cost_ || possibly_inscribed_cost_ < 1)) {


### PR DESCRIPTION
otherwise the controller crashes at ObstaclesCritic::costAtPose because x_i and y_i isn't initialized.

![Screenshot_20230912_220501](https://github.com/ros-planning/navigation2/assets/3888062/ddc26620-b92f-4d90-9210-268f13b250da)
