### PR TITLE
Fixed crash in bt_service_node when the service is not available in time

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -69,9 +69,8 @@ public:
         node_->get_logger(), "\"%s\" service server not available after waiting for %.2fs",
         service_name_.c_str(), wait_for_service_timeout_.count() / 1000.0);
       throw std::runtime_error(
-              std::string(
-                "Service server %s not available",
-                service_name_.c_str()));
+              std::string("Service server ") + service_name_ +
+              std::string(" not available"));
     }
 
     RCLCPP_DEBUG(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | to be honest, I haven't tested this. |
| Robotic platform tested on | untested|
| Does this PR contain AI generated software? | no |
| Was this PR description generated by AI software? | no |

---

## Description of contribution in a few bullet points

* This fixes a crash in the bt_service_node that triggers when a service is not ready in time.
* The problem is just a silly mistake that inadvertently calls constructor 4 on this page: https://en.cppreference.com/w/cpp/string/basic_string/basic_string.html


## Description of how this change was tested

* To be honest, it wasn't tested. However, I saw this crash on the jazzy branch and noticed the bug is still present on main. Rather than open an issue, I figured I'd just throw up this trivial patch. 


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
