### PR TITLE
Critical fix for path tracking MPPI in new path align critic

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
@@ -698,7 +698,7 @@ inline unsigned int removePosesAfterFirstInversion(nav_msgs::msg::Path & path)
 inline size_t findClosestPathPt(const std::vector<float> & vec, float dist, size_t init = 0)
 {
   auto iter = std::lower_bound(vec.begin() + init, vec.end(), dist);
-  if (iter == vec.begin()) {
+  if (iter == vec.begin() + init) {
     return 0;
   }
   if (dist - *(iter - 1) < *iter - dist) {


### PR DESCRIPTION
This bug created wobbling behaviors while I was trying to optimize the performance of finding the newest path points via caching the last path point used to initialize the next. However, I missed an important condition that caused very bad static wobbles

Will need to be updated for any users, very important 