### PR TITLE
behavior_tree: migration to BT.CPP 4.5.x

### DIFF
--- a/nav2_behavior_tree/CMakeLists.txt
+++ b/nav2_behavior_tree/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
-find_package(behaviortree_cpp_v3 REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -34,7 +34,7 @@ set(dependencies
   sensor_msgs
   nav2_msgs
   nav_msgs
-  behaviortree_cpp_v3
+  behaviortree_cpp
   tf2
   tf2_ros
   tf2_geometry_msgs

--- a/nav2_behavior_tree/README.md
+++ b/nav2_behavior_tree/README.md
@@ -41,7 +41,7 @@ BehaviorTreeEngine::BehaviorTreeEngine()
 Once a new node is registered with the factory, it is now available to the BehaviorTreeEngine and can be used in Behavior Trees. For example, the following simple XML description of a BT shows the FollowPath node in use:
 
 ```XML
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4">
   <BehaviorTree ID="MainTree">
     <Sequence name="root">
       <ComputePathToPose goal="${goal}"/>

--- a/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
@@ -20,9 +20,9 @@
 #include <string>
 #include <vector>
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
-#include "behaviortree_cpp_v3/bt_factory.h"
-#include "behaviortree_cpp_v3/xml_parsing.h"
+#include "behaviortree_cpp/behavior_tree.h"
+#include "behaviortree_cpp/bt_factory.h"
+#include "behaviortree_cpp/xml_parsing.h"
 
 #include "rclcpp/rclcpp.hpp"
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -324,8 +324,6 @@ public:
 
       on_cancelled();
     }
-
-    setStatus(BT::NodeStatus::IDLE);
   }
 
 protected:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -374,12 +374,14 @@ protected:
         if (this->goal_handle_->get_goal_id() == result.goal_id) {
           goal_result_available_ = true;
           result_ = result;
+          emitWakeUpSignal();
         }
       };
     send_goal_options.feedback_callback =
       [this](typename rclcpp_action::ClientGoalHandle<ActionT>::SharedPtr,
         const std::shared_ptr<const typename ActionT::Feedback> feedback) {
         feedback_ = feedback;
+        emitWakeUpSignal();
       };
 
     future_goal_handle_ = std::make_shared<

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <chrono>
 
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 #include "nav2_util/node_utils.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "nav2_behavior_tree/bt_utils.hpp"
@@ -434,9 +434,9 @@ protected:
   void increment_recovery_count()
   {
     int recovery_count = 0;
-    config().blackboard->template get<int>("number_recoveries", recovery_count);  // NOLINT
+    [[maybe_unused]] auto res = config().blackboard->get("number_recoveries", recovery_count);  // NOLINT
     recovery_count += 1;
-    config().blackboard->template set<int>("number_recoveries", recovery_count);  // NOLINT
+    config().blackboard->set("number_recoveries", recovery_count);  // NOLINT
   }
 
   std::string action_name_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -324,6 +324,10 @@ public:
 
       on_cancelled();
     }
+
+    // this is probably redundant, since the parent node
+    // is supposed to call it, but we keep it, just in case
+    resetStatus();
   }
 
 protected:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -188,7 +188,7 @@ public:
   BT::NodeStatus tick() override
   {
     // first step to be done only at the beginning of the Action
-    if (status() == BT::NodeStatus::IDLE) {
+    if (!BT::isStatusActive(status())) {
       // setting the status to RUNNING to notify the BT Loggers (if any)
       setStatus(BT::NodeStatus::RUNNING);
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -237,8 +237,8 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
   // Create the Behavior Tree from the XML input
   try {
     tree_ = bt_->createTreeFromFile(filename, blackboard_);
-    for (auto& subtree: tree_.subtrees) {
-      auto& blackboard = subtree->blackboard;
+    for (auto & subtree: tree_.subtrees) {
+      auto & blackboard = subtree->blackboard;
       blackboard->set("node", client_node_);
       blackboard->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);
       blackboard->set<std::chrono::milliseconds>("bt_loop_duration", bt_loop_duration_);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -237,7 +237,8 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
   // Create the Behavior Tree from the XML input
   try {
     tree_ = bt_->createTreeFromFile(filename, blackboard_);
-    for (auto & blackboard : tree_.blackboard_stack) {
+    for (auto& subtree: tree_.subtrees) {
+      auto& blackboard = subtree->blackboard;
       blackboard->set("node", client_node_);
       blackboard->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);
       blackboard->set<std::chrono::milliseconds>("bt_loop_duration", bt_loop_duration_);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -237,7 +237,7 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
   // Create the Behavior Tree from the XML input
   try {
     tree_ = bt_->createTreeFromFile(filename, blackboard_);
-    for (auto & subtree: tree_.subtrees) {
+    for (auto & subtree : tree_.subtrees) {
       auto & blackboard = subtree->blackboard;
       blackboard->set("node", client_node_);
       blackboard->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_cancel_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_cancel_action_node.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <chrono>
 
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 #include "nav2_util/node_utils.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "nav2_behavior_tree/bt_utils.hpp"

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -157,7 +157,6 @@ public:
   void halt() override
   {
     request_sent_ = false;
-    setStatus(BT::NodeStatus::IDLE);
   }
 
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <chrono>
 
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 #include "nav2_util/node_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_behavior_tree/bt_utils.hpp"
@@ -230,9 +230,9 @@ protected:
   void increment_recovery_count()
   {
     int recovery_count = 0;
-    config().blackboard->template get<int>("number_recoveries", recovery_count);  // NOLINT
+    [[maybe_unused]] auto res = config().blackboard->get("number_recoveries", recovery_count);  // NOLINT
     recovery_count += 1;
-    config().blackboard->template set<int>("number_recoveries", recovery_count);  // NOLINT
+    config().blackboard->set("number_recoveries", recovery_count);  // NOLINT
   }
 
   std::string service_name_, service_node_name_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -157,6 +157,7 @@ public:
   void halt() override
   {
     request_sent_ = false;
+    resetStatus();
   }
 
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_utils.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_utils.hpp
@@ -20,7 +20,7 @@
 
 #include "rclcpp/time.hpp"
 #include "rclcpp/node.hpp"
-#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp/behavior_tree.h"
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/controller_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/controller_selector_node.hpp
@@ -21,7 +21,7 @@
 
 #include "std_msgs/msg/string.hpp"
 
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 
 #include "rclcpp/rclcpp.hpp"
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/goal_checker_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/goal_checker_selector_node.hpp
@@ -21,7 +21,7 @@
 
 #include "std_msgs/msg/string.hpp"
 
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 
 #include "rclcpp/rclcpp.hpp"
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/planner_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/planner_selector_node.hpp
@@ -21,7 +21,7 @@
 
 #include "std_msgs/msg/string.hpp"
 
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 
 #include "rclcpp/rclcpp.hpp"
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/progress_checker_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/progress_checker_selector_node.hpp
@@ -20,7 +20,7 @@
 
 #include "std_msgs/msg/string.hpp"
 
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 
 #include "rclcpp/rclcpp.hpp"
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_passed_goals_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/remove_passed_goals_action.hpp
@@ -22,7 +22,7 @@
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smoother_selector_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/smoother_selector_node.hpp
@@ -21,7 +21,7 @@
 
 #include "std_msgs/msg/string.hpp"
 
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 
 #include "rclcpp/rclcpp.hpp"
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_action.hpp
@@ -21,7 +21,7 @@
 
 #include "nav_msgs/msg/path.hpp"
 
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_local_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_local_action.hpp
@@ -22,7 +22,7 @@
 
 #include "nav_msgs/msg/path.hpp"
 
-#include "behaviortree_cpp_v3/action_node.h"
+#include "behaviortree_cpp/action_node.h"
 #include "tf2_ros/buffer.h"
 
 namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.hpp
@@ -21,7 +21,7 @@
 #include <set>
 
 #include "rclcpp/rclcpp.hpp"
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/distance_traveled_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/distance_traveled_condition.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <memory>
 
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/globally_updated_goal_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/globally_updated_goal_condition.hpp
@@ -20,7 +20,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_reached_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_reached_condition.hpp
@@ -19,7 +19,7 @@
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 #include "tf2_ros/buffer.h"
 
 namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_updated_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_updated_condition.hpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
 namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/initial_pose_received_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/initial_pose_received_condition.hpp
@@ -16,7 +16,7 @@
 #define NAV2_BEHAVIOR_TREE__PLUGINS__CONDITION__INITIAL_POSE_RECEIVED_CONDITION_HPP_
 
 #include <string>
-#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp/behavior_tree.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.hpp
@@ -21,7 +21,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/battery_state.hpp"
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_low_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_battery_low_condition.hpp
@@ -22,7 +22,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/battery_state.hpp"
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_path_valid_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_path_valid_condition.hpp
@@ -19,7 +19,7 @@
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_msgs/srv/is_path_valid.hpp"
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_stuck_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_stuck_condition.hpp
@@ -20,7 +20,7 @@
 #include <deque>
 
 #include "rclcpp/rclcpp.hpp"
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 #include "nav_msgs/msg/odometry.hpp"
 
 namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/path_expiring_timer_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/path_expiring_timer_condition.hpp
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 #include "nav_msgs/msg/path.hpp"
 
 namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/time_expired_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/time_expired_condition.hpp
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/transform_available_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/transform_available_condition.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 #include "tf2_ros/buffer.h"
 
 namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/pipeline_sequence.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/pipeline_sequence.hpp
@@ -16,8 +16,8 @@
 #define NAV2_BEHAVIOR_TREE__PLUGINS__CONTROL__PIPELINE_SEQUENCE_HPP_
 
 #include <string>
-#include "behaviortree_cpp_v3/control_node.h"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/control_node.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
@@ -16,7 +16,7 @@
 #define NAV2_BEHAVIOR_TREE__PLUGINS__CONTROL__RECOVERY_NODE_HPP_
 
 #include <string>
-#include "behaviortree_cpp_v3/control_node.h"
+#include "behaviortree_cpp/control_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
@@ -17,8 +17,8 @@
 
 #include <string>
 
-#include "behaviortree_cpp_v3/control_node.h"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/control_node.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
@@ -87,7 +87,6 @@ public:
 private:
   unsigned int current_child_idx_{0};
   unsigned int num_failed_children_{0};
-  unsigned int num_skipped_children_{0};
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/round_robin_node.hpp
@@ -87,6 +87,7 @@ public:
 private:
   unsigned int current_child_idx_{0};
   unsigned int num_failed_children_{0};
+  unsigned int num_skipped_children_{0};
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/distance_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/distance_controller.hpp
@@ -22,7 +22,7 @@
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "tf2_ros/buffer.h"
 
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updated_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updated_controller.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp
@@ -21,7 +21,7 @@
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 
 #include "rclcpp/rclcpp.hpp"
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.hpp
@@ -21,7 +21,7 @@
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav_msgs/msg/path.hpp"
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 #include "rclcpp/rclcpp.hpp"
 
 namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/rate_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/rate_controller.hpp
@@ -18,7 +18,7 @@
 #include <chrono>
 #include <string>
 
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/single_trigger_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/single_trigger_node.hpp
@@ -18,7 +18,7 @@
 #include <chrono>
 #include <string>
 
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/speed_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/speed_controller.hpp
@@ -24,7 +24,7 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "nav2_util/odometry_utils.hpp"
 
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/ros_topic_logger.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/ros_topic_logger.hpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <utility>
 
-#include "behaviortree_cpp_v3/loggers/abstract_logger.h"
+#include "behaviortree_cpp/loggers/abstract_logger.h"
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_msgs/msg/behavior_tree_log.hpp"
 #include "nav2_msgs/msg/behavior_tree_status_change.h"

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -4,7 +4,7 @@
   please refer to the groot_instructions.md and REAMDE.md respectively located in the
   nav2_behavior_tree package.
 -->
-<root>
+<root BTCPP_format="4">
   <TreeNodesModel>
     <!-- ############################### ACTION NODES ################################# -->
     <Action ID="BackUp">

--- a/nav2_behavior_tree/package.xml
+++ b/nav2_behavior_tree/package.xml
@@ -17,7 +17,7 @@
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_action</build_depend>
   <build_depend>rclcpp_lifecycle</build_depend>
-  <build_depend>behaviortree_cpp_v3</build_depend>
+  <build_depend>behaviortree_cpp</build_depend>
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -36,7 +36,7 @@
   <exec_depend>rclcpp_action</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>behaviortree_cpp_v3</exec_depend>
+  <exec_depend>behaviortree_cpp</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>

--- a/nav2_behavior_tree/plugins/action/assisted_teleop_action.cpp
+++ b/nav2_behavior_tree/plugins/action/assisted_teleop_action.cpp
@@ -70,7 +70,7 @@ BT::NodeStatus AssistedTeleopAction::on_cancelled()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/assisted_teleop_cancel_node.cpp
+++ b/nav2_behavior_tree/plugins/action/assisted_teleop_cancel_node.cpp
@@ -32,7 +32,7 @@ AssistedTeleopCancel::AssistedTeleopCancel(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/back_up_action.cpp
+++ b/nav2_behavior_tree/plugins/action/back_up_action.cpp
@@ -76,7 +76,7 @@ BT::NodeStatus BackUpAction::on_cancelled()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/back_up_cancel_node.cpp
+++ b/nav2_behavior_tree/plugins/action/back_up_cancel_node.cpp
@@ -32,7 +32,7 @@ BackUpCancel::BackUpCancel(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/clear_costmap_service.cpp
+++ b/nav2_behavior_tree/plugins/action/clear_costmap_service.cpp
@@ -60,7 +60,7 @@ void ClearCostmapAroundRobotService::on_tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::ClearEntireCostmapService>("ClearEntireCostmap");

--- a/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_through_poses_action.cpp
@@ -65,7 +65,7 @@ BT::NodeStatus ComputePathThroughPosesAction::on_cancelled()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
@@ -71,7 +71,7 @@ void ComputePathToPoseAction::halt()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/controller_cancel_node.cpp
+++ b/nav2_behavior_tree/plugins/action/controller_cancel_node.cpp
@@ -32,7 +32,7 @@ ControllerCancel::ControllerCancel(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/controller_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/controller_selector_node.cpp
@@ -84,7 +84,7 @@ ControllerSelector::callbackControllerSelect(const std_msgs::msg::String::Shared
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::ControllerSelector>("ControllerSelector");

--- a/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
+++ b/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
@@ -74,7 +74,7 @@ BT::NodeStatus DriveOnHeadingAction::on_cancelled()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/drive_on_heading_cancel_node.cpp
+++ b/nav2_behavior_tree/plugins/action/drive_on_heading_cancel_node.cpp
@@ -32,7 +32,7 @@ DriveOnHeadingCancel::DriveOnHeadingCancel(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/follow_path_action.cpp
@@ -96,7 +96,7 @@ void FollowPathAction::on_wait_for_result(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/goal_checker_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/goal_checker_selector_node.cpp
@@ -75,7 +75,7 @@ GoalCheckerSelector::callbackGoalCheckerSelect(const std_msgs::msg::String::Shar
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::GoalCheckerSelector>("GoalCheckerSelector");

--- a/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_through_poses_action.cpp
@@ -61,7 +61,7 @@ BT::NodeStatus NavigateThroughPosesAction::on_cancelled()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
@@ -59,7 +59,7 @@ BT::NodeStatus NavigateToPoseAction::on_cancelled()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/planner_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/planner_selector_node.cpp
@@ -84,7 +84,7 @@ PlannerSelector::callbackPlannerSelect(const std_msgs::msg::String::SharedPtr ms
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::PlannerSelector>("PlannerSelector");

--- a/nav2_behavior_tree/plugins/action/progress_checker_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/progress_checker_selector_node.cpp
@@ -74,7 +74,7 @@ ProgressCheckerSelector::callbackProgressCheckerSelect(const std_msgs::msg::Stri
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::ProgressCheckerSelector>("ProgressCheckerSelector");

--- a/nav2_behavior_tree/plugins/action/reinitialize_global_localization_service.cpp
+++ b/nav2_behavior_tree/plugins/action/reinitialize_global_localization_service.cpp
@@ -26,7 +26,7 @@ ReinitializeGlobalLocalizationService::ReinitializeGlobalLocalizationService(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::ReinitializeGlobalLocalizationService>(

--- a/nav2_behavior_tree/plugins/action/remove_passed_goals_action.cpp
+++ b/nav2_behavior_tree/plugins/action/remove_passed_goals_action.cpp
@@ -89,7 +89,7 @@ inline BT::NodeStatus RemovePassedGoals::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::RemovePassedGoals>("RemovePassedGoals");

--- a/nav2_behavior_tree/plugins/action/smooth_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/smooth_path_action.cpp
@@ -64,7 +64,7 @@ BT::NodeStatus SmoothPathAction::on_cancelled()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/smoother_selector_node.cpp
+++ b/nav2_behavior_tree/plugins/action/smoother_selector_node.cpp
@@ -85,7 +85,7 @@ SmootherSelector::callbackSmootherSelect(const std_msgs::msg::String::SharedPtr 
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::SmootherSelector>("SmootherSelector");

--- a/nav2_behavior_tree/plugins/action/spin_action.cpp
+++ b/nav2_behavior_tree/plugins/action/spin_action.cpp
@@ -72,7 +72,7 @@ BT::NodeStatus SpinAction::on_cancelled()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/spin_cancel_node.cpp
+++ b/nav2_behavior_tree/plugins/action/spin_cancel_node.cpp
@@ -32,7 +32,7 @@ SpinCancel::SpinCancel(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/truncate_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/truncate_path_action.cpp
@@ -20,7 +20,7 @@
 #include "nav_msgs/msg/path.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_util/geometry_utils.hpp"
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 
 #include "nav2_behavior_tree/plugins/action/truncate_path_action.hpp"
 
@@ -82,7 +82,7 @@ inline BT::NodeStatus TruncatePath::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::TruncatePath>("TruncatePath");

--- a/nav2_behavior_tree/plugins/action/truncate_path_local_action.cpp
+++ b/nav2_behavior_tree/plugins/action/truncate_path_local_action.cpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
@@ -150,7 +150,7 @@ TruncatePathLocal::poseDistance(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory) {
   factory.registerNodeType<nav2_behavior_tree::TruncatePathLocal>(
     "TruncatePathLocal");

--- a/nav2_behavior_tree/plugins/action/wait_action.cpp
+++ b/nav2_behavior_tree/plugins/action/wait_action.cpp
@@ -56,7 +56,7 @@ void WaitAction::on_tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/action/wait_cancel_node.cpp
+++ b/nav2_behavior_tree/plugins/action/wait_cancel_node.cpp
@@ -32,7 +32,7 @@ WaitCancel::WaitCancel(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   BT::NodeBuilder builder =

--- a/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.cpp
@@ -14,7 +14,7 @@
 
 #include "nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::AreErrorCodesPresent>(

--- a/nav2_behavior_tree/plugins/condition/distance_traveled_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/distance_traveled_condition.cpp
@@ -92,7 +92,7 @@ BT::NodeStatus DistanceTraveledCondition::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::DistanceTraveledCondition>("DistanceTraveled");

--- a/nav2_behavior_tree/plugins/condition/distance_traveled_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/distance_traveled_condition.cpp
@@ -56,7 +56,7 @@ BT::NodeStatus DistanceTraveledCondition::tick()
     initialize();
   }
 
-  if (status() == BT::NodeStatus::IDLE) {
+  if (!BT::isStatusActive(status())) {
     if (!nav2_util::getCurrentPose(
         start_pose_, *tf_, global_frame_, robot_base_frame_,
         transform_tolerance_))

--- a/nav2_behavior_tree/plugins/condition/globally_updated_goal_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/globally_updated_goal_condition.cpp
@@ -55,7 +55,7 @@ BT::NodeStatus GloballyUpdatedGoalCondition::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::GloballyUpdatedGoalCondition>("GlobalUpdatedGoal");

--- a/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
@@ -90,7 +90,7 @@ bool GoalReachedCondition::isGoalReached()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::GoalReachedCondition>("GoalReached");

--- a/nav2_behavior_tree/plugins/condition/goal_updated_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_updated_condition.cpp
@@ -50,7 +50,7 @@ BT::NodeStatus GoalUpdatedCondition::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::GoalUpdatedCondition>("GoalUpdated");

--- a/nav2_behavior_tree/plugins/condition/goal_updated_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_updated_condition.cpp
@@ -28,7 +28,7 @@ GoalUpdatedCondition::GoalUpdatedCondition(
 
 BT::NodeStatus GoalUpdatedCondition::tick()
 {
-  if (status() == BT::NodeStatus::IDLE) {
+  if (!BT::isStatusActive(status())) {
     BT::getInputOrBlackboard("goals", goals_);
     BT::getInputOrBlackboard("goal", goal_);
     return BT::NodeStatus::FAILURE;

--- a/nav2_behavior_tree/plugins/condition/initial_pose_received_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/initial_pose_received_condition.cpp
@@ -33,7 +33,7 @@ BT::NodeStatus InitialPoseReceived::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::InitialPoseReceived>("InitialPoseReceived");

--- a/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.cpp
@@ -59,7 +59,7 @@ void IsBatteryChargingCondition::batteryCallback(sensor_msgs::msg::BatteryState:
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::IsBatteryChargingCondition>("IsBatteryCharging");

--- a/nav2_behavior_tree/plugins/condition/is_battery_low_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_battery_low_condition.cpp
@@ -77,7 +77,7 @@ void IsBatteryLowCondition::batteryCallback(sensor_msgs::msg::BatteryState::Shar
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::IsBatteryLowCondition>("IsBatteryLow");

--- a/nav2_behavior_tree/plugins/condition/is_path_valid_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_path_valid_condition.cpp
@@ -64,7 +64,7 @@ BT::NodeStatus IsPathValidCondition::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::IsPathValidCondition>("IsPathValid");

--- a/nav2_behavior_tree/plugins/condition/is_stuck_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_stuck_condition.cpp
@@ -143,7 +143,7 @@ bool IsStuckCondition::isStuck()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::IsStuckCondition>("IsStuck");

--- a/nav2_behavior_tree/plugins/condition/path_expiring_timer_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/path_expiring_timer_condition.cpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <memory>
 
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 
 #include "nav2_behavior_tree/plugins/condition/path_expiring_timer_condition.hpp"
 
@@ -68,7 +68,7 @@ BT::NodeStatus PathExpiringTimerCondition::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::PathExpiringTimerCondition>("PathExpiringTimer");

--- a/nav2_behavior_tree/plugins/condition/time_expired_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/time_expired_condition.cpp
@@ -46,7 +46,7 @@ BT::NodeStatus TimeExpiredCondition::tick()
     initialize();
   }
 
-  if (status() == BT::NodeStatus::IDLE) {
+  if (!BT::isStatusActive(status())) {
     start_ = node_->now();
     return BT::NodeStatus::FAILURE;
   }

--- a/nav2_behavior_tree/plugins/condition/time_expired_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/time_expired_condition.cpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <memory>
 
-#include "behaviortree_cpp_v3/condition_node.h"
+#include "behaviortree_cpp/condition_node.h"
 
 #include "nav2_behavior_tree/plugins/condition/time_expired_condition.hpp"
 
@@ -67,7 +67,7 @@ BT::NodeStatus TimeExpiredCondition::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::TimeExpiredCondition>("TimeExpired");

--- a/nav2_behavior_tree/plugins/condition/transform_available_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/transform_available_condition.cpp
@@ -83,7 +83,7 @@ BT::NodeStatus TransformAvailableCondition::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::TransformAvailableCondition>("TransformAvailable");

--- a/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.cpp
@@ -33,7 +33,7 @@ WouldAControllerRecoveryHelp::WouldAControllerRecoveryHelp(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::WouldAControllerRecoveryHelp>(

--- a/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.cpp
@@ -35,7 +35,7 @@ WouldAPlannerRecoveryHelp::WouldAPlannerRecoveryHelp(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::WouldAPlannerRecoveryHelp>(

--- a/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.cpp
@@ -33,7 +33,7 @@ WouldASmootherRecoveryHelp::WouldASmootherRecoveryHelp(
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::WouldASmootherRecoveryHelp>(

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -122,7 +122,7 @@ void RecoveryNode::halt()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::RecoveryNode>("RecoveryNode");

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -48,7 +48,7 @@ BT::NodeStatus RecoveryNode::tick()
         case BT::NodeStatus::SKIPPED:
           // If first child is skipped, the entire branch is considered skipped
           halt();
-          return BT::NodeStatus::SKIPPED
+          return BT::NodeStatus::SKIPPED;
 
         case BT::NodeStatus::SUCCESS:
           // reset node and return success when first child returns success
@@ -83,7 +83,7 @@ BT::NodeStatus RecoveryNode::tick()
             // if we skip the recovery (maybe a precondition fails), then we
             // should assume that no recovery is possible. For this reason,
             // we should return FAILURE and reset the index.
-            // This does not count as a retry.      
+            // This does not count as a retry.
             current_child_idx_ = 0;
             ControlNode::haltChild(1);
             return BT::NodeStatus::FAILURE;

--- a/nav2_behavior_tree/plugins/control/round_robin_node.cpp
+++ b/nav2_behavior_tree/plugins/control/round_robin_node.cpp
@@ -49,6 +49,7 @@ BT::NodeStatus RoundRobinNode::tick()
             current_child_idx_ = 0;
           }
           num_failed_children_ = 0;
+          num_skipped_children_ = 0;
           ControlNode::haltChildren();
           return BT::NodeStatus::SUCCESS;
         }
@@ -66,6 +67,7 @@ BT::NodeStatus RoundRobinNode::tick()
         num_skipped_children_++;
         // If all the children were skipped, this node is considered skipped
         if (num_skipped_children_ == num_children) {
+          halt();
           return BT::NodeStatus::SKIPPED;
         }
         break;

--- a/nav2_behavior_tree/plugins/control/round_robin_node.cpp
+++ b/nav2_behavior_tree/plugins/control/round_robin_node.cpp
@@ -87,7 +87,6 @@ void RoundRobinNode::halt()
   ControlNode::halt();
   current_child_idx_ = 0;
   num_failed_children_ = 0;
-  num_skipped_children_ = 0;
 }
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/plugins/control/round_robin_node.cpp
+++ b/nav2_behavior_tree/plugins/control/round_robin_node.cpp
@@ -36,8 +36,9 @@ BT::NodeStatus RoundRobinNode::tick()
   const auto num_children = children_nodes_.size();
 
   setStatus(BT::NodeStatus::RUNNING);
+  unsigned num_skipped_children = 0;
 
-  while (num_failed_children_ + num_skipped_children_ < num_children) {
+  while (num_failed_children_ + num_skipped_children < num_children) {
     TreeNode * child_node = children_nodes_[current_child_idx_];
     const BT::NodeStatus child_status = child_node->executeTick();
 
@@ -52,7 +53,6 @@ BT::NodeStatus RoundRobinNode::tick()
       case BT::NodeStatus::SUCCESS:
         {
           num_failed_children_ = 0;
-          num_skipped_children_ = 0;
           ControlNode::haltChildren();
           return BT::NodeStatus::SUCCESS;
         }
@@ -65,7 +65,7 @@ BT::NodeStatus RoundRobinNode::tick()
 
       case BT::NodeStatus::SKIPPED:
         {
-          num_skipped_children_++;
+          num_skipped_children++;
           break;
         }
       case BT::NodeStatus::RUNNING:
@@ -76,7 +76,7 @@ BT::NodeStatus RoundRobinNode::tick()
     }
   }
 
-  const bool all_skipped = (num_skipped_children_ == num_children);
+  const bool all_skipped = (num_skipped_children == num_children);
   halt();
   // If all the children were skipped, this node is considered skipped
   return all_skipped ? BT::NodeStatus::SKIPPED : BT::NodeStatus::FAILURE;

--- a/nav2_behavior_tree/plugins/decorator/distance_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/distance_controller.cpp
@@ -23,7 +23,7 @@
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "tf2_ros/buffer.h"
 
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 
 #include "nav2_behavior_tree/plugins/decorator/distance_controller.hpp"
 #include "nav2_behavior_tree/bt_utils.hpp"
@@ -114,7 +114,7 @@ inline BT::NodeStatus DistanceController::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::DistanceController>("DistanceController");

--- a/nav2_behavior_tree/plugins/decorator/distance_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/distance_controller.cpp
@@ -51,7 +51,7 @@ DistanceController::DistanceController(
 
 inline BT::NodeStatus DistanceController::tick()
 {
-  if (status() == BT::NodeStatus::IDLE) {
+  if (!BT::isStatusActive(status())) {
     // Reset the starting position since we're starting a new iteration of
     // the distance controller (moving from IDLE to RUNNING)
     if (!nav2_util::getCurrentPose(
@@ -90,8 +90,9 @@ inline BT::NodeStatus DistanceController::tick()
     const BT::NodeStatus child_state = child_node_->executeTick();
 
     switch (child_state) {
+      case BT::NodeStatus::SKIPPED:
       case BT::NodeStatus::RUNNING:
-        return BT::NodeStatus::RUNNING;
+        return child_state;
 
       case BT::NodeStatus::SUCCESS:
         if (!nav2_util::getCurrentPose(

--- a/nav2_behavior_tree/plugins/decorator/goal_updated_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updated_controller.cpp
@@ -17,7 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 #include "nav2_behavior_tree/plugins/decorator/goal_updated_controller.hpp"
 #include "nav2_behavior_tree/bt_utils.hpp"
 
@@ -81,7 +81,7 @@ BT::NodeStatus GoalUpdatedController::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::GoalUpdatedController>("GoalUpdatedController");

--- a/nav2_behavior_tree/plugins/decorator/goal_updated_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updated_controller.cpp
@@ -33,7 +33,7 @@ GoalUpdatedController::GoalUpdatedController(
 
 BT::NodeStatus GoalUpdatedController::tick()
 {
-  if (status() == BT::NodeStatus::IDLE) {
+  if (!BT::isStatusActive(status())) {
     // Reset since we're starting a new iteration of
     // the goal updated controller (moving from IDLE to RUNNING)
 
@@ -61,19 +61,7 @@ BT::NodeStatus GoalUpdatedController::tick()
   // 'til completion
   if ((child_node_->status() == BT::NodeStatus::RUNNING) || goal_was_updated_) {
     goal_was_updated_ = false;
-    const BT::NodeStatus child_state = child_node_->executeTick();
-
-    switch (child_state) {
-      case BT::NodeStatus::RUNNING:
-        return BT::NodeStatus::RUNNING;
-
-      case BT::NodeStatus::SUCCESS:
-        return BT::NodeStatus::SUCCESS;
-
-      case BT::NodeStatus::FAILURE:
-      default:
-        return BT::NodeStatus::FAILURE;
-    }
+    return child_node_->executeTick();
   }
 
   return status();

--- a/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
+++ b/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
@@ -17,7 +17,7 @@
 #include <memory>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "behaviortree_cpp_v3/decorator_node.h"
+#include "behaviortree_cpp/decorator_node.h"
 
 #include "nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp"
 
@@ -84,7 +84,7 @@ GoalUpdater::callback_updated_goal(const geometry_msgs::msg::PoseStamped::Shared
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::GoalUpdater>("GoalUpdater");

--- a/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
+++ b/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
@@ -97,7 +97,7 @@ inline BT::NodeStatus PathLongerOnApproach::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::PathLongerOnApproach>("PathLongerOnApproach");

--- a/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
+++ b/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
@@ -62,7 +62,7 @@ inline BT::NodeStatus PathLongerOnApproach::tick()
   getInput("prox_len", prox_len_);
   getInput("length_factor", length_factor_);
 
-  if (status() == BT::NodeStatus::IDLE) {
+  if (!BT::isStatusActive(status())) {
     // Reset the starting point since we're starting a new iteration of
     // PathLongerOnApproach (moving from IDLE to RUNNING)
     first_time_ = true;
@@ -77,14 +77,14 @@ inline BT::NodeStatus PathLongerOnApproach::tick()
   {
     const BT::NodeStatus child_state = child_node_->executeTick();
     switch (child_state) {
+      case BT::NodeStatus::SKIPPED:
       case BT::NodeStatus::RUNNING:
-        return BT::NodeStatus::RUNNING;
+        return child_state;
       case BT::NodeStatus::SUCCESS:
-        old_path_ = new_path_;
-        return BT::NodeStatus::SUCCESS;
       case BT::NodeStatus::FAILURE:
         old_path_ = new_path_;
-        return BT::NodeStatus::FAILURE;
+        resetChild();
+        return child_state;
       default:
         old_path_ = new_path_;
         return BT::NodeStatus::FAILURE;

--- a/nav2_behavior_tree/plugins/decorator/rate_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/rate_controller.cpp
@@ -88,7 +88,7 @@ BT::NodeStatus RateController::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::RateController>("RateController");

--- a/nav2_behavior_tree/plugins/decorator/rate_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/rate_controller.cpp
@@ -43,7 +43,7 @@ BT::NodeStatus RateController::tick()
     initialize();
   }
 
-  if (status() == BT::NodeStatus::IDLE) {
+  if (!BT::isStatusActive(status())) {
     // Reset the starting point since we're starting a new iteration of
     // the rate controller (moving from IDLE to RUNNING)
     start_ = std::chrono::high_resolution_clock::now();
@@ -70,14 +70,15 @@ BT::NodeStatus RateController::tick()
     const BT::NodeStatus child_state = child_node_->executeTick();
 
     switch (child_state) {
+      case BT::NodeStatus::SKIPPED:
       case BT::NodeStatus::RUNNING:
-        return BT::NodeStatus::RUNNING;
+      case BT::NodeStatus::FAILURE:
+        return child_state;
 
       case BT::NodeStatus::SUCCESS:
         start_ = std::chrono::high_resolution_clock::now();  // Reset the timer
         return BT::NodeStatus::SUCCESS;
 
-      case BT::NodeStatus::FAILURE:
       default:
         return BT::NodeStatus::FAILURE;
     }

--- a/nav2_behavior_tree/plugins/decorator/single_trigger_node.cpp
+++ b/nav2_behavior_tree/plugins/decorator/single_trigger_node.cpp
@@ -62,7 +62,7 @@ BT::NodeStatus SingleTrigger::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::SingleTrigger>("SingleTrigger");

--- a/nav2_behavior_tree/plugins/decorator/single_trigger_node.cpp
+++ b/nav2_behavior_tree/plugins/decorator/single_trigger_node.cpp
@@ -30,7 +30,7 @@ SingleTrigger::SingleTrigger(
 
 BT::NodeStatus SingleTrigger::tick()
 {
-  if (status() == BT::NodeStatus::IDLE) {
+  if (!BT::isStatusActive(status())) {
     first_time_ = true;
   }
 
@@ -40,16 +40,14 @@ BT::NodeStatus SingleTrigger::tick()
     const BT::NodeStatus child_state = child_node_->executeTick();
 
     switch (child_state) {
+      case BT::NodeStatus::SKIPPED:
       case BT::NodeStatus::RUNNING:
-        return BT::NodeStatus::RUNNING;
-
-      case BT::NodeStatus::SUCCESS:
-        first_time_ = false;
-        return BT::NodeStatus::SUCCESS;
+        return child_state;
 
       case BT::NodeStatus::FAILURE:
+      case BT::NodeStatus::SUCCESS:
         first_time_ = false;
-        return BT::NodeStatus::FAILURE;
+        return child_state;
 
       default:
         first_time_ = false;

--- a/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
@@ -121,7 +121,7 @@ inline BT::NodeStatus SpeedController::tick()
 
 }  // namespace nav2_behavior_tree
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
   factory.registerNodeType<nav2_behavior_tree::SpeedController>("SpeedController");

--- a/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
@@ -59,7 +59,7 @@ SpeedController::SpeedController(
 
 inline BT::NodeStatus SpeedController::tick()
 {
-  if (status() == BT::NodeStatus::IDLE) {
+  if (!BT::isStatusActive(status())) {
     // Reset since we're starting a new iteration of
     // the speed controller (moving from IDLE to RUNNING)
     BT::getInputOrBlackboard("goals", goals_);
@@ -101,19 +101,7 @@ inline BT::NodeStatus SpeedController::tick()
       start_ = node_->now();
     }
 
-    const BT::NodeStatus child_state = child_node_->executeTick();
-
-    switch (child_state) {
-      case BT::NodeStatus::RUNNING:
-        return BT::NodeStatus::RUNNING;
-
-      case BT::NodeStatus::SUCCESS:
-        return BT::NodeStatus::SUCCESS;
-
-      case BT::NodeStatus::FAILURE:
-      default:
-        return BT::NodeStatus::FAILURE;
-    }
+    return child_node_->executeTick();
   }
 
   return status();

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -20,7 +20,7 @@
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"
-#include "behaviortree_cpp_v3/utils/shared_library.h"
+#include "behaviortree_cpp/utils/shared_library.h"
 
 namespace nav2_behavior_tree
 {
@@ -32,6 +32,11 @@ BehaviorTreeEngine::BehaviorTreeEngine(
   for (const auto & p : plugin_libraries) {
     factory_.registerFromPlugin(loader.getOSName(p));
   }
+
+  // FIXME: the next two line are needed for back-compatibility with BT.CPP 3.8.x
+  // Note that the can be removed, once we migrate from BT.CPP 4.5.x to 4.6+
+  BT::ReactiveSequence::EnableException(false);
+  BT::ReactiveFallback::EnableException(false);
 }
 
 BtStatus
@@ -52,7 +57,7 @@ BehaviorTreeEngine::run(
         return BtStatus::CANCELED;
       }
 
-      result = tree->tickRoot();
+      result = tree->tickOnce();
 
       onLoop();
 

--- a/nav2_behavior_tree/test/plugins/action/test_assisted_teleop_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_assisted_teleop_action.cpp
@@ -17,7 +17,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/assisted_teleop_action.hpp"
@@ -123,7 +123,7 @@ TEST_F(AssistedTeleopActionTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <AssistedTeleop />
         </BehaviorTree>
@@ -134,7 +134,7 @@ TEST_F(AssistedTeleopActionTestFixture, test_ports)
 
   xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <AssistedTeleop time_allowance="20"/>
         </BehaviorTree>
@@ -148,7 +148,7 @@ TEST_F(AssistedTeleopActionTestFixture, test_tick)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <AssistedTeleop is_recovery="true"/>
         </BehaviorTree>
@@ -172,7 +172,7 @@ TEST_F(AssistedTeleopActionTestFixture, test_failure)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <AssistedTeleop is_recovery="true"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_assisted_teleop_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_assisted_teleop_cancel_node.cpp
@@ -17,7 +17,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/assisted_teleop_cancel_node.hpp"
@@ -122,7 +122,7 @@ TEST_F(CancelAssistedTeleopActionTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
              <CancelAssistedTeleop name="AssistedTeleopCancel"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_action.cpp
@@ -18,7 +18,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/back_up_action.hpp"
@@ -122,7 +122,7 @@ TEST_F(BackUpActionTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <BackUp />
         </BehaviorTree>
@@ -134,7 +134,7 @@ TEST_F(BackUpActionTestFixture, test_ports)
 
   xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <BackUp backup_dist="2" backup_speed="0.26" />
         </BehaviorTree>
@@ -149,7 +149,7 @@ TEST_F(BackUpActionTestFixture, test_tick)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <BackUp backup_dist="2" backup_speed="0.26" />
         </BehaviorTree>
@@ -174,7 +174,7 @@ TEST_F(BackUpActionTestFixture, test_failure)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <BackUp backup_dist="2" backup_speed="0.26" />
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_back_up_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_back_up_cancel_node.cpp
@@ -17,7 +17,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/back_up_cancel_node.hpp"
@@ -120,7 +120,7 @@ TEST_F(CancelBackUpActionTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
              <CancelBackUp name="BackUpCancel"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
@@ -316,8 +316,10 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_success)
   // the BT should have failed
   EXPECT_EQ(result, BT::NodeStatus::FAILURE);
 
-  // since the server timeout is 20ms and bt loop duration is 10ms, number of ticks should be 2
-  EXPECT_EQ(ticks, 2);
+  // since the server timeout is 20ms and bt loop duration is 10ms, number of ticks should 
+  // be at most 2, but it can be 1 too, because the tickOnce may execute two ticks.
+  EXPECT_LE(ticks, 2);
+  EXPECT_GE(ticks, 1);
 }
 
 TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)

--- a/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
@@ -23,7 +23,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 #include "nav2_behavior_tree/bt_action_node.hpp"
 
 #include "test_msgs/action/fibonacci.hpp"
@@ -238,7 +238,7 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_success)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <Fibonacci order="5" />
         </BehaviorTree>
@@ -264,7 +264,7 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_success)
 
   // main BT execution loop
   while (rclcpp::ok() && result == BT::NodeStatus::RUNNING) {
-    result = tree_->tickRoot();
+    result = tree_->tickOnce();
     ticks++;
     loopRate.sleep();
   }
@@ -307,7 +307,7 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_success)
 
   // main BT execution loop
   while (rclcpp::ok() && result == BT::NodeStatus::RUNNING) {
-    result = tree_->tickRoot();
+    result = tree_->tickOnce();
     ticks++;
     loopRate.sleep();
   }
@@ -325,7 +325,7 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <Fibonacci order="2" />
         </BehaviorTree>
@@ -352,7 +352,7 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)
 
   // main BT execution loop
   while (rclcpp::ok() && result == BT::NodeStatus::RUNNING) {
-    result = tree_->tickRoot();
+    result = tree_->tickOnce();
     ticks++;
     loopRate.sleep();
   }
@@ -386,7 +386,7 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_failure)
 
   // main BT execution loop
   while (rclcpp::ok() && result == BT::NodeStatus::RUNNING) {
-    result = tree_->tickRoot();
+    result = tree_->tickOnce();
     ticks++;
     loopRate.sleep();
   }
@@ -401,7 +401,7 @@ TEST_F(BTActionNodeTestFixture, test_server_cancel)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <Fibonacci order="1000000" />
         </BehaviorTree>
@@ -429,7 +429,7 @@ TEST_F(BTActionNodeTestFixture, test_server_cancel)
 
   // main BT execution loop
   while (rclcpp::ok() && result == BT::NodeStatus::RUNNING && ticks < 5) {
-    result = tree_->tickRoot();
+    result = tree_->tickOnce();
     ticks++;
     loopRate.sleep();
   }
@@ -461,7 +461,7 @@ TEST_F(BTActionNodeTestFixture, test_server_cancel)
 
   // main BT execution loop
   while (rclcpp::ok() && result == BT::NodeStatus::RUNNING && ticks < 7) {
-    result = tree_->tickRoot();
+    result = tree_->tickOnce();
     ticks++;
     loopRate.sleep();
   }

--- a/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_bt_action_node.cpp
@@ -316,7 +316,7 @@ TEST_F(BTActionNodeTestFixture, test_server_timeout_success)
   // the BT should have failed
   EXPECT_EQ(result, BT::NodeStatus::FAILURE);
 
-  // since the server timeout is 20ms and bt loop duration is 10ms, number of ticks should 
+  // since the server timeout is 20ms and bt loop duration is 10ms, number of ticks should
   // be at most 2, but it can be 1 too, because the tickOnce may execute two ticks.
   EXPECT_LE(ticks, 2);
   EXPECT_GE(ticks, 1);

--- a/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_clear_costmap_service.cpp
@@ -18,7 +18,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_service.hpp"
 #include "nav2_behavior_tree/plugins/action/clear_costmap_service.hpp"
@@ -100,7 +100,7 @@ TEST_F(ClearEntireCostmapServiceTestFixture, test_tick)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <ClearEntireCostmap service_name="clear_entire_costmap"/>
         </BehaviorTree>
@@ -195,7 +195,7 @@ TEST_F(ClearCostmapExceptRegionServiceTestFixture, test_tick)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <ClearCostmapExceptRegion service_name="clear_costmap_except_region"/>
         </BehaviorTree>
@@ -290,7 +290,7 @@ TEST_F(ClearCostmapAroundRobotServiceTestFixture, test_tick)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <ClearCostmapAroundRobot service_name="clear_costmap_around_robot"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_through_poses_action.cpp
@@ -22,7 +22,7 @@
 #include "nav_msgs/msg/path.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/compute_path_through_poses_action.hpp"
@@ -128,7 +128,7 @@ TEST_F(ComputePathThroughPosesActionTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <ComputePathThroughPoses goals="{goals}" path="{path}" planner_id="GridBased"/>
         </BehaviorTree>
@@ -187,7 +187,7 @@ TEST_F(ComputePathThroughPosesActionTestFixture, test_tick_use_start)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <ComputePathThroughPoses goals="{goals}" start="{start}" path="{path}" planner_id="GridBased"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_compute_path_to_pose_action.cpp
@@ -21,7 +21,7 @@
 #include "nav_msgs/msg/path.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp"
@@ -125,7 +125,7 @@ TEST_F(ComputePathToPoseActionTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"/>
         </BehaviorTree>
@@ -184,7 +184,7 @@ TEST_F(ComputePathToPoseActionTestFixture, test_tick_use_start)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <ComputePathToPose goal="{goal}" start="{start}" path="{path}" planner_id="GridBased"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_controller_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_controller_cancel_node.cpp
@@ -17,7 +17,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/controller_cancel_node.hpp"
@@ -120,7 +120,7 @@ TEST_F(CancelControllerActionTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
              <CancelControl name="ControlCancel"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_controller_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_controller_selector_node.cpp
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "utils/test_action_server.hpp"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 #include "nav2_behavior_tree/plugins/action/controller_selector_node.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -80,7 +80,7 @@ TEST_F(ControllerSelectorTestFixture, test_custom_topic)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <ControllerSelector selected_controller="{selected_controller}" default_controller="DWB" topic_name="controller_selector_custom_topic_name"/>
         </BehaviorTree>
@@ -128,7 +128,7 @@ TEST_F(ControllerSelectorTestFixture, test_default_topic)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <ControllerSelector selected_controller="{selected_controller}" default_controller="GridBased"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_drive_on_heading_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_drive_on_heading_action.cpp
@@ -18,7 +18,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/drive_on_heading_action.hpp"
@@ -118,7 +118,7 @@ TEST_F(DriveOnHeadingActionTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <DriveOnHeading />
         </BehaviorTree>
@@ -131,7 +131,7 @@ TEST_F(DriveOnHeadingActionTestFixture, test_ports)
 
   xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <DriveOnHeading dist_to_travel="2" speed="0.26" />
         </BehaviorTree>
@@ -146,7 +146,7 @@ TEST_F(DriveOnHeadingActionTestFixture, test_tick)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <DriveOnHeading dist_to_travel="2" speed="0.26" />
         </BehaviorTree>
@@ -169,7 +169,7 @@ TEST_F(DriveOnHeadingActionTestFixture, test_failure)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <DriveOnHeading dist_to_travel="2" speed="0.26" />
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_drive_on_heading_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_drive_on_heading_cancel_node.cpp
@@ -17,7 +17,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/drive_on_heading_cancel_node.hpp"
@@ -123,7 +123,7 @@ TEST_F(CancelDriveOnHeadingTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
              <CancelDriveOnHeading name="CancelDriveOnHeading"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_follow_path_action.cpp
@@ -21,7 +21,7 @@
 #include "nav_msgs/msg/path.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/follow_path_action.hpp"
@@ -118,7 +118,7 @@ TEST_F(FollowPathActionTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <FollowPath path="{path}" controller_id="FollowPath"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_goal_checker_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_goal_checker_selector_node.cpp
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "utils/test_action_server.hpp"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 #include "nav2_behavior_tree/plugins/action/goal_checker_selector_node.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -80,7 +80,7 @@ TEST_F(GoalCheckerSelectorTestFixture, test_custom_topic)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <GoalCheckerSelector selected_goal_checker="{selected_goal_checker}" default_goal_checker="SimpleGoalCheck" topic_name="goal_checker_selector_custom_topic_name"/>
         </BehaviorTree>
@@ -128,7 +128,7 @@ TEST_F(GoalCheckerSelectorTestFixture, test_default_topic)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <GoalCheckerSelector selected_goal_checker="{selected_goal_checker}" default_goal_checker="GridBased"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_through_poses_action.cpp
@@ -23,7 +23,7 @@
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/navigate_through_poses_action.hpp"
@@ -124,7 +124,7 @@ TEST_F(NavigateThroughPosesActionTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <NavigateThroughPoses goals="{goals}" />
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_navigate_to_pose_action.cpp
@@ -22,7 +22,7 @@
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/navigate_to_pose_action.hpp"
@@ -119,7 +119,7 @@ TEST_F(NavigateToPoseActionTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <NavigateToPose goal="{goal}" />
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_planner_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_planner_selector_node.cpp
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "utils/test_action_server.hpp"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 #include "nav2_behavior_tree/plugins/action/planner_selector_node.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -78,7 +78,7 @@ TEST_F(PlannerSelectorTestFixture, test_custom_topic)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <PlannerSelector selected_planner="{selected_planner}" default_planner="GridBased" topic_name="planner_selector_custom_topic_name"/>
         </BehaviorTree>
@@ -126,7 +126,7 @@ TEST_F(PlannerSelectorTestFixture, test_default_topic)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <PlannerSelector selected_planner="{selected_planner}" default_planner="GridBased"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_progress_checker_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_progress_checker_selector_node.cpp
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "utils/test_action_server.hpp"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 #include "nav2_behavior_tree/plugins/action/progress_checker_selector_node.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -79,7 +79,7 @@ TEST_F(ProgressCheckerSelectorTestFixture, test_custom_topic)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <ProgressCheckerSelector selected_progress_checker="{selected_progress_checker}" default_progress_checker="SimpleProgressCheck" topic_name="progress_checker_selector_custom_topic_name"/>
         </BehaviorTree>
@@ -94,7 +94,7 @@ TEST_F(ProgressCheckerSelectorTestFixture, test_custom_topic)
 
   // check default value
   std::string selected_progress_checker_result;
-  config_->blackboard->get("selected_progress_checker", selected_progress_checker_result);
+  [[maybe_unused]] auto res = config_->blackboard->get("selected_progress_checker", selected_progress_checker_result);
 
   EXPECT_EQ(selected_progress_checker_result, "SimpleProgressCheck");
 
@@ -119,7 +119,7 @@ TEST_F(ProgressCheckerSelectorTestFixture, test_custom_topic)
   }
 
   // check progress_checker updated
-  config_->blackboard->get("selected_progress_checker", selected_progress_checker_result);
+  res = config_->blackboard->get("selected_progress_checker", selected_progress_checker_result);
   EXPECT_EQ("AngularProgressChecker", selected_progress_checker_result);
 }
 
@@ -128,7 +128,7 @@ TEST_F(ProgressCheckerSelectorTestFixture, test_default_topic)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <ProgressCheckerSelector selected_progress_checker="{selected_progress_checker}" default_progress_checker="GridBased"/>
         </BehaviorTree>
@@ -143,7 +143,7 @@ TEST_F(ProgressCheckerSelectorTestFixture, test_default_topic)
 
   // check default value
   std::string selected_progress_checker_result;
-  config_->blackboard->get("selected_progress_checker", selected_progress_checker_result);
+  [[maybe_unused]] auto res = config_->blackboard->get("selected_progress_checker", selected_progress_checker_result);
 
   EXPECT_EQ(selected_progress_checker_result, "GridBased");
 
@@ -167,7 +167,7 @@ TEST_F(ProgressCheckerSelectorTestFixture, test_default_topic)
   }
 
   // check goal_checker updated
-  config_->blackboard->get("selected_progress_checker", selected_progress_checker_result);
+  res = config_->blackboard->get("selected_progress_checker", selected_progress_checker_result);
   EXPECT_EQ("RRT", selected_progress_checker_result);
 }
 

--- a/nav2_behavior_tree/test/plugins/action/test_progress_checker_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_progress_checker_selector_node.cpp
@@ -94,7 +94,9 @@ TEST_F(ProgressCheckerSelectorTestFixture, test_custom_topic)
 
   // check default value
   std::string selected_progress_checker_result;
-  [[maybe_unused]] auto res = config_->blackboard->get("selected_progress_checker", selected_progress_checker_result);
+  [[maybe_unused]] auto res = config_->blackboard->get(
+    "selected_progress_checker",
+    selected_progress_checker_result);
 
   EXPECT_EQ(selected_progress_checker_result, "SimpleProgressCheck");
 
@@ -143,7 +145,9 @@ TEST_F(ProgressCheckerSelectorTestFixture, test_default_topic)
 
   // check default value
   std::string selected_progress_checker_result;
-  [[maybe_unused]] auto res = config_->blackboard->get("selected_progress_checker", selected_progress_checker_result);
+  [[maybe_unused]] auto res = config_->blackboard->get(
+    "selected_progress_checker",
+    selected_progress_checker_result);
 
   EXPECT_EQ(selected_progress_checker_result, "GridBased");
 

--- a/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_reinitialize_global_localization_service.cpp
@@ -18,7 +18,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_service.hpp"
 #include "nav2_behavior_tree/plugins/action/reinitialize_global_localization_service.hpp"
@@ -97,7 +97,7 @@ TEST_F(ReinitializeGlobalLocalizationServiceTestFixture, test_tick)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <ReinitializeGlobalLocalization service_name="reinitialize_global_localization"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_remove_passed_goals_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_remove_passed_goals_action.cpp
@@ -23,7 +23,7 @@
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_util/geometry_utils.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/remove_passed_goals_action.hpp"
@@ -105,7 +105,7 @@ TEST_F(RemovePassedGoalsTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <RemovePassedGoals radius="0.5" input_goals="{goals}" output_goals="{goals}"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_smooth_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_smooth_path_action.cpp
@@ -21,7 +21,7 @@
 
 #include "nav_msgs/msg/path.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/smooth_path_action.hpp"
@@ -118,7 +118,7 @@ TEST_F(SmoothPathActionTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <SmoothPath unsmoothed_path="{unsmoothed_path}" />
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_smoother_selector_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_smoother_selector_node.cpp
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "utils/test_action_server.hpp"
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 #include "nav2_behavior_tree/plugins/action/smoother_selector_node.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "std_msgs/msg/string.hpp"
@@ -80,7 +80,7 @@ TEST_F(SmootherSelectorTestFixture, test_custom_topic)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <SmootherSelector selected_smoother="{selected_smoother}" default_smoother="DWB" topic_name="smoother_selector_custom_topic_name"/>
         </BehaviorTree>
@@ -128,7 +128,7 @@ TEST_F(SmootherSelectorTestFixture, test_default_topic)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <SmootherSelector selected_smoother="{selected_smoother}" default_smoother="GridBased"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
@@ -18,7 +18,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/spin_action.hpp"
@@ -122,7 +122,7 @@ TEST_F(SpinActionTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <Spin server_name="spin"/>
         </BehaviorTree>
@@ -133,7 +133,7 @@ TEST_F(SpinActionTestFixture, test_ports)
 
   xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <Spin spin_dist="3.14" />
         </BehaviorTree>
@@ -147,7 +147,7 @@ TEST_F(SpinActionTestFixture, test_tick)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <Spin spin_dist="3.14" />
         </BehaviorTree>
@@ -169,7 +169,7 @@ TEST_F(SpinActionTestFixture, test_failure)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <Spin spin_dist="3.14" />
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_spin_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_spin_cancel_node.cpp
@@ -17,7 +17,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/spin_cancel_node.hpp"
@@ -120,7 +120,7 @@ TEST_F(CancelSpinActionTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
              <CancelSpin name="SpinCancel"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_truncate_path_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_truncate_path_action.cpp
@@ -22,7 +22,7 @@
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_util/geometry_utils.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/truncate_path_action.hpp"
@@ -87,7 +87,7 @@ TEST_F(TruncatePathTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <TruncatePath distance="1.0" input_path="{path}" output_path="{truncated_path}"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_truncate_path_local_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_truncate_path_local_action.cpp
@@ -21,7 +21,7 @@
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_util/geometry_utils.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_behavior_tree_fixture.hpp"
 #include "nav2_behavior_tree/plugins/action/truncate_path_local_action.hpp"
@@ -107,7 +107,7 @@ TEST_F(TruncatePathLocalTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <TruncatePathLocal
             distance_forward="2.0"
@@ -201,7 +201,7 @@ TEST_F(TruncatePathLocalTestFixture, test_success_on_empty_path)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <TruncatePathLocal
             distance_forward="2.0"
@@ -245,7 +245,7 @@ TEST_F(TruncatePathLocalTestFixture, test_failure_on_no_pose)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <TruncatePathLocal
             distance_forward="2.0"
@@ -287,7 +287,7 @@ TEST_F(TruncatePathLocalTestFixture, test_failure_on_invalid_robot_frame)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <TruncatePathLocal
             distance_forward="2.0"
@@ -328,7 +328,7 @@ TEST_F(TruncatePathLocalTestFixture, test_path_pruning)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <TruncatePathLocal
             distance_forward="2.0"

--- a/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_wait_action.cpp
@@ -18,7 +18,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/wait_action.hpp"
@@ -113,7 +113,7 @@ TEST_F(WaitActionTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <Wait />
         </BehaviorTree>
@@ -124,7 +124,7 @@ TEST_F(WaitActionTestFixture, test_ports)
 
   xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <Wait wait_duration="10.0" />
         </BehaviorTree>
@@ -138,7 +138,7 @@ TEST_F(WaitActionTestFixture, test_tick)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <Wait wait_duration="-5.0"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/action/test_wait_cancel_node.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_wait_cancel_node.cpp
@@ -17,7 +17,7 @@
 #include <set>
 #include <string>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/action/wait_cancel_node.hpp"
@@ -120,7 +120,7 @@ TEST_F(CancelWaitActionTestFixture, test_ports)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
              <CancelWait name="WaitCancel"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/condition/test_are_error_codes_present.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_are_error_codes_present.cpp
@@ -34,7 +34,7 @@ public:
 
     std::string xml_txt =
       R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <AreErrorCodesPresent error_code="{error_code}" error_codes_to_check="{error_codes_to_check}"/>
         </BehaviorTree>
@@ -65,7 +65,7 @@ TEST_F(AreErrorCodesPresentFixture, test_condition)
 
   for (const auto & error_to_status : error_to_status_map) {
     config_->blackboard->set("error_code", error_to_status.first);
-    EXPECT_EQ(tree_->tickRoot(), error_to_status.second);
+    EXPECT_EQ(tree_->tickOnce(), error_to_status.second);
   }
 }
 

--- a/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
@@ -43,7 +43,7 @@ public:
 
     std::string xml_txt =
       R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <GoalReached goal="{goal}" robot_base_frame="base_link"/>
         </BehaviorTree>
@@ -66,32 +66,32 @@ std::shared_ptr<BT::Tree> GoalReachedConditionTestFixture::tree_ = nullptr;
 
 TEST_F(GoalReachedConditionTestFixture, test_behavior)
 {
-  EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::FAILURE);
 
   geometry_msgs::msg::Pose pose;
   pose.position.x = 0.0;
   pose.position.y = 0.0;
   transform_handler_->updateRobotPose(pose);
   std::this_thread::sleep_for(500ms);
-  EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::FAILURE);
 
   pose.position.x = 0.5;
   pose.position.y = 0.5;
   transform_handler_->updateRobotPose(pose);
   std::this_thread::sleep_for(500ms);
-  EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::FAILURE);
 
   pose.position.x = 0.9;
   pose.position.y = 0.9;
   transform_handler_->updateRobotPose(pose);
   std::this_thread::sleep_for(500ms);
-  EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::SUCCESS);
 
   pose.position.x = 1.0;
   pose.position.y = 1.0;
   transform_handler_->updateRobotPose(pose);
   std::this_thread::sleep_for(500ms);
-  EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::SUCCESS);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_behavior_tree/test/plugins/condition/test_is_battery_charging.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_battery_charging.cpp
@@ -73,7 +73,7 @@ TEST_F(IsBatteryChargingConditionTestFixture, test_behavior_power_supply_status)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <IsBatteryCharging battery_topic="/battery_status"/>
         </BehaviorTree>
@@ -86,32 +86,32 @@ TEST_F(IsBatteryChargingConditionTestFixture, test_behavior_power_supply_status)
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.power_supply_status = sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_CHARGING;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
 
   battery_msg.power_supply_status = sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_DISCHARGING;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.power_supply_status =
     sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_NOT_CHARGING;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.power_supply_status = sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_FULL;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_behavior_tree/test/plugins/condition/test_is_battery_low.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_battery_low.cpp
@@ -74,7 +74,7 @@ TEST_F(IsBatteryLowConditionTestFixture, test_behavior_percentage)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <IsBatteryLow min_battery="0.5" battery_topic="/battery_status"/>
         </BehaviorTree>
@@ -87,32 +87,32 @@ TEST_F(IsBatteryLowConditionTestFixture, test_behavior_percentage)
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.percentage = 0.49;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
 
   battery_msg.percentage = 0.51;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.percentage = 0.0;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
 }
 
 TEST_F(IsBatteryLowConditionTestFixture, test_behavior_voltage)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <IsBatteryLow min_battery="5.0" battery_topic="/battery_status" is_voltage="true"/>
         </BehaviorTree>
@@ -125,25 +125,25 @@ TEST_F(IsBatteryLowConditionTestFixture, test_behavior_voltage)
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.voltage = 4.9;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
 
   battery_msg.voltage = 5.1;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
 
   battery_msg.voltage = 0.0;
   battery_pub_->publish(battery_msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   rclcpp::spin_some(node_);
-  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_behavior_tree/test/plugins/condition/test_is_path_valid.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_path_valid.cpp
@@ -92,7 +92,7 @@ TEST_F(IsPathValidTestFixture, test_behavior)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <IsPathValid/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_transform_available.cpp
@@ -65,7 +65,7 @@ public:
   {
     std::string xml_txt =
       R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <TransformAvailable child="base_link" parent="map" />
         </BehaviorTree>
@@ -99,10 +99,10 @@ std::shared_ptr<BT::Tree> TransformAvailableConditionTestFixture::tree_ = nullpt
 
 TEST_F(TransformAvailableConditionTestFixture, test_behavior)
 {
-  EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::FAILURE);
   transform_handler_->activate();
   transform_handler_->waitForTransform();
-  EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::SUCCESS);
 }
 
 int main(int argc, char ** argv)

--- a/nav2_behavior_tree/test/plugins/condition/test_would_a_controller_recovery_help.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_would_a_controller_recovery_help.cpp
@@ -32,7 +32,7 @@ public:
 
     std::string xml_txt =
       R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <WouldAControllerRecoveryHelp error_code="{error_code}"/>
         </BehaviorTree>
@@ -69,7 +69,7 @@ TEST_F(WouldAControllerRecoveryHelpFixture, test_condition)
 
   for (const auto & error_to_status : error_to_status_map) {
     config_->blackboard->set("error_code", error_to_status.first);
-    EXPECT_EQ(tree_->tickRoot(), error_to_status.second);
+    EXPECT_EQ(tree_->tickOnce(), error_to_status.second);
   }
 }
 

--- a/nav2_behavior_tree/test/plugins/condition/test_would_a_planner_recovery_help.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_would_a_planner_recovery_help.cpp
@@ -32,7 +32,7 @@ public:
 
     std::string xml_txt =
       R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <WouldAPlannerRecoveryHelp error_code="{error_code}"/>
         </BehaviorTree>
@@ -64,7 +64,7 @@ TEST_F(WouldAPlannerRecoveryHelpFixture, test_condition)
 
   for (const auto & error_to_status : error_to_status_map) {
     config_->blackboard->set("error_code", error_to_status.first);
-    EXPECT_EQ(tree_->tickRoot(), error_to_status.second);
+    EXPECT_EQ(tree_->tickOnce(), error_to_status.second);
   }
 }
 

--- a/nav2_behavior_tree/test/plugins/condition/test_would_a_smoother_recovery_help.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_would_a_smoother_recovery_help.cpp
@@ -32,7 +32,7 @@ public:
 
     std::string xml_txt =
       R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <WouldASmootherRecoveryHelp error_code="{error_code}"/>
         </BehaviorTree>
@@ -66,7 +66,7 @@ TEST_F(WouldASmootherRecoveryHelpFixture, test_condition)
 
   for (const auto & error_to_status : error_to_status_map) {
     config_->blackboard->set("error_code", error_to_status.first);
-    EXPECT_EQ(tree_->tickRoot(), error_to_status.second);
+    EXPECT_EQ(tree_->tickOnce(), error_to_status.second);
   }
 }
 

--- a/nav2_behavior_tree/test/plugins/control/test_pipeline_sequence.cpp
+++ b/nav2_behavior_tree/test/plugins/control/test_pipeline_sequence.cpp
@@ -125,6 +125,33 @@ TEST_F(PipelineSequenceTestFixture, test_behavior)
   EXPECT_EQ(third_child_->status(), BT::NodeStatus::IDLE);
 }
 
+TEST_F(PipelineSequenceTestFixture, test_skipped)
+{
+  first_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  second_child_->changeStatus(BT::NodeStatus::SUCCESS);
+  third_child_->changeStatus(BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(third_child_->status(), BT::NodeStatus::IDLE);
+
+  first_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  second_child_->changeStatus(BT::NodeStatus::SUCCESS);
+  third_child_->changeStatus(BT::NodeStatus::FAILURE);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(third_child_->status(), BT::NodeStatus::IDLE);
+
+  first_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  second_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  third_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::SKIPPED);
+  EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(third_child_->status(), BT::NodeStatus::IDLE);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_behavior_tree/test/plugins/control/test_recovery_node.cpp
+++ b/nav2_behavior_tree/test/plugins/control/test_recovery_node.cpp
@@ -144,6 +144,26 @@ TEST_F(RecoveryNodeTestFixture, test_failure_one_retry)
   EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
 }
 
+TEST_F(RecoveryNodeTestFixture, test_skipping)
+{
+  // first child skipped
+  first_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  second_child_->changeStatus(BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::SKIPPED);
+  EXPECT_EQ(bt_node_->status(), BT::NodeStatus::SKIPPED);
+  EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
+
+  // first child fails, second child skipped
+  first_child_->changeStatus(BT::NodeStatus::FAILURE);
+  second_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(bt_node_->status(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
+}
+
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_behavior_tree/test/plugins/control/test_recovery_node.cpp
+++ b/nav2_behavior_tree/test/plugins/control/test_recovery_node.cpp
@@ -150,7 +150,7 @@ TEST_F(RecoveryNodeTestFixture, test_skipping)
   first_child_->changeStatus(BT::NodeStatus::SKIPPED);
   second_child_->changeStatus(BT::NodeStatus::SUCCESS);
   EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::SKIPPED);
-  EXPECT_EQ(bt_node_->status(), BT::NodeStatus::SKIPPED);
+  EXPECT_EQ(bt_node_->status(), BT::NodeStatus::IDLE);
   EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
   EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
 

--- a/nav2_behavior_tree/test/plugins/control/test_round_robin_node.cpp
+++ b/nav2_behavior_tree/test/plugins/control/test_round_robin_node.cpp
@@ -114,6 +114,33 @@ TEST_F(RoundRobinNodeTestFixture, test_behavior)
   EXPECT_EQ(third_child_->status(), BT::NodeStatus::IDLE);
 }
 
+TEST_F(RoundRobinNodeTestFixture, test_skikpped)
+{
+  first_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  second_child_->changeStatus(BT::NodeStatus::SUCCESS);
+  third_child_->changeStatus(BT::NodeStatus::FAILURE);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(third_child_->status(), BT::NodeStatus::IDLE);
+
+  first_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  second_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  third_child_->changeStatus(BT::NodeStatus::FAILURE);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(third_child_->status(), BT::NodeStatus::IDLE);
+
+  first_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  second_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  third_child_->changeStatus(BT::NodeStatus::SKIPPED);
+  EXPECT_EQ(bt_node_->executeTick(), BT::NodeStatus::SKIPPED);
+  EXPECT_EQ(first_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(second_child_->status(), BT::NodeStatus::IDLE);
+  EXPECT_EQ(third_child_->status(), BT::NodeStatus::IDLE);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/nav2_behavior_tree/test/plugins/decorator/test_goal_updater_node.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_goal_updater_node.cpp
@@ -21,7 +21,7 @@
 #include "nav_msgs/msg/path.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 
 #include "utils/test_action_server.hpp"
 #include "nav2_behavior_tree/plugins/decorator/goal_updater_node.hpp"
@@ -86,7 +86,7 @@ TEST_F(GoalUpdaterTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <GoalUpdater input_goal="{goal}" output_goal="{updated_goal}">
             <AlwaysSuccess/>
@@ -115,7 +115,7 @@ TEST_F(GoalUpdaterTestFixture, test_older_goal_update)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <GoalUpdater input_goal="{goal}" output_goal="{updated_goal}">
             <AlwaysSuccess/>
@@ -153,7 +153,7 @@ TEST_F(GoalUpdaterTestFixture, test_get_latest_goal_update)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <GoalUpdater input_goal="{goal}" output_goal="{updated_goal}">
             <AlwaysSuccess/>

--- a/nav2_behavior_tree/test/plugins/decorator/test_path_longer_on_approach.cpp
+++ b/nav2_behavior_tree/test/plugins/decorator/test_path_longer_on_approach.cpp
@@ -89,7 +89,7 @@ TEST_F(PathLongerOnApproachTestFixture, test_tick)
   // create tree
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <PathLongerOnApproach path="{path}" prox_len="5.0" length_factor="2.0">
             <AlwaysSuccess/>
@@ -115,7 +115,7 @@ TEST_F(PathLongerOnApproachTestFixture, test_tick)
   // create tree
   xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
           <PathLongerOnApproach path="{path}" prox_len="20.0" length_factor="1.0">
             <AlwaysFailure/>

--- a/nav2_behavior_tree/test/test_bt_utils.cpp
+++ b/nav2_behavior_tree/test/test_bt_utils.cpp
@@ -22,7 +22,7 @@
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 #include "nav2_behavior_tree/bt_utils.hpp"
 
 template<typename T>
@@ -51,7 +51,7 @@ TEST(PointPortTest, test_wrong_syntax)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <PointPort test="1.0;2.0;3.0;4.0" />
         </BehaviorTree>
@@ -69,7 +69,7 @@ TEST(PointPortTest, test_wrong_syntax)
 
   xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <PointPort test="1.0;2.0" />
         </BehaviorTree>
@@ -86,7 +86,7 @@ TEST(PointPortTest, test_correct_syntax)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <PointPort test="1.0;2.0;3.0" />
         </BehaviorTree>
@@ -107,7 +107,7 @@ TEST(QuaternionPortTest, test_wrong_syntax)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <QuaternionPort test="1.0;2.0;3.0;4.0;5.0" />
         </BehaviorTree>
@@ -126,7 +126,7 @@ TEST(QuaternionPortTest, test_wrong_syntax)
 
   xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <QuaternionPort test="1.0;2.0;3.0" />
         </BehaviorTree>
@@ -144,7 +144,7 @@ TEST(QuaternionPortTest, test_correct_syntax)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <QuaternionPort test="0.7;0.0;0.0;0.7" />
         </BehaviorTree>
@@ -166,7 +166,7 @@ TEST(PoseStampedPortTest, test_wrong_syntax)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <PoseStampedPort test="0;map;1.0;2.0;3.0;4.0;5.0;6.0;7.0;8.0" />
         </BehaviorTree>
@@ -190,7 +190,7 @@ TEST(PoseStampedPortTest, test_wrong_syntax)
 
   xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <PoseStampedPort test="0;map;1.0;2.0;3.0;4.0;5.0;6.0" />
         </BehaviorTree>
@@ -213,7 +213,7 @@ TEST(PoseStampedPortTest, test_correct_syntax)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <PoseStampedPort test="0;map;1.0;2.0;3.0;4.0;5.0;6.0;7.0" />
         </BehaviorTree>
@@ -241,7 +241,7 @@ TEST(MillisecondsPortTest, test_correct_syntax)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <MillisecondsPort test="10000" />
         </BehaviorTree>
@@ -257,7 +257,7 @@ TEST(MillisecondsPortTest, test_correct_syntax)
 
   xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <MillisecondsPort test="123.4" />
         </BehaviorTree>
@@ -272,7 +272,7 @@ TEST(ErrorCodePortTest, test_correct_syntax)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <ErrorCodePort test="100;204;212"/>
         </BehaviorTree>
@@ -295,7 +295,7 @@ TEST(deconflictPortAndParamFrameTest, test_correct_syntax)
 {
   std::string xml_txt =
     R"(
-      <root main_tree_to_execute = "MainTree" >
+      <root BTCPP_format="4">
         <BehaviorTree ID="MainTree">
             <ParamPort test="1"/>
         </BehaviorTree>

--- a/nav2_behavior_tree/test/utils/test_behavior_tree_fixture.hpp
+++ b/nav2_behavior_tree/test/utils/test_behavior_tree_fixture.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include <set>
 
-#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp/bt_factory.h"
 #include "rclcpp/rclcpp.hpp"
 
 #include "test_transform_handler.hpp"

--- a/nav2_behavior_tree/test/utils/test_dummy_tree_node.hpp
+++ b/nav2_behavior_tree/test/utils/test_dummy_tree_node.hpp
@@ -36,7 +36,11 @@ public:
 
   void changeStatus(BT::NodeStatus status)
   {
-    setStatus(status);
+    if(status == BT::NodeStatus::IDLE) {
+      resetStatus()
+    } else {
+      setStatus(status);
+    }
   }
 
   BT::NodeStatus executeTick() override

--- a/nav2_behavior_tree/test/utils/test_dummy_tree_node.hpp
+++ b/nav2_behavior_tree/test/utils/test_dummy_tree_node.hpp
@@ -16,8 +16,8 @@
 #ifndef UTILS__TEST_DUMMY_TREE_NODE_HPP_
 #define UTILS__TEST_DUMMY_TREE_NODE_HPP_
 
-#include <behaviortree_cpp_v3/basic_types.h>
-#include <behaviortree_cpp_v3/action_node.h>
+#include <behaviortree_cpp/basic_types.h>
+#include <behaviortree_cpp/action_node.h>
 
 namespace nav2_behavior_tree
 {

--- a/nav2_behavior_tree/test/utils/test_dummy_tree_node.hpp
+++ b/nav2_behavior_tree/test/utils/test_dummy_tree_node.hpp
@@ -36,8 +36,8 @@ public:
 
   void changeStatus(BT::NodeStatus status)
   {
-    if(status == BT::NodeStatus::IDLE) {
-      resetStatus()
+    if (status == BT::NodeStatus::IDLE) {
+      resetStatus();
     } else {
       setStatus(status);
     }

--- a/nav2_bt_navigator/CMakeLists.txt
+++ b/nav2_bt_navigator/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav2_behavior_tree REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(nav2_msgs REQUIRED)
-find_package(behaviortree_cpp_v3 REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(nav2_core REQUIRED)
@@ -43,7 +43,7 @@ set(dependencies
   nav2_behavior_tree
   nav_msgs
   nav2_msgs
-  behaviortree_cpp_v3
+  behaviortree_cpp
   std_srvs
   nav2_util
   nav2_core

--- a/nav2_bt_navigator/behavior_trees/follow_point.xml
+++ b/nav2_bt_navigator/behavior_trees/follow_point.xml
@@ -2,7 +2,7 @@
   This Behavior Tree follows a dynamic pose to a certain distance
 -->
 
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <PipelineSequence name="NavigateWithReplanning">
       <ControllerSelector selected_controller="{selected_controller}" default_controller="FollowPath" topic_name="controller_selector"/>

--- a/nav2_bt_navigator/behavior_trees/nav_to_pose_with_consistent_replanning_and_if_path_becomes_invalid.xml
+++ b/nav2_bt_navigator/behavior_trees/nav_to_pose_with_consistent_replanning_and_if_path_becomes_invalid.xml
@@ -3,7 +3,7 @@
   recovery actions specific to planning / control as well as general system issues.
   This will be continuous if a kinematically valid planner is selected.
 -->
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <RecoveryNode number_of_retries="6" name="NavigateRecovery">
       <PipelineSequence name="NavigateWithReplanning">

--- a/nav2_bt_navigator/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml
@@ -3,7 +3,7 @@
   This Behavior Tree replans the global path periodically at 1 Hz through an array of poses continuously
    and it also has recovery actions specific to planning / control as well as general system issues.
 -->
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <RecoveryNode number_of_retries="6" name="NavigateRecovery">
       <PipelineSequence name="NavigateWithReplanning">

--- a/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml
@@ -4,7 +4,7 @@
   recovery actions specific to planning / control as well as general system issues.
   This will be continuous if a kinematically valid planner is selected.
 -->
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <RecoveryNode number_of_retries="6" name="NavigateRecovery">
       <PipelineSequence name="NavigateWithReplanning">

--- a/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_goal_patience_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_goal_patience_and_recovery.xml
@@ -5,7 +5,7 @@
   make the robot wait for a specific time, to see if the obstacle clears out before
   navigating along a significantly longer path to reach the goal location.
 -->
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <RecoveryNode number_of_retries="6" name="NavigateRecovery">
       <PipelineSequence name="NavigateWithReplanning">

--- a/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_goal_patience_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_goal_patience_and_recovery.xml
@@ -20,10 +20,10 @@
         <ReactiveSequence name="MonitorAndFollowPath">
           <PathLongerOnApproach path="{path}" prox_len="3.0" length_factor="2.0">
             <RetryUntilSuccessful num_attempts="1">
-              <SequenceStar name="CancelingControlAndWait">
+              <SequenceWithMemory name="CancelingControlAndWait">
                 <CancelControl name="ControlCancel"/>
                 <Wait wait_duration="5.0"/>
-              </SequenceStar>
+              </SequenceWithMemory>
             </RetryUntilSuccessful>
           </PathLongerOnApproach>
           <RecoveryNode number_of_retries="1" name="FollowPath">

--- a/nav2_bt_navigator/behavior_trees/navigate_w_recovery_and_replanning_only_if_path_becomes_invalid.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_recovery_and_replanning_only_if_path_becomes_invalid.xml
@@ -4,7 +4,7 @@
   recovery actions specific to planning / control as well as general system issues.
   This will be continuous if a kinematically valid planner is selected.
 -->
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <RecoveryNode number_of_retries="6" name="NavigateRecovery">
       <PipelineSequence>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_distance.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_distance.xml
@@ -2,7 +2,7 @@
   This Behavior Tree replans the global path after every 1m.
 -->
 
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <PipelineSequence name="NavigateWithReplanning">
       <ControllerSelector selected_controller="{selected_controller}" default_controller="FollowPath" topic_name="controller_selector"/>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_only_if_goal_is_updated.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_only_if_goal_is_updated.xml
@@ -2,7 +2,7 @@
   This Behavior Tree replans the global path only when the goal is updated.
 -->
 
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <PipelineSequence name="NavigateWithReplanning">
       <ControllerSelector selected_controller="{selected_controller}" default_controller="FollowPath" topic_name="controller_selector"/>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_only_if_path_becomes_invalid.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_only_if_path_becomes_invalid.xml
@@ -1,7 +1,7 @@
 <!--
   This Behavior Tree replans the global path only if the path becomes invalid
 -->
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <PipelineSequence name="NavigateWithReplanning">
       <ControllerSelector selected_controller="{selected_controller}" default_controller="FollowPath" topic_name="controller_selector"/>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_speed.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_speed.xml
@@ -2,7 +2,7 @@
   This Behavior Tree replans the global path periodically proprortional to speed.
 -->
 
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <PipelineSequence name="NavigateWithReplanning">
       <ControllerSelector selected_controller="{selected_controller}" default_controller="FollowPath" topic_name="controller_selector"/>

--- a/nav2_bt_navigator/behavior_trees/navigate_w_replanning_time.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_w_replanning_time.xml
@@ -2,7 +2,7 @@
   This Behavior Tree replans the global path periodically at 1 Hz.
 -->
 
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <PipelineSequence name="NavigateWithReplanning">
       <ControllerSelector selected_controller="{selected_controller}" default_controller="FollowPath" topic_name="controller_selector"/>

--- a/nav2_bt_navigator/behavior_trees/odometry_calibration.xml
+++ b/nav2_bt_navigator/behavior_trees/odometry_calibration.xml
@@ -2,7 +2,7 @@
   his Behavior Tree drives in a square for odometry calibration experiments
 -->
 
-<root main_tree_to_execute="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <Repeat num_cycles="3">
       <Sequence name="Drive in a square">

--- a/nav2_bt_navigator/package.xml
+++ b/nav2_bt_navigator/package.xml
@@ -17,7 +17,7 @@
   <build_depend>nav2_behavior_tree</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>nav2_msgs</build_depend>
-  <build_depend>behaviortree_cpp_v3</build_depend>
+  <build_depend>behaviortree_cpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
@@ -25,7 +25,7 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>nav2_core</build_depend>
 
-  <exec_depend>behaviortree_cpp_v3</exec_depend>
+  <exec_depend>behaviortree_cpp</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_action</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -103,7 +103,7 @@ NavigateThroughPosesNavigator::onLoop()
   auto blackboard = bt_action_server_->getBlackboard();
 
   Goals goal_poses;
-  blackboard->get<Goals>(goals_blackboard_id_, goal_poses);
+  [[maybe_unused]] auto res = blackboard->get(goals_blackboard_id_, goal_poses);
 
   if (goal_poses.size() == 0) {
     bt_action_server_->publishFeedback(feedback_msg);
@@ -123,7 +123,7 @@ NavigateThroughPosesNavigator::onLoop()
   try {
     // Get current path points
     nav_msgs::msg::Path current_path;
-    blackboard->get<nav_msgs::msg::Path>(path_blackboard_id_, current_path);
+    res = blackboard->get(path_blackboard_id_, current_path);
 
     // Find the closest pose to current pose on global path
     auto find_closest_pose_idx =
@@ -166,7 +166,7 @@ NavigateThroughPosesNavigator::onLoop()
   }
 
   int recovery_count = 0;
-  blackboard->get<int>("number_recoveries", recovery_count);
+  res = blackboard->get("number_recoveries", recovery_count);
   feedback_msg->number_of_recoveries = recovery_count;
   feedback_msg->current_pose = current_pose;
   feedback_msg->navigation_time = clock_->now() - start_time_;

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -126,7 +126,7 @@ NavigateToPoseNavigator::onLoop()
   try {
     // Get current path points
     nav_msgs::msg::Path current_path;
-    blackboard->get<nav_msgs::msg::Path>(path_blackboard_id_, current_path);
+    [[maybe_unused]] auto res = blackboard->get(path_blackboard_id_, current_path);
 
     // Find the closest pose to current pose on global path
     auto find_closest_pose_idx =
@@ -169,7 +169,7 @@ NavigateToPoseNavigator::onLoop()
   }
 
   int recovery_count = 0;
-  blackboard->get<int>("number_recoveries", recovery_count);
+  [[maybe_unused]] auto res = blackboard->get("number_recoveries", recovery_count);
   feedback_msg->number_of_recoveries = recovery_count;
   feedback_msg->current_pose = current_pose;
   feedback_msg->navigation_time = clock_->now() - start_time_;

--- a/nav2_system_tests/CMakeLists.txt
+++ b/nav2_system_tests/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(nav2_navfn_planner REQUIRED)
 find_package(nav2_planner REQUIRED)
 find_package(navigation2)
 find_package(angles REQUIRED)
-find_package(behaviortree_cpp_v3 REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
 find_package(pluginlib REQUIRED)
 
 nav2_package()
@@ -45,7 +45,7 @@ set(dependencies
   nav2_planner
   nav2_navfn_planner
   angles
-  behaviortree_cpp_v3
+  behaviortree_cpp
   pluginlib
 )
 

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -22,9 +22,9 @@
 
 #include "gtest/gtest.h"
 
-#include "behaviortree_cpp_v3/behavior_tree.h"
-#include "behaviortree_cpp_v3/bt_factory.h"
-#include "behaviortree_cpp_v3/utils/shared_library.h"
+#include "behaviortree_cpp/behavior_tree.h"
+#include "behaviortree_cpp/bt_factory.h"
+#include "behaviortree_cpp/utils/shared_library.h"
 
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
@@ -224,7 +224,7 @@ TEST_F(BehaviorTreeTestFixture, TestAllSuccess)
   BT::NodeStatus result = BT::NodeStatus::RUNNING;
 
   while (result == BT::NodeStatus::RUNNING) {
-    result = bt_handler->tree.tickRoot();
+    result = bt_handler->tree.tickOnce();
     std::this_thread::sleep_for(10ms);
   }
 
@@ -275,7 +275,7 @@ TEST_F(BehaviorTreeTestFixture, TestAllFailure)
   BT::NodeStatus result = BT::NodeStatus::RUNNING;
 
   while (result == BT::NodeStatus::RUNNING) {
-    result = bt_handler->tree.tickRoot();
+    result = bt_handler->tree.tickOnce();
     std::this_thread::sleep_for(10ms);
   }
 
@@ -324,7 +324,7 @@ TEST_F(BehaviorTreeTestFixture, TestNavigateSubtreeRecoveries)
   BT::NodeStatus result = BT::NodeStatus::RUNNING;
 
   while (result == BT::NodeStatus::RUNNING) {
-    result = bt_handler->tree.tickRoot();
+    result = bt_handler->tree.tickOnce();
     std::this_thread::sleep_for(10ms);
   }
 
@@ -382,7 +382,7 @@ TEST_F(BehaviorTreeTestFixture, TestNavigateRecoverySimple)
   BT::NodeStatus result = BT::NodeStatus::RUNNING;
 
   while (result == BT::NodeStatus::RUNNING) {
-    result = bt_handler->tree.tickRoot();
+    result = bt_handler->tree.tickOnce();
     std::this_thread::sleep_for(10ms);
   }
 
@@ -476,7 +476,7 @@ TEST_F(BehaviorTreeTestFixture, TestNavigateRecoveryComplex)
   BT::NodeStatus result = BT::NodeStatus::RUNNING;
 
   while (result == BT::NodeStatus::RUNNING) {
-    result = bt_handler->tree.tickRoot();
+    result = bt_handler->tree.tickOnce();
     std::this_thread::sleep_for(10ms);
   }
 
@@ -540,7 +540,7 @@ TEST_F(BehaviorTreeTestFixture, TestRecoverySubtreeGoalUpdated)
   BT::NodeStatus result = BT::NodeStatus::RUNNING;
 
   while (result == BT::NodeStatus::RUNNING) {
-    result = bt_handler->tree.tickRoot();
+    result = bt_handler->tree.tickOnce();
 
     // Update goal on blackboard after Spin has been triggered once
     // to simulate a goal update during a recovery action

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -67,6 +67,8 @@ public:
     for (const auto & p : plugin_libs) {
       factory_.registerFromPlugin(BT::SharedLibrary::getOSName(p));
     }
+    // Allow the old name, for backward compatibility
+    factory_.registerNodeType<BT::SequenceWithMemory>("SequenceStar");
   }
 
   bool loadBehaviorTree(const std::string & filename)

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -67,8 +67,6 @@ public:
     for (const auto & p : plugin_libs) {
       factory_.registerFromPlugin(BT::SharedLibrary::getOSName(p));
     }
-    // Allow the old name, for backward compatibility
-    factory_.registerNodeType<BT::SequenceWithMemory>("SequenceStar");
   }
 
   bool loadBehaviorTree(const std::string & filename)

--- a/tools/bt2img.py
+++ b/tools/bt2img.py
@@ -27,7 +27,7 @@ control_nodes = [
     'ReactiveFallback',
     'ReactiveSequence',
     'Sequence',
-    'SequenceStar',
+    'SequenceWithMemory',
     'BlackboardCheckInt',
     'BlackboardCheckDouble',
     'BlackboardCheckString',


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4059 |
| Primary OS tested on | Ubuntu 22.04, Rolling |
| Robotic platform tested on | none |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Moving from BT.CPP 3.8 to BT.CPP 4.5 (latest in Rolling).

TODO:
- [x] Compile without errors.
- [x] Fix failing unit tests.
- [x] Handle `NodeStatus::SKIPPED` in Control Nodes and Decorators.
- [ ] Add documentation in "Migration guide".

List of changes:

- **XML**: adding `BTCPP_format="4"` to **root** and removing the redundant `main_tree_to_execute`
- `blackboard->get` is `[[nodiscard]]` in BT.CPP 4.x.
- Fix the different behavior of `ReactiveSequence` and `ReactiveFallback`
- `tickRoot` renamed to `tickOnce`



## Description of documentation updates required from your changes

None of these changes should affect the user's code, nor in terms of Behavior or API. 

But we need to add the migration guide to the website.
I will also need to update mine here: https://www.behaviortree.dev/docs/migration

---

## Future work that may be required in bullet points

1. Groot2 publisher to be added to the BT executor.
2. Reminder that using `blackboard->get` prevent the use of **SubTrees**, but not the topic of this PR.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
