### PR TITLE
Fix incorrect topic name in nav2_velocity_smoother README

### DIFF
--- a/nav2_velocity_smoother/README.md
+++ b/nav2_velocity_smoother/README.md
@@ -25,7 +25,7 @@ This package was created to do the following:
 
 This is a lifecycle-component node, using the lifecycle manager for state management and composition for process management.
 It is designed to take in a command from Nav2's controller server and smooth it for use on robot hardware controllers.
-Thusly, it takes in a command via the `cmd_vel` topic and produces a smoothed output on `smoothed_cmd_vel`.
+Thusly, it takes in a command via the `cmd_vel` topic and produces a smoothed output on `cmd_vel_smoothed`.
 
 The node is designed on a regular timer running at a configurable rate.
 This is in contrast to simply computing a smoothed velocity command in the callback of each `cmd_vel` input from Nav2.
@@ -66,7 +66,7 @@ velocity_smoother:
 
 | Topic            | Type                    | Use                           |
 |------------------|-------------------------|-------------------------------|
-| smoothed_cmd_vel | geometry_msgs/Twist or  geometry_msgs/TwistStamped | Publish smoothed velocities   |
+| cmd_vel_smoothed | geometry_msgs/Twist or  geometry_msgs/TwistStamped | Publish smoothed velocities   |
 | cmd_vel          | geometry_msgs/Twist or  geometry_msgs/TwistStamped | Subscribe to input velocities |
 
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

## Issue
The README in nav2_velocity_smoother incorrectly lists the publisher topic as `smoothed_cmd_vel`, while the actual topic in code is `cmd_vel_smoothed`.

## Description of contribution
* Updated the [README](https://github.com/ros-navigation/navigation2/tree/main/nav2_velocity_smoother) to reflect the correct topic name of the Twist message publisher.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
