### PR TITLE
fix wrong initial value for pop_z

### DIFF
--- a/nav2_amcl/src/pf/pf.c
+++ b/nav2_amcl/src/pf/pf.c
@@ -69,7 +69,7 @@ pf_t * pf_alloc(
   // p), where p is the probability that the error on the estimated
   // distrubition will be less than [err].
   pf->pop_err = 0.01;
-  pf->pop_z = 3;
+  pf->pop_z = 0.99;
   pf->dist_threshold = 0.5;
 
   pf->current_set = 0;


### PR DESCRIPTION
By definition this should be (1-p) and the previous value 3 doesn't make any sense.