### PR TITLE
Fix: Add covariance magnitude (Issue #5611)

### DIFF
--- a/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
+++ b/nav2_ros_common/include/nav2_ros_common/validate_messages.hpp
@@ -56,7 +56,8 @@ bool validateMsg(const double & num)
   return true;
 }
 
-const double MAX_COVARIANCE = 1e6;
+const double MAX_COVARIANCE = 1e9;
+const double MIN_COVARIANCE = 0;
 
 template<size_t N>
 bool validateMsg(const std::array<double, N> & msg)
@@ -68,7 +69,7 @@ bool validateMsg(const std::array<double, N> & msg)
   for (const auto & element : msg) {
     if (!validateMsg(element)) {return false;}
 
-    if (std::abs(element) > MAX_COVARIANCE && element < 0.0) {
+    if (std::abs(element) > MAX_COVARIANCE || element < MIN_COVARIANCE) {
       return false;
     }
   }

--- a/nav2_ros_common/test/test_validation_messages.cpp
+++ b/nav2_ros_common/test/test_validation_messages.cpp
@@ -343,7 +343,7 @@ TEST(ValidateMessagesTest, PoseWithCovarianceCheck) {
   // Test below MIN value PoseWithCovariance message
   geometry_msgs::msg::PoseWithCovariance invalidate_msg4;
 
-  invalidate_msg4.covariance[0] = 1e-5;  // < MIN_COVARIANCE (1e-4)
+  invalidate_msg4.covariance[0] = -0.01;  // < MIN_COVARIANCE (0)
   for (size_t i = 1; i < invalidate_msg4.covariance.size(); ++i) {
     invalidate_msg4.covariance[i] = 0.01;  // Valid value
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #5611 ) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
