### PR TITLE
replace layered_costmap_->isRolling() with map_frame_ == global_frame_ in static layer

### DIFF
--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -387,15 +387,15 @@ StaticLayer::updateCosts(
     return;
   }
 
-  if (!layered_costmap_->isRolling()) {
-    // if not rolling, the layered costmap (master_grid) has same coordinates as this layer
+  if (map_frame_ == global_frame_) {
+    // When map_frame_ equals global_frame_, the layered costmap (master_grid) has same coordinates as this layer
     if (!use_maximum_) {
       updateWithTrueOverwrite(master_grid, min_i, min_j, max_i, max_j);
     } else {
       updateWithMax(master_grid, min_i, min_j, max_i, max_j);
     }
   } else {
-    // If rolling window, the master_grid is unlikely to have same coordinates as this layer
+    // When map_frame_ does not equal global_frame_, the coordinates in this layer must be transformed to align with those in the master_grid.
     unsigned int mx, my;
     double wx, wy;
     // Might even be in a different frame


### PR DESCRIPTION
The costmap frame can be directly compared with the static layer frame, instead of inferring their relationship based on `isRolling()`.

Typically, the static layer always utilizes the `map` frame. The global costmap (isRolling == true) uses the `map` frame, whereas the local costmap (isRolling == false) employs the `odom` frame. For a local costmap, the map cells are transformed from the map frame to the odom frame.

Rather than using `isRolling` to distinguish between the global and local costmaps, we can directly check if `map_frame_` equals `global_frame_`. This not only enhances readability but also permits the static layer in the global costmap to use a different frame from the costmap. For instance, the static layer frame could be `map_docker`, while the global costmap continues to use `map`. The transformation would be from `map_docker` to `map`.


 

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
