### PR TITLE
Adjust the Variable types in Nav2_costmap_2d pkg in [nav2_humble] 

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/denoise/image.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/denoise/image.hpp
@@ -50,7 +50,7 @@ public:
    * Share image data between new and old object.
    * Changing data in a new object will affect the given one and vice versa
    */
-  Image(Image & other);
+  Image(const Image & other);
 
   /**
    * @brief Create image from the other (move constructor)
@@ -132,7 +132,7 @@ Image<T>::Image(size_t rows, size_t columns, T * data, size_t step)
 }
 
 template<class T>
-Image<T>::Image(Image & other)
+Image<T>::Image(const Image & other)
 : data_start_{other.data_start_},
   rows_{other.rows_}, columns_{other.columns_}, step_{other.step_} {}
 


### PR DESCRIPTION
#3891 

To improve the compatibility of navigation2-[ROS2-humble] with the latest version of the compilation environment , we modify the code in `nav2_costmap_2d` refer to the ISSUE #3891 
