### PR TITLE
Direction change index computation during initialization

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/node_lattice.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_lattice.hpp
@@ -104,6 +104,7 @@ struct LatticeMotionTable
   float rotation_penalty;
   bool allow_reverse_expansion;
   std::vector<std::vector<MotionPrimitive>> motion_primitives;
+  std::vector<unsigned int> direction_change_indices;
   ompl::base::StateSpacePtr state_space;
   std::vector<TrigValues> trig_values;
   std::string current_lattice_filepath;


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #3966 ) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points
Prior the direction change index was being computed in ever getNeighbor call, now its done at parse time.

* added an attribute (vector) to the LatticeMotionTable class to hold direction change indices
* Logic to decide if current angle index  requires a direction change  modified to point to the above attribute.


## Description of documentation updates required from your changes

-- N.A --

---

## Future work 
* I think instead of holding the reverse indices in a vector, we could instead obtain it in the getMotionPrimitives function in the lines below:
https://github.com/akchobby/navigation2/blob/3966-reverse-index-calculation/nav2_smac_planner/src/node_lattice.cpp#L138-L146 
* this would require the modification of the getMotionPrimitives function parameters.

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
