### PR TITLE
Prevent Nav2 AMCL from fixing srand48 seed

### DIFF
--- a/nav2_amcl/src/pf/pf_pdf.c
+++ b/nav2_amcl/src/pf/pf_pdf.c
@@ -36,9 +36,6 @@
 
 #include "nav2_amcl/portable_utils.hpp"
 
-// Random number generator seed value
-static unsigned int pf_pdf_seed;
-
 
 /**************************************************************************
  * Gaussian
@@ -66,7 +63,6 @@ pf_pdf_gaussian_t * pf_pdf_gaussian_alloc(pf_vector_t x, pf_matrix_t cx)
   // Initialize the random number generator
   // pdf->rng = gsl_rng_alloc(gsl_rng_taus);
   // gsl_rng_set(pdf->rng, ++pf_pdf_seed);
-  srand48(++pf_pdf_seed);
 
   return pdf;
 }


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu) |
| Robotic platform tested on |  |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

This is not so much a bug fix as it is a conversation starter. 

Basically, while AMCL does set the seed for its PRNG based on the current timestamp ([here](https://github.com/ros-planning/navigation/blob/9ad644198e132d0e950579a3bc72c29da46e60b0/amcl/src/amcl/pf/pf.c#L55)), it then overrides it with a (likely) fixed seed right after ([here](https://github.com/ros-planning/navigation/blob/9ad644198e132d0e950579a3bc72c29da46e60b0/amcl/src/amcl/pf/pf_pdf.c#L68)). This seems like a historical accident that's been around since the time [Player](https://github.com/playerproject/player)'s implementation of AMCL was first migrated to ROS.

I spotted this when I couldn't make sense out of the consistency in Nav2 AMCL's performance for a given dataset. Consistency is good, if your estimations are consistently good. It turns out seed variance translates into performance variance, and you may hit a tail of the error distribution for a fixed seed over a given trajectory. On the other hand, you may not, and allowing seeds to vary opens the door to sporadic performance degrade. 

So I don't know what the right answer is. Perhaps whoever migrated this didn't either. One way or another, I think it should be explicit in documentation somewhere. It can skew comparisons with other localization systems.

---

## Future work that may be required in bullet points

TBD

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
