### PR TITLE
Add namespace support for rviz costmap cost tool

### DIFF
--- a/nav2_rviz_plugins/src/costmap_cost_tool.cpp
+++ b/nav2_rviz_plugins/src/costmap_cost_tool.cpp
@@ -54,12 +54,12 @@ void CostmapCostTool::onInitialize()
   rclcpp::Node::SharedPtr node = node_ptr_->get_raw_node();
   local_cost_client_ =
     std::make_shared<nav2_util::ServiceClient<nav2_msgs::srv::GetCosts>>(
-    "/local_costmap/get_cost_local_costmap",
+    "local_costmap/get_cost_local_costmap",
     node,
     false /* Does not create and spin an internal executor*/);
   global_cost_client_ =
     std::make_shared<nav2_util::ServiceClient<nav2_msgs::srv::GetCosts>>(
-    "/global_costmap/get_cost_global_costmap",
+    "global_costmap/get_cost_global_costmap",
     node,
     false /* Does not create and spin an internal executor*/);
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | My robot |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |

---

## Description of contribution in a few bullet points

When adding the costmap cost tool in rviz, I noticed it does not return the value of global/local costmap tool when clicking, it is mainly because I have a namespace for my node, so I removed the "/" part

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

Tested on my robot

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
