### PR TITLE
[velocity smoother] Protect properly againt invalid max_accel and max_decel values

### DIFF
--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -373,7 +373,9 @@ VelocitySmoother::dynamicParametersCallback(std::vector<rclcpp::Parameter> param
             result.successful = false;
           }
         }
-        max_accels_ = parameter.as_double_array();
+        if (result.successful) {
+          max_accels_ = parameter.as_double_array();
+        }
       } else if (name == "max_decel") {
         for (unsigned int i = 0; i != 3; i++) {
           if (parameter.as_double_array()[i] > 0.0) {
@@ -383,7 +385,9 @@ VelocitySmoother::dynamicParametersCallback(std::vector<rclcpp::Parameter> param
             result.successful = false;
           }
         }
-        max_decels_ = parameter.as_double_array();
+        if (result.successful) {
+          max_decels_ = parameter.as_double_array();
+        }
       } else if (name == "deadband_velocity") {
         deadband_velocities_ = parameter.as_double_array();
       }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory's Robot |

---

## Description of contribution in a few bullet points

On dynamic change of `max_accel` or `max_decel` parameters, invalid values (wrong sign) were triggering an error message and returning `false`, but the invalid values were still set internally.

This PR fixes it. `break` was not used as we are in a nested for loop there.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
