### PR TITLE
change pointer free order in amcl to avoid use-after-free bug mentioned in #4068

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -329,7 +329,7 @@ AmclNode::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   initial_pose_sub_.reset();
   laser_scan_connection_.disconnect();
 
-  tf_listener_.reset(); // tf_listener_ will access laser_scan_filter, so it should be reset earlier
+  tf_listener_.reset();  // tf_listener_ will access laser_scan_filter, so it should be reset earlier
   laser_scan_filter_.reset();
   laser_scan_sub_.reset();
 

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -328,6 +328,8 @@ AmclNode::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   nomotion_update_srv_.reset();
   initial_pose_sub_.reset();
   laser_scan_connection_.disconnect();
+
+  tf_listener_.reset(); // tf_listener_ will access laser_scan_filter, so it should be reset earlier
   laser_scan_filter_.reset();
   laser_scan_sub_.reset();
 
@@ -341,7 +343,6 @@ AmclNode::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
 
   // Transforms
   tf_broadcaster_.reset();
-  tf_listener_.reset();
   tf_buffer_.reset();
 
   // PubSub


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4068 |
| Primary OS tested on | Ubuntu22.04 |
| Robotic platform tested on |  gazebo simulation  |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

make `tf_listener_.reset()` before `lase_scan_filter_.reset()`


---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
