### PR TITLE
Move isValidVelocity back to kinematic_parameters

### DIFF
--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/kinematic_parameters.hpp
@@ -35,12 +35,13 @@
 #ifndef DWB_PLUGINS__KINEMATIC_PARAMETERS_HPP_
 #define DWB_PLUGINS__KINEMATIC_PARAMETERS_HPP_
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 namespace dwb_plugins
 {
@@ -74,6 +75,36 @@ struct KinematicParameters
 
   inline double getMinSpeedXY_SQ() {return min_speed_xy_sq_;}
   inline double getMaxSpeedXY_SQ() {return max_speed_xy_sq_;}
+
+  /**
+   * @brief Check to see whether the combined x/y/theta velocities are valid
+   * @return True if the magnitude hypot(x,y) and theta are within the robot's
+   * absolute limits
+   *
+   * This is based on three parameters: min_speed_xy, max_speed_xy and
+   * min_speed_theta. The speed is valid if 1) The combined magnitude hypot(x,y)
+   * is less than max_speed_xy (or max_speed_xy is negative) AND 2) min_speed_xy
+   * is negative or min_speed_theta is negative or hypot(x,y) is greater than
+   * min_speed_xy or fabs(theta) is greater than min_speed_theta.
+   */
+  inline bool isValidSpeed(double x, double y, double theta)
+  {
+    double vmag_sq = x * x + y * y;
+    if (max_speed_xy_ >= 0.0 &&
+      vmag_sq > max_speed_xy_sq_ + std::numeric_limits<float>::epsilon())
+    {
+      return false;
+    }
+    if (
+      min_speed_xy_ >= 0.0 && vmag_sq + std::numeric_limits<float>::epsilon() < min_speed_xy_sq_ &&
+      min_speed_theta_ >= 0.0 &&
+      fabs(theta) + std::numeric_limits<float>::epsilon() < min_speed_theta_)
+    {
+      return false;
+    }
+    if (vmag_sq == 0.0 && theta == 0.0) {return false;}
+    return true;
+  }
 
 protected:
   // For parameter descriptions, see cfg/KinematicParams.cfg
@@ -127,8 +158,8 @@ protected:
    * @brief Callback executed when a paramter change is detected
    * @param parameters list of changed parameters
    */
-  rcl_interfaces::msg::SetParametersResult
-  dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
+  rcl_interfaces::msg::SetParametersResult dynamicParametersCallback(
+    std::vector<rclcpp::Parameter> parameters);
   void update_kinematics(KinematicParameters kinematics);
   std::string plugin_name_;
 };

--- a/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
+++ b/nav2_dwb_controller/dwb_plugins/include/dwb_plugins/xy_theta_iterator.hpp
@@ -58,18 +58,6 @@ public:
   nav_2d_msgs::msg::Twist2D nextTwist() override;
 
 protected:
-  /**
-   * @brief Check to see whether the combined x/y/theta velocities are valid
-   * @return True if the magnitude hypot(x,y) and theta are within the robot's absolute limits
-   *
-   * This is based on three parameters: min_speed_xy, max_speed_xy and min_speed_theta.
-   * The speed is valid if
-   *  1) The combined magnitude hypot(x,y) is less than max_speed_xy (or max_speed_xy is negative)
-   *  AND
-   *  2) min_speed_xy is negative or min_speed_theta is negative or
-   *     hypot(x,y) is greater than min_speed_xy or fabs(theta) is greater than min_speed_theta.
-   */
-  bool isValidSpeed(double x, double y, double theta);
   virtual bool isValidVelocity();
   void iterateToValidVelocity();
   int vx_samples_, vy_samples_, vtheta_samples_;

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -41,8 +41,6 @@
 #include "nav_2d_utils/parameters.hpp"
 #include "nav2_util/node_utils.hpp"
 
-#define EPSILON 1E-5
-
 namespace dwb_plugins
 {
 void XYThetaIterator::initialize(
@@ -92,29 +90,10 @@ void XYThetaIterator::startNewIteration(
   }
 }
 
-bool XYThetaIterator::isValidSpeed(double x, double y, double theta)
-{
-  KinematicParameters kinematics = kinematics_handler_->getKinematics();
-  double vmag_sq = x * x + y * y;
-  if (kinematics.getMaxSpeedXY() >= 0.0 && vmag_sq > kinematics.getMaxSpeedXY_SQ() + EPSILON) {
-    return false;
-  }
-  if (kinematics.getMinSpeedXY() >= 0.0 && vmag_sq + EPSILON < kinematics.getMinSpeedXY_SQ() &&
-    kinematics.getMinSpeedTheta() >= 0.0 && fabs(theta) + EPSILON < kinematics.getMinSpeedTheta())
-  {
-    return false;
-  }
-  if (vmag_sq == 0.0 && theta == 0.0) {
-    return false;
-  }
-  return true;
-}
-
 bool XYThetaIterator::isValidVelocity()
 {
-  return isValidSpeed(
-    x_it_->getVelocity(), y_it_->getVelocity(),
-    th_it_->getVelocity());
+  return kinematics_handler_->getKinematics().isValidSpeed(
+    x_it_->getVelocity(), y_it_->getVelocity(), th_it_->getVelocity());
 }
 
 bool XYThetaIterator::hasMoreTwists()

--- a/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
+++ b/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp
@@ -104,7 +104,7 @@ bool XYThetaIterator::isValidSpeed(double x, double y, double theta)
   {
     return false;
   }
-  if (vmag_sq == 0.0 && th_it_->getVelocity() == 0.0) {
+  if (vmag_sq == 0.0 && theta == 0.0) {
     return false;
   }
   return true;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |

---

## Description of contribution in a few bullet points
[isValidVelocity](https://github.com/ros-planning/navigation2/blob/main/nav2_dwb_controller/dwb_plugins/src/xy_theta_iterator.cpp#L95) should not be in xy_theta_iterator. It is only related to kineamtic_parameters and should be made available for use without xy_theta_iterator. In ROS1 (robot_navigation) this also used to be in [kinematic_parameters](https://github.com/locusrobotics/robot_navigation/blob/noetic/dwb_plugins/src/kinematic_parameters.cpp#L116). 

## NOTE
If you decide to keep the function in xy_theta_iterator you should cherry-pick the first commit of this pr which fixes a small bug that currently has no effect.
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform

-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
