### PR TITLE
[WIP] Expose launch substitutions to frontends

### DIFF
--- a/nav2_common/nav2_common/__init__.py
+++ b/nav2_common/nav2_common/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Open Navigation LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import launch
+
+__all__ = [
+    'launch',
+]

--- a/nav2_common/nav2_common/launch/has_node_params.py
+++ b/nav2_common/nav2_common/launch/has_node_params.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Sequence
+
 import launch
 import yaml
 
 
+@launch.frontend.expose_substitution('has-node-params')
 class HasNodeParams(launch.Substitution):
     """
     Substitution that checks if a param file contains parameters for a node.
@@ -40,6 +43,18 @@ class HasNodeParams(launch.Substitution):
         self.__source_file: list[launch.Substitution] = \
             normalize_to_list_of_substitutions(source_file)
         self.__node_name = node_name
+
+    @classmethod
+    def parse(cls, data: Sequence[launch.SomeSubstitutionsType]):
+        num_args = len(data)
+        if num_args != 2:
+            raise TypeError(
+                f'has-node-params substitution takes 2 arguments, got {num_args}')
+        kwargs = {
+            'source_file': data[0],
+            'node_name': data[1],
+        }
+        return cls, kwargs
 
     @property
     def name(self) -> list[launch.Substitution]:

--- a/nav2_common/nav2_common/launch/launch_config_as_bool.py
+++ b/nav2_common/nav2_common/launch/launch_config_as_bool.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Sequence
+
 import launch
 from launch import LaunchContext
 from launch.substitutions import LaunchConfiguration
 from launch.utilities import perform_substitutions
 
 
+@launch.frontend.expose_substitution('as-bool')
 class LaunchConfigAsBool(launch.Substitution):
     """
     Converts a LaunchConfiguration value into a normalized boolean string: 'true' or 'false'.
@@ -29,6 +32,16 @@ class LaunchConfigAsBool(launch.Substitution):
     def __init__(self, name: str) -> None:
         super().__init__()
         self._config = LaunchConfiguration(name)
+
+    @classmethod
+    def parse(cls, data: Sequence[launch.SomeSubstitutionsType]):
+        if len(data) != 1:
+            raise TypeError(f'as-bool substitution takes 1 arg, got {len(data)}')
+        kwargs = {
+            'name': data[0]
+        }
+        return cls, kwargs
+
 
     def perform(self, context: LaunchContext) -> str:
         value = perform_substitutions(context, [self._config])

--- a/nav2_common/nav2_common/launch/replace_string.py
+++ b/nav2_common/nav2_common/launch/replace_string.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import tempfile
-from typing import IO, Optional
+from typing import IO, Optional, Sequence
 
 import launch
 
 
+@launch.frontend.expose_substitution('replace-string')
 class ReplaceString(launch.Substitution):
     """
     Substitution that replaces strings on a given file.
@@ -45,6 +46,10 @@ class ReplaceString(launch.Substitution):
                 replacements[key]
             )
         self.__condition = condition
+
+    @classmethod
+    def parse(cls, data: Sequence[launch.SomeSubstitutionsType]):
+        raise NotImplementedError()
 
     @property
     def name(self) -> list[launch.Substitution]:

--- a/nav2_common/nav2_common/launch/rewritten_yaml.py
+++ b/nav2_common/nav2_common/launch/rewritten_yaml.py
@@ -14,7 +14,7 @@
 
 from collections.abc import Generator
 import tempfile
-from typing import Optional, TypeAlias, Union
+from typing import Optional, TypeAlias, Union, Sequence
 
 import launch
 import yaml
@@ -35,6 +35,7 @@ class DictItemReference:
         self.dictionary[self.dictKey] = value
 
 
+@launch.frontend.expose_substitution('rewritten-yaml')
 class RewrittenYaml(launch.Substitution):
     """
     Substitution that modifies the given YAML file.
@@ -89,6 +90,10 @@ class RewrittenYaml(launch.Substitution):
                 )
         if root_key is not None:
             self.__root_key = normalize_to_list_of_substitutions(root_key)
+
+    @classmethod
+    def parse(cls, data: Sequence[launch.SomeSubstitutionsType]):
+        raise NotImplementedError()
 
     @property
     def name(self) -> list[launch.Substitution]:

--- a/nav2_common/setup.cfg
+++ b/nav2_common/setup.cfg
@@ -1,0 +1,3 @@
+[options.entry_points]
+launch.frontend.launch_extension:
+  nav2_common = nav2_common


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

- Expose the launch Substitutions in `nav2_common` to the launch frontend, so they can also be used in YAML, XML, etc.
- Added `@expose_substitution` decorator
- Added `parse` class method
- Added `setup.cfg` to register the importlib entry point, so `launch` finds these
- Added content to `__init__.py` to force the substitutions to get registered on module import

## Description of documentation updates required from your changes

Will need to add YAML/XML examples of nav2 launchfiles.

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
