### PR TITLE
check params of costmap to avoid abnormal memory usage caused by user-misconfiguration mentioned in issue #4005

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -449,6 +449,18 @@ Costmap2DROS::getParameters()
         footprint_.c_str(), robot_radius_);
     }
   }
+
+  // 4. The width and height of map cannot be negative or 0 (to avoid abnoram memory usage)
+  if (map_width_meters_ <= 0) {
+    RCLCPP_ERROR(
+      get_logger(), "You try to set width of map to be negative or zero,"
+      " this isn't allowed, please give a positive value.");
+  }
+  if (map_height_meters_ <= 0) {
+    RCLCPP_ERROR(
+      get_logger(), "You try to set height of map to be negative or zero,"
+      " this isn't allowed, please give a positive value.");
+  }
 }
 
 void


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4005 |
| Primary OS tested on | all |
| Robotic platform tested on |  gazebo simulation of Tally |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

As the issue #4005 showed:
If user-misconfiguration (user wrongly set the height or the width of costmap to be negative or zero) existed, the memory usage would sharply increase and even make user's equipment unable to continue working.

so I added some `if` condition in function `Costmap2DROS::getParameters()` in costmap_2d_ros to avoid such unexpected situation.


## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

I noticed that here's already some similar check in `dynamicParametersCallback()` : 
[costmap_2d_ros.cppL740-L762](https://github.com/ros-planning/navigation2/blob/main/nav2_costmap_2d/src/costmap_2d_ros.cpp#L740-762)

It's obvious that the check needed in `dynamicParametersCallback` is also needed to add into `getParameters()` all the time,

So for clearer code, shall we create a `checkParameters()` function especially for check (which is being referenced by both `getParameters()` and `dynamicParametersCallback()`) ? 

