### PR TITLE
[RPP] Prevent collision check premature termination

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/src/collision_checker.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/collision_checker.cpp
@@ -112,8 +112,11 @@ bool CollisionChecker::isCollisionImminent(
     theta += projection_time * angular_vel;
     curr_pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(theta);
 
-    // Stop simulating if we've gone past the simulation distance limit (max: carrot or min distance)
-    if (hypot(curr_pose.position.x - robot_xy.x, curr_pose.position.y - robot_xy.y) > simulation_distance_limit) {
+    // Stop simulating if we've gone past the simulation distance limit
+    // (max: carrot or min distance)
+    if (hypot(curr_pose.position.x - robot_xy.x,
+        curr_pose.position.y - robot_xy.y) > simulation_distance_limit)
+    {
       break;
     }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5595 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | Physical Robot (differential-drive) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

- Fixes a bug in RPP where the robot would "creep" forward after stopping for an obstacle if min_lookahead was set lower than min_distance_to_obstacle
- Change _isCollisionImminent_ logic to always cover at least up to min_distance_to_obstacle, even when carrot_dist shrinks.

## Description of documentation updates required from your changes

None 

## Description of how this change was tested

Tested for a week on a physical differential-drive robot using a 270-degree LiDAR in a real-world environment. The tests included various routes with both static and dynamic obstacles placed in the robot's path. No negative side effects or degradation in general navigation behavior were observed.

---

## Future work that may be required in bullet points

I don't like to create a entire new variable just that it receives carrot_dist if min_distance_to_obstacle is unused, but I can't think of a better way to do that. I'm open to suggestions.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
