### PR TITLE
[nav2_costmap_2d] add the `std::unique_lock` before  `layered_costmap->isCurrent()`

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -169,8 +169,12 @@ public:
   /** @brief Same as getLayeredCostmap()->isCurrent(). */
   bool isCurrent()
   {
+    // lock the costmap because no costmap-reset is allowed until the isCurrent() finished
+    std::unique_lock<Costmap2D::mutex_t> lock(*(layered_costmap_->getCostmap()->getMutex()));
+    
     return layered_costmap_->isCurrent();
   }
+
 
   /**
    * @brief Get the pose of the robot in the global frame of the costmap

--- a/nav2_costmap_2d/include/nav2_costmap_2d/denoise/image.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/denoise/image.hpp
@@ -50,7 +50,7 @@ public:
    * Share image data between new and old object.
    * Changing data in a new object will affect the given one and vice versa
    */
-  Image(Image & other);
+  Image(const Image & other);
 
   /**
    * @brief Create image from the other (move constructor)
@@ -132,7 +132,7 @@ Image<T>::Image(size_t rows, size_t columns, T * data, size_t step)
 }
 
 template<class T>
-Image<T>::Image(Image & other)
+Image<T>::Imagec(const Image & other)
 : data_start_{other.data_start_},
   rows_{other.rows_}, columns_{other.columns_}, step_{other.step_} {}
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/denoise/image.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/denoise/image.hpp
@@ -132,7 +132,7 @@ Image<T>::Image(size_t rows, size_t columns, T * data, size_t step)
 }
 
 template<class T>
-Image<T>::Imagec(const Image & other)
+Image<T>::Image(const Image & other)
 : data_start_{other.data_start_},
   rows_{other.rows_}, columns_{other.columns_}, step_{other.step_} {}
 


### PR DESCRIPTION
following ISSUE #3940 : 

# BUG Description
When in complex scenarios (like within frequent movement of obstacles), 

significant changes in the external environment fed back by sensors messages will lead to a **reset of the costmap** , which **free pointers** of `plugin` and `filter` ;

At the same time, it happened that goal action server access `plugin` and `filter` pointers in `isCurrent()`, resulting in a **crash** of the program.

# Solution
The only place  where  `plugin` and `filter` pointers could be freed: 

 in file `nav2_costmap_2d/src/clear_costmap_service.cpp`, in function as following:

```cpp
void ClearCostmapService::clearEntirely()
{
  std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getCostmap()->getMutex()));
  costmap_.resetLayers();
}
```

`costmap_.resetLayers()` could free `plugin` and `filter` pointers

**here's already a `std::unique_lock<>` , to avoid some other functions running while `resetLayers()` function running**

**but not to avoid `layered_costmap_->isCurrent()` while  `resetLayers()`**

#### so, in file `nav2_costmap_2d/include/costmap_2d_ros.hpp`, we insert the same lock in function as following:

```cpp
  /** @brief Same as getLayeredCostmap()->isCurrent(). */
  bool isCurrent()
  {
    // lock the costmap because no costmap-reset is allowed until the isCurrent() finished
    std::unique_lock<Costmap2D::mutex_t> lock(*(layered_costmap_->getCostmap()->getMutex()));
    
    return layered_costmap_->isCurrent();
  }

```