### PR TITLE
fixing static layer update bounds with different fram

### DIFF
--- a/nav2_costmap_2d/test/integration/inflation_tests.cpp
+++ b/nav2_costmap_2d/test/integration/inflation_tests.cpp
@@ -201,7 +201,7 @@ TEST_F(TestNode, testAdjacentToObstacleCanStillMove)
 {
   initNode(4.1);
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   // Footprint with inscribed radius = 2.1
@@ -233,7 +233,7 @@ TEST_F(TestNode, testInflationShouldNotCreateUnknowns)
 {
   initNode(4.1);
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   // Footprint with inscribed radius = 2.1
@@ -269,7 +269,7 @@ TEST_F(TestNode, testInflationInUnknown)
   node_->set_parameter(rclcpp::Parameter("track_unknown_space", true));
 
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, true);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, true);
   layers.resizeMap(9, 9, 1, 0, 0);
 
   // Footprint with inscribed radius = 2.1
@@ -305,7 +305,7 @@ TEST_F(TestNode, testInflationAroundUnknown)
   node_->set_parameter(rclcpp::Parameter("track_unknown_space", true));
 
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   // Footprint with inscribed radius = 2.1
@@ -330,7 +330,7 @@ TEST_F(TestNode, testCostFunctionCorrectness)
 {
   initNode(10.5);
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   layers.resizeMap(100, 100, 1, 0, 0);
   // Footprint with inscribed radius = 5.0
@@ -405,7 +405,7 @@ TEST_F(TestNode, testInflationOrderCorrectness)
   const double inflation_radius = 4.1;
   initNode(inflation_radius);
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   // Footprint with inscribed radius = 2.1
@@ -438,7 +438,7 @@ TEST_F(TestNode, testInflation)
 {
   initNode(1);
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   // Footprint with inscribed radius = 2.1
   // circumscribed radius = 3.1
@@ -516,7 +516,7 @@ TEST_F(TestNode, testInflation2)
 {
   initNode(1);
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   // Footprint with inscribed radius = 2.1
   // circumscribed radius = 3.1
@@ -554,7 +554,7 @@ TEST_F(TestNode, testInflation3)
 {
   initNode(3);
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   // 1 2 3

--- a/nav2_costmap_2d/test/integration/obstacle_tests.cpp
+++ b/nav2_costmap_2d/test/integration/obstacle_tests.cpp
@@ -148,7 +148,7 @@ protected:
 TEST_F(TestNode, testRaytracing) {
   tf2_ros::Buffer tf(node_->get_clock());
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   addStaticLayer(layers, tf, node_);
   auto olayer = addObstacleLayer(layers, tf, node_);
 
@@ -170,7 +170,7 @@ TEST_F(TestNode, testRaytracing) {
  */
 TEST_F(TestNode, testRaytracing2) {
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   addStaticLayer(layers, tf, node_);
   auto olayer = addObstacleLayer(layers, tf, node_);
 
@@ -227,7 +227,7 @@ TEST_F(TestNode, testWaveInterference) {
   tf2_ros::Buffer tf(node_->get_clock());
   node_->set_parameter(rclcpp::Parameter("track_unknown_space", true));
   // Start with an empty map, no rolling window, tracking unknown
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, true);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, true);
   layers.resizeMap(10, 10, 1, 0, 0);
   auto olayer = addObstacleLayer(layers, tf, node_);
 
@@ -255,7 +255,7 @@ TEST_F(TestNode, testWaveInterference) {
 TEST_F(TestNode, testZThreshold) {
   tf2_ros::Buffer tf(node_->get_clock());
   // Start with an empty map
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, true);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, true);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   auto olayer = addObstacleLayer(layers, tf, node_);
@@ -275,7 +275,7 @@ TEST_F(TestNode, testZThreshold) {
  */
 TEST_F(TestNode, testDynamicObstacles) {
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   addStaticLayer(layers, tf, node_);
 
   auto olayer = addObstacleLayer(layers, tf, node_);
@@ -300,7 +300,7 @@ TEST_F(TestNode, testDynamicObstacles) {
  */
 TEST_F(TestNode, testMultipleAdditions) {
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   addStaticLayer(layers, tf, node_);
 
   auto olayer = addObstacleLayer(layers, tf, node_);
@@ -319,7 +319,7 @@ TEST_F(TestNode, testMultipleAdditions) {
  */
 TEST_F(TestNode, testRepeatedResets) {
   tf2_ros::Buffer tf(node_->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   std::shared_ptr<nav2_costmap_2d::StaticLayer> slayer = nullptr;
   addStaticLayer(layers, tf, node_, slayer);
@@ -370,7 +370,7 @@ TEST_F(TestNode, testRepeatedResets) {
 TEST_F(TestNode, testRaytracing) {
   tf2_ros::Buffer tf(node_->get_clock());
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   std::shared_ptr<nav2_costmap_2d::StaticLayer> slayer = nullptr;
@@ -555,7 +555,7 @@ TEST_F(TestNode, testMaxCombinationMethod) {
   tf2_ros::Buffer tf(node_->get_clock());
 
   // Create a costmap with full unknown space
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, true);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, true);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   std::shared_ptr<nav2_costmap_2d::ObstacleLayer> olayer = nullptr;
@@ -600,7 +600,7 @@ TEST_F(TestNodeWithoutUnknownOverwrite, testMaxWithoutUnknownOverwriteCombinatio
   tf2_ros::Buffer tf(node_->get_clock());
 
   // Create a costmap with full unknown space
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, true);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, true);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   std::shared_ptr<nav2_costmap_2d::ObstacleLayer> olayer = nullptr;

--- a/nav2_costmap_2d/test/integration/plugin_container_tests.cpp
+++ b/nav2_costmap_2d/test/integration/plugin_container_tests.cpp
@@ -158,7 +158,7 @@ protected:
 TEST_F(TestNode, testObstacleLayers) {
   tf2_ros::Buffer tf(node_->get_clock());
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   std::shared_ptr<nav2_costmap_2d::PluginContainerLayer> pclayer_a = nullptr;
@@ -191,7 +191,7 @@ TEST_F(TestNode, testObstacleAndStaticLayers) {
   node_->declare_parameter("pclayer_a.static.map_topic",
     rclcpp::ParameterValue(std::string("map")));
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   layers.resizeMap(10, 10, 1, 0, 0);
 
@@ -232,7 +232,7 @@ TEST_F(TestNode, testDifferentInflationLayers) {
   node_->declare_parameter("pclayer_b.inflation.inflation_radius",
     rclcpp::ParameterValue(1.0));
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   layers.resizeMap(10, 10, 1, 0, 0);
 
@@ -281,7 +281,7 @@ TEST_F(TestNode, testDifferentInflationLayers2) {
   node_->declare_parameter("pclayer_a.inflation.inflation_radius",
     rclcpp::ParameterValue(1.0));
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   layers.resizeMap(10, 10, 1, 0, 0);
 
@@ -336,7 +336,7 @@ TEST_F(TestNode, testResetting) {
   node_->declare_parameter("pclayer_b.inflation.inflation_radius",
     rclcpp::ParameterValue(1.0));
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   layers.resizeMap(10, 10, 1, 0, 0);
 
@@ -407,7 +407,7 @@ TEST_F(TestNode, testClearing) {
   node_->declare_parameter("pclayer_b.inflation.inflation_radius",
     rclcpp::ParameterValue(1.0));
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   layers.resizeMap(10, 10, 1, 0, 0);
 
@@ -473,7 +473,7 @@ TEST_F(TestNode, testOverwriteCombinationMethods) {
   node_->declare_parameter("pclayer_b.inflation.inflation_radius",
     rclcpp::ParameterValue(1.0));
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   layers.resizeMap(10, 10, 1, 0, 0);
 
@@ -534,7 +534,7 @@ TEST_F(TestNode, testWithoutUnknownOverwriteCombinationMethods) {
   node_->declare_parameter("pclayer_b.inflation.inflation_radius",
     rclcpp::ParameterValue(1.0));
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, true);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, true);
 
   layers.resizeMap(10, 10, 1, 0, 0);
 
@@ -580,7 +580,7 @@ TEST_F(TestNode, testWithoutUnknownOverwriteCombinationMethods) {
 TEST_F(TestNode, testClearable) {
   tf2_ros::Buffer tf(node_->get_clock());
 
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   std::shared_ptr<nav2_costmap_2d::PluginContainerLayer> pclayer_a = nullptr;
   addPluginContainerLayer(layers, tf, node_, pclayer_a, "pclayer_a");

--- a/nav2_costmap_2d/test/unit/declare_parameter_test.cpp
+++ b/nav2_costmap_2d/test/unit/declare_parameter_test.cpp
@@ -34,7 +34,7 @@ TEST(DeclareParameter, useValidParameter)
   nav2_util::LifecycleNode::SharedPtr node =
     std::make_shared<nav2_util::LifecycleNode>("test_node");
   tf2_ros::Buffer tf(node->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   layer.initialize(&layers, "test_layer", &tf, node, nullptr);
 
@@ -53,7 +53,7 @@ TEST(DeclareParameter, useInvalidParameter)
   nav2_util::LifecycleNode::SharedPtr node =
     std::make_shared<nav2_util::LifecycleNode>("test_node");
   tf2_ros::Buffer tf(node->get_clock());
-  nav2_costmap_2d::LayeredCostmap layers("frame", false, false);
+  nav2_costmap_2d::LayeredCostmap layers("map", false, false);
 
   layer.initialize(&layers, "test_layer", &tf, node, nullptr);
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | gazebo simulation |
| Does this PR contain AI generated software? | No |

---

## Description of contribution in a few bullet points

Fix incomplete update bounds issue for static layers if global frame has rotation with map frame.

## Description of how this change was tested

Fixed and tested in ROS1 navigation package on my physical robot platform in production for 1 week, migrated to ROS2.

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
