### PR TITLE
Added cast to float to getClosestAngularBin return for behavior consistency

### DIFF
--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -332,7 +332,7 @@ MotionPoses HybridMotionTable::getProjections(const NodeHybrid * node)
 
 unsigned int HybridMotionTable::getClosestAngularBin(const double & theta)
 {
-  return static_cast<unsigned int>(floor(theta / bin_size));
+  return static_cast<unsigned int>(floor(static_cast<float>(theta) / bin_size));
 }
 
 float HybridMotionTable::getAngleFromBin(const unsigned int & bin_idx)

--- a/nav2_smac_planner/test/test_nodehybrid.cpp
+++ b/nav2_smac_planner/test/test_nodehybrid.cpp
@@ -374,3 +374,33 @@ TEST(NodeHybridTest, test_node_reeds_neighbors)
   // should be empty since totally invalid
   EXPECT_EQ(neighbors.size(), 0u);
 }
+
+TEST(NodeHybridTest, basic_get_closest_angular_bin_noPi_test)
+{
+  // Tests to check getClosestAngularBin behavior for different input types
+  nav2_smac_planner::HybridMotionTable motion_table;
+
+  {
+    motion_table.bin_size = 3.1415926;
+    double test_theta = 3.1415926;
+    unsigned int expected_angular_bin = 1;
+    unsigned int calculated_angular_bin = motion_table.getClosestAngularBin(test_theta);
+    EXPECT_EQ(expected_angular_bin, calculated_angular_bin);
+  }
+
+  {
+    motion_table.bin_size = M_PI;
+    double test_theta = M_PI;
+    unsigned int expected_angular_bin = 1;
+    unsigned int calculated_angular_bin = motion_table.getClosestAngularBin(test_theta);
+    EXPECT_EQ(expected_angular_bin, calculated_angular_bin);
+  }
+
+  {
+    motion_table.bin_size = M_PI;
+    float test_theta = M_PI;
+    unsigned int expected_angular_bin = 1;
+    unsigned int calculated_angular_bin = motion_table.getClosestAngularBin(test_theta);
+    EXPECT_EQ(expected_angular_bin, calculated_angular_bin);
+  }
+}

--- a/nav2_smac_planner/test/test_nodehybrid.cpp
+++ b/nav2_smac_planner/test/test_nodehybrid.cpp
@@ -375,7 +375,7 @@ TEST(NodeHybridTest, test_node_reeds_neighbors)
   EXPECT_EQ(neighbors.size(), 0u);
 }
 
-TEST(NodeHybridTest, basic_get_closest_angular_bin_noPi_test)
+TEST(NodeHybridTest, basic_get_closest_angular_bin_test)
 {
   // Tests to check getClosestAngularBin behavior for different input types
   nav2_smac_planner::HybridMotionTable motion_table;


### PR DESCRIPTION


<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4094 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* This small fix improves the behavioral consistency of the NodeHybrid::getClosestAngularBin method.
* Unit tests of the method are added.

## Description of documentation updates required from your changes

* N/A

---

## Future work that may be required in bullet points

* N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
