### PR TITLE
adjust link to point to v3.8 of behavior tree docs instead of v4.3

### DIFF
--- a/nav2_behavior_tree/README.md
+++ b/nav2_behavior_tree/README.md
@@ -63,4 +63,4 @@ The BehaviorTree engine has a run method that accepts an XML description of a BT
 
 See the code in the [BT Navigator](../nav2_bt_navigator/src/bt_navigator.cpp) for an example usage of the BehaviorTreeEngine.
 
-For more information about the behavior tree nodes that are available in the default BehaviorTreeCPP library, see documentation here: https://www.behaviortree.dev/docs/learn-the-basics/bt_basics/
+For more information about the behavior tree nodes that are available in the default BehaviorTreeCPP library, see documentation here: https://www.behaviortree.dev/docs/3.8/learn-the-basics/BT_basics


### PR DESCRIPTION
## Description of contribution in a few bullet points

I fixed the broken link a few days ago in #3822 but just realized that the new one points to the BT.CPPv4.3 docs and nav2 is currently using v3.8


This might result in some confusion if:
- using this link to continue browsing the BT docs since there are some differences between v3 vs. v4
- the latest doc version is bumped to an incompatible version and not comparable to v3

Not sure if it's worth the update :) your choice regardless

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
