### PR TITLE
Fix compiler warning ‘error_level’ may be used uninitialized

### DIFF
--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -177,7 +177,7 @@ LifecycleManager::CreateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &
       error_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
       message = "Managed nodes have been shut down";
       break;
-    case NodeState::UNKNOWN:
+    default:  // NodeState::UNKNOWN
       error_level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
       message = "An error has occurred during a node state transition";
       break;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros/diagnostics/issues/337 |
| Primary OS tested on | Ubuntu Noble |
| Robotic platform tested on | None |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Since `-Werror` is enforced in navigation2, it was unable to compile on newer cmake versions (ROS rolling, ubuntu Nobleo, cmake 3.28.3).
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
