### PR TITLE
Scale cost critic's weight when dynamically updated

### DIFF
--- a/nav2_mppi_controller/src/critics/cost_critic.cpp
+++ b/nav2_mppi_controller/src/critics/cost_critic.cpp
@@ -34,6 +34,12 @@ void CostCritic::initialize()
   // Normalized by cost value to put in same regime as other weights
   weight_ /= 254.0f;
 
+  // Normalize weight when parameter is changed dynamically as well
+  auto weightDynamicCb = [&](const rclcpp::Parameter & weight) {
+      weight_ = weight.as_double() / 254.0f;
+    };
+  parameters_handler_->addDynamicParamCallback(name_ + ".cost_weight", weightDynamicCb);
+
   collision_checker_.setCostmap(costmap_);
   possible_collision_cost_ = findCircumscribedCost(costmap_ros_);
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Gazebo custom robot |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

* Cost critic's weight was not scaled by the max possible cost when dynamically updated. I'm now scaling it by 254.0 after a dynamic update

## Description of documentation updates required from your changes

None to my knowledge

---

## Future work that may be required in bullet points

None to my knowledge


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
