### PR TITLE
Fix for  robot footprint collision in obstacles critic

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/obstacles_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/obstacles_critic.hpp
@@ -92,6 +92,7 @@ protected:
   float possibly_inscribed_cost_;
   float collision_margin_distance_;
   float near_goal_distance_;
+  float circumscribed_cost_{0}, circumscribed_radius_{0};
 
   unsigned int power_{0};
   float repulsion_weight_, critical_weight_{0};

--- a/nav2_mppi_controller/src/critics/obstacles_critic.cpp
+++ b/nav2_mppi_controller/src/critics/obstacles_critic.cpp
@@ -91,6 +91,7 @@ float ObstaclesCritic::findCircumscribedCost(
 
   circumscribed_radius_ = static_cast<float>(circum_radius);
   circumscribed_cost_ = static_cast<float>(result);
+
   return circumscribed_cost_;
 }
 
@@ -115,8 +116,17 @@ void ObstaclesCritic::score(CriticData & data)
   if (!enabled_) {
     return;
   }
-
-  possibly_inscribed_cost_ = findCircumscribedCost(costmap_ros_);
+  auto parent = parent_.lock();
+  auto t0 = parent->now(); // xx!!
+  if (consider_footprint_) {
+    // footprint has almost certainly changed since initialize()
+    possibly_inscribed_cost_ = findCircumscribedCost(costmap_ros_);
+  }
+  auto t1 = parent->now();
+  auto dt = (t1 - t0).seconds();
+  static double fcc_dt = 0.05;
+  fcc_dt = 0.9 * fcc_dt + 0.1 * dt;
+  RCLCPP_WARN_THROTTLE(logger_, *(parent->get_clock()), 500, "findCircumscribedCost took %f ms (%f)", 1000.0*dt, 1000.0*fcc_dt);
 
   // If near the goal, don't apply the preferential term since the goal is near obstacles
   bool near_goal = false;
@@ -170,6 +180,12 @@ void ObstaclesCritic::score(CriticData & data)
     (repulsion_weight_ * repulsive_cost / traj_len),
     power_);
   data.fail_flag = all_trajectories_collide;
+
+  auto t2 = parent->now();
+  dt = (t2 - t0).seconds();
+  static double score_dt = 0.05;
+  score_dt = 0.9 * score_dt + 0.1 * dt;
+  RCLCPP_WARN_THROTTLE(logger_, *(parent->get_clock()), 500, "score took %f ms (%f)", 1000.0*dt, 1000.0*score_dt);
 }
 
 /**

--- a/nav2_mppi_controller/src/critics/obstacles_critic.cpp
+++ b/nav2_mppi_controller/src/critics/obstacles_critic.cpp
@@ -55,6 +55,13 @@ float ObstaclesCritic::findCircumscribedCost(
 {
   double result = -1.0;
   bool inflation_layer_found = false;
+
+  const double circum_radius = costmap->getLayeredCostmap()->getCircumscribedRadius();
+  if (static_cast<float>(circum_radius) == circumscribed_radius_) {
+    // early return if footprint size is unchanged
+    return circumscribed_cost_;
+  }
+
   // check if the costmap has an inflation layer
   for (auto layer = costmap->getLayeredCostmap()->getPlugins()->begin();
     layer != costmap->getLayeredCostmap()->getPlugins()->end();
@@ -66,7 +73,6 @@ float ObstaclesCritic::findCircumscribedCost(
     }
 
     inflation_layer_found = true;
-    const double circum_radius = costmap->getLayeredCostmap()->getCircumscribedRadius();
     const double resolution = costmap->getCostmap()->getResolution();
     result = inflation_layer->computeCost(circum_radius / resolution);
     inflation_scale_factor_ = static_cast<float>(inflation_layer->getCostScalingFactor());
@@ -83,7 +89,9 @@ float ObstaclesCritic::findCircumscribedCost(
       "significantly slow down planning times and not avoid anything but absolute collisions!");
   }
 
-  return static_cast<float>(result);
+  circumscribed_radius_ = static_cast<float>(circum_radius);
+  circumscribed_cost_ = static_cast<float>(result);
+  return circumscribed_cost_;
 }
 
 float ObstaclesCritic::distanceToObstacle(const CollisionCost & cost)

--- a/nav2_mppi_controller/src/critics/obstacles_critic.cpp
+++ b/nav2_mppi_controller/src/critics/obstacles_critic.cpp
@@ -108,6 +108,8 @@ void ObstaclesCritic::score(CriticData & data)
     return;
   }
 
+  possibly_inscribed_cost_ = findCircumscribedCost(costmap_ros_);
+
   // If near the goal, don't apply the preferential term since the goal is near obstacles
   bool near_goal = false;
   if (utils::withinPositionGoalTolerance(near_goal_distance_, data.state.pose.pose, data.path)) {

--- a/nav2_mppi_controller/src/critics/obstacles_critic.cpp
+++ b/nav2_mppi_controller/src/critics/obstacles_critic.cpp
@@ -118,8 +118,7 @@ void ObstaclesCritic::score(CriticData & data)
   }
 
   if (consider_footprint_) {
-    // footprint has almost certainly changed since initialize()
-    // and may continue to change
+    // footprint may have changed since initialization if user has dynamic footprints
     possibly_inscribed_cost_ = findCircumscribedCost(costmap_ros_);
   }
 

--- a/nav2_mppi_controller/src/critics/obstacles_critic.cpp
+++ b/nav2_mppi_controller/src/critics/obstacles_critic.cpp
@@ -116,17 +116,12 @@ void ObstaclesCritic::score(CriticData & data)
   if (!enabled_) {
     return;
   }
-  auto parent = parent_.lock();
-  auto t0 = parent->now(); // xx!!
+
   if (consider_footprint_) {
     // footprint has almost certainly changed since initialize()
+    // and may continue to change
     possibly_inscribed_cost_ = findCircumscribedCost(costmap_ros_);
   }
-  auto t1 = parent->now();
-  auto dt = (t1 - t0).seconds();
-  static double fcc_dt = 0.05;
-  fcc_dt = 0.9 * fcc_dt + 0.1 * dt;
-  RCLCPP_WARN_THROTTLE(logger_, *(parent->get_clock()), 500, "findCircumscribedCost took %f ms (%f)", 1000.0*dt, 1000.0*fcc_dt);
 
   // If near the goal, don't apply the preferential term since the goal is near obstacles
   bool near_goal = false;
@@ -180,12 +175,6 @@ void ObstaclesCritic::score(CriticData & data)
     (repulsion_weight_ * repulsive_cost / traj_len),
     power_);
   data.fail_flag = all_trajectories_collide;
-
-  auto t2 = parent->now();
-  dt = (t2 - t0).seconds();
-  static double score_dt = 0.05;
-  score_dt = 0.9 * score_dt + 0.1 * dt;
-  RCLCPP_WARN_THROTTLE(logger_, *(parent->get_clock()), 500, "score took %f ms (%f)", 1000.0*dt, 1000.0*score_dt);
 }
 
 /**


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | No known tickets |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |Peanut's in-house robot (sim) |

---

## Description of contribution in a few bullet points

* Inscribed/Circumscribed costs must be updated to take into account the current shape of the robot.
* `ObstaclesCritic::findCircumscribedCost()` was only being called once, in initialize()
* in `initialize()`, `findCircumscribedCost()` uses placeholder inner/outer radius values which come from` robot_radius`.
* `findCircumscribedCost()` was never called again, and the circumscribed cost was never updated based on the footprint.
* depending on the value of `robot_radius`, this could cause too much or too little footprint checking in `costAtPose()`


## Description of documentation updates required from your changes
* No documentation changes.

---

## Future work that may be required in bullet points
* The SMAC planner may have a similar problem. I will investigate when I have time.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
