### PR TITLE
`bt_navigator_***_rclcpp_node`  - Namespacing + NodeOptions forwarding

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -125,21 +125,6 @@ template<class ActionT, class NodeT>
 BtActionServer<ActionT, NodeT>::~BtActionServer()
 {}
 
-void replaceOrAddArgument(
-  std::vector<std::string> & arguments, const std::string & option,
-  const std::string & arg_name, const std::string & new_argument)
-{
-  auto argument = std::find_if(arguments.begin(), arguments.end(),
-      [arg_name](const std::string & value){return value.find(arg_name) != std::string::npos;});
-  if (argument != arguments.end()) {
-    *argument = new_argument;
-  } else {
-    arguments.push_back("--ros-args");
-    arguments.push_back(option);
-    arguments.push_back(new_argument);
-  }
-}
-
 template<class ActionT, class NodeT>
 bool BtActionServer<ActionT, NodeT>::on_configure()
 {
@@ -154,7 +139,7 @@ bool BtActionServer<ActionT, NodeT>::on_configure()
   // Use suffix '_rclcpp_node' to keep parameter file consistency #1773
 
   auto new_arguments = node->get_node_options().arguments();
-  replaceOrAddArgument(new_arguments, "-r", "__node", std::string("__node:=") +
+  nav2::replaceOrAddArgument(new_arguments, "-r", "__node", std::string("__node:=") +
     std::string(node->get_name()) + "_" + client_node_name + "_rclcpp_node");
   auto options = node->get_node_options();
   options = options.arguments(new_arguments);

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_ros.hpp
@@ -433,15 +433,6 @@ protected:
 // free functions
 
 /**
-  * @brief Given a specified argument name, replaces it with the specified
-  * new value. If the argument is not in the existing list, a new argument
-  * is created with the specified option.
-  */
-void replaceOrAddArgument(
-  std::vector<std::string> & arguments, const std::string & option,
-  const std::string & arg_name, const std::string & new_argument);
-
-/**
   * @brief Given the node options of a parent node, expands of replaces
   *         the fields for the node name, namespace and use_sim_time
   */

--- a/nav2_costmap_2d/src/costmap_2d_ros.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_ros.cpp
@@ -71,21 +71,6 @@ Costmap2DROS::Costmap2DROS(const rclcpp::NodeOptions & options)
   init();
 }
 
-void replaceOrAddArgument(
-  std::vector<std::string> & arguments, const std::string & option,
-  const std::string & arg_name, const std::string & new_argument)
-{
-  auto argument = std::find_if(arguments.begin(), arguments.end(),
-      [arg_name](const std::string & value){return value.find(arg_name) != std::string::npos;});
-  if (argument != arguments.end()) {
-    *argument = new_argument;
-  } else {
-    arguments.push_back("--ros-args");
-    arguments.push_back(option);
-    arguments.push_back(new_argument);
-  }
-}
-
 rclcpp::NodeOptions getChildNodeOptions(
   const std::string & name,
   const std::string & parent_namespace,
@@ -93,10 +78,10 @@ rclcpp::NodeOptions getChildNodeOptions(
   const rclcpp::NodeOptions & parent_options)
 {
   std::vector<std::string> new_arguments = parent_options.arguments();
-  replaceOrAddArgument(new_arguments, "-r", "__ns",
+  nav2::replaceOrAddArgument(new_arguments, "-r", "__ns",
       "__ns:=" + nav2::add_namespaces(parent_namespace, name));
-  replaceOrAddArgument(new_arguments, "-r", "__node", name + ":" + "__node:=" + name);
-  replaceOrAddArgument(new_arguments, "-p", "use_sim_time",
+  nav2::replaceOrAddArgument(new_arguments, "-r", "__node", name + ":" + "__node:=" + name);
+  nav2::replaceOrAddArgument(new_arguments, "-p", "use_sim_time",
       "use_sim_time:=" + std::string(use_sim_time ? "true" : "false"));
   return rclcpp::NodeOptions().arguments(new_arguments);
 }

--- a/nav2_ros_common/include/nav2_ros_common/node_utils.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/node_utils.hpp
@@ -378,6 +378,26 @@ inline void setIntrospectionMode(
   #endif
 }
 
+/**
+  * @brief Given a specified argument name, replaces it with the specified
+  * new value. If the argument is not in the existing list, a new argument
+  * is created with the specified option.
+  */
+inline void replaceOrAddArgument(
+  std::vector<std::string> & arguments, const std::string & option,
+  const std::string & arg_name, const std::string & new_argument)
+{
+  auto argument = std::find_if(arguments.begin(), arguments.end(),
+      [arg_name](const std::string & value){return value.find(arg_name) != std::string::npos;});
+  if (argument != arguments.end()) {
+    *argument = new_argument;
+  } else {
+    arguments.push_back("--ros-args");
+    arguments.push_back(option);
+    arguments.push_back(new_argument);
+  }
+}
+
 }  // namespace nav2
 
 #endif  // NAV2_ROS_COMMON__NODE_UTILS_HPP_


### PR DESCRIPTION
Closes #5242 
Inspired by: #5202
AI generated software: **NO**

- `bt_navigator_***_rclcpp_node` now gets the same namespace of  `bt_navigator`
- `bt_navigator_***_rclcpp_node` now gets the same node options of  `bt_navigator` (apart from node name, that is still forced to respect the pattern `bt_navigator_***_rclcpp_node` )

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.