### PR TITLE
Make copy of shared objects in messages (can_loan_messages)

### DIFF
--- a/nav2_collision_monitor/src/pointcloud.cpp
+++ b/nav2_collision_monitor/src/pointcloud.cpp
@@ -139,7 +139,7 @@ void PointCloud::getParameters(std::string & source_topic)
 
 void PointCloud::dataCallback(sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
-  data_ = msg;
+  data_ = std::make_shared<sensor_msgs::msg::PointCloud2>(*msg);
 }
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/src/range.cpp
+++ b/nav2_collision_monitor/src/range.cpp
@@ -160,7 +160,7 @@ void Range::getParameters(std::string & source_topic)
 
 void Range::dataCallback(sensor_msgs::msg::Range::ConstSharedPtr msg)
 {
-  data_ = msg;
+  data_ = std::make_shared<sensor_msgs::msg::Range>(*msg);
 }
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/src/scan.cpp
+++ b/nav2_collision_monitor/src/scan.cpp
@@ -122,7 +122,7 @@ void Scan::getData(
 
 void Scan::dataCallback(sensor_msgs::msg::LaserScan::ConstSharedPtr msg)
 {
-  data_ = msg;
+  data_ = std::make_shared<sensor_msgs::msg::LaserScan>(*msg);
 }
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/test/collision_detector_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_detector_node_test.cpp
@@ -198,7 +198,7 @@ bool Tester::waitState(const std::chrono::nanoseconds & timeout)
 
 void Tester::stateCallback(nav2_msgs::msg::CollisionDetectorState::SharedPtr msg)
 {
-  state_msg_ = msg;
+  state_msg_ = std::make_shared<nav2_msgs::msg::CollisionDetectorState>(*msg);
 }
 
 void Tester::setCommonParameters()

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -625,12 +625,12 @@ bool Tester::waitActionState(const std::chrono::nanoseconds & timeout)
 
 void Tester::cmdVelOutCallback(geometry_msgs::msg::Twist::SharedPtr msg)
 {
-  cmd_vel_out_ = msg;
+  cmd_vel_out_ = std::make_shared<geometry_msgs::msg::Twist>(*msg);
 }
 
 void Tester::actionStateCallback(nav2_msgs::msg::CollisionMonitorState::SharedPtr msg)
 {
-  action_state_ = msg;
+  action_state_ = std::make_shared<nav2_msgs::msg::CollisionMonitorState>(*msg);
 }
 
 TEST_F(Tester, testProcessStopSlowdownLimit)

--- a/nav2_collision_monitor/test/polygons_test.cpp
+++ b/nav2_collision_monitor/test/polygons_test.cpp
@@ -127,7 +127,7 @@ public:
 
   void polygonCallback(geometry_msgs::msg::PolygonStamped::SharedPtr msg)
   {
-    polygon_received_ = msg;
+    polygon_received_ = std::make_shared<geometry_msgs::msg::PolygonStamped>(*msg);
   }
 
   geometry_msgs::msg::PolygonStamped::SharedPtr waitPolygonReceived(

--- a/nav2_constrained_smoother/test/test_constrained_smoother.cpp
+++ b/nav2_constrained_smoother/test/test_constrained_smoother.cpp
@@ -81,7 +81,7 @@ public:
 
   void setCostmap(nav2_msgs::msg::Costmap::SharedPtr msg)
   {
-    costmap_msg_ = msg;
+    costmap_msg_ = std::make_shared<nav2_msgs::msg::Costmap>(*msg);
     costmap_received_ = true;
   }
 };

--- a/nav2_costmap_2d/plugins/costmap_filters/binary_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/binary_filter.cpp
@@ -161,7 +161,7 @@ void BinaryFilter::maskCallback(
     filter_mask_.reset();
   }
 
-  filter_mask_ = msg;
+  filter_mask_ = std::make_shared<nav_msgs::msg::OccupancyGrid>(*msg);
 }
 
 void BinaryFilter::process(

--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -143,7 +143,7 @@ void KeepoutFilter::maskCallback(
   }
 
   // Store filter_mask_
-  filter_mask_ = msg;
+  filter_mask_ = std::make_shared<nav_msgs::msg::OccupancyGrid>(*msg);
 }
 
 void KeepoutFilter::process(

--- a/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/speed_filter.cpp
@@ -168,7 +168,7 @@ void SpeedFilter::maskCallback(
     filter_mask_.reset();
   }
 
-  filter_mask_ = msg;
+  filter_mask_ = std::make_shared<nav_msgs::msg::OccupancyGrid>(*msg);
 }
 
 void SpeedFilter::process(

--- a/nav2_costmap_2d/test/integration/test_costmap_topic_collision_checker.cpp
+++ b/nav2_costmap_2d/test/integration/test_costmap_topic_collision_checker.cpp
@@ -62,7 +62,7 @@ public:
 
   void setCostmap(nav2_msgs::msg::Costmap::SharedPtr msg)
   {
-    costmap_msg_ = msg;
+    costmap_msg_ = std::make_shared<nav2_msgs::msg::Costmap>(*msg);
     costmap_received_ = true;
   }
 };
@@ -79,7 +79,7 @@ public:
 
   void setFootprint(geometry_msgs::msg::PolygonStamped::SharedPtr msg)
   {
-    footprint_ = msg;
+    footprint_ = std::make_shared<geometry_msgs::msg::PolygonStamped>(*msg);
     footprint_received_ = true;
   }
 };

--- a/nav2_costmap_2d/test/unit/speed_filter_test.cpp
+++ b/nav2_costmap_2d/test/unit/speed_filter_test.cpp
@@ -115,7 +115,7 @@ public:
   void speedLimitCallback(
     const nav2_msgs::msg::SpeedLimit::SharedPtr msg)
   {
-    msg_ = msg;
+    msg_ = std::make_shared<nav2_msgs::msg::SpeedLimit>(*msg);
     speed_limit_updated_ = true;
   }
 

--- a/nav2_map_server/test/unit/test_costmap_filter_info_server.cpp
+++ b/nav2_map_server/test/unit/test_costmap_filter_info_server.cpp
@@ -130,7 +130,7 @@ private:
   void infoCallback(const nav2_msgs::msg::CostmapFilterInfo::SharedPtr msg)
   {
     std::lock_guard<mutex_t> guard(*getMutex());
-    info_ = msg;
+    info_ = std::make_shared<nav2_msgs::msg::CostmapFilterInfo>(*msg);
   }
 
   rclcpp::Subscription<nav2_msgs::msg::CostmapFilterInfo>::SharedPtr subscription_;

--- a/nav2_smoother/test/test_smoother_server.cpp
+++ b/nav2_smoother/test/test_smoother_server.cpp
@@ -145,7 +145,7 @@ public:
 
   void setCostmap(nav2_msgs::msg::Costmap::SharedPtr msg)
   {
-    costmap_msg_ = msg;
+    costmap_msg_ = std::make_shared<nav2_msgs::msg::Costmap>(*msg);
     costmap_received_ = true;
   }
 };
@@ -177,7 +177,7 @@ public:
 
   void setFootprint(geometry_msgs::msg::PolygonStamped::SharedPtr msg)
   {
-    footprint_ = msg;
+    footprint_ = std::make_shared<geometry_msgs::msg::PolygonStamped>(*msg);
     footprint_received_ = true;
   }
 };

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -187,7 +187,7 @@ void VelocitySmoother::inputCommandCallback(const geometry_msgs::msg::Twist::Sha
     return;
   }
 
-  command_ = msg;
+  command_ = std::make_shared<geometry_msgs::msg::Twist>(*msg);
   last_command_time_ = now();
 }
 

--- a/nav2_waypoint_follower/plugins/photo_at_waypoint.cpp
+++ b/nav2_waypoint_follower/plugins/photo_at_waypoint.cpp
@@ -138,7 +138,7 @@ bool PhotoAtWaypoint::processAtWaypoint(
 void PhotoAtWaypoint::imageCallback(const sensor_msgs::msg::Image::SharedPtr msg)
 {
   std::lock_guard<std::mutex> guard(global_mutex_);
-  curr_frame_msg_ = msg;
+  curr_frame_msg_ = std::make_shared<sensor_msgs::msg::Image>(*msg);
 }
 
 void PhotoAtWaypoint::deepCopyMsg2Mat(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None known |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Peanut's in-house robot simulator |

---

## Description of contribution in a few bullet points
* Under certain circumstances, messages passed by shared pointer cannot be used outside the callback.
* Save a copy of message in callbacks, so they can safely be used outside the callback.
* This is necessary when using Fast-DDS which currently enables `can_loan_messages`.
* Not necessary for Cyclone DDS, which disables `can_loan_messages`.
* Might be a RCLPP bug.
* Might be a Middleware bug
* Replaces https://github.com/ros-planning/navigation2/pull/3863


## Description of documentation updates required from your changes
No documentation changes needed.

---

## Future work that may be required in bullet points

* If the RCLPP/MW behavior changes and the bug is fixed, this PR can be discarded.
* May want to check a flag and not do these copies if can_loan_messages is false.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
