### PR TITLE
Add subscription options to odometry subscriptions

### DIFF
--- a/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
+++ b/nav2_dwb_controller/nav_2d_utils/include/nav_2d_utils/odom_subscriber.hpp
@@ -74,7 +74,6 @@ public:
 
     rclcpp::SubscriptionOptions sub_options;
     sub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-
     odom_sub_ =
       nh->create_subscription<nav_msgs::msg::Odometry>(
       odom_topic,

--- a/nav2_util/src/odometry_utils.cpp
+++ b/nav2_util/src/odometry_utils.cpp
@@ -34,7 +34,6 @@ OdomSmoother::OdomSmoother(
 
   rclcpp::SubscriptionOptions sub_options;
   sub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-
   odom_sub_ = node->create_subscription<nav_msgs::msg::Odometry>(
     odom_topic,
     rclcpp::SystemDefaultsQoS(),
@@ -59,7 +58,6 @@ OdomSmoother::OdomSmoother(
 
   rclcpp::SubscriptionOptions sub_options;
   sub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-
   odom_sub_ = node->create_subscription<nav_msgs::msg::Odometry>(
     odom_topic,
     rclcpp::SystemDefaultsQoS(),


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu 22.04 docker container) |
| Robotic platform tested on | Gazebo simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Added `rclcpp::SubscriptionOptions` to the odometry topic subscribers to allow qos overrides in the configuration.  We run our odometry topics with Unreliable QoS to prevent network issues that are common with high-rate, reliable DDS transmissions.  This change allows us to override the Reliable QoS of the odom subscriptions to allow matching.


## Description of documentation updates required from your changes

I would expect that this should be documented as a new configuration option, but I'm not entirely sure where that would happen.

## Description of how this change was tested

We run a gazebo simulation of a surface vessel (similar to the WAM-V).  Using the following configuration `ros__parameters`:
```
maneuver/controller_server:
    ros__parameters:
        ...
        qos_overrides:
            /localization/global/odometry:
                subscription:
                    reliability: best_effort
                    depth: 1

maneuver/task_manager:
    ros__parameters:
        ...
        qos_overrides:
            /localization/local/odometry:
                subscription:
                    reliability: best_effort
                    depth: 1
```

Prior to this change, I would see QoS mismatches between the nav2 susbcribers and my odom publishers:
```
[]$ ros2 topic info -v /localization/local/odometry
Type: nav_msgs/msg/Odometry

Publisher count: 1

Node name: ekf_odom
Node namespace: /localization/local
Topic type: nav_msgs/msg/Odometry
Topic type hash: RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0
Endpoint type: PUBLISHER
GID: 01.10.05.60.b9.86.71.a6.70.56.6a.1c.00.00.2d.03
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 5
...
Node name: task_manager
Node namespace: /maneuver
Topic type: nav_msgs/msg/Odometry
Topic type hash: RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0
Endpoint type: SUBSCRIPTION
GID: 01.10.5d.47.e3.a9.04.4e.97.ff.1b.54.00.00.33.04
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

```
and
```
[]$ ros2 topic info -v /localization/global/odometry
Type: nav_msgs/msg/Odometry

Publisher count: 1

Node name: ekf_map
Node namespace: /localization/global
Topic type: nav_msgs/msg/Odometry
Topic type hash: RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0
Endpoint type: PUBLISHER
GID: 01.10.a7.a9.a4.52.ec.04.d2.54.89.14.00.00.2d.03
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 5
...
Node name: controller_server
Node namespace: /maneuver
Topic type: nav_msgs/msg/Odometry
Topic type hash: RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0
Endpoint type: SUBSCRIPTION
GID: 01.10.de.ff.08.3b.c1.67.5b.7a.2a.9e.00.01.36.04
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```

After this change, I verified there were no such mismatches.
```
[]$ ros2 topic info -v /localization/local/odometry
Type: nav_msgs/msg/Odometry

Publisher count: 1

Node name: ekf_odom
Node namespace: /localization/local
Topic type: nav_msgs/msg/Odometry
Topic type hash: RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0
Endpoint type: PUBLISHER
GID: 01.10.05.60.b9.86.71.a6.70.56.6a.1c.00.00.2d.03
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 5
...
Node name: task_manager
Node namespace: /maneuver
Topic type: nav_msgs/msg/Odometry
Topic type hash: RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0
Endpoint type: SUBSCRIPTION
GID: 01.10.e7.0e.a9.87.2c.19.ae.f1.2e.bb.00.00.33.04
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Node name: task_manager_bt_rclcpp_node
Node namespace: /maneuver
Topic type: nav_msgs/msg/Odometry
Topic type hash: RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0
Endpoint type: SUBSCRIPTION
GID: 01.10.e7.0e.a9.87.2c.19.ae.f1.2e.bb.00.00.47.04
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): KEEP_LAST (5)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```
and
```
[]$ ros2 topic info -v /localization/global/odometry
Type: nav_msgs/msg/Odometry

Publisher count: 1

Node name: ekf_map
Node namespace: /localization/global
Topic type: nav_msgs/msg/Odometry
Topic type hash: RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0
Endpoint type: PUBLISHER
GID: 01.10.a7.a9.a4.52.ec.04.d2.54.89.14.00.00.2d.03
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 5
...
Node name: controller_server
Node namespace: /maneuver
Topic type: nav_msgs/msg/Odometry
Topic type hash: RIHS01_3cc97dc7fb7502f8714462c526d369e35b603cfc34d946e3f2eda2766dfec6e0
Endpoint type: SUBSCRIPTION
GID: 01.10.9e.8f.e6.2f.00.f4.2d.9a.e5.3f.00.01.36.04
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```
---

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
