### PR TITLE
[SMAC planner] Same cell start/goal corner case bin check

### DIFF
--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -414,15 +414,17 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
             std::to_string(start.pose.position.y) + ") was outside bounds");
   }
 
-  double orientation_bin = std::round(tf2::getYaw(start.pose.orientation) / _angle_bin_size);
-  while (orientation_bin < 0.0) {
-    orientation_bin += static_cast<float>(_angle_quantizations);
+  double start_orientation_bin = std::round(tf2::getYaw(start.pose.orientation) / _angle_bin_size);
+  while (start_orientation_bin < 0.0) {
+    start_orientation_bin += static_cast<float>(_angle_quantizations);
   }
   // This is needed to handle precision issues
-  if (orientation_bin >= static_cast<float>(_angle_quantizations)) {
-    orientation_bin -= static_cast<float>(_angle_quantizations);
+  if (start_orientation_bin >= static_cast<float>(_angle_quantizations)) {
+    start_orientation_bin -= static_cast<float>(_angle_quantizations);
   }
-  _a_star->setStart(mx_start, my_start, static_cast<unsigned int>(orientation_bin));
+  unsigned int start_orientation_bin_int =
+    static_cast<unsigned int>(start_orientation_bin);
+  _a_star->setStart(mx_start, my_start, start_orientation_bin_int);
 
   // Set goal point, in A* bin search coordinates
   if (!costmap->worldToMapContinuous(
@@ -435,15 +437,17 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
             "Goal Coordinates of(" + std::to_string(goal.pose.position.x) + ", " +
             std::to_string(goal.pose.position.y) + ") was outside bounds");
   }
-  orientation_bin = std::round(tf2::getYaw(goal.pose.orientation) / _angle_bin_size);
-  while (orientation_bin < 0.0) {
-    orientation_bin += static_cast<float>(_angle_quantizations);
+  double goal_orientation_bin = std::round(tf2::getYaw(goal.pose.orientation) / _angle_bin_size);
+  while (goal_orientation_bin < 0.0) {
+    goal_orientation_bin += static_cast<float>(_angle_quantizations);
   }
   // This is needed to handle precision issues
-  if (orientation_bin >= static_cast<float>(_angle_quantizations)) {
-    orientation_bin -= static_cast<float>(_angle_quantizations);
+  if (goal_orientation_bin >= static_cast<float>(_angle_quantizations)) {
+    goal_orientation_bin -= static_cast<float>(_angle_quantizations);
   }
-  _a_star->setGoal(mx_goal, my_goal, static_cast<unsigned int>(orientation_bin),
+  unsigned int goal_orientation_bin_int =
+    static_cast<unsigned int>(goal_orientation_bin);
+  _a_star->setGoal(mx_goal, my_goal, static_cast<unsigned int>(goal_orientation_bin_int),
     _goal_heading_mode, _coarse_search_resolution);
 
   // Setup message
@@ -460,7 +464,8 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
 
   // Corner case of start and goal being on the same cell
   if (std::floor(mx_start) == std::floor(mx_goal) &&
-    std::floor(my_start) == std::floor(my_goal))
+    std::floor(my_start) == std::floor(my_goal) &&
+    start_orientation_bin_int == goal_orientation_bin_int)
   {
     pose.pose = start.pose;
     pose.pose.orientation = goal.pose.orientation;

--- a/nav2_smac_planner/src/smac_planner_lattice.cpp
+++ b/nav2_smac_planner/src/smac_planner_lattice.cpp
@@ -338,9 +338,9 @@ nav_msgs::msg::Path SmacPlannerLattice::createPlan(
             "Start Coordinates of(" + std::to_string(start.pose.position.x) + ", " +
             std::to_string(start.pose.position.y) + ") was outside bounds");
   }
-  _a_star->setStart(
-    mx_start, my_start,
-    NodeLattice::motion_table.getClosestAngularBin(tf2::getYaw(start.pose.orientation)));
+  unsigned int start_bin =
+    NodeLattice::motion_table.getClosestAngularBin(tf2::getYaw(start.pose.orientation));
+  _a_star->setStart(mx_start, my_start, start_bin);
 
   // Set goal point, in A* bin search coordinates
   if (!_costmap->worldToMapContinuous(
@@ -353,9 +353,10 @@ nav_msgs::msg::Path SmacPlannerLattice::createPlan(
             "Goal Coordinates of(" + std::to_string(goal.pose.position.x) + ", " +
             std::to_string(goal.pose.position.y) + ") was outside bounds");
   }
+  unsigned int goal_bin =
+    NodeLattice::motion_table.getClosestAngularBin(tf2::getYaw(goal.pose.orientation));
   _a_star->setGoal(
-    mx_goal, my_goal,
-    NodeLattice::motion_table.getClosestAngularBin(tf2::getYaw(goal.pose.orientation)),
+    mx_goal, my_goal, goal_bin,
       _goal_heading_mode, _coarse_search_resolution);
 
   // Setup message
@@ -372,7 +373,8 @@ nav_msgs::msg::Path SmacPlannerLattice::createPlan(
 
   // Corner case of start and goal being on the same cell
   if (std::floor(mx_start) == std::floor(mx_goal) &&
-    std::floor(my_start) == std::floor(my_goal))
+    std::floor(my_start) == std::floor(my_goal) &&
+    start_bin == goal_bin)
   {
     pose.pose = start.pose;
     pose.pose.orientation = goal.pose.orientation;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | Dexory Sim|
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Adds a check for start/goal bin equality to the corner case of start and goal being on the same cell.
Without it, the planner will fail to compute a proper path inversion if the start and goal are on the same cell but with opposite orientations.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
