### PR TITLE
Use ament_export_targets for all targets in nav2_costmap_2d

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -26,16 +26,9 @@ find_package(visualization_msgs REQUIRED)
 find_package(angles REQUIRED)
 
 remove_definitions(-DDISABLE_LIBUSB-1.0)
-find_package(Eigen3 REQUIRED)
+find_package(Eigen3 3.3 REQUIRED)
 
 nav2_package()
-
-include_directories(
-  include
-  ${EIGEN3_INCLUDE_DIRS}
-)
-
-add_definitions(${EIGEN3_DEFINITIONS})
 
 add_library(nav2_costmap_2d_core SHARED
   src/costmap_2d.cpp
@@ -50,6 +43,13 @@ add_library(nav2_costmap_2d_core SHARED
   src/clear_costmap_service.cpp
   src/footprint_collision_checker.cpp
   plugins/costmap_filters/costmap_filter.cpp
+)
+add_library(${PROJECT_NAME}::nav2_costmap_2d_core ALIAS nav2_costmap_2d_core)
+
+target_include_directories(nav2_costmap_2d_core
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
 
 set(dependencies
@@ -78,6 +78,7 @@ set(dependencies
 ament_target_dependencies(nav2_costmap_2d_core
   ${dependencies}
 )
+target_link_libraries(nav2_costmap_2d_core Eigen3::Eigen)
 
 add_library(layers SHARED
   plugins/inflation_layer.cpp
@@ -88,11 +89,12 @@ add_library(layers SHARED
   plugins/range_sensor_layer.cpp
   plugins/denoise_layer.cpp
 )
+add_library(${PROJECT_NAME}::layers ALIAS layers)
 ament_target_dependencies(layers
   ${dependencies}
 )
 target_link_libraries(layers
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 add_library(filters SHARED
@@ -100,11 +102,14 @@ add_library(filters SHARED
   plugins/costmap_filters/speed_filter.cpp
   plugins/costmap_filters/binary_filter.cpp
 )
+add_library(${PROJECT_NAME}::filters ALIAS filters)
+
+
 ament_target_dependencies(filters
   ${dependencies}
 )
 target_link_libraries(filters
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 add_library(nav2_costmap_2d_client SHARED
@@ -112,18 +117,19 @@ add_library(nav2_costmap_2d_client SHARED
   src/costmap_subscriber.cpp
   src/costmap_topic_collision_checker.cpp
 )
+add_library(${PROJECT_NAME}::nav2_costmap_2d_client ALIAS nav2_costmap_2d_client)
 
 ament_target_dependencies(nav2_costmap_2d_client
   ${dependencies}
 )
 
 target_link_libraries(nav2_costmap_2d_client
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 add_executable(nav2_costmap_2d_markers src/costmap_2d_markers.cpp)
 target_link_libraries(nav2_costmap_2d_markers
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 ament_target_dependencies(nav2_costmap_2d_markers
@@ -132,7 +138,7 @@ ament_target_dependencies(nav2_costmap_2d_markers
 
 add_executable(nav2_costmap_2d_cloud src/costmap_2d_cloud.cpp)
 target_link_libraries(nav2_costmap_2d_cloud
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 add_executable(nav2_costmap_2d src/costmap_2d_node.cpp)
@@ -141,26 +147,24 @@ ament_target_dependencies(nav2_costmap_2d
 )
 
 target_link_libraries(nav2_costmap_2d
-  nav2_costmap_2d_core
-  layers
-  filters
+  ${PROJECT_NAME}::nav2_costmap_2d_core
+  ${PROJECT_NAME}::layers
+  ${PROJECT_NAME}::filters
 )
 
 install(TARGETS
-  nav2_costmap_2d_core
   layers
   filters
+  nav2_costmap_2d_core
   nav2_costmap_2d_client
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
-install(TARGETS
-  nav2_costmap_2d
-  nav2_costmap_2d_markers
-  nav2_costmap_2d_cloud
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+install(TARGETS nav2_costmap_2d_markers nav2_costmap_2d_cloud nav2_costmap_2d
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 install(FILES costmap_plugins.xml
@@ -168,7 +172,7 @@ install(FILES costmap_plugins.xml
 )
 
 install(DIRECTORY include/
-  DESTINATION include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
@@ -183,8 +187,7 @@ if(BUILD_TESTING)
   pluginlib_export_plugin_description_file(nav2_costmap_2d test/regression/order_layer.xml)
 endif()
 
-ament_export_include_directories(include)
-ament_export_libraries(layers filters nav2_costmap_2d_core nav2_costmap_2d_client)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${dependencies})
 pluginlib_export_plugin_description_file(nav2_costmap_2d costmap_plugins.xml)
 ament_package()

--- a/nav2_costmap_2d/test/integration/CMakeLists.txt
+++ b/nav2_costmap_2d/test/integration/CMakeLists.txt
@@ -1,90 +1,66 @@
 ament_add_gtest_executable(footprint_tests_exec
   footprint_tests.cpp
 )
-ament_target_dependencies(footprint_tests_exec
-  ${dependencies}
-)
 target_link_libraries(footprint_tests_exec
-  nav2_costmap_2d_core
-  layers
+  ${PROJECT_NAME}::nav2_costmap_2d_core
+  ${PROJECT_NAME}::layers
 )
 
 ament_add_gtest_executable(test_collision_checker_exec
   test_costmap_topic_collision_checker.cpp
 )
-ament_target_dependencies(test_collision_checker_exec
-  ${dependencies}
-)
 target_link_libraries(test_collision_checker_exec
-  nav2_costmap_2d_core
-  nav2_costmap_2d_client
-  layers
+  ${PROJECT_NAME}::nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_client
+  ${PROJECT_NAME}::layers
 )
 
 ament_add_gtest_executable(inflation_tests_exec
   inflation_tests.cpp
 )
-ament_target_dependencies(inflation_tests_exec
-  ${dependencies}
-)
 target_link_libraries(inflation_tests_exec
-  nav2_costmap_2d_core
-  layers
+  ${PROJECT_NAME}::nav2_costmap_2d_core
+  ${PROJECT_NAME}::layers
 )
 
 ament_add_gtest_executable(obstacle_tests_exec
   obstacle_tests.cpp
 )
-ament_target_dependencies(obstacle_tests_exec
-  ${dependencies}
-)
 target_link_libraries(obstacle_tests_exec
-  nav2_costmap_2d_core
-  layers
+  ${PROJECT_NAME}::nav2_costmap_2d_core
+  ${PROJECT_NAME}::layers
 )
 
 ament_add_gtest_executable(range_tests_exec
   range_tests.cpp
 )
-ament_target_dependencies(range_tests_exec
-  ${dependencies}
-)
 target_link_libraries(range_tests_exec
-  nav2_costmap_2d_core
-  layers
+  ${PROJECT_NAME}::nav2_costmap_2d_core
+  ${PROJECT_NAME}::layers
 )
 
 ament_add_gtest(dyn_params_tests
   dyn_params_tests.cpp
 )
-ament_target_dependencies(dyn_params_tests
-  ${dependencies}
-)
 target_link_libraries(dyn_params_tests
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 ament_add_gtest_executable(test_costmap_publisher_exec
     test_costmap_2d_publisher.cpp
 )
-ament_target_dependencies(test_costmap_publisher_exec
-    ${dependencies}
-)
 target_link_libraries(test_costmap_publisher_exec
-    nav2_costmap_2d_core
-    nav2_costmap_2d_client
-    layers
+    ${PROJECT_NAME}::nav2_costmap_2d_core
+    ${PROJECT_NAME}::nav2_costmap_2d_client
+    ${PROJECT_NAME}::layers
 )
 
 ament_add_gtest_executable(test_costmap_subscriber_exec
 test_costmap_subscriber.cpp
 )
-ament_target_dependencies(test_costmap_subscriber_exec
-    ${dependencies}
-)
 target_link_libraries(test_costmap_subscriber_exec
-    nav2_costmap_2d_core
-    nav2_costmap_2d_client
+    ${PROJECT_NAME}::nav2_costmap_2d_core
+    ${PROJECT_NAME}::nav2_costmap_2d_client
 )
 
 ament_add_test(test_collision_checker
@@ -166,6 +142,6 @@ ament_add_test(test_costmap_subscriber_exec
 #   ${dependencies}
 # )
 # target_link_libraries(costmap_tester
-#   nav2_costmap_2d_core
+#   ${PROJECT_NAME}::nav2_costmap_2d_core
 #   layers
 # )

--- a/nav2_costmap_2d/test/regression/CMakeLists.txt
+++ b/nav2_costmap_2d/test/regression/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Bresenham2D corner cases test
 ament_add_gtest(costmap_bresenham_2d costmap_bresenham_2d.cpp)
 target_link_libraries(costmap_bresenham_2d
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 # OrderLayer for checking Costmap2D plugins API calling order
@@ -11,7 +11,7 @@ ament_target_dependencies(order_layer
   ${dependencies}
 )
 target_link_libraries(order_layer
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 install(TARGETS
   order_layer
@@ -23,5 +23,5 @@ install(TARGETS
 # Costmap2D plugins API calling order test
 ament_add_gtest(plugin_api_order plugin_api_order.cpp)
 target_link_libraries(plugin_api_order
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )

--- a/nav2_costmap_2d/test/unit/CMakeLists.txt
+++ b/nav2_costmap_2d/test/unit/CMakeLists.txt
@@ -1,57 +1,58 @@
 ament_add_gtest(collision_footprint_test footprint_collision_checker_test.cpp)
 target_link_libraries(collision_footprint_test
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 ament_add_gtest(costmap_convesion_test costmap_conversion_test.cpp)
 target_link_libraries(costmap_convesion_test
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 ament_add_gtest(declare_parameter_test declare_parameter_test.cpp)
 target_link_libraries(declare_parameter_test
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 ament_add_gtest(costmap_filter_test costmap_filter_test.cpp)
 target_link_libraries(costmap_filter_test
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 ament_add_gtest(keepout_filter_test keepout_filter_test.cpp)
 target_link_libraries(keepout_filter_test
-  nav2_costmap_2d_core
-  filters
+  ${PROJECT_NAME}::nav2_costmap_2d_core
+  ${PROJECT_NAME}::filters
 )
 
 ament_add_gtest(speed_filter_test speed_filter_test.cpp)
 target_link_libraries(speed_filter_test
-  nav2_costmap_2d_core
-  filters
+  ${PROJECT_NAME}::nav2_costmap_2d_core
+  ${PROJECT_NAME}::filters
 )
 
 ament_add_gtest(binary_filter_test binary_filter_test.cpp)
 target_link_libraries(binary_filter_test
-  nav2_costmap_2d_core
-  filters
+  ${PROJECT_NAME}::nav2_costmap_2d_core
+  ${PROJECT_NAME}::filters
 )
 
 ament_add_gtest(copy_window_test copy_window_test.cpp)
 target_link_libraries(copy_window_test
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 ament_add_gtest(costmap_filter_service_test costmap_filter_service_test.cpp)
 target_link_libraries(costmap_filter_service_test
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )
 
 ament_add_gtest(denoise_layer_test denoise_layer_test.cpp image_test.cpp image_processing_test.cpp)
 target_link_libraries(denoise_layer_test
-  nav2_costmap_2d_core layers
+  ${PROJECT_NAME}::nav2_costmap_2d_core
+  ${PROJECT_NAME}::layers
 )
 
 ament_add_gtest(lifecycle_test lifecycle_test.cpp)
 target_link_libraries(lifecycle_test
-  nav2_costmap_2d_core
+  ${PROJECT_NAME}::nav2_costmap_2d_core
 )


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  https://github.com/ANYbotics/grid_map/issues/403 |
| Primary OS tested on |  Ubuntu 22.04  |
| Robotic platform tested on | N/A ||
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Switch nav2_costmap_2d to use the latest recommended usage of ament_cmake with ament_export_targets.
* Export includes directories with targets that use it
* Add support for consuming packages to link against the `nav2_costmap_2d::nav2_costmap_2d_core` target
* Use ALIAS library for internal linkage when possible on all libraries
* Don't use ament_target_dependencies when already linking to core because it's unnecessary

## Description of documentation updates required from your changes

N/A

---

## Future work that may be required in bullet points

* Concerting more of NAV2 to abide by the Ament CMake recommendations.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
