### PR TITLE
[RPP] Adding support for rotate in place cusps

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -419,9 +419,24 @@ double RegulatedPurePursuitController::findVelocitySignChange(
     /* Checking for the existance of cusp, in the path, using the dot product
     and determine it's distance from the robot. If there is no cusp in the path,
     then just determine the distance to the goal location. */
-    if ( (oa_x * ab_x) + (oa_y * ab_y) < 0.0) {
+    const double dot_prod = (oa_x * ab_x) + (oa_y * ab_y);
+    if (dot_prod < 0.0) {
       // returning the distance if there is a cusp
       // The transformed path is in the robots frame, so robot is at the origin
+      return hypot(
+        transformed_plan.poses[pose_id].pose.position.x,
+        transformed_plan.poses[pose_id].pose.position.y);
+    } else if (
+      (hypot(oa_x, oa_y) == 0.0 &&
+        transformed_plan.poses[pose_id - 1].pose.orientation !=
+        transformed_plan.poses[pose_id].pose.orientation)
+      ||
+      (hypot(ab_x, ab_y) == 0.0 &&
+        transformed_plan.poses[pose_id].pose.orientation !=
+        transformed_plan.poses[pose_id + 1].pose.orientation))
+    {
+      // returning the distance since the points overlap
+      // but are not simply duplicate points (e.g. in place rotation)
       return hypot(
         transformed_plan.poses[pose_id].pose.position.x,
         transformed_plan.poses[pose_id].pose.position.y);

--- a/nav2_util/include/nav2_util/geometry_utils.hpp
+++ b/nav2_util/include/nav2_util/geometry_utils.hpp
@@ -132,7 +132,7 @@ inline Iter min_by(Iter begin, Iter end, Getter getCompareVal)
   Iter lowest_it = begin;
   for (Iter it = ++begin; it != end; ++it) {
     auto comp = getCompareVal(*it);
-    if (comp < lowest) {
+    if (comp <= lowest) {
       lowest = comp;
       lowest_it = it;
     }


### PR DESCRIPTION
@Aposhian  @vinnnyr  @doisyg  I could use a sanity check here as I'm proposing a solution to https://github.com/ros-planning/navigation2/issues/3089.

Previously, cusps that involve in-place rotations from the state lattice planner are ignored. This is an attempted solution which I don't think has any negative side effects, but its subtle and worth expanding upon for visibility and understandability.

Previously, we check the dot project is negative, meaning that we have a discontinuity in the path that is a direction change. Since in place rotations have the same position, the dot product is `0` which isn't triggered.  That's a problem.

So, I adjusted a new check if we're `0` and that the orientations of the poses are different -- that way if we simply have 2 overlapping exactly same points, this won't trigger (only true rotate in place represntations). Rather than parameterizing it, this **always triggers** with the assumption that if you're providing a feasible path with an in-place rotation, your robot can handle it since you gave the planner a motion model that can do it. Also in the case that the cusp direction changes (not just a 'going forward -> rotate -> going forward' still), you still want to identify the cusp. Its now that 'going forward -> rotate -> going forward' will **also** now trigger.

So now we've identified the cusp with rotate in place & general rotate in places. Cool. That'll impact the lookahead point selection as any cusp would that we know works, so no need to beat that analysis to death, other than to mention that the `min_by` finds the closes path point to the robot to prune all path points prior to.

To support this, I needed to change the comparison so that we find the **last, closest** point, instead of the **first, closest** point when there are N points the same distance away (e.g. rotate in place, same position). That way, we prune to the final path-pose in the rotation sequence, not the first.

In the ticket, we discussed adding a `shouldRotateAlongPath`, but actually I think that's not necessary. The `shouldRotateToPath` should actually implicitly do what we need to do. If rotate-to-path is valid and the error is sufficiently large, we do it. I think that covers our rotate to path heading needs for inplace rotations. When that rotation is very small - - then we don't really functionally need to do it here and it'll take care of itself in the immediate path tracking request curvature velocities. The same `use_rotate_to_heading` param applies. 

So, I think this fully resolves the issue - with relatively minor changes.  What do you think?

