### PR TITLE
Fix robot not stopping after reaching dock position

### DIFF
--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -321,6 +321,7 @@ void DockingServer::dockRobot()
           // We are docked, wait for charging to begin
           RCLCPP_INFO(
             get_logger(), "Made contact with dock, waiting for charge to start (if applicable).");
+          publishZeroVelocity();
           if (waitForCharge(dock)) {
             if (dock->plugin->isCharger()) {
               RCLCPP_INFO(get_logger(), "Robot is charging!");


### PR DESCRIPTION
Publish a zero velocity command after reaching the dock position to ensure that the robot is stopped while waiting for the charge to start.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Publish zero velocity after reaching the dock position

## Description of documentation updates required from your changes

NA

## Description of how this change was tested

Not tested, I just observed my robot continue in simulation environement after the dock while waiting the for the charge to start.

## Future work that may be required in bullet points

Maybe another improvement https://github.com/ros-navigation/navigation2/issues/5567

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
