### PR TITLE
nav2_controller: add loop rate log

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -452,6 +452,8 @@ void ControllerServer::computeControl()
     last_valid_cmd_time_ = now();
     rclcpp::WallRate loop_rate(controller_frequency_);
     while (rclcpp::ok()) {
+      auto start_time = this->now();
+
       if (action_server_ == nullptr || !action_server_->is_server_active()) {
         RCLCPP_DEBUG(get_logger(), "Action server unavailable or inactive. Stopping.");
         return;
@@ -479,10 +481,13 @@ void ControllerServer::computeControl()
         break;
       }
 
+      auto cycle_duration = this->now() - start_time;
+
       if (!loop_rate.sleep()) {
         RCLCPP_WARN(
-          get_logger(), "Control loop missed its desired rate of %.4fHz",
-          controller_frequency_);
+          get_logger(),
+          "Control loop missed its desired rate of %.4f Hz. Current loop rate is %.4f Hz.",
+          controller_frequency_, 1 / cycle_duration.seconds());
       }
     }
   } catch (nav2_core::InvalidController & e) {

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -482,7 +482,6 @@ void ControllerServer::computeControl()
       }
 
       auto cycle_duration = this->now() - start_time;
-
       if (!loop_rate.sleep()) {
         RCLCPP_WARN(
           get_logger(),


### PR DESCRIPTION
Following the format [here](https://github.com/ros-planning/navigation2/blob/c9d9b5c698d1f5aff060806481d18ba7e9b18cb2/nav2_planner/src/planner_server.cpp#L444) added loop rate logging to nav2_controller/controller_server.cpp.

has been tested with low and too-high frequencies to make sure it is not printed when not needed, and printed when needed.

I'm only not sure if defining the start_time where I did makes sense or it should've been later maybe. My logic was that all the checks being done are part of the controller loop and however long they take, it is slowing the controller down.