### PR TITLE
Handle NaNs in AMCL beam sensor model

### DIFF
--- a/nav2_amcl/src/sensors/laser/beam_model.cpp
+++ b/nav2_amcl/src/sensors/laser/beam_model.cpp
@@ -74,7 +74,7 @@ BeamModel::sensorFunction(LaserData * data, pf_sample_set_t * set)
       obs_range = data->ranges[i][0];
 
       // Check for NaN
-      if (obs_range != obs_range) {
+      if (isnan(obs_range)) {
         continue;
       }
 

--- a/nav2_amcl/src/sensors/laser/beam_model.cpp
+++ b/nav2_amcl/src/sensors/laser/beam_model.cpp
@@ -72,6 +72,12 @@ BeamModel::sensorFunction(LaserData * data, pf_sample_set_t * set)
     step = (data->range_count - 1) / (self->max_beams_ - 1);
     for (i = 0; i < data->range_count; i += step) {
       obs_range = data->ranges[i][0];
+
+      // Check for NaN
+      if (obs_range != obs_range) {
+        continue;
+      }
+
       obs_bearing = data->ranges[i][1];
 
       // Compute the range according to the map


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Data-driven benchmark |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
Pretty much what the title says. I accidentally came across this bug while running AMCL against a dataset with LaserScan messages that happened to bear NaNs every now and then.

Here I apply the same NaN check that the other sensor models use, for consistency.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
None.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
None.
#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
