### PR TITLE
[gazebo-migration] Make gazebo_ros_pkgs optional in nav2_system_tests

### DIFF
--- a/nav2_system_tests/CMakeLists.txt
+++ b/nav2_system_tests/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(visualization_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(gazebo_ros_pkgs REQUIRED)
+find_package(gazebo_ros_pkgs)
 find_package(nav2_amcl REQUIRED)
 find_package(nav2_lifecycle_manager REQUIRED)
 find_package(rclpy REQUIRED)
@@ -37,7 +37,6 @@ set(dependencies
   nav2_amcl
   nav2_lifecycle_manager
   nav2_behavior_tree
-  gazebo_ros_pkgs
   geometry_msgs
   std_msgs
   tf2_geometry_msgs
@@ -100,6 +99,13 @@ install(FILES src/error_codes/smoother_plugins.xml
     DESTINATION share/${PROJECT_NAME}
 )
 
+if(gazebo_ros_pkgs_FOUND)
+  list(APPEND dependencies gazebo_ros_pkgs)
+else()
+  message(AUTHOR_WARNING "Some system tests are disabled because Gazebo Classic was not found. "
+    "GZ_VERSION is set to '$ENV{GZ_VERSION}'.")
+endif()
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
@@ -109,19 +115,23 @@ if(BUILD_TESTING)
 
   add_subdirectory(src/behavior_tree)
   add_subdirectory(src/planning)
-  add_subdirectory(src/localization)
-  add_subdirectory(src/system)
-  add_subdirectory(src/system_failure)
   add_subdirectory(src/updown)
-  add_subdirectory(src/waypoint_follower)
-  add_subdirectory(src/gps_navigation)
-  add_subdirectory(src/behaviors/spin)
-  add_subdirectory(src/behaviors/wait)
-  add_subdirectory(src/behaviors/backup)
-  add_subdirectory(src/behaviors/drive_on_heading)
-  add_subdirectory(src/behaviors/assisted_teleop)
-  add_subdirectory(src/costmap_filters)
   add_subdirectory(src/error_codes)
+
+  if(gazebo_ros_pkgs_FOUND)
+    add_subdirectory(src/behaviors/assisted_teleop)
+    add_subdirectory(src/behaviors/backup)
+    add_subdirectory(src/behaviors/drive_on_heading)
+    add_subdirectory(src/behaviors/spin)
+    add_subdirectory(src/behaviors/wait)
+    add_subdirectory(src/costmap_filters)
+    add_subdirectory(src/gps_navigation)
+    add_subdirectory(src/localization)
+    add_subdirectory(src/system)
+    add_subdirectory(src/system_failure)
+    add_subdirectory(src/waypoint_follower)
+  endif()
+
   install(DIRECTORY maps DESTINATION share/${PROJECT_NAME})
 
 endif()

--- a/nav2_system_tests/README.md
+++ b/nav2_system_tests/README.md
@@ -12,3 +12,6 @@ Most tests in this package will spin up Gazebo instances of a robot in an enviro
 - Testing system failures are properly recorded and can be recovered from
 
 This is primarily for use in Nav2 CI to establish a high degree of maintainer confidence when merging in large architectural changes to the Nav2 project. However, this is also useful to test installs of Nav2 locally or for additional information.
+
+To disable system tests depending on Gazebo Classic, which is end of life January 29th, 2025,
+set the environment variable `GZ_VERSION` to your chosen GZ name, such as `ignition` or `harmonic`. 

--- a/nav2_system_tests/package.xml
+++ b/nav2_system_tests/package.xml
@@ -26,7 +26,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
-  <build_depend>gazebo_ros_pkgs</build_depend>
+  <build_depend condition="$GZ_VERSION == ''">gazebo_ros_pkgs</build_depend>
   <build_depend>launch_ros</build_depend>
   <build_depend>launch_testing</build_depend>
   <build_depend>nav2_planner</build_depend>
@@ -48,7 +48,7 @@
   <exec_depend>nav2_amcl</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
-  <exec_depend>gazebo_ros_pkgs</exec_depend>
+  <exec_depend condition="$GZ_VERSION == ''">gazebo_ros_pkgs</exec_depend>
   <exec_depend>navigation2</exec_depend>
   <exec_depend>lcov</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/nav2_system_tests/src/updown/test_updown_reliability
+++ b/nav2_system_tests/src/updown/test_updown_reliability
@@ -13,9 +13,8 @@ do
     # Bound the time of the bringup/shutdown in case it hangs
     timeout 100 ./start_nav2
 
-    # Make sure there aren't any stray gazebo or ros2 processes hanging around
+    # Make sure there aren't any stray ros2 processes hanging around
     # that were not properly killed by the launch script
-    #kill -9 $(pgrep gzserver) &> /dev/null
     kill -9 $(pgrep ros2) &> /dev/null
 
     echo "======== END OF RUN: $i =========="


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on |  Ubuntu 22|
| Robotic platform tested on | No |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Leverage common environment variable `GZ_VERSION` to control which gazebo is linked to in system_tests
* Add author warning when some system tests are disabled
* Making gazebo classic optional is one of the first things to help migration
* This allows users to build all of nav2 with new gazebo installed without any special flags
* Conditionally skip rosdep for gazebo classic based on the same environment variable
* This is backward compatible to `humble` and should not result in any change in behavior for existing CI
* Allow developers to use new gazebo binaries on their Ubuntu 22.04 OS, build nav2 from source, and not deal with the [dependency conflict](https://gazebosim.org/docs/garden/install_ubuntu#binary-installation-on-ubuntu).

## Description of documentation updates required from your changes

* If you like the proposal, I can add user docs

---

## Future work that may be required in bullet points

* Continue this pattern to make all of gazebo classic optional in NAV2
* Port user examples to new gazebo
* Port system tests to new gazebo
* Remove gazebo dependencies 11 entirely

## Screenshots of warnings when you are missing gazebo classic

These will show up on `colcon build` if you have the `GZ_VERSION` environment variable set to something other than an empty string.

![image](https://github.com/ros-planning/navigation2/assets/25047695/c4f9c890-4b24-4d3d-8b61-043022584220)

![image](https://github.com/ros-planning/navigation2/assets/25047695/15e2fe0f-b24d-4bbc-b20c-1815321a5cb8)


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
