### PR TITLE
Synchronize map size information during map initialization

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d.cpp
+++ b/nav2_costmap_2d/src/costmap_2d.cpp
@@ -49,13 +49,13 @@ namespace nav2_costmap_2d
 Costmap2D::Costmap2D(
   unsigned int cells_size_x, unsigned int cells_size_y, double resolution,
   double origin_x, double origin_y, unsigned char default_value)
-: size_x_(cells_size_x), size_y_(cells_size_y), resolution_(resolution), origin_x_(origin_x),
+: resolution_(resolution), origin_x_(origin_x),
   origin_y_(origin_y), costmap_(NULL), default_value_(default_value)
 {
   access_ = new mutex_t();
 
   // create the costmap
-  initMaps(size_x_, size_y_);
+  initMaps(cells_size_x, cells_size_y);
   resetMaps();
 }
 
@@ -111,8 +111,6 @@ void Costmap2D::resizeMap(
   unsigned int size_x, unsigned int size_y, double resolution,
   double origin_x, double origin_y)
 {
-  size_x_ = size_x;
-  size_y_ = size_y;
   resolution_ = resolution;
   origin_x_ = origin_x;
   origin_y_ = origin_y;
@@ -168,15 +166,12 @@ bool Costmap2D::copyCostmapWindow(
     // ROS_ERROR("Cannot window a map that the window bounds don't fit inside of");
     return false;
   }
-
-  size_x_ = upper_right_x - lower_left_x;
-  size_y_ = upper_right_y - lower_left_y;
   resolution_ = map.resolution_;
   origin_x_ = win_origin_x;
   origin_y_ = win_origin_y;
 
   // initialize our various maps and reset markers for inflation
-  initMaps(size_x_, size_y_);
+  initMaps(upper_right_x - lower_left_x, upper_right_y - lower_left_y);
 
   // copy the window of the static map and the costmap that we're taking
   copyMapRegion(

--- a/nav2_costmap_2d/src/costmap_2d.cpp
+++ b/nav2_costmap_2d/src/costmap_2d.cpp
@@ -102,6 +102,8 @@ void Costmap2D::initMaps(unsigned int size_x, unsigned int size_y)
 {
   std::unique_lock<mutex_t> lock(*access_);
   delete[] costmap_;
+  size_x_ = size_x;
+  size_y_ = size_y;
   costmap_ = new unsigned char[size_x * size_y];
 }
 


### PR DESCRIPTION
This commit updates the costmap_2d.cpp file to fix a bug where the costmap size wasn't appropriately updated. Two new lines of code have been added to ensure the size of the costmap is correctly configured each time it's instantiated.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4014 |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
