### PR TITLE
Bring back pep257 docstring

### DIFF
--- a/nav2_simple_commander/nav2_simple_commander/costmap_2d.py
+++ b/nav2_simple_commander/nav2_simple_commander/costmap_2d.py
@@ -34,6 +34,15 @@ class PyCostmap2D:
     """
 
     def __init__(self, occupancy_map):
+        """
+        Initialize costmap2D.
+
+        Args
+        ----
+        occupancy_map: OccupancyGrid
+            2D OccupancyGrid Map
+
+        """
         self.size_x = occupancy_map.info.width
         self.size_y = occupancy_map.info.height
         self.resolution = occupancy_map.info.resolution

--- a/nav2_simple_commander/nav2_simple_commander/costmap_2d.py
+++ b/nav2_simple_commander/nav2_simple_commander/costmap_2d.py
@@ -39,8 +39,11 @@ class PyCostmap2D:
 
         Args
         ----
-        occupancy_map: OccupancyGrid
-            2D OccupancyGrid Map
+            occupancy_map (OccupancyGrid): 2D OccupancyGrid Map
+
+        Returns
+        -------
+            None
 
         """
         self.size_x = occupancy_map.info.width


### PR DESCRIPTION
Works when the "Returns" is added. I can't say I know why exactly though but my hypothesis is that for the style with `Arg` (without colon) the Returns section is mandatory :man_shrugging: . For other places with `Args:` (with colon), the Returns section is missing and the test doesn't complain