### PR TITLE
Fix seg fault

### DIFF
--- a/nav2_smac_planner/src/node_lattice.cpp
+++ b/nav2_smac_planner/src/node_lattice.cpp
@@ -230,7 +230,8 @@ bool NodeLattice::isNodeValid(
   // Check primitive end pose
   // Convert grid quantization of primitives to radians, then collision checker quantization
   static const double bin_size = 2.0 * M_PI / collision_checker->getPrecomputedAngles().size();
-  const double angle = std::fmod(motion_table.getAngleFromBin(this->pose.theta), 2.0 * M_PI) / bin_size;
+  const double angle = std::fmod(motion_table.getAngleFromBin(this->pose.theta),
+      2.0 * M_PI) / bin_size;
   if (collision_checker->inCollision(
       this->pose.x, this->pose.y, angle /*bin in collision checker*/, traverse_unknown))
   {


### PR DESCRIPTION
The nav2_smac_planner lattice planner was crashing with a segmentation fault in `inCollision`. The crash occurred when accessing `oriented_footprints_[angle_bin]` with an out-of-bounds index.

The issue stems from improper angle normalization when converting from radians to collision checker angle bins. When a motion primitive angle equals exactly 2π radians (or 6.283185), the conversion `angle / bin_size` results in `angle_bin = 72.0`  which is out of bounds for a 72-element array (valid indices: 0-71).