### PR TITLE
Fix action test failure due to rate after Rolling sync API change

### DIFF
--- a/nav2_util/test/test_actions.cpp
+++ b/nav2_util/test/test_actions.cpp
@@ -548,6 +548,5 @@ int main(int argc, char ** argv)
   ::testing::InitGoogleTest(&argc, argv);
   auto result = RUN_ALL_TESTS();
   rclcpp::shutdown();
-  rclcpp::Rate(1).sleep();
   return result;
 }


### PR DESCRIPTION
FYI @AlexeyMerzlyakov I believe this is due to the context required for rate now issue :-). In no way your fault, just glad this was an API change _we_ made so I knew to think about it faster! 