### PR TITLE
Implement Critic for Velocity Deadband Hardware Constraints

### DIFF
--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(mppi_critics SHARED
   src/critics/prefer_forward_critic.cpp
   src/critics/twirling_critic.cpp
   src/critics/constraint_critic.cpp
+  src/critics/velocity_deadband_critic.cpp
 )
 
 set(libraries mppi_controller mppi_critics)

--- a/nav2_mppi_controller/critics.xml
+++ b/nav2_mppi_controller/critics.xml
@@ -45,5 +45,9 @@
       <description>mppi critic for incentivizing moving within kinematic and dynamic bounds</description>
     </class>
 
+    <class type="mppi::critics::VelocityDeadbandCritic" base_class_type="mppi::critics::CriticFunction">
+      <description>mppi critic for restricting command velocities in deadband range</description>
+    </class>
+
   </library>
 </class_libraries>

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/velocity_deadband_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/velocity_deadband_critic.hpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_MPPI_CONTROLLER__CRITICS__VELOCITY_DEADBAND_HPP_
+#define NAV2_MPPI_CONTROLLER__CRITICS__VELOCITY_DEADBAND_HPP_
+
+#include "nav2_mppi_controller/critic_function.hpp"
+#include "nav2_mppi_controller/models/state.hpp"
+#include "nav2_mppi_controller/tools/utils.hpp"
+
+namespace mppi::critics
+{
+
+/**
+ * @class mppi::critics::ConstraintCritic
+ * @brief Critic objective function for enforcing feasible constraints
+ */
+class VelocityDeadbandCritic : public CriticFunction
+{
+public:
+  /**
+   * @brief Initialize critic
+   */
+  void initialize() override;
+
+  /**
+   * @brief Evaluate cost related to goal following
+   *
+   * @param costs [out] add reference cost values to this tensor
+   */
+  void score(CriticData& data) override;
+
+  std::vector<double>& getDeadbandVelocities() { return deadband_velocities_; }
+
+protected:
+  unsigned int power_{ 0 };
+  float weight_{ 0 };
+  std::vector<double> deadband_velocities_;
+};
+
+} // namespace mppi::critics
+
+#endif // NAV2_MPPI_CONTROLLER__CRITICS__VELOCITY_DEADBAND_HPP_

--- a/nav2_mppi_controller/src/critics/velocity_deadband_critic.cpp
+++ b/nav2_mppi_controller/src/critics/velocity_deadband_critic.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_mppi_controller/critics/velocity_deadband_critic.hpp"
+
+namespace mppi::critics
+{
+
+void VelocityDeadbandCritic::initialize()
+{
+  auto getParam = parameters_handler_->getParamGetter(name_);
+
+  getParam(power_, "cost_power", 1);
+  getParam(weight_, "cost_weight", 4.0);
+  getParam(deadband_velocities_, "deadband_velocities", std::vector<double>{ 0.0, 0.0, 0.0 });
+  RCLCPP_INFO_STREAM(logger_, "VelocityDeadbandCritic instantiated with "
+                                << power_ << " power, " << weight_ << " weight, deadband_velocity [" << deadband_velocities_.at(0)
+                                << "," << deadband_velocities_.at(1) << "," << deadband_velocities_.at(2) << "]");
+}
+
+void VelocityDeadbandCritic::score(CriticData& data)
+{
+  using xt::evaluation_strategy::immediate;
+
+  if (!enabled_)
+  {
+    return;
+  }
+
+  auto& vx = data.state.vx;
+  auto& wz = data.state.wz;
+
+  auto out_of_deadband_vx_motion = xt::maximum(fabs(deadband_velocities_.at(0)) - xt::fabs(vx), 0);
+  auto out_of_deadband_wz_motion = xt::maximum(fabs(deadband_velocities_.at(2)) - xt::fabs(wz), 0);
+
+  if (data.motion_model->isHolonomic()) {
+    auto& vy = data.state.vy;
+    auto out_of_deadband_vy_motion = xt::maximum(fabs(deadband_velocities_.at(1)) - xt::fabs(vy), 0);
+    data.costs += xt::pow(
+      xt::sum((std::move(out_of_deadband_vx_motion) + std::move(out_of_deadband_vy_motion) + 
+      std::move(out_of_deadband_wz_motion)) * data.model_dt, { 1 }, immediate) *
+      weight_, power_);
+    return;
+  }
+
+  data.costs += xt::pow(
+    xt::sum((std::move(out_of_deadband_vx_motion) + std::move(out_of_deadband_wz_motion)) * data.model_dt, { 1 }, immediate) *
+    weight_, power_);
+  return;
+}
+
+} // namespace mppi::critics
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(mppi::critics::VelocityDeadbandCritic, mppi::critics::CriticFunction)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

Some platforms have deadband velocity constraints and cannot move slowly. For instance, the legged robot Unitree Go2. This PR adds a critic that penalizes trajectory samples below a deadband value.
A robot with hardware limitations cannot reach the goal with a high tolerance (0.03m in my Gazebo simulation). I have attached videos comparing my feature with the 'out of the box' MPPI.
[Original MPPI](https://youtu.be/qwjZw97DLTY?si=eaMNq1cX_obHqBd5)
[With deadband critic](https://youtu.be/9_hw7ied594?si=BHS1kdlH22dkA2_x)


| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | discussion in [slack](https://navigation2.slack.com/archives/C012L20NQLV/p1710932047032829) |
| Primary OS tested on | (Ubuntu 22.04) |
| Robotic platform tested on | Gazebo: omni robot [linorobot2](https://github.com/linorobot/linorobot2); Real: Unitree GO2 |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points


* Add new critic that penalizes trajectory samples lower than a deadband value


## Description of documentation updates required from your changes


* Added new parameter, so need to add that to default configs and documentation page

Sample to copy paste into MPPI readme:

#### Velocity Deadband Critic
 | Parameter             | Type   | Definition                                                                                                  |
 | ---------------       | ------ | ----------------------------------------------------------------------------------------------------------- |
 | cost_weight           | double | Default 35.0. Weight to apply to critic term.                                                                |
 | cost_power            | int    | Default 1. Power order to apply to term.                                                                    |
 | deadband_velocities | double[] | Default [0.05, 0.05, 0.05].  The array of deadband velocities [vx, vz, wz]. A zero array indicates that the critic will take no action.      |


---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
