### PR TITLE
1594 twist stamped publisher

### DIFF
--- a/nav2_behaviors/README.md
+++ b/nav2_behaviors/README.md
@@ -13,3 +13,6 @@ The value of the centralized behavior server is to **share resources** amongst s
 See its [Configuration Guide Page](https://navigation.ros.org/configuration/packages/configuring-behavior-server.html) for additional parameter descriptions and a [tutorial about writing behaviors](https://navigation.ros.org/plugin_tutorials/docs/writing_new_behavior_plugin.html).
 
 See the [Navigation Plugin list](https://navigation.ros.org/plugins/index.html) for a list of the currently known and available planner plugins.
+
+The `TimedBehavior` template makes use of a [nav2_util::TwistPublisher](../nav2_util/README.md#twist-publisher-and-twist-subscriber-for-commanded-velocities).
+The `AssistedTeleop` behavior makes use of a [nav2_util::TwistSubscriber](../nav2_util/README.md#twist-publisher-and-twist-subscriber-for-commanded-velocities).

--- a/nav2_behaviors/include/nav2_behaviors/plugins/assisted_teleop.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/assisted_teleop.hpp
@@ -100,7 +100,7 @@ protected:
   double projection_time_;
   double simulation_time_step_;
 
-  geometry_msgs::msg::Twist teleop_twist_;
+  geometry_msgs::msg::TwistStamped teleop_twist_;
   bool preempt_teleop_{false};
 
   // subscribers

--- a/nav2_behaviors/include/nav2_behaviors/plugins/assisted_teleop.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/assisted_teleop.hpp
@@ -23,6 +23,7 @@
 #include "std_msgs/msg/empty.hpp"
 #include "nav2_behaviors/timed_behavior.hpp"
 #include "nav2_msgs/action/assisted_teleop.hpp"
+#include "nav2_util/twist_subscriber.hpp"
 
 namespace nav2_behaviors
 {
@@ -83,12 +84,6 @@ protected:
     double projection_time);
 
   /**
-   * @brief Callback function for velocity subscriber
-   * @param msg received Twist message
-   */
-  void teleopVelocityCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
-
-  /**
    * @brief Callback function to preempt assisted teleop
    * @param msg empty message
    */
@@ -104,7 +99,7 @@ protected:
   bool preempt_teleop_{false};
 
   // subscribers
-  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr vel_sub_;
+  std::shared_ptr<nav2_util::TwistSubscriber> vel_sub_;
   rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr preempt_teleop_sub_;
 
   rclcpp::Duration command_time_allowance_{0, 0};

--- a/nav2_behaviors/include/nav2_behaviors/plugins/assisted_teleop.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/assisted_teleop.hpp
@@ -99,7 +99,7 @@ protected:
   bool preempt_teleop_{false};
 
   // subscribers
-  std::shared_ptr<nav2_util::TwistSubscriber> vel_sub_;
+  std::unique_ptr<nav2_util::TwistSubscriber> vel_sub_;
   rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr preempt_teleop_sub_;
 
   rclcpp::Duration command_time_allowance_{0, 0};

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -24,6 +24,7 @@
 #include "nav2_msgs/action/drive_on_heading.hpp"
 #include "nav2_msgs/action/back_up.hpp"
 #include "nav2_util/node_utils.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 
 namespace nav2_behaviors
 {
@@ -125,23 +126,23 @@ public:
       return ResultStatus{Status::SUCCEEDED, ActionT::Result::NONE};
     }
 
-    auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>();
-    cmd_vel->linear.y = 0.0;
-    cmd_vel->angular.z = 0.0;
-    cmd_vel->linear.x = command_speed_;
+    auto cmd_vel = geometry_msgs::msg::TwistStamped();
+    cmd_vel.twist.linear.y = 0.0;
+    cmd_vel.twist.angular.z = 0.0;
+    cmd_vel.twist.linear.x = command_speed_;
 
     geometry_msgs::msg::Pose2D pose2d;
     pose2d.x = current_pose.pose.position.x;
     pose2d.y = current_pose.pose.position.y;
     pose2d.theta = tf2::getYaw(current_pose.pose.orientation);
 
-    if (!isCollisionFree(distance, cmd_vel.get(), pose2d)) {
+    if (!isCollisionFree(distance, cmd_vel.twist, pose2d)) {
       this->stopRobot();
       RCLCPP_WARN(this->logger_, "Collision Ahead - Exiting DriveOnHeading");
       return ResultStatus{Status::FAILED, ActionT::Result::COLLISION_AHEAD};
     }
 
-    this->vel_pub_->publish(std::move(cmd_vel));
+    this->vel_pub_->publish(cmd_vel);
 
     return ResultStatus{Status::RUNNING, ActionT::Result::NONE};
   }
@@ -162,7 +163,7 @@ protected:
    */
   bool isCollisionFree(
     const double & distance,
-    geometry_msgs::msg::Twist * cmd_vel,
+    const geometry_msgs::msg::Twist & cmd_vel,
     geometry_msgs::msg::Pose2D & pose2d)
   {
     // Simulate ahead by simulate_ahead_time_ in this->cycle_frequency_ increments
@@ -174,7 +175,7 @@ protected:
     bool fetch_data = true;
 
     while (cycle_count < max_cycle_count) {
-      sim_position_change = cmd_vel->linear.x * (cycle_count / this->cycle_frequency_);
+      sim_position_change = cmd_vel.linear.x * (cycle_count / this->cycle_frequency_);
       pose2d.x = init_pose.x + sim_position_change * cos(init_pose.theta);
       pose2d.y = init_pose.y + sim_position_change * sin(init_pose.theta);
       cycle_count++;

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -127,6 +127,8 @@ public:
     }
 
     auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>();
+    cmd_vel->header.stamp = this->clock_->now();
+    cmd_vel->header.frame_id = this->robot_base_frame_;
     cmd_vel->twist.linear.y = 0.0;
     cmd_vel->twist.angular.z = 0.0;
     cmd_vel->twist.linear.x = command_speed_;

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -142,7 +142,7 @@ public:
       return ResultStatus{Status::FAILED, ActionT::Result::COLLISION_AHEAD};
     }
 
-    this->vel_pub_->publish(*cmd_vel);
+    this->vel_pub_->publish(std::move(cmd_vel));
 
     return ResultStatus{Status::RUNNING, ActionT::Result::NONE};
   }

--- a/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/drive_on_heading.hpp
@@ -126,23 +126,23 @@ public:
       return ResultStatus{Status::SUCCEEDED, ActionT::Result::NONE};
     }
 
-    auto cmd_vel = geometry_msgs::msg::TwistStamped();
-    cmd_vel.twist.linear.y = 0.0;
-    cmd_vel.twist.angular.z = 0.0;
-    cmd_vel.twist.linear.x = command_speed_;
+    auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>();
+    cmd_vel->twist.linear.y = 0.0;
+    cmd_vel->twist.angular.z = 0.0;
+    cmd_vel->twist.linear.x = command_speed_;
 
     geometry_msgs::msg::Pose2D pose2d;
     pose2d.x = current_pose.pose.position.x;
     pose2d.y = current_pose.pose.position.y;
     pose2d.theta = tf2::getYaw(current_pose.pose.orientation);
 
-    if (!isCollisionFree(distance, cmd_vel.twist, pose2d)) {
+    if (!isCollisionFree(distance, cmd_vel->twist, pose2d)) {
       this->stopRobot();
       RCLCPP_WARN(this->logger_, "Collision Ahead - Exiting DriveOnHeading");
       return ResultStatus{Status::FAILED, ActionT::Result::COLLISION_AHEAD};
     }
 
-    this->vel_pub_->publish(cmd_vel);
+    this->vel_pub_->publish(*cmd_vel);
 
     return ResultStatus{Status::RUNNING, ActionT::Result::NONE};
   }

--- a/nav2_behaviors/include/nav2_behaviors/plugins/spin.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/spin.hpp
@@ -22,6 +22,7 @@
 #include "nav2_behaviors/timed_behavior.hpp"
 #include "nav2_msgs/action/spin.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 
 namespace nav2_behaviors
 {
@@ -79,7 +80,7 @@ protected:
    */
   bool isCollisionFree(
     const double & distance,
-    geometry_msgs::msg::Twist * cmd_vel,
+    const geometry_msgs::msg::Twist & cmd_vel,
     geometry_msgs::msg::Pose2D & pose2d);
 
   SpinAction::Feedback::SharedPtr feedback_;

--- a/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
@@ -290,14 +290,14 @@ protected:
   // Stop the robot with a commanded velocity
   void stopRobot()
   {
-    auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>();
-    cmd_vel->header.frame_id = "base_link";
-    cmd_vel->header.stamp = rclcpp::Time();
-    cmd_vel->twist.linear.x = 0.0;
-    cmd_vel->twist.linear.y = 0.0;
-    cmd_vel->twist.angular.z = 0.0;
+    auto cmd_vel = geometry_msgs::msg::TwistStamped();
+    cmd_vel.header.frame_id = "base_link";
+    cmd_vel.header.stamp = rclcpp::Time();
+    cmd_vel.twist.linear.x = 0.0;
+    cmd_vel.twist.linear.y = 0.0;
+    cmd_vel.twist.angular.z = 0.0;
 
-    // vel_pub_->publish(std::move(cmd_vel));
+    vel_pub_->publish(cmd_vel);
   }
 };
 

--- a/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
@@ -29,8 +29,9 @@
 #include "tf2_ros/transform_listener.h"
 #include "tf2_ros/create_timer_ros.h"
 #include "geometry_msgs/msg/twist.hpp"
-#include "nav2_util/simple_action_server.hpp"
 #include "nav2_util/robot_utils.hpp"
+#include "nav2_util/twist_publisher.hpp"
+#include "nav2_util/simple_action_server.hpp"
 #include "nav2_core/behavior.hpp"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
@@ -150,7 +151,7 @@ public:
     local_collision_checker_ = local_collision_checker;
     global_collision_checker_ = global_collision_checker;
 
-    vel_pub_ = node->template create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
+    vel_pub_ = std::make_unique<nav2_util::TwistPublisher>(node, "cmd_vel", 1);
 
     onConfigure();
   }
@@ -185,7 +186,7 @@ protected:
   rclcpp_lifecycle::LifecycleNode::WeakPtr node_;
 
   std::string behavior_name_;
-  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr vel_pub_;
+  std::unique_ptr<nav2_util::TwistPublisher> vel_pub_;
   std::shared_ptr<ActionServer> action_server_;
   std::shared_ptr<nav2_costmap_2d::CostmapTopicCollisionChecker> local_collision_checker_;
   std::shared_ptr<nav2_costmap_2d::CostmapTopicCollisionChecker> global_collision_checker_;
@@ -289,12 +290,14 @@ protected:
   // Stop the robot with a commanded velocity
   void stopRobot()
   {
-    auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>();
-    cmd_vel->linear.x = 0.0;
-    cmd_vel->linear.y = 0.0;
-    cmd_vel->angular.z = 0.0;
+    auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>();
+    cmd_vel->header.frame_id = "base_link";
+    cmd_vel->header.stamp = rclcpp::Time();
+    cmd_vel->twist.linear.x = 0.0;
+    cmd_vel->twist.linear.y = 0.0;
+    cmd_vel->twist.angular.z = 0.0;
 
-    vel_pub_->publish(std::move(cmd_vel));
+    // vel_pub_->publish(std::move(cmd_vel));
   }
 };
 

--- a/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
@@ -290,14 +290,14 @@ protected:
   // Stop the robot with a commanded velocity
   void stopRobot()
   {
-    auto cmd_vel = geometry_msgs::msg::TwistStamped();
-    cmd_vel.header.frame_id = "base_link";
-    cmd_vel.header.stamp = rclcpp::Time();
-    cmd_vel.twist.linear.x = 0.0;
-    cmd_vel.twist.linear.y = 0.0;
-    cmd_vel.twist.angular.z = 0.0;
+    auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>();
+    cmd_vel->header.frame_id = "base_link";
+    cmd_vel->header.stamp = rclcpp::Time();
+    cmd_vel->twist.linear.x = 0.0;
+    cmd_vel->twist.linear.y = 0.0;
+    cmd_vel->twist.angular.z = 0.0;
 
-    vel_pub_->publish(cmd_vel);
+    vel_pub_->publish(*cmd_vel);
   }
 };
 

--- a/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
@@ -291,8 +291,8 @@ protected:
   void stopRobot()
   {
     auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>();
-    cmd_vel->header.frame_id = "base_link";
-    cmd_vel->header.stamp = rclcpp::Time();
+    cmd_vel->header.frame_id = robot_base_frame_;
+    cmd_vel->header.stamp = clock_->now();
     cmd_vel->twist.linear.x = 0.0;
     cmd_vel->twist.linear.y = 0.0;
     cmd_vel->twist.angular.z = 0.0;

--- a/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
@@ -297,7 +297,7 @@ protected:
     cmd_vel->twist.linear.y = 0.0;
     cmd_vel->twist.angular.z = 0.0;
 
-    vel_pub_->publish(*cmd_vel);
+    vel_pub_->publish(std::move(cmd_vel));
   }
 };
 

--- a/nav2_behaviors/plugins/assisted_teleop.cpp
+++ b/nav2_behaviors/plugins/assisted_teleop.cpp
@@ -50,8 +50,7 @@ void AssistedTeleop::onConfigure()
   std::string cmd_vel_teleop;
   node->get_parameter("cmd_vel_teleop", cmd_vel_teleop);
 
-
-  vel_sub_ = std::make_shared<nav2_util::TwistSubscriber>(
+  vel_sub_ = std::make_unique<nav2_util::TwistSubscriber>(
     node,
     cmd_vel_teleop, rclcpp::SystemDefaultsQoS(),
     [&](geometry_msgs::msg::Twist::SharedPtr msg) {

--- a/nav2_behaviors/plugins/assisted_teleop.cpp
+++ b/nav2_behaviors/plugins/assisted_teleop.cpp
@@ -119,7 +119,7 @@ ResultStatus AssistedTeleop::onCycleUpdate()
   projected_pose.y = current_pose.pose.position.y;
   projected_pose.theta = tf2::getYaw(current_pose.pose.orientation);
 
-  geometry_msgs::msg::TwistStamped scaled_twist = teleop_twist_;
+  auto scaled_twist = std::make_unique<geometry_msgs::msg::TwistStamped>(teleop_twist_);
   for (double time = simulation_time_step_; time < projection_time_;
     time += simulation_time_step_)
   {
@@ -132,9 +132,9 @@ ResultStatus AssistedTeleop::onCycleUpdate()
           *clock_,
           1000,
           behavior_name_.c_str() << " collided on first time step, setting velocity to zero");
-        scaled_twist.twist.linear.x = 0.0f;
-        scaled_twist.twist.linear.y = 0.0f;
-        scaled_twist.twist.angular.z = 0.0f;
+        scaled_twist->twist.linear.x = 0.0f;
+        scaled_twist->twist.linear.y = 0.0f;
+        scaled_twist->twist.angular.z = 0.0f;
         break;
       } else {
         RCLCPP_DEBUG_STREAM_THROTTLE(
@@ -143,9 +143,9 @@ ResultStatus AssistedTeleop::onCycleUpdate()
           1000,
           behavior_name_.c_str() << " collision approaching in " << time << " seconds");
         double scale_factor = time / projection_time_;
-        scaled_twist.twist.linear.x *= scale_factor;
-        scaled_twist.twist.linear.y *= scale_factor;
-        scaled_twist.twist.angular.z *= scale_factor;
+        scaled_twist->twist.linear.x *= scale_factor;
+        scaled_twist->twist.linear.y *= scale_factor;
+        scaled_twist->twist.angular.z *= scale_factor;
         break;
       }
     }

--- a/nav2_behaviors/plugins/assisted_teleop.cpp
+++ b/nav2_behaviors/plugins/assisted_teleop.cpp
@@ -73,7 +73,7 @@ ResultStatus AssistedTeleop::onRun(const std::shared_ptr<const AssistedTeleopAct
 
 void AssistedTeleop::onActionCompletion(std::shared_ptr<AssistedTeleopActionResult>/*result*/)
 {
-  teleop_twist_ = geometry_msgs::msg::Twist();
+  teleop_twist_ = geometry_msgs::msg::TwistStamped();
   preempt_teleop_ = false;
 }
 
@@ -115,11 +115,11 @@ ResultStatus AssistedTeleop::onCycleUpdate()
   projected_pose.y = current_pose.pose.position.y;
   projected_pose.theta = tf2::getYaw(current_pose.pose.orientation);
 
-  geometry_msgs::msg::Twist scaled_twist = teleop_twist_;
+  geometry_msgs::msg::TwistStamped scaled_twist = teleop_twist_;
   for (double time = simulation_time_step_; time < projection_time_;
     time += simulation_time_step_)
   {
-    projected_pose = projectPose(projected_pose, teleop_twist_, simulation_time_step_);
+    projected_pose = projectPose(projected_pose, teleop_twist_.twist, simulation_time_step_);
 
     if (!local_collision_checker_->isCollisionFree(projected_pose)) {
       if (time == simulation_time_step_) {
@@ -128,9 +128,9 @@ ResultStatus AssistedTeleop::onCycleUpdate()
           *clock_,
           1000,
           behavior_name_.c_str() << " collided on first time step, setting velocity to zero");
-        scaled_twist.linear.x = 0.0f;
-        scaled_twist.linear.y = 0.0f;
-        scaled_twist.angular.z = 0.0f;
+        scaled_twist.twist.linear.x = 0.0f;
+        scaled_twist.twist.linear.y = 0.0f;
+        scaled_twist.twist.angular.z = 0.0f;
         break;
       } else {
         RCLCPP_DEBUG_STREAM_THROTTLE(
@@ -139,9 +139,9 @@ ResultStatus AssistedTeleop::onCycleUpdate()
           1000,
           behavior_name_.c_str() << " collision approaching in " << time << " seconds");
         double scale_factor = time / projection_time_;
-        scaled_twist.linear.x *= scale_factor;
-        scaled_twist.linear.y *= scale_factor;
-        scaled_twist.angular.z *= scale_factor;
+        scaled_twist.twist.linear.x *= scale_factor;
+        scaled_twist.twist.linear.y *= scale_factor;
+        scaled_twist.twist.angular.z *= scale_factor;
         break;
       }
     }
@@ -173,7 +173,7 @@ geometry_msgs::msg::Pose2D AssistedTeleop::projectPose(
 
 void AssistedTeleop::teleopVelocityCallback(const geometry_msgs::msg::Twist::SharedPtr msg)
 {
-  teleop_twist_ = *msg;
+  teleop_twist_.twist = *msg;
 }
 
 void AssistedTeleop::preemptTeleopCallback(const std_msgs::msg::Empty::SharedPtr)

--- a/nav2_behaviors/plugins/spin.cpp
+++ b/nav2_behaviors/plugins/spin.cpp
@@ -138,28 +138,28 @@ ResultStatus Spin::onCycleUpdate()
   double vel = sqrt(2 * rotational_acc_lim_ * remaining_yaw);
   vel = std::min(std::max(vel, min_rotational_vel_), max_rotational_vel_);
 
-  auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>();
-  cmd_vel->angular.z = copysign(vel, cmd_yaw_);
+  auto cmd_vel = geometry_msgs::msg::TwistStamped();
+  cmd_vel.twist.angular.z = copysign(vel, cmd_yaw_);
 
   geometry_msgs::msg::Pose2D pose2d;
   pose2d.x = current_pose.pose.position.x;
   pose2d.y = current_pose.pose.position.y;
   pose2d.theta = tf2::getYaw(current_pose.pose.orientation);
 
-  if (!isCollisionFree(relative_yaw_, cmd_vel.get(), pose2d)) {
+  if (!isCollisionFree(relative_yaw_, cmd_vel.twist, pose2d)) {
     stopRobot();
     RCLCPP_WARN(logger_, "Collision Ahead - Exiting Spin");
     return ResultStatus{Status::FAILED, SpinActionResult::COLLISION_AHEAD};
   }
 
-  vel_pub_->publish(std::move(cmd_vel));
+  vel_pub_->publish(cmd_vel);
 
   return ResultStatus{Status::RUNNING, SpinActionResult::NONE};
 }
 
 bool Spin::isCollisionFree(
   const double & relative_yaw,
-  geometry_msgs::msg::Twist * cmd_vel,
+  const geometry_msgs::msg::Twist & cmd_vel,
   geometry_msgs::msg::Pose2D & pose2d)
 {
   // Simulate ahead by simulate_ahead_time_ in cycle_frequency_ increments
@@ -170,7 +170,7 @@ bool Spin::isCollisionFree(
   bool fetch_data = true;
 
   while (cycle_count < max_cycle_count) {
-    sim_position_change = cmd_vel->angular.z * (cycle_count / cycle_frequency_);
+    sim_position_change = cmd_vel.angular.z * (cycle_count / cycle_frequency_);
     pose2d.theta = init_pose.theta + sim_position_change;
     cycle_count++;
 

--- a/nav2_behaviors/plugins/spin.cpp
+++ b/nav2_behaviors/plugins/spin.cpp
@@ -138,21 +138,21 @@ ResultStatus Spin::onCycleUpdate()
   double vel = sqrt(2 * rotational_acc_lim_ * remaining_yaw);
   vel = std::min(std::max(vel, min_rotational_vel_), max_rotational_vel_);
 
-  auto cmd_vel = geometry_msgs::msg::TwistStamped();
-  cmd_vel.twist.angular.z = copysign(vel, cmd_yaw_);
+  auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>();
+  cmd_vel->twist.angular.z = copysign(vel, cmd_yaw_);
 
   geometry_msgs::msg::Pose2D pose2d;
   pose2d.x = current_pose.pose.position.x;
   pose2d.y = current_pose.pose.position.y;
   pose2d.theta = tf2::getYaw(current_pose.pose.orientation);
 
-  if (!isCollisionFree(relative_yaw_, cmd_vel.twist, pose2d)) {
+  if (!isCollisionFree(relative_yaw_, cmd_vel->twist, pose2d)) {
     stopRobot();
     RCLCPP_WARN(logger_, "Collision Ahead - Exiting Spin");
     return ResultStatus{Status::FAILED, SpinActionResult::COLLISION_AHEAD};
   }
 
-  vel_pub_->publish(cmd_vel);
+  vel_pub_->publish(*cmd_vel);
 
   return ResultStatus{Status::RUNNING, SpinActionResult::NONE};
 }

--- a/nav2_behaviors/plugins/spin.cpp
+++ b/nav2_behaviors/plugins/spin.cpp
@@ -152,7 +152,7 @@ ResultStatus Spin::onCycleUpdate()
     return ResultStatus{Status::FAILED, SpinActionResult::COLLISION_AHEAD};
   }
 
-  vel_pub_->publish(*cmd_vel);
+  vel_pub_->publish(std::move(cmd_vel));
 
   return ResultStatus{Status::RUNNING, SpinActionResult::NONE};
 }

--- a/nav2_behaviors/plugins/spin.cpp
+++ b/nav2_behaviors/plugins/spin.cpp
@@ -139,6 +139,8 @@ ResultStatus Spin::onCycleUpdate()
   vel = std::min(std::max(vel, min_rotational_vel_), max_rotational_vel_);
 
   auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>();
+  cmd_vel->header.frame_id = robot_base_frame_;
+  cmd_vel->header.stamp = clock_->now();
   cmd_vel->twist.angular.z = copysign(vel, cmd_yaw_);
 
   geometry_msgs::msg::Pose2D pose2d;

--- a/nav2_collision_monitor/README.md
+++ b/nav2_collision_monitor/README.md
@@ -88,3 +88,5 @@ The zones around the robot and the data sources are the same as for the Collisio
 ### Configuration
 
 Detailed configuration parameters, their description and how to setup a Collision Detector could be found at its [Configuration Guide](https://navigation.ros.org/configuration/packages/collision_monitor/configuring-collision-detector-node.html).
+
+The `CollisionMonitor` node makes use of a [nav2_util::TwistSubscriber](../nav2_util/README.md#twist-publisher-and-twist-subscriber-for-commanded-velocities).

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -29,6 +29,7 @@
 #include "tf2_ros/transform_listener.h"
 
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/twist_subscriber.hpp"
 #include "nav2_msgs/msg/collision_monitor_state.hpp"
 
 #include "nav2_collision_monitor/types.hpp"
@@ -205,8 +206,8 @@ protected:
   std::vector<std::shared_ptr<Source>> sources_;
 
   // Input/output speed controls
-  /// @beirf Input cmd_vel subscriber
-  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_in_sub_;
+  /// @brief Input cmd_vel subscriber
+  std::shared_ptr<nav2_util::TwistSubscriber> cmd_vel_in_sub_;
   /// @brief Output cmd_vel publisher
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_out_pub_;
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -104,8 +104,9 @@ protected:
    * @brief Publishes output cmd_vel. If robot was stopped more than stop_pub_timeout_ seconds,
    * quit to publish 0-velocity.
    * @param robot_action Robot action to publish
+   * @param header TwistStamped header to use
    */
-  void publishVelocity(const Action & robot_action);
+  void publishVelocity(const Action & robot_action, const std_msgs::msg::Header & header);
 
   /**
    * @brief Supporting routine obtaining all ROS-parameters
@@ -149,8 +150,9 @@ protected:
   /**
    * @brief Main processing routine
    * @param cmd_vel_in Input desired robot velocity
+   * @param header Twist header
    */
-  void process(const Velocity & cmd_vel_in);
+  void process(const Velocity & cmd_vel_in, const std_msgs::msg::Header & header);
 
   /**
    * @brief Processes the polygon of STOP, SLOWDOWN and LIMIT action type

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -98,8 +98,8 @@ protected:
    * @brief Callback for input cmd_vel
    * @param msg Input cmd_vel message
    */
-  void cmdVelInCallbackStamped(geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
-  void cmdVelInCallbackUnstamped(geometry_msgs::msg::Twist::ConstSharedPtr msg);
+  void cmdVelInCallbackStamped(geometry_msgs::msg::TwistStamped::SharedPtr msg);
+  void cmdVelInCallbackUnstamped(geometry_msgs::msg::Twist::SharedPtr msg);
   /**
    * @brief Publishes output cmd_vel. If robot was stopped more than stop_pub_timeout_ seconds,
    * quit to publish 0-velocity.
@@ -208,7 +208,7 @@ protected:
 
   // Input/output speed controls
   /// @brief Input cmd_vel subscriber
-  std::shared_ptr<nav2_util::TwistSubscriber> cmd_vel_in_sub_;
+  std::unique_ptr<nav2_util::TwistSubscriber> cmd_vel_in_sub_;
   /// @brief Output cmd_vel publisher
   std::unique_ptr<nav2_util::TwistPublisher> cmd_vel_out_pub_;
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -29,6 +29,7 @@
 #include "tf2_ros/transform_listener.h"
 
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/twist_publisher.hpp"
 #include "nav2_util/twist_subscriber.hpp"
 #include "nav2_msgs/msg/collision_monitor_state.hpp"
 
@@ -97,8 +98,8 @@ protected:
    * @brief Callback for input cmd_vel
    * @param msg Input cmd_vel message
    */
-  void cmdVelInCallback(geometry_msgs::msg::Twist::ConstSharedPtr msg);
   void cmdVelInCallbackStamped(geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
+  void cmdVelInCallbackUnstamped(geometry_msgs::msg::Twist::ConstSharedPtr msg);
   /**
    * @brief Publishes output cmd_vel. If robot was stopped more than stop_pub_timeout_ seconds,
    * quit to publish 0-velocity.
@@ -209,7 +210,7 @@ protected:
   /// @brief Input cmd_vel subscriber
   std::shared_ptr<nav2_util::TwistSubscriber> cmd_vel_in_sub_;
   /// @brief Output cmd_vel publisher
-  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_out_pub_;
+  std::unique_ptr<nav2_util::TwistPublisher> cmd_vel_out_pub_;
 
   /// @brief CollisionMonitor state publisher
   rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::CollisionMonitorState>::SharedPtr

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -22,6 +22,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 
 #include "tf2/time.h"
 #include "tf2_ros/buffer.h"
@@ -96,6 +97,7 @@ protected:
    * @param msg Input cmd_vel message
    */
   void cmdVelInCallback(geometry_msgs::msg::Twist::ConstSharedPtr msg);
+  void cmdVelInCallbackStamped(geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
   /**
    * @brief Publishes output cmd_vel. If robot was stopped more than stop_pub_timeout_ seconds,
    * quit to publish 0-velocity.

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -214,15 +214,15 @@ void CollisionMonitor::publishVelocity(const Action & robot_action)
     }
   }
 
-  auto cmd_vel_out_msg = geometry_msgs::msg::TwistStamped();
-  cmd_vel_out_msg.header.stamp = this->now();
+  auto cmd_vel_out_msg = std::make_unique<geometry_msgs::msg::TwistStamped>();
+  cmd_vel_out_msg->header.stamp = this->now();
 
-  cmd_vel_out_msg.twist.linear.x = robot_action.req_vel.x;
-  cmd_vel_out_msg.twist.linear.y = robot_action.req_vel.y;
-  cmd_vel_out_msg.twist.angular.z = robot_action.req_vel.tw;
+  cmd_vel_out_msg->twist.linear.x = robot_action.req_vel.x;
+  cmd_vel_out_msg->twist.linear.y = robot_action.req_vel.y;
+  cmd_vel_out_msg->twist.angular.z = robot_action.req_vel.tw;
   // linear.z, angular.x and angular.y will remain 0.0
 
-  cmd_vel_out_pub_->publish(cmd_vel_out_msg);
+  cmd_vel_out_pub_->publish(*cmd_vel_out_msg);
 }
 
 bool CollisionMonitor::getParameters(

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -191,7 +191,7 @@ void CollisionMonitor::cmdVelInCallbackStamped(geometry_msgs::msg::TwistStamped:
     return;
   }
 
-  process({msg->twist.linear.x, msg->twist.linear.y, msg->twist.angular.z});
+  process({msg->twist.linear.x, msg->twist.linear.y, msg->twist.angular.z}, msg->header);
 }
 
 void CollisionMonitor::cmdVelInCallbackUnstamped(geometry_msgs::msg::Twist::SharedPtr msg)
@@ -201,7 +201,8 @@ void CollisionMonitor::cmdVelInCallbackUnstamped(geometry_msgs::msg::Twist::Shar
   cmdVelInCallbackStamped(twist_stamped);
 }
 
-void CollisionMonitor::publishVelocity(const Action & robot_action)
+void CollisionMonitor::publishVelocity(
+  const Action & robot_action, const std_msgs::msg::Header & header)
 {
   if (robot_action.req_vel.isZero()) {
     if (!robot_action_prev_.req_vel.isZero()) {
@@ -215,7 +216,7 @@ void CollisionMonitor::publishVelocity(const Action & robot_action)
   }
 
   auto cmd_vel_out_msg = std::make_unique<geometry_msgs::msg::TwistStamped>();
-  cmd_vel_out_msg->header.stamp = this->now();
+  cmd_vel_out_msg->header = header;
   cmd_vel_out_msg->twist.linear.x = robot_action.req_vel.x;
   cmd_vel_out_msg->twist.linear.y = robot_action.req_vel.y;
   cmd_vel_out_msg->twist.angular.z = robot_action.req_vel.tw;
@@ -389,7 +390,7 @@ bool CollisionMonitor::configureSources(
   return true;
 }
 
-void CollisionMonitor::process(const Velocity & cmd_vel_in)
+void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg::Header & header)
 {
   // Current timestamp for all inner routines prolongation
   rclcpp::Time curr_time = this->now();
@@ -483,7 +484,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
   }
 
   // Publish required robot velocity
-  publishVelocity(robot_action);
+  publishVelocity(robot_action, header);
 
   // Publish polygons for better visualization
   publishPolygons();

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -63,9 +63,13 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & /*state*/)
     return nav2_util::CallbackReturn::FAILURE;
   }
 
-  cmd_vel_in_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
-    cmd_vel_in_topic, 1,
-    std::bind(&CollisionMonitor::cmdVelInCallback, this, std::placeholders::_1));
+  cmd_vel_in_sub_ = std::make_shared<nav2_util::TwistSubscriber>(
+    shared_from_this(),
+    cmd_vel_in_topic,
+    1,
+    std::bind(&CollisionMonitor::cmdVelInCallback, this, std::placeholders::_1),
+    std::bind(&CollisionMonitor::cmdVelInCallbackStamped, this, std::placeholders::_1));
+
   cmd_vel_out_pub_ = this->create_publisher<geometry_msgs::msg::Twist>(
     cmd_vel_out_topic, 1);
 

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -191,6 +191,11 @@ void CollisionMonitor::cmdVelInCallback(geometry_msgs::msg::Twist::ConstSharedPt
   process({msg->linear.x, msg->linear.y, msg->angular.z});
 }
 
+void CollisionMonitor::cmdVelInCallbackStamped(geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+{
+  cmdVelInCallback(std::make_shared<geometry_msgs::msg::Twist>(msg->twist));
+}
+
 void CollisionMonitor::publishVelocity(const Action & robot_action)
 {
   if (robot_action.req_vel.isZero()) {

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -67,11 +67,11 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & /*state*/)
     shared_from_this(),
     cmd_vel_in_topic,
     1,
-    std::bind(&CollisionMonitor::cmdVelInCallback, this, std::placeholders::_1),
+    std::bind(&CollisionMonitor::cmdVelInCallbackUnstamped, this, std::placeholders::_1),
     std::bind(&CollisionMonitor::cmdVelInCallbackStamped, this, std::placeholders::_1));
 
-  cmd_vel_out_pub_ = this->create_publisher<geometry_msgs::msg::Twist>(
-    cmd_vel_out_topic, 1);
+  auto node = shared_from_this();
+  cmd_vel_out_pub_ = std::make_unique<nav2_util::TwistPublisher>(node, cmd_vel_out_topic, 1);
 
   if (!state_topic.empty()) {
     state_pub_ = this->create_publisher<nav2_msgs::msg::CollisionMonitorState>(
@@ -81,7 +81,6 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & /*state*/)
   collision_points_marker_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
     "~/collision_points_marker", 1);
 
-  auto node = shared_from_this();
   nav2_util::declare_parameter_if_not_declared(
     node, "use_realtime_priority", rclcpp::ParameterValue(false));
   bool use_realtime_priority = false;
@@ -184,7 +183,7 @@ CollisionMonitor::on_shutdown(const rclcpp_lifecycle::State & /*state*/)
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
-void CollisionMonitor::cmdVelInCallback(geometry_msgs::msg::Twist::ConstSharedPtr msg)
+void CollisionMonitor::cmdVelInCallbackStamped(geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
 {
   // If message contains NaN or Inf, ignore
   if (!nav2_util::validateTwist(*msg)) {
@@ -192,12 +191,14 @@ void CollisionMonitor::cmdVelInCallback(geometry_msgs::msg::Twist::ConstSharedPt
     return;
   }
 
-  process({msg->linear.x, msg->linear.y, msg->angular.z});
+  process({msg->twist.linear.x, msg->twist.linear.y, msg->twist.angular.z});
 }
 
-void CollisionMonitor::cmdVelInCallbackStamped(geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+void CollisionMonitor::cmdVelInCallbackUnstamped(geometry_msgs::msg::Twist::ConstSharedPtr msg)
 {
-  cmdVelInCallback(std::make_shared<geometry_msgs::msg::Twist>(msg->twist));
+  geometry_msgs::msg::TwistStamped twist_stamped;
+  twist_stamped.twist = *msg;
+  cmdVelInCallbackStamped(std::make_shared<geometry_msgs::msg::TwistStamped>(twist_stamped));
 }
 
 void CollisionMonitor::publishVelocity(const Action & robot_action)
@@ -213,14 +214,15 @@ void CollisionMonitor::publishVelocity(const Action & robot_action)
     }
   }
 
-  std::unique_ptr<geometry_msgs::msg::Twist> cmd_vel_out_msg =
-    std::make_unique<geometry_msgs::msg::Twist>();
-  cmd_vel_out_msg->linear.x = robot_action.req_vel.x;
-  cmd_vel_out_msg->linear.y = robot_action.req_vel.y;
-  cmd_vel_out_msg->angular.z = robot_action.req_vel.tw;
+  auto cmd_vel_out_msg = geometry_msgs::msg::TwistStamped();
+  cmd_vel_out_msg.header.stamp = this->now();
+
+  cmd_vel_out_msg.twist.linear.x = robot_action.req_vel.x;
+  cmd_vel_out_msg.twist.linear.y = robot_action.req_vel.y;
+  cmd_vel_out_msg.twist.angular.z = robot_action.req_vel.tw;
   // linear.z, angular.x and angular.y will remain 0.0
 
-  cmd_vel_out_pub_->publish(std::move(cmd_vel_out_msg));
+  cmd_vel_out_pub_->publish(cmd_vel_out_msg);
 }
 
 bool CollisionMonitor::getParameters(

--- a/nav2_controller/README.md
+++ b/nav2_controller/README.md
@@ -7,3 +7,5 @@ An execution module implementing the `nav2_msgs::action::FollowPath` action serv
 See the [Navigation Plugin list](https://navigation.ros.org/plugins/index.html) for a list of the currently known and available controller plugins. 
 
 See its [Configuration Guide Page](https://navigation.ros.org/configuration/packages/configuring-controller-server.html) for additional parameter descriptions and a [tutorial about writing controller plugins](https://navigation.ros.org/plugin_tutorials/docs/writing_new_nav2controller_plugin.html).
+
+The `ControllerServer` makes use of a [nav2_util::TwistPublisher](../nav2_util/README.md#twist-publisher-and-twist-subscriber-for-commanded-velocities).

--- a/nav2_controller/include/nav2_controller/controller_server.hpp
+++ b/nav2_controller/include/nav2_controller/controller_server.hpp
@@ -33,6 +33,7 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_util/simple_action_server.hpp"
 #include "nav2_util/robot_utils.hpp"
+#include "nav2_util/twist_publisher.hpp"
 #include "pluginlib/class_loader.hpp"
 #include "pluginlib/class_list_macros.hpp"
 
@@ -229,7 +230,7 @@ protected:
 
   // Publishers and subscribers
   std::unique_ptr<nav_2d_utils::OdomSubscriber> odom_sub_;
-  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr vel_publisher_;
+  std::unique_ptr<nav2_util::TwistPublisher> vel_publisher_;
   rclcpp::Subscription<nav2_msgs::msg::SpeedLimit>::SharedPtr speed_limit_sub_;
 
   // Progress Checker Plugin

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -595,6 +595,8 @@ void ControllerServer::computeAndPublishVelocity()
       nav_2d_utils::twist2Dto3D(twist),
       goal_checkers_[current_goal_checker_].get());
     last_valid_cmd_time_ = now();
+    cmd_vel_2d.header.frame_id = costmap_ros_->getBaseFrameID();
+    cmd_vel_2d.header.stamp = last_valid_cmd_time_;
     // Only no valid control exception types are valid to attempt to have control patience, as
     // other types will not be resolved with more attempts
   } catch (nav2_core::NoValidControl & e) {

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -215,7 +215,7 @@ ControllerServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     "Controller Server has %s controllers available.", controller_ids_concat_.c_str());
 
   odom_sub_ = std::make_unique<nav_2d_utils::OdomSubscriber>(node);
-  vel_publisher_ = create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
+  vel_publisher_ = std::make_unique<nav2_util::TwistPublisher>(node, "cmd_vel", 1);
 
   double action_server_result_timeout;
   get_parameter("action_server_result_timeout", action_server_result_timeout);
@@ -693,9 +693,8 @@ void ControllerServer::updateGlobalPath()
 
 void ControllerServer::publishVelocity(const geometry_msgs::msg::TwistStamped & velocity)
 {
-  auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>(velocity.twist);
   if (vel_publisher_->is_activated() && vel_publisher_->get_subscription_count() > 0) {
-    vel_publisher_->publish(std::move(cmd_vel));
+    vel_publisher_->publish(velocity);
   }
 }
 

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -695,14 +695,15 @@ void ControllerServer::updateGlobalPath()
 
 void ControllerServer::publishVelocity(const geometry_msgs::msg::TwistStamped & velocity)
 {
+  auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>(velocity);
   if (vel_publisher_->is_activated() && vel_publisher_->get_subscription_count() > 0) {
-    vel_publisher_->publish(velocity);
+    vel_publisher_->publish(*cmd_vel);
   }
 }
 
 void ControllerServer::publishZeroVelocity()
 {
-  geometry_msgs::msg::TwistStamped velocity;
+  auto velocity = geometry_msgs::msg::TwistStamped();
   velocity.twist.angular.x = 0;
   velocity.twist.angular.y = 0;
   velocity.twist.angular.z = 0;

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -697,13 +697,13 @@ void ControllerServer::publishVelocity(const geometry_msgs::msg::TwistStamped & 
 {
   auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>(velocity);
   if (vel_publisher_->is_activated() && vel_publisher_->get_subscription_count() > 0) {
-    vel_publisher_->publish(*cmd_vel);
+    vel_publisher_->publish(std::move(cmd_vel));
   }
 }
 
 void ControllerServer::publishZeroVelocity()
 {
-  auto velocity = geometry_msgs::msg::TwistStamped();
+  geometry_msgs::msg::TwistStamped velocity;
   velocity.twist.angular.x = 0;
   velocity.twist.angular.y = 0;
   velocity.twist.angular.z = 0;

--- a/nav2_util/README.md
+++ b/nav2_util/README.md
@@ -29,13 +29,3 @@ The utility has the following effect:
 Every node in `nav2` that subscribes or publishes velocity commands with `Twist` now supports this optional behavior.
 The behavior up through ROS 2 Iron is preserved - using `Twist`. In a future ROS 2 version, when enough of the
 ROS ecosystem has moved to `TwistStamped`, the default may change. 
-
-### Usage
-
-See [test/test_twist_publisher.cpp](test/test_twist_publisher.cpp) or [test/test_twist_subscriber.cpp](test/test_twist_subscriber.cpp) for examples.
-
-To use `Twist`, you can rely on the default value of `enable_stamped_cmd_vel`, or set it to `False` in your parameter file.
-To use `TwistStamped`, set `enable_stamped_cmd_vel` to `True`. 
-Each node in `nav2` that uses a `TwistPublisher` or `TwistSubscriber` has it documented in the README.
-
-The parameter is read-only, therefore it must be set at launch time. Do not try changing the value at runtime.

--- a/nav2_util/README.md
+++ b/nav2_util/README.md
@@ -18,7 +18,6 @@ The long-term aim is for these utilities to find more permanent homes in other p
 The Twist Publisher and Twist Subscriber are utility classes to assist NAV2 transition from 
 [Twist](https://github.com/ros2/common_interfaces/blob/humble/geometry_msgs/msg/Twist.msg) to [TwistStamped](https://github.com/ros2/common_interfaces/blob/humble/geometry_msgs/msg/TwistStamped.msg).
 
-This utility is in support of the following [GSoC Project](https://navigation.ros.org/2021summerOfCode/projects/twist_n_config.html#convert-twist-to-twiststamped-in-ecosystem-and-run-time-configuration).
 Details on the migration are found in [#1594](https://github.com/ros-planning/navigation2/issues/1594).
 
 Certain applications of NAV2, such as in ROS Aerial mandate the usage of `TwistStamped`, while many other applications still use `Twist`.

--- a/nav2_util/README.md
+++ b/nav2_util/README.md
@@ -7,6 +7,36 @@ The `nav2_util` package contains utilities abstracted from individual packages w
 - Simplified service clients
 - Simplified action servers
 - Transformation and robot pose helpers
+- Twist Subscriber and Twist Publisher
 
 The long-term aim is for these utilities to find more permanent homes in other packages (within and outside of Nav2) or migrate to the raw tools made available in ROS 2.
- 
+
+## Twist Publisher and Twist Subscriber for commanded velocities
+
+### Background 
+
+The Twist Publisher and Twist Subscriber are utility classes to assist NAV2 transition from 
+[Twist](https://github.com/ros2/common_interfaces/blob/humble/geometry_msgs/msg/Twist.msg) to [TwistStamped](https://github.com/ros2/common_interfaces/blob/humble/geometry_msgs/msg/TwistStamped.msg).
+
+This utility is in support of the following [GSoC Project](https://navigation.ros.org/2021summerOfCode/projects/twist_n_config.html#convert-twist-to-twiststamped-in-ecosystem-and-run-time-configuration).
+Details on the migration are found in [#1594](https://github.com/ros-planning/navigation2/issues/1594).
+
+Certain applications of NAV2, such as in ROS Aerial mandate the usage of `TwistStamped`, while many other applications still use `Twist`.
+
+The utility has the following effect:
+* Allows use of either `Twist` or `TwistStamped`, controlled by ROS parameter `enable_stamped_cmd_vel`
+* Preserves existing topic names without duplication of data
+
+Every node in `nav2` that subscribes or publishes velocity commands with `Twist` now supports this optional behavior.
+The behavior up through ROS 2 Iron is preserved - using `Twist`. In a future ROS 2 version, when enough of the
+ROS ecosystem has moved to `TwistStamped`, the default may change. 
+
+### Usage
+
+See [test/test_twist_publisher.cpp](test/test_twist_publisher.cpp) or [test/test_twist_subscriber.cpp](test/test_twist_subscriber.cpp) for examples.
+
+To use `Twist`, you can rely on the default value of `enable_stamped_cmd_vel`, or set it to `False` in your parameter file.
+To use `TwistStamped`, set `enable_stamped_cmd_vel` to `True`. 
+Each node in `nav2` that uses a `TwistPublisher` or `TwistSubscriber` has it documented in the README.
+
+The parameter is read-only, therefore it must be set at launch time. Do not try changing the value at runtime.

--- a/nav2_util/include/nav2_util/robot_utils.hpp
+++ b/nav2_util/include/nav2_util/robot_utils.hpp
@@ -22,6 +22,7 @@
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 #include "tf2/time.h"
 #include "tf2_ros/buffer.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
@@ -103,7 +104,8 @@ bool getTransform(
  * @param msg Twist message to validate
  * @return True if valid, false if contains unactionable values
  */
-bool validateTwist(const geometry_msgs::msg::Twist & msg);
+[[nodiscard]] bool validateTwist(const geometry_msgs::msg::Twist & msg);
+[[nodiscard]] bool validateTwist(const geometry_msgs::msg::TwistStamped & msg);
 
 }  // end namespace nav2_util
 

--- a/nav2_util/include/nav2_util/twist_publisher.hpp
+++ b/nav2_util/include/nav2_util/twist_publisher.hpp
@@ -47,21 +47,20 @@ public:
   * @param qos publisher quality of service
   */
   explicit TwistPublisher(
-    nav2_util::LifecycleNode::SharedPtr nh,
+    nav2_util::LifecycleNode::SharedPtr node,
     const std::string & topic,
     const rclcpp::QoS & qos
   )
-  : topic_(topic), node_(nh)
+  : topic_(topic)
   {
-    assert(nh != nullptr);
-    node_->declare_parameter("enable_stamped_cmd_vel", false);
-    node_->get_parameter("enable_stamped_cmd_vel", is_stamped_);
+    node->declare_parameter("enable_stamped_cmd_vel", false);
+    node->get_parameter("enable_stamped_cmd_vel", is_stamped_);
     if (is_stamped_) {
-      twist_stamped_pub_ = node_->create_publisher<geometry_msgs::msg::TwistStamped>(
+      twist_stamped_pub_ = node->create_publisher<geometry_msgs::msg::TwistStamped>(
         topic_,
         qos);
     } else {
-      twist_pub_ = node_->create_publisher<geometry_msgs::msg::Twist>(
+      twist_pub_ = node->create_publisher<geometry_msgs::msg::Twist>(
         topic_,
         qos);
     }
@@ -115,7 +114,6 @@ public:
 
 protected:
   std::string topic_;
-  nav2_util::LifecycleNode::SharedPtr node_;
   bool is_stamped_;
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub_;
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::TwistStamped>::SharedPtr

--- a/nav2_util/include/nav2_util/twist_publisher.hpp
+++ b/nav2_util/include/nav2_util/twist_publisher.hpp
@@ -21,9 +21,14 @@
 #include <string>
 
 #include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "rclcpp/parameter_service.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 #include "rclcpp/qos.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include "lifecycle_node.hpp"
+#include "node_utils.hpp"
 
 namespace nav2_util
 {
@@ -53,7 +58,10 @@ public:
   )
   : topic_(topic)
   {
-    node->declare_parameter("enable_stamped_cmd_vel", false);
+    using nav2_util::declare_parameter_if_not_declared;
+    declare_parameter_if_not_declared(
+      node, "enable_stamped_cmd_vel",
+      rclcpp::ParameterValue{false});
     node->get_parameter("enable_stamped_cmd_vel", is_stamped_);
     if (is_stamped_) {
       twist_stamped_pub_ = node->create_publisher<geometry_msgs::msg::TwistStamped>(
@@ -65,7 +73,6 @@ public:
         qos);
     }
   }
-
 
   void on_activate()
   {

--- a/nav2_util/include/nav2_util/twist_publisher.hpp
+++ b/nav2_util/include/nav2_util/twist_publisher.hpp
@@ -42,8 +42,9 @@ class TwistPublisher
 public:
   /**
   * @brief A constructor
-  * @param service_name name of the service to call
-  * @param provided_node Node to create the service client off of
+  * @param nh The node
+  * @param topic publisher topic name
+  * @param qos publisher quality of service
   */
   explicit TwistPublisher(
     nav2_util::LifecycleNode::SharedPtr nh,
@@ -99,8 +100,6 @@ public:
     if (is_stamped_) {
       twist_stamped_pub_->publish(velocity);
     } else {
-      [[maybe_unused]] const auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>(
-        velocity.twist);
       twist_pub_->publish(velocity.twist);
     }
   }

--- a/nav2_util/include/nav2_util/twist_publisher.hpp
+++ b/nav2_util/include/nav2_util/twist_publisher.hpp
@@ -1,0 +1,128 @@
+// Copyright (C) 2023 Ryan Friedman
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef NAV2_UTIL__TWIST_PUBLISHER_HPP_
+#define NAV2_UTIL__TWIST_PUBLISHER_HPP_
+
+
+#include <memory>
+#include <string>
+
+#include "geometry_msgs/msg/twist.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+#include "rclcpp/qos.hpp"
+
+namespace nav2_util
+{
+
+/**
+ * @class nav2_util::TwistPublisher
+ * @brief A simple wrapper on a Twist publisher that provides either Twist or TwistStamped
+ *
+ * The default is to publish Twist to preserve backwards compatibility, but it can be overridden
+ * using the "enable_stamped_cmd_vel" parameter to publish TwistStamped.
+ *
+ */
+
+class TwistPublisher
+{
+public:
+  /**
+  * @brief A constructor
+  * @param service_name name of the service to call
+  * @param provided_node Node to create the service client off of
+  */
+  explicit TwistPublisher(
+    nav2_util::LifecycleNode::SharedPtr nh,
+    const std::string & topic,
+    const rclcpp::QoS & qos
+  )
+  : topic_(topic), node_(nh)
+  {
+    assert(nh != nullptr);
+    node_->declare_parameter("enable_stamped_cmd_vel", false);
+    node_->get_parameter("enable_stamped_cmd_vel", is_stamped_);
+    if (is_stamped_) {
+      twist_stamped_pub_ = node_->create_publisher<geometry_msgs::msg::TwistStamped>(
+        topic_,
+        qos);
+    } else {
+      twist_pub_ = node_->create_publisher<geometry_msgs::msg::Twist>(
+        topic_,
+        qos);
+    }
+  }
+
+
+  void on_activate()
+  {
+    if (is_stamped_) {
+      twist_stamped_pub_->on_activate();
+    } else {
+      twist_pub_->on_activate();
+    }
+  }
+
+  void on_deactivate()
+  {
+    if (is_stamped_) {
+      twist_stamped_pub_->on_deactivate();
+    } else {
+      twist_pub_->on_deactivate();
+    }
+  }
+
+  [[nodiscard]] bool is_activated() const
+  {
+    if (is_stamped_) {
+      return twist_stamped_pub_->is_activated();
+    } else {
+      return twist_pub_->is_activated();
+    }
+  }
+
+  void publish(const geometry_msgs::msg::TwistStamped & velocity)
+  {
+    if (is_stamped_) {
+      twist_stamped_pub_->publish(velocity);
+    } else {
+      [[maybe_unused]] const auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>(
+        velocity.twist);
+      twist_pub_->publish(velocity.twist);
+    }
+  }
+
+  [[nodiscard]] size_t get_subscription_count() const
+  {
+    if (is_stamped_) {
+      return twist_stamped_pub_->get_subscription_count();
+    } else {
+      return twist_pub_->get_subscription_count();
+    }
+  }
+
+protected:
+  std::string topic_;
+  nav2_util::LifecycleNode::SharedPtr node_;
+  bool is_stamped_;
+  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::TwistStamped>::SharedPtr
+    twist_stamped_pub_;
+};
+
+}  // namespace nav2_util
+
+#endif  // NAV2_UTIL__TWIST_PUBLISHER_HPP_

--- a/nav2_util/include/nav2_util/twist_publisher.hpp
+++ b/nav2_util/include/nav2_util/twist_publisher.hpp
@@ -106,7 +106,8 @@ public:
     if (is_stamped_) {
       twist_stamped_pub_->publish(std::move(velocity));
     } else {
-      twist_pub_->publish(std::move(std::make_unique<geometry_msgs::msg::Twist>(velocity->twist)));
+      auto twist_msg = std::make_unique<geometry_msgs::msg::Twist>(velocity->twist);
+      twist_pub_->publish(std::move(twist_msg));
     }
   }
 

--- a/nav2_util/include/nav2_util/twist_publisher.hpp
+++ b/nav2_util/include/nav2_util/twist_publisher.hpp
@@ -54,8 +54,7 @@ public:
   explicit TwistPublisher(
     nav2_util::LifecycleNode::SharedPtr node,
     const std::string & topic,
-    const rclcpp::QoS & qos
-  )
+    const rclcpp::QoS & qos)
   : topic_(topic)
   {
     using nav2_util::declare_parameter_if_not_declared;

--- a/nav2_util/include/nav2_util/twist_publisher.hpp
+++ b/nav2_util/include/nav2_util/twist_publisher.hpp
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
@@ -100,12 +101,12 @@ public:
     }
   }
 
-  void publish(const geometry_msgs::msg::TwistStamped & velocity)
+  void publish(std::unique_ptr<geometry_msgs::msg::TwistStamped> velocity)
   {
     if (is_stamped_) {
-      twist_stamped_pub_->publish(velocity);
+      twist_stamped_pub_->publish(std::move(velocity));
     } else {
-      twist_pub_->publish(velocity.twist);
+      twist_pub_->publish(std::move(std::make_unique<geometry_msgs::msg::Twist>(velocity->twist)));
     }
   }
 

--- a/nav2_util/include/nav2_util/twist_subscriber.hpp
+++ b/nav2_util/include/nav2_util/twist_subscriber.hpp
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"

--- a/nav2_util/include/nav2_util/twist_subscriber.hpp
+++ b/nav2_util/include/nav2_util/twist_subscriber.hpp
@@ -91,9 +91,9 @@ public:
   )
   {
     nav2_util::declare_parameter_if_not_declared(
-      node, stamped_param_name_,
-      rclcpp::ParameterValue{is_stamped_});
-    node->get_parameter(stamped_param_name_, is_stamped_);
+      node, "enable_stamped_cmd_vel",
+      rclcpp::ParameterValue(false));
+    node->get_parameter("enable_stamped_cmd_vel", is_stamped_);
     if (is_stamped_) {
       twist_stamped_sub_ = node->create_subscription<geometry_msgs::msg::TwistStamped>(
         topic,
@@ -124,9 +124,9 @@ public:
   )
   {
     nav2_util::declare_parameter_if_not_declared(
-      node, stamped_param_name_,
-      rclcpp::ParameterValue{is_stamped_});
-    node->get_parameter(stamped_param_name_, is_stamped_);
+      node, "enable_stamped_cmd_vel",
+      rclcpp::ParameterValue(false));
+    node->get_parameter("enable_stamped_cmd_vel", is_stamped_);
     if (is_stamped_) {
       twist_stamped_sub_ = node->create_subscription<geometry_msgs::msg::TwistStamped>(
         topic,
@@ -134,8 +134,7 @@ public:
         std::forward<TwistStampedCallbackT>(TwistStampedCallback));
     } else {
       throw std::invalid_argument(
-              "The parameter '%s' must be true when using this constructor!",
-              stamped_param_name_);
+              "enable_stamped_cmd_vel must be true when using this constructor!");
     }
   }
 
@@ -146,8 +145,6 @@ protected:
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_ {nullptr};
   //! @brief The subscription when using TwistStamped
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_stamped_sub_ {nullptr};
-  //! @brief The name of the ROS parameter that controls whether twist data is stamped
-  const std::string stamped_param_name_ {"enable_stamped_cmd_vel"};
 };
 
 

--- a/nav2_util/include/nav2_util/twist_subscriber.hpp
+++ b/nav2_util/include/nav2_util/twist_subscriber.hpp
@@ -139,36 +139,6 @@ public:
     }
   }
 
-  // /**
-  // * @brief A constructor that only supports Twist
-  // * @param node The node to add the Twist subscriber to
-  // * @param topic The subscriber topic name
-  // * @param qos The subscriber quality of service
-  // * @param TwistCallback The subscriber callback for Twist messages
-  // * @throw std::invalid_argument When configured with an invalid ROS parameter
-  // */
-  // template<typename TwistCallbackT>
-  // explicit TwistSubscriber(
-  //   nav2_util::LifecycleNode::SharedPtr node,
-  //   const std::string & topic,
-  //   const rclcpp::QoS & qos,
-  //   TwistCallbackT && TwistCallback
-  // )
-  // {
-  //   nav2_util::declare_parameter_if_not_declared(
-  //     node, stamped_param_name_,
-  //     rclcpp::ParameterValue{is_stamped_});
-  //   node->get_parameter(stamped_param_name_, is_stamped_);
-  //   if (is_stamped_) {
-  //     throw std::invalid_argument("The parameter '%s' must be false when using this constructor!", stamped_param_name_);
-  //   } else {
-  //     twist_sub_ = node->create_subscription<geometry_msgs::msg::Twist>(
-  //       topic,
-  //       qos,
-  //       std::forward<TwistCallbackT>(TwistCallback));
-  //   }
-  // }
-
 protected:
   //! @brief The user-configured value for ROS parameter enable_stamped_cmd_vel
   bool is_stamped_{false};

--- a/nav2_util/include/nav2_util/twist_subscriber.hpp
+++ b/nav2_util/include/nav2_util/twist_subscriber.hpp
@@ -60,7 +60,8 @@ public:
     const rclcpp::QoS & qos,
     TwistCallbackT && TwistCallback,
     TwistStampedCallbackT && TwistStampedCallback
-  ) {
+  )
+  {
     using nav2_util::declare_parameter_if_not_declared;
     declare_parameter_if_not_declared(
       node, "enable_stamped_cmd_vel",
@@ -78,51 +79,6 @@ public:
         std::forward<TwistCallbackT>(TwistCallback));
     }
   }
-
-  // void on_activate()
-  // {
-  //   if (is_stamped_) {
-  //     twist_stamped_pub_->on_activate();
-  //   } else {
-  //     twist_pub_->on_activate();
-  //   }
-  // }
-
-  // void on_deactivate()
-  // {
-  //   if (is_stamped_) {
-  //     twist_stamped_pub_->on_deactivate();
-  //   } else {
-  //     twist_pub_->on_deactivate();
-  //   }
-  // }
-
-  // [[nodiscard]] bool is_activated() const
-  // {
-  //   if (is_stamped_) {
-  //     return twist_stamped_pub_->is_activated();
-  //   } else {
-  //     return twist_pub_->is_activated();
-  //   }
-  // }
-
-  // void publish(const geometry_msgs::msg::TwistStamped & velocity)
-  // {
-  //   if (is_stamped_) {
-  //     twist_stamped_pub_->publish(velocity);
-  //   } else {
-  //     twist_pub_->publish(velocity.twist);
-  //   }
-  // }
-
-  // [[nodiscard]] size_t get_subscription_count() const
-  // {
-  //   if (is_stamped_) {
-  //     return twist_stamped_pub_->get_subscription_count();
-  //   } else {
-  //     return twist_pub_->get_subscription_count();
-  //   }
-  // }
 
 protected:
   bool is_stamped_;

--- a/nav2_util/include/nav2_util/twist_subscriber.hpp
+++ b/nav2_util/include/nav2_util/twist_subscriber.hpp
@@ -36,31 +36,31 @@ namespace nav2_util
 
 /**
  * @class nav2_util::TwistSubscriber
- * @brief A simple wrapper on a Twist subscriber that receives either 
+ * @brief A simple wrapper on a Twist subscriber that receives either
  *        geometry_msgs::msg::TwistStamped or geometry_msgs::msg::Twist
  *
  * @note Usage:
  * The default behavior is to subscribe to Twist, which preserves backwards compatibility
- * with ROS distributions up to Iron. 
- * The behavior can be overridden using the "enable_stamped_cmd_vel" parameter. 
+ * with ROS distributions up to Iron.
+ * The behavior can be overridden using the "enable_stamped_cmd_vel" parameter.
  * By setting that to "True", the TwistSubscriber class would subscribe to TwistStamped.
- * 
+ *
  * @note Why use Twist Stamped over Twist?
- * Twist has been used widely in many ROS applications, typically for body-frame velocity control, 
- * and between ROS nodes on the same computer. Many ROS interfaces are moving to using TwistStamped 
- * because it is more robust for stale data protection. This protection is especially important 
- * when sending velocity control over lossy communication links. 
- * An example application where this matters is a drone with a Linux computer running a ROS 
- * controller that sends Twist commands to an embedded autopilot. If the autopilot failed to 
- * recognize a highly latent connection, it could result in instability or a crash because of the 
+ * Twist has been used widely in many ROS applications, typically for body-frame velocity control,
+ * and between ROS nodes on the same computer. Many ROS interfaces are moving to using TwistStamped
+ * because it is more robust for stale data protection. This protection is especially important
+ * when sending velocity control over lossy communication links.
+ * An example application where this matters is a drone with a Linux computer running a ROS
+ * controller that sends Twist commands to an embedded autopilot. If the autopilot failed to
+ * recognize a highly latent connection, it could result in instability or a crash because of the
  * decreased phase margin for control.
- * TwistStamped also has a frame ID, allowing explicit control for multiple frames, rather than 
+ * TwistStamped also has a frame ID, allowing explicit control for multiple frames, rather than
  * relying on an assumption of body-frame control or having to create a different topic.
- * Adding a header is low-cost for most ROS applications; the header can be set to an empty string 
+ * Adding a header is low-cost for most ROS applications; the header can be set to an empty string
  * if bandwidth is of concern.
- * 
+ *
  * @note Implementation Design Notes:
- * Compared to the naive approach of setting up one subscriber for each message type, 
+ * Compared to the naive approach of setting up one subscriber for each message type,
  * only one subscriber is created at a time; the other is nullptr.
  * This reduces RAM usage and ROS discovery traffic.
  * This approach allows NAV2 libraries to be flexible in which Twist message they support,
@@ -133,7 +133,9 @@ public:
         qos,
         std::forward<TwistStampedCallbackT>(TwistStampedCallback));
     } else {
-      throw std::invalid_argument("The parameter '%s' must be true when using this constructor!", stamped_param_name_);
+      throw std::invalid_argument(
+              "The parameter '%s' must be true when using this constructor!",
+              stamped_param_name_);
     }
   }
 
@@ -177,7 +179,6 @@ protected:
   //! @brief The name of the ROS parameter that controls whether twist data is stamped
   const std::string stamped_param_name_ {"enable_stamped_cmd_vel"};
 };
-
 
 
 }  // namespace nav2_util

--- a/nav2_util/include/nav2_util/twist_subscriber.hpp
+++ b/nav2_util/include/nav2_util/twist_subscriber.hpp
@@ -1,0 +1,136 @@
+// Copyright (C) 2023 Ryan Friedman
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef NAV2_UTIL__TWIST_SUBSCRIBER_HPP_
+#define NAV2_UTIL__TWIST_SUBSCRIBER_HPP_
+
+
+#include <memory>
+#include <string>
+
+#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "rclcpp/parameter_service.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include "lifecycle_node.hpp"
+#include "node_utils.hpp"
+
+namespace nav2_util
+{
+
+/**
+ * @class nav2_util::TwistSubscriber
+ * @brief A simple wrapper on a Twist subscriber that receives either Twist or TwistStamped
+ *
+ * The default is to subscribe to Twist to preserve backwards compatibility, but it can be overridden
+ * using the "enable_stamped_cmd_vel" parameter to subscribe to TwistStamped.
+ *
+ */
+
+class TwistSubscriber
+{
+public:
+  /**
+  * @brief A constructor
+  * @param nh The node
+  * @param topic publisher topic name
+  * @param qos publisher quality of service
+  */
+  template<typename TwistCallbackT,
+    typename TwistStampedCallbackT
+  >
+  explicit TwistSubscriber(
+    nav2_util::LifecycleNode::SharedPtr node,
+    const std::string & topic,
+    const rclcpp::QoS & qos,
+    TwistCallbackT && TwistCallback,
+    TwistStampedCallbackT && TwistStampedCallback
+  )
+  : {
+    using nav2_util::declare_parameter_if_not_declared;
+    declare_parameter_if_not_declared(
+      node, "enable_stamped_cmd_vel",
+      rclcpp::ParameterValue{false});
+    node->get_parameter("enable_stamped_cmd_vel", is_stamped_);
+    if (is_stamped_) {
+      twist_stamped_sub_ = node->create_subscription<geometry_msgs::msg::TwistStamped>(
+        topic,
+        qos,
+        std::forward<TwistStampedCallbackT>(TwistStampedCallback));
+    } else {
+      twist_sub_ = node->create_subscription<geometry_msgs::msg::Twist>(
+        topic,
+        qos,
+        std::forward<TwistCallbackT>(TwistCallback));
+    }
+  }
+
+  // void on_activate()
+  // {
+  //   if (is_stamped_) {
+  //     twist_stamped_pub_->on_activate();
+  //   } else {
+  //     twist_pub_->on_activate();
+  //   }
+  // }
+
+  // void on_deactivate()
+  // {
+  //   if (is_stamped_) {
+  //     twist_stamped_pub_->on_deactivate();
+  //   } else {
+  //     twist_pub_->on_deactivate();
+  //   }
+  // }
+
+  // [[nodiscard]] bool is_activated() const
+  // {
+  //   if (is_stamped_) {
+  //     return twist_stamped_pub_->is_activated();
+  //   } else {
+  //     return twist_pub_->is_activated();
+  //   }
+  // }
+
+  // void publish(const geometry_msgs::msg::TwistStamped & velocity)
+  // {
+  //   if (is_stamped_) {
+  //     twist_stamped_pub_->publish(velocity);
+  //   } else {
+  //     twist_pub_->publish(velocity.twist);
+  //   }
+  // }
+
+  // [[nodiscard]] size_t get_subscription_count() const
+  // {
+  //   if (is_stamped_) {
+  //     return twist_stamped_pub_->get_subscription_count();
+  //   } else {
+  //     return twist_pub_->get_subscription_count();
+  //   }
+  // }
+
+protected:
+  bool is_stamped_;
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_stamped_sub_;
+};
+
+}  // namespace nav2_util
+
+#endif  // NAV2_UTIL__TWIST_SUBSCRIBER_HPP_

--- a/nav2_util/include/nav2_util/twist_subscriber.hpp
+++ b/nav2_util/include/nav2_util/twist_subscriber.hpp
@@ -60,8 +60,7 @@ public:
     const rclcpp::QoS & qos,
     TwistCallbackT && TwistCallback,
     TwistStampedCallbackT && TwistStampedCallback
-  )
-  : {
+  ) {
     using nav2_util::declare_parameter_if_not_declared;
     declare_parameter_if_not_declared(
       node, "enable_stamped_cmd_vel",

--- a/nav2_util/src/robot_utils.cpp
+++ b/nav2_util/src/robot_utils.cpp
@@ -172,4 +172,9 @@ bool validateTwist(const geometry_msgs::msg::Twist & msg)
   return true;
 }
 
+bool validateTwist(const geometry_msgs::msg::TwistStamped & msg)
+{
+  return validateTwist(msg.twist);
+}
+
 }  // end namespace nav2_util

--- a/nav2_util/test/CMakeLists.txt
+++ b/nav2_util/test/CMakeLists.txt
@@ -44,3 +44,7 @@ target_link_libraries(test_robot_utils ${library_name})
 
 ament_add_gtest(test_array_parser test_array_parser.cpp)
 target_link_libraries(test_array_parser ${library_name})
+
+ament_add_gtest(test_twist_publisher test_twist_publisher.cpp)
+ament_target_dependencies(test_twist_publisher rclcpp_lifecycle)
+target_link_libraries(test_twist_publisher ${library_name})

--- a/nav2_util/test/CMakeLists.txt
+++ b/nav2_util/test/CMakeLists.txt
@@ -48,3 +48,7 @@ target_link_libraries(test_array_parser ${library_name})
 ament_add_gtest(test_twist_publisher test_twist_publisher.cpp)
 ament_target_dependencies(test_twist_publisher rclcpp_lifecycle)
 target_link_libraries(test_twist_publisher ${library_name})
+
+ament_add_gtest(test_twist_subscriber test_twist_subscriber.cpp)
+ament_target_dependencies(test_twist_subscriber rclcpp_lifecycle)
+target_link_libraries(test_twist_subscriber ${library_name})

--- a/nav2_util/test/test_twist_publisher.cpp
+++ b/nav2_util/test/test_twist_publisher.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Intel Corporation
+// Copyright (C) 2023 Ryan Friedman
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nav2_util/test/test_twist_publisher.cpp
+++ b/nav2_util/test/test_twist_publisher.cpp
@@ -47,6 +47,7 @@ TEST(TwistPublisher, Unstamped)
 
   const geometry_msgs::msg::TwistStamped twist_stamped {};
   vel_publisher->publish(twist_stamped);
+  rclcpp::spin_some(node->get_node_base_interface());
   node->deactivate();
   SUCCEED();
 }

--- a/nav2_util/test/test_twist_publisher.cpp
+++ b/nav2_util/test/test_twist_publisher.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+
+#include "nav2_util/twist_publisher.hpp"
+#include "nav2_util/lifecycle_utils.hpp"
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+using nav2_util::startup_lifecycle_nodes;
+using nav2_util::reset_lifecycle_nodes;
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+RclCppFixture g_rclcppfixture;
+
+TEST(TwistPublisher, Unstamped)
+{
+  auto node = std::make_shared<nav2_util::LifecycleNode>("test_node", "");
+  node->declare_parameter("enable_stamped_cmd_vel", false);
+
+  node->configure();
+  node->activate();
+
+  auto vel_publisher = std::make_unique<nav2_util::TwistPublisher>(node, "cmd_vel", 1);
+  ASSERT_EQ(vel_publisher->get_subscription_count(), 0);
+
+  vel_publisher->on_activate();
+
+  const geometry_msgs::msg::TwistStamped twist_stamped {};
+  vel_publisher->publish(twist_stamped);
+  node->deactivate();
+  SUCCEED();
+}

--- a/nav2_util/test/test_twist_publisher.cpp
+++ b/nav2_util/test/test_twist_publisher.cpp
@@ -24,14 +24,6 @@
 using nav2_util::startup_lifecycle_nodes;
 using nav2_util::reset_lifecycle_nodes;
 
-class RclCppFixture
-{
-public:
-  RclCppFixture() {}
-  ~RclCppFixture() {}
-};
-RclCppFixture g_rclcppfixture;
-
 TEST(TwistPublisher, Unstamped)
 {
   rclcpp::init(0, nullptr);

--- a/nav2_util/test/test_twist_subscriber.cpp
+++ b/nav2_util/test/test_twist_subscriber.cpp
@@ -1,0 +1,70 @@
+// Copyright (C) 2023 Ryan Friedman
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+
+#include "nav2_util/twist_subscriber.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+// #include "nav2_util/lifecycle_utils.hpp"
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+// #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+// using nav2_util::startup_lifecycle_nodes;
+// using nav2_util::reset_lifecycle_nodes;
+
+TEST(TwistPublisher, Unstamped)
+{
+  rclcpp::init(0, nullptr);
+  auto sub_node = std::make_shared<nav2_util::LifecycleNode>("pub_node", "");
+  sub_node->configure();
+  sub_node->activate();
+
+  geometry_msgs::msg::TwistStamped sub_msg {};
+  auto vel_subscriber = std::make_unique<nav2_util::TwistSubscriber>(
+    sub_node, "cmd_vel", 1,
+    [&](const geometry_msgs::msg::Twist msg) {sub_msg.twist = msg;},
+    [&](const geometry_msgs::msg::TwistStamped msg) {sub_msg = msg;}
+  );
+//   ASSERT_EQ(vel_publisher->get_subscription_count(), 0);
+//   EXPECT_FALSE(vel_publisher->is_activated());
+//   pub_node->activate();
+//   EXPECT_TRUE(vel_publisher->is_activated());
+//   vel_publisher->on_activate();
+//   auto pub_thread = std::thread([&]() {rclcpp::spin(pub_node->get_node_base_interface());});
+
+//   auto sub_node = std::make_shared<nav2_util::LifecycleNode>("sub_node", "");
+//   pub_node->configure();
+
+
+//   geometry_msgs::msg::TwistStamped pub_msg {};
+//   pub_msg.twist.linear.x = 42.0;
+
+//   geometry_msgs::msg::Twist sub_msg {};
+//   auto my_sub = sub_node->create_subscription<geometry_msgs::msg::Twist>(
+//     "cmd_vel", 10,
+//     [&](const geometry_msgs::msg::Twist msg) {sub_msg = msg;});
+
+//   vel_publisher->publish(pub_msg);
+//   rclcpp::spin_some(sub_node->get_node_base_interface());
+
+//   EXPECT_EQ(pub_msg.twist.linear.x, sub_msg.linear.x);
+//   ASSERT_EQ(vel_publisher->get_subscription_count(), 1);
+//   pub_node->deactivate();
+  sub_node->deactivate();
+  rclcpp::shutdown();
+  // Have to join thread after rclcpp is shut down otherwise test hangs.
+//   pub_thread.join();
+}

--- a/nav2_velocity_smoother/README.md
+++ b/nav2_velocity_smoother/README.md
@@ -65,8 +65,8 @@ velocity_smoother:
 
 | Topic            | Type                    | Use                           |
 |------------------|-------------------------|-------------------------------|
-| smoothed_cmd_vel | geometry_msgs/Twist     | Publish smoothed velocities   |
-| cmd_vel          | geometry_msgs/Twist     | Subscribe to input velocities |
+| smoothed_cmd_vel | geometry_msgs/Twist or  geometry_msgs/TwistStamped | Publish smoothed velocities   |
+| cmd_vel          | geometry_msgs/Twist or  geometry_msgs/TwistStamped | Subscribe to input velocities |
 
 
 ## Install

--- a/nav2_velocity_smoother/README.md
+++ b/nav2_velocity_smoother/README.md
@@ -59,6 +59,7 @@ velocity_smoother:
    	max_decel: [-2.5, 0.0, -3.2]  # Maximum deceleration, ordered [Ax, Ay, Aw]
    	odom_topic: "odom"  # Topic of odometry to use for estimating current velocities
    	odom_duration: 0.1  # Period of time (s) to sample odometry information in for velocity estimation
+	enable_stamped_cmd_vel: false
 ```
 
 ## Topics
@@ -85,3 +86,5 @@ When in doubt, open-loop is a reasonable choice for most users.
 The minimum and maximum velocities for rotation (e.g. ``Vw``) represent left and right turns. While we make it possible to specify these separately, most users would be wise to set these values the same (but signed) for rotation. Additionally, the parameters are signed, so it is important to specify maximum deceleration with negative signs to represent deceleration. Minimum velocities with negatives when moving backward, so backward movement can be restricted by setting this to ``0``.
 
 Deadband velocities are minimum thresholds, below which we set its value to `0`. This can be useful when your robot's breaking torque from stand still is non-trivial so sending very small values will pull high amounts of current.
+
+The `VelocitySmoother` node makes use of a [nav2_util::TwistSubscriber](../nav2_util/README.md#twist-publisher-and-twist-subscriber-for-commanded-velocities).

--- a/nav2_velocity_smoother/README.md
+++ b/nav2_velocity_smoother/README.md
@@ -59,7 +59,7 @@ velocity_smoother:
    	max_decel: [-2.5, 0.0, -3.2]  # Maximum deceleration, ordered [Ax, Ay, Aw]
    	odom_topic: "odom"  # Topic of odometry to use for estimating current velocities
    	odom_duration: 0.1  # Period of time (s) to sample odometry information in for velocity estimation
-	enable_stamped_cmd_vel: false
+	enable_stamped_cmd_vel: false # Whether to stamp the velocity. True uses TwistStamped. False uses Twist
 ```
 
 ## Topics

--- a/nav2_velocity_smoother/include/nav2_velocity_smoother/velocity_smoother.hpp
+++ b/nav2_velocity_smoother/include/nav2_velocity_smoother/velocity_smoother.hpp
@@ -26,6 +26,9 @@
 #include "nav2_util/node_utils.hpp"
 #include "nav2_util/odometry_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
+#include "nav2_util/twist_subscriber.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 
 namespace nav2_velocity_smoother
 {
@@ -114,6 +117,7 @@ protected:
    * @param msg Twist message
    */
   void inputCommandCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+  void inputCommandStampedCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
 
   /**
    * @brief Main worker timer function
@@ -131,7 +135,7 @@ protected:
   std::unique_ptr<nav2_util::OdomSmoother> odom_smoother_;
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr
     smoothed_cmd_pub_;
-  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_sub_;
+  std::shared_ptr<nav2_util::TwistSubscriber> cmd_sub_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   rclcpp::Clock::SharedPtr clock_;

--- a/nav2_velocity_smoother/include/nav2_velocity_smoother/velocity_smoother.hpp
+++ b/nav2_velocity_smoother/include/nav2_velocity_smoother/velocity_smoother.hpp
@@ -26,6 +26,7 @@
 #include "nav2_util/node_utils.hpp"
 #include "nav2_util/odometry_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
+#include "nav2_util/twist_publisher.hpp"
 #include "nav2_util/twist_subscriber.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
@@ -116,7 +117,7 @@ protected:
    * @brief Callback for incoming velocity commands
    * @param msg Twist message
    */
-  void inputCommandCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+  void inputCommandCallback(const geometry_msgs::msg::Twist::ConstSharedPtr msg);
   void inputCommandStampedCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
 
   /**
@@ -133,14 +134,13 @@ protected:
 
   // Network interfaces
   std::unique_ptr<nav2_util::OdomSmoother> odom_smoother_;
-  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr
-    smoothed_cmd_pub_;
+  std::unique_ptr<nav2_util::TwistPublisher> smoothed_cmd_pub_;
   std::shared_ptr<nav2_util::TwistSubscriber> cmd_sub_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   rclcpp::Clock::SharedPtr clock_;
-  geometry_msgs::msg::Twist last_cmd_;
-  geometry_msgs::msg::Twist::SharedPtr command_;
+  geometry_msgs::msg::TwistStamped last_cmd_;
+  geometry_msgs::msg::TwistStamped::SharedPtr command_;
 
   // Parameters
   double smoothing_frequency_;

--- a/nav2_velocity_smoother/include/nav2_velocity_smoother/velocity_smoother.hpp
+++ b/nav2_velocity_smoother/include/nav2_velocity_smoother/velocity_smoother.hpp
@@ -117,8 +117,8 @@ protected:
    * @brief Callback for incoming velocity commands
    * @param msg Twist message
    */
-  void inputCommandCallback(const geometry_msgs::msg::Twist::ConstSharedPtr msg);
-  void inputCommandStampedCallback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
+  void inputCommandCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
+  void inputCommandStampedCallback(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
 
   /**
    * @brief Main worker timer function
@@ -135,7 +135,7 @@ protected:
   // Network interfaces
   std::unique_ptr<nav2_util::OdomSmoother> odom_smoother_;
   std::unique_ptr<nav2_util::TwistPublisher> smoothed_cmd_pub_;
-  std::shared_ptr<nav2_util::TwistSubscriber> cmd_sub_;
+  std::unique_ptr<nav2_util::TwistSubscriber> cmd_sub_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   rclcpp::Clock::SharedPtr clock_;

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -289,6 +289,7 @@ void VelocitySmoother::smootherTimer()
   }
 
   auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>();
+  cmd_vel->header = command_->header;
 
   // Check for velocity timeout. If nothing received, publish zeros to apply deceleration
   if (now() - last_command_time_ > velocity_timeout_) {

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -128,9 +128,9 @@ VelocitySmoother::on_configure(const rclcpp_lifecycle::State &)
   }
 
   // Setup inputs / outputs
-  smoothed_cmd_pub_ = create_publisher<geometry_msgs::msg::Twist>("cmd_vel_smoothed", 1);
+  smoothed_cmd_pub_ = std::make_unique<nav2_util::TwistPublisher>(node, "cmd_vel_smoothed", 1);
   cmd_sub_ = std::make_shared<nav2_util::TwistSubscriber>(
-    shared_from_this(),
+    node,
     "cmd_vel", rclcpp::QoS(1),
     std::bind(&VelocitySmoother::inputCommandCallback, this, std::placeholders::_1),
     std::bind(&VelocitySmoother::inputCommandStampedCallback, this, std::placeholders::_1)
@@ -202,22 +202,30 @@ VelocitySmoother::on_shutdown(const rclcpp_lifecycle::State &)
   return nav2_util::CallbackReturn::SUCCESS;
 }
 
-void VelocitySmoother::inputCommandCallback(const geometry_msgs::msg::Twist::SharedPtr msg)
+void VelocitySmoother::inputCommandStampedCallback(
+  const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
 {
   // If message contains NaN or Inf, ignore
-  if (!nav2_util::validateTwist(*msg)) {
+  if (!nav2_util::validateTwist(msg->twist)) {
     RCLCPP_ERROR(get_logger(), "Velocity message contains NaNs or Infs! Ignoring as invalid!");
     return;
   }
 
-  command_ = msg;
-  last_command_time_ = now();
+  command_ = std::make_shared<geometry_msgs::msg::TwistStamped>(*msg);
+  if (msg->header.stamp.sec == 0 && msg->header.stamp.nanosec == 0) {
+    last_command_time_ = now();
+  } else {
+    last_command_time_ = msg->header.stamp;
+  }
+
 }
 
-void VelocitySmoother::inputCommandStampedCallback(
-  geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+void VelocitySmoother::inputCommandCallback(
+  geometry_msgs::msg::Twist::ConstSharedPtr msg)
 {
-  inputCommandCallback(std::make_shared<geometry_msgs::msg::Twist>(msg->twist));
+  auto twist_stamped = geometry_msgs::msg::TwistStamped();
+  twist_stamped.twist = *msg;
+  inputCommandStampedCallback(std::make_shared<geometry_msgs::msg::TwistStamped>(twist_stamped));
 }
 
 double VelocitySmoother::findEtaConstraint(
@@ -281,31 +289,37 @@ void VelocitySmoother::smootherTimer()
     return;
   }
 
-  auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>();
+  auto cmd_vel = std::make_unique<geometry_msgs::msg::TwistStamped>();
 
   // Check for velocity timeout. If nothing received, publish zeros to apply deceleration
   if (now() - last_command_time_ > velocity_timeout_) {
-    if (last_cmd_ == geometry_msgs::msg::Twist() || stopped_) {
+    if (last_cmd_ == geometry_msgs::msg::TwistStamped() || stopped_) {
       stopped_ = true;
       return;
     }
-    *command_ = geometry_msgs::msg::Twist();
+    *command_ = geometry_msgs::msg::TwistStamped();
   }
 
   stopped_ = false;
 
   // Get current velocity based on feedback type
-  geometry_msgs::msg::Twist current_;
+  geometry_msgs::msg::TwistStamped current_;
   if (open_loop_) {
     current_ = last_cmd_;
   } else {
-    current_ = odom_smoother_->getTwist();
+    current_ = odom_smoother_->getTwistStamped();
   }
 
   // Apply absolute velocity restrictions to the command
-  command_->linear.x = std::clamp(command_->linear.x, min_velocities_[0], max_velocities_[0]);
-  command_->linear.y = std::clamp(command_->linear.y, min_velocities_[1], max_velocities_[1]);
-  command_->angular.z = std::clamp(command_->angular.z, min_velocities_[2], max_velocities_[2]);
+  command_->twist.linear.x = std::clamp(
+    command_->twist.linear.x, min_velocities_[0],
+    max_velocities_[0]);
+  command_->twist.linear.y = std::clamp(
+    command_->twist.linear.y, min_velocities_[1],
+    max_velocities_[1]);
+  command_->twist.angular.z = std::clamp(
+    command_->twist.angular.z, min_velocities_[2],
+    max_velocities_[2]);
 
   // Find if any component is not within the acceleration constraints. If so, store the most
   // significant scale factor to apply to the vector <dvx, dvy, dvw>, eta, to reduce all axes
@@ -317,39 +331,41 @@ void VelocitySmoother::smootherTimer()
     double curr_eta = -1.0;
 
     curr_eta = findEtaConstraint(
-      current_.linear.x, command_->linear.x, max_accels_[0], max_decels_[0]);
+      current_.twist.linear.x, command_->twist.linear.x, max_accels_[0], max_decels_[0]);
     if (curr_eta > 0.0 && std::fabs(1.0 - curr_eta) > std::fabs(1.0 - eta)) {
       eta = curr_eta;
     }
 
     curr_eta = findEtaConstraint(
-      current_.linear.y, command_->linear.y, max_accels_[1], max_decels_[1]);
+      current_.twist.linear.y, command_->twist.linear.y, max_accels_[1], max_decels_[1]);
     if (curr_eta > 0.0 && std::fabs(1.0 - curr_eta) > std::fabs(1.0 - eta)) {
       eta = curr_eta;
     }
 
     curr_eta = findEtaConstraint(
-      current_.angular.z, command_->angular.z, max_accels_[2], max_decels_[2]);
+      current_.twist.angular.z, command_->twist.angular.z, max_accels_[2], max_decels_[2]);
     if (curr_eta > 0.0 && std::fabs(1.0 - curr_eta) > std::fabs(1.0 - eta)) {
       eta = curr_eta;
     }
   }
 
-  cmd_vel->linear.x = applyConstraints(
-    current_.linear.x, command_->linear.x, max_accels_[0], max_decels_[0], eta);
-  cmd_vel->linear.y = applyConstraints(
-    current_.linear.y, command_->linear.y, max_accels_[1], max_decels_[1], eta);
-  cmd_vel->angular.z = applyConstraints(
-    current_.angular.z, command_->angular.z, max_accels_[2], max_decels_[2], eta);
+  cmd_vel->twist.linear.x = applyConstraints(
+    current_.twist.linear.x, command_->twist.linear.x, max_accels_[0], max_decels_[0], eta);
+  cmd_vel->twist.linear.y = applyConstraints(
+    current_.twist.linear.y, command_->twist.linear.y, max_accels_[1], max_decels_[1], eta);
+  cmd_vel->twist.angular.z = applyConstraints(
+    current_.twist.angular.z, command_->twist.angular.z, max_accels_[2], max_decels_[2], eta);
   last_cmd_ = *cmd_vel;
 
   // Apply deadband restrictions & publish
-  cmd_vel->linear.x = fabs(cmd_vel->linear.x) < deadband_velocities_[0] ? 0.0 : cmd_vel->linear.x;
-  cmd_vel->linear.y = fabs(cmd_vel->linear.y) < deadband_velocities_[1] ? 0.0 : cmd_vel->linear.y;
-  cmd_vel->angular.z = fabs(cmd_vel->angular.z) <
-    deadband_velocities_[2] ? 0.0 : cmd_vel->angular.z;
+  cmd_vel->twist.linear.x = fabs(cmd_vel->twist.linear.x) <
+    deadband_velocities_[0] ? 0.0 : cmd_vel->twist.linear.x;
+  cmd_vel->twist.linear.y = fabs(cmd_vel->twist.linear.y) <
+    deadband_velocities_[1] ? 0.0 : cmd_vel->twist.linear.y;
+  cmd_vel->twist.angular.z = fabs(cmd_vel->twist.angular.z) <
+    deadband_velocities_[2] ? 0.0 : cmd_vel->twist.angular.z;
 
-  smoothed_cmd_pub_->publish(std::move(cmd_vel));
+  smoothed_cmd_pub_->publish(*cmd_vel);
 }
 
 rcl_interfaces::msg::SetParametersResult

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -217,7 +217,6 @@ void VelocitySmoother::inputCommandStampedCallback(
   } else {
     last_command_time_ = msg->header.stamp;
   }
-
 }
 
 void VelocitySmoother::inputCommandCallback(

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -23,6 +23,7 @@
 #include "nav2_velocity_smoother/velocity_smoother.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "geometry_msgs/msg/twist.hpp"
+#include "nav2_util/twist_subscriber.hpp"
 
 using namespace std::chrono_literals;
 
@@ -66,11 +67,14 @@ TEST(VelocitySmootherTest, openLoopTestTimer)
   smoother->activate(state);
 
   std::vector<double> linear_vels;
-  auto subscription = smoother->create_subscription<geometry_msgs::msg::Twist>(
+  auto subscription = nav2_util::TwistSubscriber(
+    smoother,
     "cmd_vel_smoothed",
     1,
     [&](geometry_msgs::msg::Twist::SharedPtr msg) {
       linear_vels.push_back(msg->linear.x);
+    }, [&](geometry_msgs::msg::TwistStamped::SharedPtr msg) {
+      linear_vels.push_back(msg->twist.linear.x);
     });
 
   // Send a velocity command
@@ -117,11 +121,14 @@ TEST(VelocitySmootherTest, approxClosedLoopTestTimer)
   smoother->activate(state);
 
   std::vector<double> linear_vels;
-  auto subscription = smoother->create_subscription<geometry_msgs::msg::Twist>(
+  auto subscription = nav2_util::TwistSubscriber(
+    smoother,
     "cmd_vel_smoothed",
     1,
     [&](geometry_msgs::msg::Twist::SharedPtr msg) {
       linear_vels.push_back(msg->linear.x);
+    }, [&](geometry_msgs::msg::TwistStamped::SharedPtr msg) {
+      linear_vels.push_back(msg->twist.linear.x);
     });
 
   auto odom_pub = smoother->create_publisher<nav_msgs::msg::Odometry>("odom", 1);

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -48,7 +48,7 @@ public:
 
   bool isOdomSmoother() {return odom_smoother_ ? true : false;}
   bool hasCommandMsg() {return last_command_time_.nanoseconds() != 0;}
-  geometry_msgs::msg::Twist::SharedPtr lastCommandMsg() {return command_;}
+  geometry_msgs::msg::TwistStamped::SharedPtr lastCommandMsg() {return command_;}
 
   void sendCommandMsg(geometry_msgs::msg::Twist::SharedPtr msg) {inputCommandCallback(msg);}
 };
@@ -573,7 +573,7 @@ TEST(VelocitySmootherTest, testCommandCallback)
   rclcpp::spin_some(smoother->get_node_base_interface());
 
   EXPECT_TRUE(smoother->hasCommandMsg());
-  EXPECT_EQ(smoother->lastCommandMsg()->linear.x, 100.0);
+  EXPECT_EQ(smoother->lastCommandMsg()->twist.linear.x, 100.0);
 }
 
 TEST(VelocitySmootherTest, testClosedLoopSub)


### PR DESCRIPTION
See https://github.com/ros-planning/navigation2/pull/3775; this is the same PR but opened back up. 


Replaces https://github.com/ros-planning/navigation2/pull/4031, by pulling in all 3 commits, as well as more changes since then. 

This has been tested by backporting to humble against ArduPilot by @srmainwaring. No bugs were reported.
