### PR TITLE
fix: Move SmootherParams declaration outside smooth_path conditional

### DIFF
--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -273,9 +273,9 @@ void SmacPlannerHybrid::configure(
     _angle_quantizations);
 
   // Initialize path smoother
+  SmootherParams params;
+  params.get(node, name);
   if (smooth_path) {
-    SmootherParams params;
-    params.get(node, name);
     _smoother = std::make_unique<Smoother>(params);
     _smoother->initialize(_minimum_turning_radius_global_coords);
   }

--- a/nav2_smac_planner/src/smac_planner_lattice.cpp
+++ b/nav2_smac_planner/src/smac_planner_lattice.cpp
@@ -230,9 +230,9 @@ void SmacPlannerLattice::configure(
     _metadata.number_of_headings);
 
   // Initialize path smoother
+  SmootherParams params;
+  params.get(node, name);
   if (smooth_path) {
-    SmootherParams params;
-    params.get(node, name);
     _smoother = std::make_unique<Smoother>(params);
     _smoother->initialize(_metadata.min_turning_radius);
   }


### PR DESCRIPTION
Fixes crash when dynamically changing smooth_path parameter from false to true.

The issue occurred because SmootherParams were only declared when smooth_path was initially true, causing ParameterModifiedInCallbackException when trying to declare parameters within the dynamic parameter callback.

Now SmootherParams are always declared, making them available for dynamic reconfiguration regardless of the initial smooth_path value.

Fixes #5472

Generated with [Claude Code](https://claude.ai/code)