### PR TITLE
fix bug mentioned in #3958

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -284,6 +284,7 @@ ControllerServer::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
    */
   if (costmap_ros_->get_current_state().id() ==
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+  //this condition could be removed
   {
     costmap_ros_->deactivate();
   }
@@ -314,6 +315,7 @@ ControllerServer::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   progress_checkers_.clear();
   if (costmap_ros_->get_current_state().id() ==
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+  //this condition could be removed
   {
     costmap_ros_->cleanup();
   }

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -151,7 +151,7 @@ public:
    */
   void on_rcl_preshutdown() override
   {
-    //do nothing
+    // do nothing
     return;
   }
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -135,6 +135,27 @@ public:
   nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
 
   /**
+   * @brief override on_rcl_preshutdown() as empty
+   * [reason] costmap only could be created by its parents like planner/controller_server
+   * [reason] costmap should react to ctrl+C later than its parents to avoid nullptr-accessed
+   * so the reaction must be later than its parent
+   *
+   * thus, it's a more perfect way to make on_rcl_preshutdown() as empty function
+   * only joint in planner/controller_server->on_deactivate()
+   * and planner/controller_server->on_cleanup()
+   *
+   * !!! a mention !!!
+   * if any other place use this class (Costmap2DROS)
+   * it's neccessary to let costmap->deactivate() joint in parent->deactivate()
+   * and let costmap->cleanup() joint in parent->cleanup()
+   */
+  void on_rcl_preshutdown() override
+  {
+    //do nothing
+    return;
+  }
+
+  /**
    * @brief  Subscribes to sensor topics if necessary and starts costmap
    * updates, can be called to restart the costmap after calls to either
    * stop() or pause()

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -220,6 +220,7 @@ PlannerServer::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
    */
   if (costmap_ros_->get_current_state().id() ==
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+  //this condition could be removed
   {
     costmap_ros_->deactivate();
   }
@@ -253,6 +254,7 @@ PlannerServer::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
    */
   if (costmap_ros_->get_current_state().id() ==
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+  //this condition could be removed
   {
     costmap_ros_->cleanup();
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #3971  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | turtlebot |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
### bug description

<!-- If you are reporting a bug delete everything below
     If you are requesting a feature deleted everything above this line -->

**costmap** is set as a Nav2::util **LifecycleNode** : [../nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp#L 73](https://github.com/ros-planning/navigation2/blob/main/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp#L73)

all LifecycleNode would react to **Ctrl+C** [../nav2_util/src/lifecycle_node.cpp#L 90](https://github.com/ros-planning/navigation2/blob/main/nav2_util/src/lifecycle_node.cpp#L90)

all LifecycleNode would react to  rcl_preshutdown **randomly**, and similar issue has been discussed before : [../ros2/rclcpp/issues/2096](https://github.com/ros2/rclcpp/issues/2096)

this explanation should have been clear enough:  [../nav2_planner/src/planner_server.cpp #L 214-L225](https://github.com/ros-planning/navigation2/blob/main/nav2_planner/src/planner_server.cpp#L214-L225)

**the bug happening in [ISSUE: #3958](https://github.com/ros-planning/navigation2/pull/3958) is caused by this.**

because during shutdown_period, `costmap_ros_` may react rcl_preshutdown earlier, so that planner/controller may try to access the `costmap_ros_` though it has been a nullptr.

### our provided solution
it seems that `costmap` is only used as a **child-thread** of planner/controller,  [../nav2_planner/src/planner_server.cpp#L 89](https://github.com/ros-planning/navigation2/blob/main/nav2_planner/src/planner_server.cpp#L89)

so can we make it do nothing when reacting to Ctrl+C ?

doing so, its lifecycle would be completely bond to planner/controller's lifecycle, and also going to death in order.

```cpp
//in file `costmap_2d_ros.hpp`
  /**
   * @brief override on_rcl_preshutdown() as empty
   * [reason] costmap only could be created by its parents like planner/controller_server
   * [reason] costmap may react to ctrl+C earlier than its parents to cause nullptr-accessed
   * so the costmap's reaction must be later than its parent to avoid nullptr-accessed
   * 
   * thus, it's a more perfect way to override on_rcl_preshutdown() as empty function
   * and its deactivate must be joint in planner/controller_server->on_deactivate()
   * and its cleanup must be joint in planner/controller_server->on_cleanup()
   * 
   * !!! a mention !!!
   * if any other place use this class (Costmap2DROS)
   * it's necessary to let costmap->deactivate() joint in parent->deactivate()
   * and let costmap->cleanup() joint in parent->cleanup() 
   */
  void on_rcl_preshutdown() override{
    //do nothing
    return ;
  }
```

because the `costmp_ros_` is **just a thread** created by planner/controller,  

whether program shutdown correctly or not, or even dead unexpectably, the **child-thread** could be closed all the time since **parent-LifecycleNode** sub-process dead. 

Thus there's no need to worry whether it would be still alive after whole program exit finally.

### in addition
if our solution being adopted, many checks could be removed :

-  [double check in planner_server->on_deactivate()](https://github.com/ros-planning/navigation2/blob/main/nav2_planner/src/planner_server.cpp#L221)

- [double check in planner_server->on_cleanup()](https://github.com/ros-planning/navigation2/blob/main/nav2_planner/src/planner_server.cpp#L254)

- [double check in controller_server->on_deactivate()](https://github.com/ros-planning/navigation2/blob/main/nav2_planner/src/planner_server.cpp#L285)

- [double check in controller_server->on_cleanup()](https://github.com/ros-planning/navigation2/blob/main/nav2_controller/src/controller_server.cpp#L315)

these double checks are also designed to face to bugs in situation that `costmap_ros_` may be closed earlier than planner/controller. After our code modification, these checks are useless anymore.

what's more, our solution performs perfectly during our local tests, much more than our past solutions mentioned in #3958 


---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
