### PR TITLE
Controller Frequency information outputed to user.

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -388,8 +388,10 @@ void ControllerServer::computeControl()
     progress_checker_->reset();
 
     last_valid_cmd_time_ = now();
-    rclcpp::WallRate loop_rate(controller_frequency_);
+    
+    // rclcpp::WallRate loop_rate(controller_frequency_);
     while (rclcpp::ok()) {
+      auto start_time = now();
       if (action_server_ == nullptr || !action_server_->is_server_active()) {
         RCLCPP_DEBUG(get_logger(), "Action server unavailable or inactive. Stopping.");
         return;
@@ -417,12 +419,23 @@ void ControllerServer::computeControl()
         break;
       }
 
-      if (!loop_rate.sleep()) {
+      // if (!loop_rate.sleep()) {
+      //   RCLCPP_WARN(
+      //     get_logger(), "Control loop missed its desired rate of %.4fHz",
+      //     controller_frequency_);
+      // }
+
+      auto cycle_duration = now() - start_time;
+
+      if (cycle_duration.seconds() > (1/controller_frequency_)) {
         RCLCPP_WARN(
-          get_logger(), "Control loop missed its desired rate of %.4fHz",
-          controller_frequency_);
-      }
+          get_logger(),
+          "Controller loop missed its desired rate of %.4f Hz. Current loop rate is %.4f Hz",
+          controller_frequency_, 1 / cycle_duration.seconds());
     }
+    }
+
+    
   } catch (nav2_core::PlannerException & e) {
     RCLCPP_ERROR(this->get_logger(), e.what());
     publishZeroVelocity();


### PR DESCRIPTION

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | No ticket |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | ( gazebo simulation) |

---

## Description of contribution in a few bullet points

Noticed that controller does not output the current loop rate when it fails to meet the users predefined ideal controller frequency (`controller_frequency_`). I therefore edited some lines in order to add this functionality. More specifically the changes I made were:  Added line `394`: `auto start_time = now();`

Added lines `428-436`
```
      auto cycle_duration = now() - start_time;

      if (cycle_duration.seconds() > (1/controller_frequency_)) {
        RCLCPP_WARN(
          get_logger(),
          "Controller loop missed its desired rate of %.4f Hz. Current loop rate is %.4f Hz",
          controller_frequency_, 1 / cycle_duration.seconds());
    }
    }
```
Commented out lines related to `loop_rate` (i.e., lines `422 to 426` and `392`)


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
