### PR TITLE
Target link nav2_ros_common for external use of nav2_costmap_2d

### DIFF
--- a/nav2_costmap_2d/CMakeLists.txt
+++ b/nav2_costmap_2d/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(nav2_costmap_2d_core PUBLIC
   tf2::tf2
   tf2_ros::tf2_ros
   tf2_sensor_msgs::tf2_sensor_msgs
+  nav2_ros_common::nav2_ros_common
 )
 
 add_library(layers SHARED
@@ -85,6 +86,7 @@ target_link_libraries(layers PUBLIC
   nav2_voxel_grid::voxel_grid
   nav2_costmap_2d_core
   tf2::tf2
+  nav2_ros_common::nav2_ros_common
 )
 target_link_libraries(layers PRIVATE
   pluginlib::pluginlib
@@ -122,6 +124,7 @@ target_link_libraries(nav2_costmap_2d_client PUBLIC
   nav2_costmap_2d_core
   ${std_msgs_TARGETS}
   tf2::tf2
+  nav2_ros_common::nav2_ros_common
 )
 
 add_executable(nav2_costmap_2d_markers src/costmap_2d_markers.cpp)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory sim |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

- Added nav2_ros_common to target link in order to have external packages using nav2_costmap_2d building properly, otherwise they are complaining about not finding "nav2_ros_common/lifecycle_node.hpp". 
In my case, uncovered it while trying to build `grid_map_costmap_2d`

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
