### PR TITLE
spin_plugin: add disable_collision_checks option (humble)

### DIFF
--- a/nav2_behaviors/include/nav2_behaviors/plugins/spin.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/plugins/spin.hpp
@@ -80,6 +80,7 @@ protected:
   double prev_yaw_;
   double relative_yaw_;
   double simulate_ahead_time_;
+  bool cmd_disable_collision_checks_;
   rclcpp::Duration command_time_allowance_{0, 0};
   rclcpp::Time end_time_;
 };

--- a/nav2_behaviors/plugins/spin.cpp
+++ b/nav2_behaviors/plugins/spin.cpp
@@ -37,7 +37,8 @@ Spin::Spin()
   cmd_yaw_(0.0),
   prev_yaw_(0.0),
   relative_yaw_(0.0),
-  simulate_ahead_time_(0.0)
+  simulate_ahead_time_(0.0),
+  cmd_disable_collision_checks_(false)
 {
 }
 
@@ -81,6 +82,8 @@ Status Spin::onRun(const std::shared_ptr<const SpinAction::Goal> command)
     RCLCPP_ERROR(logger_, "Current robot pose is not available.");
     return Status::FAILED;
   }
+
+  cmd_disable_collision_checks_ = command->disable_collision_checks;
 
   prev_yaw_ = tf2::getYaw(current_pose.pose.orientation);
   relative_yaw_ = 0.0;
@@ -163,6 +166,7 @@ bool Spin::isCollisionFree(
   geometry_msgs::msg::Pose2D & pose2d)
 {
   // Simulate ahead by simulate_ahead_time_ in cycle_frequency_ increments
+  if (cmd_disable_collision_checks_) return true;
   int cycle_count = 0;
   double sim_position_change;
   const int max_cycle_count = static_cast<int>(cycle_frequency_ * simulate_ahead_time_);

--- a/nav2_msgs/action/Spin.action
+++ b/nav2_msgs/action/Spin.action
@@ -1,6 +1,7 @@
 #goal definition
 float32 target_yaw
 builtin_interfaces/Duration time_allowance
+bool disable_collision_checks
 ---
 #result definition
 builtin_interfaces/Duration total_elapsed_time


### PR DESCRIPTION
## Basic Info

| Info | Value |
|------|-------|
| Ticket(s) this addresses | N/A |
| Primary OS tested on | Ubuntu 22.04 LTS |
| Robotic platform tested on | Simulated environment (Carter_ROS + IsaacSim 5.0.0 + Nav2 Humble) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Added a new optional field `disable_collision_checks` to the `nav2_msgs/action/Spin` goal message.  
* Updated the `Spin` behavior plugin to respect this flag and skip collision checking when set to `true`.  
* Enables developers to use the spin behavior safely in constrained or simulation-only contexts where collision checking is unnecessary (e.g., SLAM initialization or visual localization resets).  
* Default behavior remains unchanged – collision checks are still enabled unless explicitly disabled.

---

## Description of documentation updates required from your changes

* Update [`Spin` behavior documentation](https://docs.nav2.org/configuration/packages/configuring-bt-navigator.html#spin-action) to mention the new `disable_collision_checks` field.  
* Add the new field to default YAML examples under `behavior_server` configurations.  
* Note that this is an optional runtime flag for advanced users.

---

## Description of how this change was tested

* Built and run within ROS 2 Humble (see Repository [SAGE](https://github.com/KevinEppacher/SAGE.git))
* Verified `Spin` behavior with and without `disable_collision_checks: true` flag using `bt_navigator` and custom launch configuration.  
* Confirmed normal behavior when omitted, and confirmed immediate spin without collision look-ahead when set to `true`.  

```cpp
bool Robot::spin(double yaw, double durationSec)
{
    if (!spinClient)
        spinClient = rclcpp_action::create_client<NavSpin>(node, "/spin");

    if (!spinClient->wait_for_action_server(1s))
    {
        RCLCPP_ERROR(node->get_logger(), "Spin action server not available");
        return false;
    }

    NavSpin::Goal goal;
    goal.target_yaw = yaw;
    goal.disable_collision_checks = true;
    goal.time_allowance = rclcpp::Duration::from_seconds(durationSec);

    spinDone = false;
    spinResult = rclcpp_action::ResultCode::UNKNOWN;

    auto options = rclcpp_action::Client<NavSpin>::SendGoalOptions();
    options.result_callback = [this](const GoalHandleSpin::WrappedResult& result)
    {
        spinDone = true;
        spinResult = result.code;
    };

    goalHandleFuture = spinClient->async_send_goal(goal, options);
    this->halted = false;
    return true;
}
```
---

## Future work that may be required in bullet points

* Add automated unit tests to confirm correct disabling of collision simulation.

---

#### For Maintainers
- [ ] Check that new parameter is documented on docs.nav2.org  
- [ ] Add to migration and tuning guides if applicable  
- [ ] Confirm Doxygen and test coverage  
- [ ] Consider backport tag `backport-humble`  
