### PR TITLE
TwistSubscriber: add constructor using NodeInterfaces

### DIFF
--- a/nav2_behaviors/plugins/assisted_teleop.cpp
+++ b/nav2_behaviors/plugins/assisted_teleop.cpp
@@ -51,7 +51,7 @@ void AssistedTeleop::onConfigure()
   node->get_parameter("cmd_vel_teleop", cmd_vel_teleop);
 
   vel_sub_ = std::make_unique<nav2_util::TwistSubscriber>(
-    node,
+    *node,
     cmd_vel_teleop, rclcpp::SystemDefaultsQoS(),
     [&](geometry_msgs::msg::Twist::SharedPtr msg) {
       teleop_twist_.twist = *msg;

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -65,7 +65,7 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
   }
 
   cmd_vel_in_sub_ = std::make_unique<nav2_util::TwistSubscriber>(
-    shared_from_this(),
+    *this,
     cmd_vel_in_topic,
     1,
     std::bind(&CollisionMonitor::cmdVelInCallbackUnstamped, this, std::placeholders::_1),

--- a/nav2_costmap_2d/include/nav2_costmap_2d/plugin_container_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/plugin_container_layer.hpp
@@ -46,7 +46,7 @@ public:
   /**
    * @brief Initialization process of layer on startup
    */
-  virtual void onInitialize();
+  virtual void onInitialize() override;
   /**
    * @brief Update the bounds of the master costmap by this layer's update
    *dimensions
@@ -65,7 +65,7 @@ public:
     double * min_x,
     double * min_y,
     double * max_x,
-    double * max_y);
+    double * max_y) override;
   /**
    * @brief Update the costs in the master costmap in the window
    * @param master_grid The master costmap grid to update
@@ -79,26 +79,26 @@ public:
     int min_i,
     int min_j,
     int max_i,
-    int max_j);
-  virtual void onFootprintChanged();
+    int max_j) override;
+  virtual void onFootprintChanged() override;
   /** @brief Update the footprint to match size of the parent costmap. */
-  virtual void matchSize();
+  virtual void matchSize() override;
   /**
    * @brief Deactivate the layer
    */
-  virtual void deactivate();
+  virtual void deactivate() override;
   /**
    * @brief Activate the layer
    */
-  virtual void activate();
+  virtual void activate() override;
   /**
    * @brief Reset this costmap
    */
-  virtual void reset();
+  virtual void reset() override;
   /**
    * @brief If clearing operations should be processed on this layer or not
    */
-  virtual bool isClearable();
+  virtual bool isClearable() override;
   /**
    * @brief Clear an area in the constituent costmaps with the given dimension
    * if invert, then clear everything except these dimensions

--- a/nav2_util/include/nav2_util/node_utils.hpp
+++ b/nav2_util/include/nav2_util/node_utils.hpp
@@ -16,6 +16,8 @@
 #ifndef NAV2_UTIL__NODE_UTILS_HPP_
 #define NAV2_UTIL__NODE_UTILS_HPP_
 
+#include <rclcpp/node_interfaces/node_interfaces.hpp>
+#include <rclcpp/node_interfaces/node_parameters_interface.hpp>
 #include <vector>
 #include <string>
 #include "rclcpp/rclcpp.hpp"
@@ -102,6 +104,21 @@ void declare_parameter_if_not_declared(
     node->declare_parameter(parameter_name, default_value, parameter_descriptor);
   }
 }
+
+/// Declares static ROS2 parameter and sets it to a given value if it was not already declared
+/* Declares static ROS2 parameter and sets it to a given value
+ * if it was not already declared.
+ *
+ * \param[in] node A node in which given parameter to be declared
+ * \param[in] parameter_name The name of parameter
+ * \param[in] default_value Parameter value to initialize with
+ * \param[in] parameter_descriptor Parameter descriptor (optional)
+ */
+void declare_parameter_if_not_declared(
+  rclcpp::node_interfaces::NodeInterfaces<rclcpp::node_interfaces::NodeParametersInterface> node,
+  const std::string & parameter_name,
+  const rclcpp::ParameterValue & default_value,
+  const ParameterDescriptor & parameter_descriptor = ParameterDescriptor());
 
 /// Declares static ROS2 parameter with given type if it was not already declared
 /* Declares static ROS2 parameter with given type if it was not already declared.

--- a/nav2_util/src/node_utils.cpp
+++ b/nav2_util/src/node_utils.cpp
@@ -75,6 +75,18 @@ std::string time_to_string(size_t len)
   return output;
 }
 
+void declare_parameter_if_not_declared(
+  rclcpp::node_interfaces::NodeInterfaces<rclcpp::node_interfaces::NodeParametersInterface> node,
+  const std::string & parameter_name,
+  const rclcpp::ParameterValue & default_value,
+  const ParameterDescriptor & parameter_descriptor)
+{
+  if (!node.get_node_parameters_interface()->has_parameter(parameter_name)) {
+    node.get_node_parameters_interface()->declare_parameter(parameter_name, default_value,
+        parameter_descriptor);
+  }
+}
+
 std::string generate_internal_node_name(const std::string & prefix)
 {
   return sanitize_node_name(prefix) + "_" + time_to_string(8);

--- a/nav2_util/test/test_twist_subscriber.cpp
+++ b/nav2_util/test/test_twist_subscriber.cpp
@@ -32,7 +32,7 @@ TEST(TwistSubscriber, Unstamped)
 
   geometry_msgs::msg::TwistStamped sub_msg {};
   auto vel_subscriber = std::make_unique<nav2_util::TwistSubscriber>(
-    sub_node, "cmd_vel", 1,
+    *sub_node, "cmd_vel", 1,
     [&](const geometry_msgs::msg::Twist msg) {sub_msg.twist = msg;},
     [&](const geometry_msgs::msg::TwistStamped msg) {sub_msg = msg;}
   );
@@ -69,7 +69,7 @@ TEST(TwistSubscriber, Stamped)
 
   geometry_msgs::msg::TwistStamped sub_msg {};
   auto vel_subscriber = std::make_unique<nav2_util::TwistSubscriber>(
-    sub_node, "cmd_vel", 1,
+    *sub_node, "cmd_vel", 1,
     [&](const geometry_msgs::msg::Twist msg) {sub_msg.twist = msg;},
     [&](const geometry_msgs::msg::TwistStamped msg) {sub_msg = msg;}
   );

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -148,7 +148,7 @@ VelocitySmoother::on_configure(const rclcpp_lifecycle::State & state)
   // Setup inputs / outputs
   smoothed_cmd_pub_ = std::make_unique<nav2_util::TwistPublisher>(node, "cmd_vel_smoothed", 1);
   cmd_sub_ = std::make_unique<nav2_util::TwistSubscriber>(
-    node,
+    *node,
     "cmd_vel", rclcpp::QoS(1),
     std::bind(&VelocitySmoother::inputCommandCallback, this, std::placeholders::_1),
     std::bind(&VelocitySmoother::inputCommandStampedCallback, this, std::placeholders::_1)

--- a/nav2_velocity_smoother/test/test_velocity_smoother.cpp
+++ b/nav2_velocity_smoother/test/test_velocity_smoother.cpp
@@ -71,7 +71,7 @@ TEST(VelocitySmootherTest, openLoopTestTimer)
 
   std::vector<double> linear_vels;
   auto subscription = nav2_util::TwistSubscriber(
-    smoother,
+    *smoother,
     "cmd_vel_smoothed",
     1,
     [&](geometry_msgs::msg::Twist::SharedPtr msg) {
@@ -125,7 +125,7 @@ TEST(VelocitySmootherTest, approxClosedLoopTestTimer)
 
   std::vector<double> linear_vels;
   auto subscription = nav2_util::TwistSubscriber(
-    smoother,
+    *smoother,
     "cmd_vel_smoothed",
     1,
     [&](geometry_msgs::msg::Twist::SharedPtr msg) {


### PR DESCRIPTION
This adds constructors using NodeInterfaces to TwistSubscriber. This allows use outside of nav2 with non-lifecycle nodes. It would also allow use in places where NodeInterfaces are already used, or places where a node handle is available in any other form than `shared_ptr<LifecycleNode>`.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (none) |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | TBD |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Adds constructors using NodeInterfaces to TwistSubscriber
* Adds NodeInterfaces version of `declare_parameter_if_not_declared` (used in ctor)
* Change all uses to use new constructor, requiring passing the node by reference instead of shared_ptr. I would like to revert that if and when i find a way to make the new and old constructors non-ambiguous. I'm not quite sure why they are, as far as i can tell, only ever one is applicable in any situation.

## Description of documentation updates required from your changes

* [ ] TODO: Check for any doxygen that needs updating

## Description of how this change was tested

* [ ] TODO: Add appropriate unit tests if both constructors are kept.
* [ ] TODO: Add unit test for stamped-only constructor, i think there are none currently.

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
