### PR TITLE
Implement Critic for Velocity Deadband Hardware Constraints

### DIFF
--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -88,6 +88,7 @@ add_library(mppi_critics SHARED
   src/critics/prefer_forward_critic.cpp
   src/critics/twirling_critic.cpp
   src/critics/constraint_critic.cpp
+  src/critics/velocity_deadband_critic.cpp
 )
 
 set(libraries mppi_controller mppi_critics)

--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -171,6 +171,15 @@ Uses inflated costmap cost directly to avoid obstacles
  | cost_weight           | double | Default 10.0. Weight to apply to critic term.                                                               |
  | cost_power            | int    | Default 1. Power order to apply to term.                                                                    |
 
+
+#### Velocity Deadband Critic
+ | Parameter             | Type     | Definition                                                                                                  |
+ | ---------------       | ------   | ----------------------------------------------------------------------------------------------------------- |
+ | cost_weight           | double   | Default 100.0. Weight to apply to critic term. (100.0 fits for turtlebot3, 35.0 for linorobot2)             |
+ | cost_power            | int      | Default 1. Power order to apply to term.                                                                    |
+ | deadband_velocities   | double[] | Default [0.0, 0.0, 0.0].  The array of deadband velocities [vx, vz, wz]. A zero array indicates that the critic will take no action.      |
+
+
 ### XML configuration example
 ```
 controller_server:
@@ -200,7 +209,7 @@ controller_server:
         time_step: 3
       AckermannConstraints:
         min_turning_r: 0.2
-      critics: ["ConstraintCritic", "CostCritic", "GoalCritic", "GoalAngleCritic", "PathAlignCritic", "PathFollowCritic", "PathAngleCritic", "PreferForwardCritic"]
+      critics: ["ConstraintCritic", "CostCritic", "GoalCritic", "GoalAngleCritic", "PathAlignCritic", "PathFollowCritic", "PathAngleCritic", "PreferForwardCritic", "VelocityDeadbandCritic"]
       ConstraintCritic:
         enabled: true
         cost_power: 1
@@ -262,6 +271,11 @@ controller_server:
         threshold_to_consider: 0.5
         max_angle_to_furthest: 1.0
         forward_preference: true
+      VelocityDeadbandCritic:
+        enabled: false
+        cost_power: 1
+        cost_weight: 100.0
+        deadband_velocities: [0.08, 0.08, 0.08]
       # TwirlingCritic:
       #   enabled: true
       #   twirling_cost_power: 1

--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -175,7 +175,7 @@ Uses inflated costmap cost directly to avoid obstacles
 #### Velocity Deadband Critic
  | Parameter             | Type     | Definition                                                                                                  |
  | ---------------       | ------   | ----------------------------------------------------------------------------------------------------------- |
- | cost_weight           | double   | Default 100.0. Weight to apply to critic term. (100.0 fits for turtlebot3, 35.0 for linorobot2)             |
+ | cost_weight           | double   | Default 35.0. Weight to apply to critic term.                                                               |
  | cost_power            | int      | Default 1. Power order to apply to term.                                                                    |
  | deadband_velocities   | double[] | Default [0.0, 0.0, 0.0].  The array of deadband velocities [vx, vz, wz]. A zero array indicates that the critic will take no action.      |
 

--- a/nav2_mppi_controller/README.md
+++ b/nav2_mppi_controller/README.md
@@ -209,7 +209,7 @@ controller_server:
         time_step: 3
       AckermannConstraints:
         min_turning_r: 0.2
-      critics: ["ConstraintCritic", "CostCritic", "GoalCritic", "GoalAngleCritic", "PathAlignCritic", "PathFollowCritic", "PathAngleCritic", "PreferForwardCritic", "VelocityDeadbandCritic"]
+      critics: ["ConstraintCritic", "CostCritic", "GoalCritic", "GoalAngleCritic", "PathAlignCritic", "PathFollowCritic", "PathAngleCritic", "PreferForwardCritic"]
       ConstraintCritic:
         enabled: true
         cost_power: 1
@@ -271,11 +271,11 @@ controller_server:
         threshold_to_consider: 0.5
         max_angle_to_furthest: 1.0
         forward_preference: true
-      VelocityDeadbandCritic:
-        enabled: false
-        cost_power: 1
-        cost_weight: 100.0
-        deadband_velocities: [0.08, 0.08, 0.08]
+      # VelocityDeadbandCritic:
+      #   enabled: true
+      #   cost_power: 1
+      #   cost_weight: 35.0
+      #   deadband_velocities: [0.05, 0.05, 0.05]
       # TwirlingCritic:
       #   enabled: true
       #   twirling_cost_power: 1

--- a/nav2_mppi_controller/critics.xml
+++ b/nav2_mppi_controller/critics.xml
@@ -41,5 +41,9 @@
       <description>mppi critic for incentivizing moving within kinematic and dynamic bounds</description>
     </class>
 
+    <class type="mppi::critics::VelocityDeadbandCritic" base_class_type="mppi::critics::CriticFunction">
+      <description>mppi critic for restricting command velocities in deadband range</description>
+    </class>
+
   </library>
 </class_libraries>

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/velocity_deadband_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/velocity_deadband_critic.hpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_MPPI_CONTROLLER__CRITICS__VELOCITY_DEADBAND_CRITIC_HPP_
+#define NAV2_MPPI_CONTROLLER__CRITICS__VELOCITY_DEADBAND_CRITIC_HPP_
+
+#include <vector>
+
+#include "nav2_mppi_controller/critic_function.hpp"
+#include "nav2_mppi_controller/models/state.hpp"
+#include "nav2_mppi_controller/tools/utils.hpp"
+
+namespace mppi::critics
+{
+
+/**
+ * @class mppi::critics::VelocityDeadbandCritic
+ * @brief Critic objective function for enforcing feasible constraints
+ */
+class VelocityDeadbandCritic : public CriticFunction
+{
+public:
+  /**
+   * @brief Initialize critic
+   */
+  void initialize() override;
+
+  /**
+   * @brief Evaluate cost related to goal following
+   *
+   * @param costs [out] add reference cost values to this tensor
+   */
+  void score(CriticData & data) override;
+
+protected:
+  unsigned int power_{0};
+  float weight_{0};
+  std::vector<float> deadband_velocities_{0.0f, 0.0f, 0.0f};
+};
+
+}  // namespace mppi::critics
+
+#endif  // NAV2_MPPI_CONTROLLER__CRITICS__VELOCITY_DEADBAND_CRITIC_HPP_

--- a/nav2_mppi_controller/src/critics/velocity_deadband_critic.cpp
+++ b/nav2_mppi_controller/src/critics/velocity_deadband_critic.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2022 Samsung Research America, @artofnothingness Alexey Budyakov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_mppi_controller/critics/velocity_deadband_critic.hpp"
+
+namespace mppi::critics
+{
+
+void VelocityDeadbandCritic::initialize()
+{
+  auto getParam = parameters_handler_->getParamGetter(name_);
+
+  getParam(power_, "cost_power", 1);
+  getParam(weight_, "cost_weight", 100.0);
+
+  // Recast double to float
+  std::vector<double> deadband_velocities{0.0, 0.0, 0.0};
+  getParam(deadband_velocities, "deadband_velocities", std::vector<double>{0.0, 0.0, 0.0});
+  std::transform(
+    deadband_velocities.begin(), deadband_velocities.end(), deadband_velocities_.begin(),
+    [](double d) {return static_cast<float>(d);});
+
+  RCLCPP_INFO_STREAM(
+    logger_, "VelocityDeadbandCritic instantiated with "
+      << power_ << " power, " << weight_ << " weight, deadband_velocity ["
+      << deadband_velocities_.at(0) << "," << deadband_velocities_.at(1) << ","
+      << deadband_velocities_.at(2) << "]");
+}
+
+void VelocityDeadbandCritic::score(CriticData & data)
+{
+  using xt::evaluation_strategy::immediate;
+
+  if (!enabled_) {
+    return;
+  }
+
+  auto & vx = data.state.vx;
+  auto & wz = data.state.wz;
+
+  if (data.motion_model->isHolonomic()) {
+    auto & vy = data.state.vy;
+    if (power_ > 1u) {
+      data.costs += xt::pow(
+        xt::sum(
+          std::move(
+            xt::maximum(fabs(deadband_velocities_.at(0)) - xt::fabs(vx), 0) +
+            xt::maximum(fabs(deadband_velocities_.at(1)) - xt::fabs(vy), 0) +
+            xt::maximum(fabs(deadband_velocities_.at(2)) - xt::fabs(wz), 0)) *
+          data.model_dt,
+          {1}, immediate) *
+        weight_,
+        power_);
+    } else {
+      data.costs += xt::sum(
+        (std::move(
+          xt::maximum(fabs(deadband_velocities_.at(0)) - xt::fabs(vx), 0) +
+          xt::maximum(fabs(deadband_velocities_.at(1)) - xt::fabs(vy), 0) +
+          xt::maximum(fabs(deadband_velocities_.at(2)) - xt::fabs(wz), 0))) *
+        data.model_dt,
+        {1}, immediate) *
+        weight_;
+    }
+    return;
+  }
+
+  if (power_ > 1u) {
+    data.costs += xt::pow(
+      xt::sum(
+        std::move(
+          xt::maximum(fabs(deadband_velocities_.at(0)) - xt::fabs(vx), 0) +
+          xt::maximum(fabs(deadband_velocities_.at(2)) - xt::fabs(wz), 0)) *
+        data.model_dt,
+        {1}, immediate) *
+      weight_,
+      power_);
+  } else {
+    data.costs += xt::sum(
+      (std::move(
+        xt::maximum(fabs(deadband_velocities_.at(0)) - xt::fabs(vx), 0) +
+        xt::maximum(fabs(deadband_velocities_.at(2)) - xt::fabs(wz), 0))) *
+      data.model_dt,
+      {1}, immediate) *
+      weight_;
+  }
+  return;
+}
+
+}  // namespace mppi::critics
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(mppi::critics::VelocityDeadbandCritic, mppi::critics::CriticFunction)

--- a/nav2_mppi_controller/src/critics/velocity_deadband_critic.cpp
+++ b/nav2_mppi_controller/src/critics/velocity_deadband_critic.cpp
@@ -22,7 +22,7 @@ void VelocityDeadbandCritic::initialize()
   auto getParam = parameters_handler_->getParamGetter(name_);
 
   getParam(power_, "cost_power", 1);
-  getParam(weight_, "cost_weight", 100.0);
+  getParam(weight_, "cost_weight", 35.0);
 
   // Recast double to float
   std::vector<double> deadband_velocities{0.0, 0.0, 0.0};

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -654,6 +654,6 @@ TEST(CriticTests, VelocityDeadbandCritic)
   state.vy = 0.02 * xt::ones<float>({1000, 30});
   state.wz = 0.021 * xt::ones<float>({1000, 30});
   critic.score(data);
-  // 100.0 weight * 0.1 model_dt * (0.07 + 0.06 + 0.059) * 30 timesteps = 56.7
-  EXPECT_NEAR(costs(1), 56.7, 0.01);
+  // 35.0 weight * 0.1 model_dt * (0.07 + 0.06 + 0.059) * 30 timesteps = 56.7
+  EXPECT_NEAR(costs(1), 19.845, 0.01);
 }

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -30,6 +30,7 @@
 #include "nav2_mppi_controller/critics/path_follow_critic.hpp"
 #include "nav2_mppi_controller/critics/prefer_forward_critic.hpp"
 #include "nav2_mppi_controller/critics/twirling_critic.hpp"
+#include "nav2_mppi_controller/critics/velocity_deadband_critic.hpp"
 #include "utils_test.cpp"  // NOLINT
 
 // Tests the various critic plugin functions
@@ -606,4 +607,53 @@ TEST(CriticTests, PathAlignCritic)
   path.y = 1.5 * xt::ones<float>({22});
   critic.score(data);
   EXPECT_NEAR(xt::sum(costs, immediate)(), 0.0, 1e-6);
+}
+
+TEST(CriticTests, VelocityDeadbandCritic)
+{
+  // Standard preamble
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("my_node");
+  auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(
+    "dummy_costmap", "", "dummy_costmap", true);
+  ParametersHandler param_handler(node);
+  auto getParam = param_handler.getParamGetter("critic");
+  std::vector<double> deadband_velocities_;
+  getParam(deadband_velocities_, "deadband_velocities", std::vector<double>{0.08, 0.08, 0.08});
+  rclcpp_lifecycle::State lstate;
+  costmap_ros->on_configure(lstate);
+
+  models::State state;
+  models::ControlSequence control_sequence;
+  models::Trajectories generated_trajectories;
+  models::Path path;
+  xt::xtensor<float, 1> costs = xt::zeros<float>({1000});
+  float model_dt = 0.1;
+  CriticData data =
+  {state, generated_trajectories, path, costs, model_dt, false, nullptr, nullptr, std::nullopt,
+    std::nullopt};
+  data.motion_model = std::make_shared<OmniMotionModel>();
+
+  // Initialization testing
+
+  // Make sure initializes correctly and that defaults are reasonable
+  VelocityDeadbandCritic critic;
+  critic.on_configure(node, "mppi", "critic", costmap_ros, &param_handler);
+  EXPECT_EQ(critic.getName(), "critic");
+
+  // Scoring testing
+
+  // provide velocities out of deadband bounds, should not have any costs
+  state.vx = 0.80 * xt::ones<float>({1000, 30});
+  state.vy = 0.60 * xt::ones<float>({1000, 30});
+  state.wz = 0.80 * xt::ones<float>({1000, 30});
+  critic.score(data);
+  EXPECT_NEAR(xt::sum(costs, immediate)(), 0, 1e-6);
+
+  // Test cost value
+  state.vx = 0.01 * xt::ones<float>({1000, 30});
+  state.vy = 0.02 * xt::ones<float>({1000, 30});
+  state.wz = 0.021 * xt::ones<float>({1000, 30});
+  critic.score(data);
+  // 100.0 weight * 0.1 model_dt * (0.07 + 0.06 + 0.059) * 30 timesteps = 56.7
+  EXPECT_NEAR(costs(1), 56.7, 0.01);
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

Some platforms have deadband velocity constraints and cannot move slowly. For instance, the legged robot Unitree Go2. This PR adds a critic that penalizes trajectory samples below a deadband value.
A robot with hardware limitations cannot reach the goal with a high tolerance (0.03m in my Gazebo simulation). I have attached videos comparing my feature with the 'out of the box' MPPI.
[Original MPPI](https://youtu.be/qwjZw97DLTY?si=eaMNq1cX_obHqBd5)
[With deadband critic](https://youtu.be/9_hw7ied594?si=BHS1kdlH22dkA2_x)


| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | discussion in [slack](https://navigation2.slack.com/archives/C012L20NQLV/p1710932047032829) |
| Primary OS tested on | (Ubuntu 22.04) |
| Robotic platform tested on | Gazebo: omni robot [linorobot2](https://github.com/linorobot/linorobot2); Real: Unitree GO2 |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points


* Add new critic that penalizes trajectory samples lower than a deadband value


## Description of documentation updates required from your changes


* Added new parameter, so need to add that to default configs and documentation page

Sample to copy paste into MPPI readme:

#### Velocity Deadband Critic
 | Parameter             | Type   | Definition                                                                                                  |
 | ---------------       | ------ | ----------------------------------------------------------------------------------------------------------- |
 | cost_weight           | double | Default 100.0. Weight to apply to critic term. (100.0 fits for turtlebot sim, 35.0 for omni robot)                                                               |
 | cost_power            | int    | Default 1. Power order to apply to term.                                                                    |
 | deadband_velocities | double[] | Default [0.05, 0.05, 0.05].  The array of deadband velocities [vx, vz, wz]. A zero array indicates that the critic will take no action.      |


---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
