### PR TITLE
fix a few outdated comments in smac planners

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
@@ -72,8 +72,7 @@ public:
   typedef std::priority_queue<NodeElement, std::vector<NodeElement>, NodeComparator> NodeQueue;
 
   /**
-   * @brief A constructor for nav2_smac_planner::PlannerServer
-   * @param neighborhood The type of neighborhood to use for search (4 or 8 connected)
+   * @brief A constructor for nav2_smac_planner::AStarAlgorithm
    */
   explicit AStarAlgorithm(const MotionModel & motion_model, const SearchInfo & search_info);
 
@@ -196,7 +195,7 @@ protected:
   inline NodePtr getNextNode();
 
   /**
-   * @brief Get pointer to next goal in open set
+   * @brief Add a node to the open set
    * @param cost The cost to sort into the open set of the node
    * @param node Node pointer reference to add to open set
    */
@@ -204,8 +203,7 @@ protected:
 
   /**
    * @brief Adds node to graph
-   * @param cost The cost to sort into the open set of the node
-   * @param node Node pointer reference to add to open set
+   * @param index Node index to add
    */
   inline NodePtr addToGraph(const unsigned int & index);
 
@@ -218,9 +216,8 @@ protected:
 
   /**
    * @brief Get cost of heuristic of node
-   * @param node Node index current
-   * @param node Node index of new
-   * @return Heuristic cost between the nodes
+   * @param node Node pointer to get heuristic for
+   * @return Heuristic cost for node
    */
   inline float getHeuristicCost(const NodePtr & node);
 

--- a/nav2_smac_planner/include/nav2_smac_planner/node_basic.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_basic.hpp
@@ -47,7 +47,6 @@ class NodeBasic
 public:
   /**
    * @brief A constructor for nav2_smac_planner::NodeBasic
-   * @param cost_in The costmap cost at this node
    * @param index The index of this node for self-reference
    */
   explicit NodeBasic(const unsigned int index)

--- a/nav2_smac_planner/include/nav2_smac_planner/node_lattice.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_lattice.hpp
@@ -58,8 +58,6 @@ struct LatticeMotionTable
   /**
    * @brief Initializing state lattice planner's motion model
    * @param size_x_in Size of costmap in X
-   * @param size_y_in Size of costmap in Y
-   * @param angle_quantization_in Size of costmap in bin sizes
    * @param search_info Parameters for searching
    */
   void initMotionModel(


### PR DESCRIPTION
Just some very basic fixes for outdated doxygen comments

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
