### PR TITLE
Fix QoS for `is_active` publisher in LifecycleManager

### DIFF
--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -243,7 +243,7 @@ LifecycleManager::createLifecyclePublishers()
   is_active_pub_ = nav2::interfaces::create_publisher<std_msgs::msg::Bool>(
     shared_from_this(),
     get_name() + std::string("/is_active"),
-    nav2::qos::LatchedSubscriptionQoS(),
+    nav2::qos::LatchedPublisherQoS(),
     callback_group_);
   is_active_pub_->on_activate();
   // Publish the initial state once at startup


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Fix QoS for `is_active` publisher in LifecycleManager that was recently added in https://github.com/ros-navigation/navigation2/pull/5627. The depth of the publisher should be set to 1 to avoid publishing historical states to late subscribers

## Description of documentation updates required from your changes

N/A

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

Echo the topic after the Nav stack has transitioned to active state. A single message should be shown with is_active=True rather than getting two messages `is_active=False` followed by `is_active=True`. 

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
