### PR TITLE
Fix goal handle was not freed correctly

### DIFF
--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -574,7 +574,7 @@ protected:
    * @param the Results object to terminate the action with
    */
   void terminate(
-    std::shared_ptr<rclcpp_action::ServerGoalHandle<ActionT>> handle,
+    std::shared_ptr<rclcpp_action::ServerGoalHandle<ActionT>>& handle,
     typename std::shared_ptr<typename ActionT::Result> result =
     std::make_shared<typename ActionT::Result>())
   {

--- a/nav2_util/include/nav2_util/simple_action_server.hpp
+++ b/nav2_util/include/nav2_util/simple_action_server.hpp
@@ -574,7 +574,7 @@ protected:
    * @param the Results object to terminate the action with
    */
   void terminate(
-    std::shared_ptr<rclcpp_action::ServerGoalHandle<ActionT>>& handle,
+    std::shared_ptr<rclcpp_action::ServerGoalHandle<ActionT>> & handle,
     typename std::shared_ptr<typename ActionT::Result> result =
     std::make_shared<typename ActionT::Result>())
   {


### PR DESCRIPTION
## Description of contribution in a few bullet points

Fix the goal handle was not freed correctly when action server terminates goal. See #4121 for more detail


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
