### PR TITLE
[behavior_tree] don't repeat yourself in "blackboard->set"

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -238,7 +238,7 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
   try {
     tree_ = bt_->createTreeFromFile(filename, blackboard_);
     for (auto & blackboard : tree_.blackboard_stack) {
-      blackboard->set<rclcpp::Node::SharedPtr>("node", client_node_);
+      blackboard->set("node", client_node_);
       blackboard->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);
       blackboard->set<std::chrono::milliseconds>("bt_loop_duration", bt_loop_duration_);
       blackboard->set<std::chrono::milliseconds>(

--- a/nav2_behavior_tree/test/plugins/action/test_assisted_teleop_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_assisted_teleop_action.cpp
@@ -59,7 +59,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -71,8 +71,8 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
-    config_->blackboard->set<int>("number_recoveries", 0);
+    config_->blackboard->set("initial_pose_received", false);
+    config_->blackboard->set("number_recoveries", 0);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)

--- a/nav2_behavior_tree/test/plugins/action/test_assisted_teleop_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_assisted_teleop_cancel_node.cpp
@@ -56,7 +56,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
@@ -59,7 +59,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -71,8 +71,8 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
-    config_->blackboard->set<int>("number_recoveries", 0);
+    config_->blackboard->set("initial_pose_received", false);
+    config_->blackboard->set("number_recoveries", 0);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_cancel_node.cpp
@@ -55,7 +55,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(

--- a/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
@@ -140,14 +140,14 @@ public:
 
   BT::NodeStatus on_success() override
   {
-    config().blackboard->set<std::vector<int>>("sequence", result_.result->sequence);
+    config().blackboard->set("sequence", result_.result->sequence);
     return BT::NodeStatus::SUCCESS;
   }
 
   BT::NodeStatus on_cancelled() override
   {
-    config().blackboard->set<std::vector<int>>("sequence", result_.result->sequence);
-    config().blackboard->set<bool>("on_cancelled_triggered", true);
+    config().blackboard->set("sequence", result_.result->sequence);
+    config().blackboard->set("on_cancelled_triggered", true);
     return BT::NodeStatus::SUCCESS;
   }
 
@@ -170,12 +170,12 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>("node", node_);
+    config_->blackboard->set("node", node_);
     config_->blackboard->set<std::chrono::milliseconds>("server_timeout", 20ms);
     config_->blackboard->set<std::chrono::milliseconds>("bt_loop_duration", 10ms);
     config_->blackboard->set<std::chrono::milliseconds>("wait_for_service_timeout", 1000ms);
-    config_->blackboard->set<bool>("initial_pose_received", false);
-    config_->blackboard->set<bool>("on_cancelled_triggered", false);
+    config_->blackboard->set("initial_pose_received", false);
+    config_->blackboard->set("on_cancelled_triggered", false);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)
@@ -303,7 +303,7 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_success)
   // reset state variables
   ticks = 0;
   result = BT::NodeStatus::RUNNING;
-  config_->blackboard->set<bool>("on_cancelled_triggered", false);
+  config_->blackboard->set("on_cancelled_triggered", false);
 
   // main BT execution loop
   while (rclcpp::ok() && result == BT::NodeStatus::RUNNING) {
@@ -382,7 +382,7 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)
   // reset state variables
   ticks = 0;
   result = BT::NodeStatus::RUNNING;
-  config_->blackboard->set<bool>("on_cancelled_triggered", false);
+  config_->blackboard->set("on_cancelled_triggered", false);
 
   // main BT execution loop
   while (rclcpp::ok() && result == BT::NodeStatus::RUNNING) {
@@ -456,7 +456,7 @@ TEST_F(BTActionNodeTestFixture, test_server_cancel)
 
   // reset state variable
   ticks = 0;
-  config_->blackboard->set<bool>("on_cancelled_triggered", false);
+  config_->blackboard->set("on_cancelled_triggered", false);
   result = BT::NodeStatus::RUNNING;
 
   // main BT execution loop

--- a/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
@@ -44,7 +44,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -56,8 +56,8 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
-    config_->blackboard->set<int>("number_recoveries", 0);
+    config_->blackboard->set("initial_pose_received", false);
+    config_->blackboard->set("number_recoveries", 0);
 
     factory_->registerNodeType<nav2_behavior_tree::ClearEntireCostmapService>("ClearEntireCostmap");
   }
@@ -133,7 +133,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -145,8 +145,8 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
-    config_->blackboard->set<int>("number_recoveries", 0);
+    config_->blackboard->set("initial_pose_received", false);
+    config_->blackboard->set("number_recoveries", 0);
 
     factory_->registerNodeType<nav2_behavior_tree::ClearCostmapExceptRegionService>(
       "ClearCostmapExceptRegion");
@@ -228,7 +228,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -240,8 +240,8 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
-    config_->blackboard->set<int>("number_recoveries", 0);
+    config_->blackboard->set("initial_pose_received", false);
+    config_->blackboard->set("number_recoveries", 0);
 
     factory_->registerNodeType<nav2_behavior_tree::ClearCostmapAroundRobotService>(
       "ClearCostmapAroundRobot");

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
@@ -67,7 +67,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -79,7 +79,7 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
+    config_->blackboard->set("initial_pose_received", false);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
@@ -65,7 +65,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -77,7 +77,7 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
+    config_->blackboard->set("initial_pose_received", false);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)

--- a/nav2_behavior_tree/test/plugins/action/test_controller_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_controller_cancel_node.cpp
@@ -55,7 +55,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(

--- a/nav2_behavior_tree/test/plugins/action/test_controller_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_controller_selector_node.cpp
@@ -38,7 +38,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>("node", node_);
+    config_->blackboard->set("node", node_);
 
     BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
         return std::make_unique<nav2_behavior_tree::ControllerSelector>(name, config);

--- a/nav2_behavior_tree/test/plugins/action/test_drive_on_heading_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_drive_on_heading_action.cpp
@@ -60,7 +60,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -72,7 +72,7 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
+    config_->blackboard->set("initial_pose_received", false);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)

--- a/nav2_behavior_tree/test/plugins/action/test_drive_on_heading_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_drive_on_heading_cancel_node.cpp
@@ -56,7 +56,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(

--- a/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
@@ -58,7 +58,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -70,7 +70,7 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
+    config_->blackboard->set("initial_pose_received", false);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)
@@ -130,7 +130,7 @@ TEST_F(FollowPathActionTestFixture, test_tick)
   nav_msgs::msg::Path path;
   path.poses.resize(1);
   path.poses[0].pose.position.x = 1.0;
-  config_->blackboard->set<nav_msgs::msg::Path>("path", path);
+  config_->blackboard->set("path", path);
 
   // tick until node succeeds
   while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
@@ -150,7 +150,7 @@ TEST_F(FollowPathActionTestFixture, test_tick)
 
   // set new goal
   path.poses[0].pose.position.x = -2.5;
-  config_->blackboard->set<nav_msgs::msg::Path>("path", path);
+  config_->blackboard->set("path", path);
 
   while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
     tree_->rootNode()->executeTick();

--- a/nav2_behavior_tree/test/plugins/action/test_goal_checker_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_goal_checker_selector_node.cpp
@@ -38,7 +38,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>("node", node_);
+    config_->blackboard->set("node", node_);
 
     BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
         return std::make_unique<nav2_behavior_tree::GoalCheckerSelector>(name, config);

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
@@ -61,7 +61,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -73,9 +73,9 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
+    config_->blackboard->set("initial_pose_received", false);
     std::vector<geometry_msgs::msg::PoseStamped> poses;
-    config_->blackboard->set<std::vector<geometry_msgs::msg::PoseStamped>>(
+    config_->blackboard->set(
       "goals", poses);
 
     BT::NodeBuilder builder =
@@ -136,7 +136,7 @@ TEST_F(NavigateThroughPosesActionTestFixture, test_tick)
   poses.resize(1);
   poses[0].pose.position.x = -2.5;
   poses[0].pose.orientation.x = 1.0;
-  config_->blackboard->set<std::vector<geometry_msgs::msg::PoseStamped>>("goals", poses);
+  config_->blackboard->set("goals", poses);
 
   // tick until node succeeds
   while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
@@ -59,7 +59,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -71,7 +71,7 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
+    config_->blackboard->set("initial_pose_received", false);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)
@@ -145,7 +145,7 @@ TEST_F(NavigateToPoseActionTestFixture, test_tick)
   // set new goal
   pose.pose.position.x = -2.5;
   pose.pose.orientation.x = 1.0;
-  config_->blackboard->set<geometry_msgs::msg::PoseStamped>("goal", pose);
+  config_->blackboard->set("goal", pose);
 
   while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
     tree_->rootNode()->executeTick();

--- a/nav2_behavior_tree/test/plugins/action/test_planner_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_planner_selector_node.cpp
@@ -38,7 +38,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>("node", node_);
+    config_->blackboard->set("node", node_);
 
     BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
         return std::make_unique<nav2_behavior_tree::PlannerSelector>(name, config);

--- a/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
@@ -44,7 +44,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -56,7 +56,7 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
+    config_->blackboard->set("initial_pose_received", false);
 
     factory_->registerNodeType<nav2_behavior_tree::ReinitializeGlobalLocalizationService>(
       "ReinitializeGlobalLocalization");

--- a/nav2_behavior_tree/test/plugins/action/test_remove_passed_goals_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_remove_passed_goals_action.cpp
@@ -43,10 +43,10 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
-    config_->blackboard->set<std::shared_ptr<tf2_ros::Buffer>>(
+    config_->blackboard->set(
       "tf_buffer",
       transform_handler_->getBuffer());
 

--- a/nav2_behavior_tree/test/plugins/action/test_smooth_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_smooth_path_action.cpp
@@ -58,7 +58,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -70,7 +70,7 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
+    config_->blackboard->set("initial_pose_received", false);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)
@@ -146,7 +146,7 @@ TEST_F(SmoothPathActionTestFixture, test_tick)
   pose.pose.position.x = -2.5;
   pose.pose.orientation.x = 1.0;
   path.poses.push_back(pose);
-  config_->blackboard->set<nav_msgs::msg::Path>("unsmoothed_path", path);
+  config_->blackboard->set("unsmoothed_path", path);
 
   while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
     tree_->rootNode()->executeTick();

--- a/nav2_behavior_tree/test/plugins/action/test_smoother_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_smoother_selector_node.cpp
@@ -38,7 +38,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>("node", node_);
+    config_->blackboard->set("node", node_);
 
     BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
         return std::make_unique<nav2_behavior_tree::SmootherSelector>(name, config);

--- a/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
@@ -59,7 +59,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -71,8 +71,8 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
-    config_->blackboard->set<int>("number_recoveries", 0);
+    config_->blackboard->set("initial_pose_received", false);
+    config_->blackboard->set("number_recoveries", 0);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)

--- a/nav2_behavior_tree/test/plugins/action/test_spin_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_spin_cancel_node.cpp
@@ -55,7 +55,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(

--- a/nav2_behavior_tree/test/plugins/action/test_truncate_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_truncate_path_action.cpp
@@ -41,7 +41,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
 

--- a/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
@@ -50,7 +50,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -62,8 +62,8 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout",
       std::chrono::milliseconds(1000));
-    config_->blackboard->set<bool>("initial_pose_received", false);
-    config_->blackboard->set<int>("number_recoveries", 0);
+    config_->blackboard->set("initial_pose_received", false);
+    config_->blackboard->set("number_recoveries", 0);
 
     BT::NodeBuilder builder =
       [](const std::string & name, const BT::NodeConfiguration & config)

--- a/nav2_behavior_tree/test/plugins/action/test_wait_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_wait_cancel_node.cpp
@@ -55,7 +55,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
     config_->blackboard->set<std::chrono::milliseconds>(

--- a/nav2_behavior_tree/test/plugins/condition/test_is_battery_charging.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_battery_charging.cpp
@@ -36,7 +36,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
 

--- a/nav2_behavior_tree/test/plugins/condition/test_is_battery_low.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_battery_low.cpp
@@ -37,7 +37,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
 

--- a/nav2_behavior_tree/test/plugins/condition/test_is_path_valid.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_path_valid.cpp
@@ -56,7 +56,7 @@ public:
     factory_ = std::make_shared<BT::BehaviorTreeFactory>();
     config_ = new BT::NodeConfiguration();
     config_->blackboard = BT::Blackboard::create();
-    config_->blackboard->set<rclcpp::Node::SharedPtr>("node", node_);
+    config_->blackboard->set("node", node_);
     config_->blackboard->set<std::chrono::milliseconds>(
       "server_timeout",
       std::chrono::milliseconds(10));

--- a/nav2_behavior_tree/test/plugins/condition/test_path_expiring_timer.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_path_expiring_timer.cpp
@@ -34,7 +34,7 @@ public:
     node_ = std::make_shared<rclcpp::Node>("test_path_expiring_condition");
     config_ = new BT::NodeConfiguration();
     config_->blackboard = BT::Blackboard::create();
-    config_->blackboard->set<rclcpp::Node::SharedPtr>("node", node_);
+    config_->blackboard->set("node", node_);
     bt_node_ = std::make_shared<nav2_behavior_tree::PathExpiringTimerCondition>(
       "time_expired", *config_);
   }
@@ -78,7 +78,7 @@ TEST_F(PathExpiringTimerConditionTestFixture, test_behavior)
   pose.pose.position.x = 1.0;
   path.poses.push_back(pose);
 
-  config_->blackboard->set<nav_msgs::msg::Path>("path", path);
+  config_->blackboard->set("path", path);
   EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::FAILURE);
   rclcpp::sleep_for(1500ms);
   EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::SUCCESS);

--- a/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
@@ -36,10 +36,10 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
-    config_->blackboard->set<std::shared_ptr<tf2_ros::Buffer>>(
+    config_->blackboard->set(
       "tf_buffer",
       transform_handler_->getBuffer());
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -48,7 +48,7 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("initial_pose_received", false);
+    config_->blackboard->set("initial_pose_received", false);
   }
 
   static void TearDownTestCase()

--- a/nav2_behavior_tree/test/plugins/decorator/test_goal_updated_controller.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_goal_updated_controller.cpp
@@ -35,7 +35,7 @@ public:
     std::vector<geometry_msgs::msg::PoseStamped> poses1;
     poses1.push_back(goal1);
     config_->blackboard->set("goal", goal1);
-    config_->blackboard->set<std::vector<geometry_msgs::msg::PoseStamped>>("goals", poses1);
+    config_->blackboard->set("goals", poses1);
 
     bt_node_ = std::make_shared<nav2_behavior_tree::GoalUpdatedController>(
       "goal_updated_controller", *config_);
@@ -86,7 +86,7 @@ TEST_F(GoalUpdatedControllerTestFixture, test_behavior)
   EXPECT_EQ(dummy_node_->status(), BT::NodeStatus::IDLE);
 
   // tick again with updated goals, dummy node should be ticked
-  config_->blackboard->set<std::vector<geometry_msgs::msg::PoseStamped>>("goals", poses2);
+  config_->blackboard->set("goals", poses2);
   dummy_node_->changeStatus(BT::NodeStatus::SUCCESS);
   EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::SUCCESS);
   EXPECT_EQ(dummy_node_->status(), BT::NodeStatus::IDLE);

--- a/nav2_behavior_tree/test/plugins/decorator/test_goal_updater_node.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_goal_updater_node.cpp
@@ -40,7 +40,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
 

--- a/nav2_behavior_tree/test/plugins/decorator/test_path_longer_on_approach.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_path_longer_on_approach.cpp
@@ -42,7 +42,7 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
 
@@ -106,7 +106,7 @@ TEST_F(PathLongerOnApproachTestFixture, test_tick)
     // Assuming distance between waypoints to be 1.5m
     new_path.poses[i].pose.position.x = 1.5 * i;
   }
-  config_->blackboard->set<nav_msgs::msg::Path>("path", new_path);
+  config_->blackboard->set("path", new_path);
 
   tree_->rootNode()->executeTick();
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
@@ -132,7 +132,7 @@ TEST_F(PathLongerOnApproachTestFixture, test_tick)
     // Assuming distance between waypoints to be 3.0m
     old_path.poses[i - 1].pose.position.x = 3.0 * i;
   }
-  config_->blackboard->set<nav_msgs::msg::Path>("path", old_path);
+  config_->blackboard->set("path", old_path);
   tree_->rootNode()->executeTick();
 
   // set new path on blackboard
@@ -141,7 +141,7 @@ TEST_F(PathLongerOnApproachTestFixture, test_tick)
     // Assuming distance between waypoints to be 1.5m
     new_path.poses[i].pose.position.x = 1.5 * i;
   }
-  config_->blackboard->set<nav_msgs::msg::Path>("path", new_path);
+  config_->blackboard->set("path", new_path);
   tree_->rootNode()->executeTick();
 
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::FAILURE);

--- a/nav2_behavior_tree/test/plugins/decorator/test_speed_controller.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_speed_controller.cpp
@@ -35,7 +35,7 @@ public:
   void SetUp()
   {
     odom_smoother_ = std::make_shared<nav2_util::OdomSmoother>(node_);
-    config_->blackboard->set<std::shared_ptr<nav2_util::OdomSmoother>>(
+    config_->blackboard->set(
       "odom_smoother", odom_smoother_);  // NOLINT
 
     geometry_msgs::msg::PoseStamped goal;

--- a/nav2_behavior_tree/test/plugins/decorator/test_speed_controller.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_speed_controller.cpp
@@ -43,7 +43,7 @@ public:
     config_->blackboard->set("goal", goal);
 
     std::vector<geometry_msgs::msg::PoseStamped> fake_poses;
-    config_->blackboard->set<std::vector<geometry_msgs::msg::PoseStamped>>("goals", fake_poses);  // NOLINT
+    config_->blackboard->set("goals", fake_poses);  // NOLINT
 
     bt_node_ = std::make_shared<nav2_behavior_tree::SpeedController>("speed_controller", *config_);
     dummy_node_ = std::make_shared<nav2_behavior_tree::DummyNode>();

--- a/nav2_behavior_tree/test/utils/test_behavior_tree_fixture.hpp
+++ b/nav2_behavior_tree/test/utils/test_behavior_tree_fixture.hpp
@@ -43,10 +43,10 @@ public:
     // Create the blackboard that will be shared by all of the nodes in the tree
     config_->blackboard = BT::Blackboard::create();
     // Put items on the blackboard
-    config_->blackboard->set<rclcpp::Node::SharedPtr>(
+    config_->blackboard->set(
       "node",
       node_);
-    config_->blackboard->set<std::shared_ptr<tf2_ros::Buffer>>(
+    config_->blackboard->set(
       "tf_buffer",
       transform_handler_->getBuffer());
     config_->blackboard->set<std::chrono::milliseconds>(
@@ -55,7 +55,7 @@ public:
     config_->blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration",
       std::chrono::milliseconds(10));
-    config_->blackboard->set<bool>("initial_pose_received", false);
+    config_->blackboard->set("initial_pose_received", false);
 
     transform_handler_->activate();
     transform_handler_->waitForTransform();

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -232,7 +232,7 @@ NavigateThroughPosesNavigator::initializeGoalPoses(ActionT::Goal::ConstSharedPtr
   // Reset state for new action feedback
   start_time_ = clock_->now();
   auto blackboard = bt_action_server_->getBlackboard();
-  blackboard->set<int>("number_recoveries", 0);  // NOLINT
+  blackboard->set("number_recoveries", 0);  // NOLINT
 
   // Update the goal pose on the blackboard
   blackboard->set<Goals>(goals_blackboard_id_, std::move(goal_poses));

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -241,10 +241,10 @@ NavigateToPoseNavigator::initializeGoalPose(ActionT::Goal::ConstSharedPtr goal)
   // Reset state for new action feedback
   start_time_ = clock_->now();
   auto blackboard = bt_action_server_->getBlackboard();
-  blackboard->set<int>("number_recoveries", 0);  // NOLINT
+  blackboard->set("number_recoveries", 0);  // NOLINT
 
   // Update the goal pose on the blackboard
-  blackboard->set<geometry_msgs::msg::PoseStamped>(goal_blackboard_id_, goal_pose);
+  blackboard->set(goal_blackboard_id_, goal_pose);
 
   return true;
 }

--- a/nav2_core/include/nav2_core/behavior_tree_navigator.hpp
+++ b/nav2_core/include/nav2_core/behavior_tree_navigator.hpp
@@ -220,10 +220,10 @@ public:
     }
 
     BT::Blackboard::Ptr blackboard = bt_action_server_->getBlackboard();
-    blackboard->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", feedback_utils.tf);  // NOLINT
-    blackboard->set<bool>("initial_pose_received", false);  // NOLINT
-    blackboard->set<int>("number_recoveries", 0);  // NOLINT
-    blackboard->set<std::shared_ptr<nav2_util::OdomSmoother>>("odom_smoother", odom_smoother);  // NOLINT
+    blackboard->set("tf_buffer", feedback_utils.tf);  // NOLINT
+    blackboard->set("initial_pose_received", false);  // NOLINT
+    blackboard->set("number_recoveries", 0);  // NOLINT
+    blackboard->set("odom_smoother", odom_smoother);  // NOLINT
 
     return configure(parent_node, odom_smoother) && ok;
   }

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -133,17 +133,17 @@ public:
     blackboard = BT::Blackboard::create();
 
     // Put items on the blackboard
-    blackboard->set<rclcpp::Node::SharedPtr>("node", node_);  // NOLINT
+    blackboard->set("node", node_);  // NOLINT
     blackboard->set<std::chrono::milliseconds>(
       "server_timeout", std::chrono::milliseconds(20));  // NOLINT
     blackboard->set<std::chrono::milliseconds>(
       "bt_loop_duration", std::chrono::milliseconds(10));  // NOLINT
     blackboard->set<std::chrono::milliseconds>(
       "wait_for_service_timeout", std::chrono::milliseconds(1000));  // NOLINT
-    blackboard->set<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer", tf_);  // NOLINT
-    blackboard->set<bool>("initial_pose_received", false);  // NOLINT
-    blackboard->set<int>("number_recoveries", 0);  // NOLINT
-    blackboard->set<std::shared_ptr<nav2_util::OdomSmoother>>("odom_smoother", odom_smoother_);  // NOLINT
+    blackboard->set("tf_buffer", tf_);  // NOLINT
+    blackboard->set("initial_pose_received", false);  // NOLINT
+    blackboard->set("number_recoveries", 0);  // NOLINT
+    blackboard->set("odom_smoother", odom_smoother_);  // NOLINT
 
     // set dummy goal on blackboard
     geometry_msgs::msg::PoseStamped goal;
@@ -157,7 +157,7 @@ public:
     goal.pose.orientation.z = 0.0;
     goal.pose.orientation.w = 1.0;
 
-    blackboard->set<geometry_msgs::msg::PoseStamped>("goal", goal);  // NOLINT
+    blackboard->set("goal", goal);  // NOLINT
 
     // Create the Behavior Tree from the XML input
     try {
@@ -599,7 +599,7 @@ TEST_F(BehaviorTreeTestFixture, TestRecoverySubtreeGoalUpdated)
       goal.pose.orientation.y = 0.0;
       goal.pose.orientation.z = 0.0;
       goal.pose.orientation.w = 1.0;
-      bt_handler->blackboard->set<geometry_msgs::msg::PoseStamped>("goal", goal);  // NOLINT
+      bt_handler->blackboard->set("goal", goal);  // NOLINT
     }
 
     std::this_thread::sleep_for(10ms);


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | not applicable |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |

---

## Description of contribution in a few bullet points

The only purpose of this PR is cosmetic.
Template deduction is doing its job, no need to write more verbose code.

I am just keeping `blackboard->set<std::chrono::milliseconds>` because is the only case where someone may accidentally introduce a bug (may fix this in the future inside BT.CPP itself, to be more permissive).

## Description of documentation updates required from your changes

Not applicable

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
