### PR TITLE
Fix lifecycle manager deadlock during shutdown

### DIFF
--- a/nav2_util/include/nav2_util/lifecycle_service_client.hpp
+++ b/nav2_util/include/nav2_util/lifecycle_service_client.hpp
@@ -36,6 +36,12 @@ public:
     const std::string & lifecycle_node_name,
     rclcpp::Node::SharedPtr parent_node);
 
+  ~LifecycleServiceClient()
+  {
+    change_state_.stop();
+    get_state_.stop();
+  }
+
   /// Trigger a state change
   /**
    * Throws std::runtime_error on failure

--- a/nav2_util/include/nav2_util/service_client.hpp
+++ b/nav2_util/include/nav2_util/service_client.hpp
@@ -145,6 +145,16 @@ public:
     return service_name_;
   }
 
+  /**
+  * @brief Stop any running spin operations on the internal executor
+  */
+  void stop()
+  {
+    if (client_) {
+      callback_group_executor_.cancel();
+    }
+  }
+
 protected:
   std::string service_name_;
   NodeT node_;


### PR DESCRIPTION
## Basic Info

Backport to jazzy for [#5438](https://github.com/ros-navigation/navigation2/pull/5438)

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5437 |
| Primary OS tested on | Ubuntu |

## Description of contribution in a few bullet points

* Fix deadlock by stopping any spin* operations

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
