### PR TITLE
Fix memory growth issue in isPoseOccupied

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_pose_occupied_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_pose_occupied_condition.hpp
@@ -61,6 +61,11 @@ public:
   void initialize();
 
   /**
+   * @brief Function to create ROS interfaces
+   */
+  void createROSInterfaces();
+
+  /**
    * @brief Creates list of BT ports
    * @return BT::PortsList Containing node-specific ports
    */
@@ -72,7 +77,8 @@ public:
 
     return {
       BT::InputPort<geometry_msgs::msg::PoseStamped>("pose", "Pose to check if occupied"),
-      BT::InputPort<std::string>("service_name", "global_costmap/get_cost_global_costmap"),
+      BT::InputPort<std::string>("service_name", "global_costmap/get_cost_global_costmap",
+        "The service name to call GetCosts"),
       BT::InputPort<double>(
         "cost_threshold", 254.0,
         "Cost threshold for considering a pose occupied"),

--- a/nav2_behavior_tree/plugins/condition/is_path_valid_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_path_valid_condition.cpp
@@ -31,13 +31,11 @@ IsPathValidCondition::IsPathValidCondition(
     node_->create_client<nav2_msgs::srv::IsPathValid>(
     "is_path_valid",
     false /* Does not create and spin an internal executor*/);
-
-  server_timeout_ = config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
 }
 
 void IsPathValidCondition::initialize()
 {
-  getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
+  getInputOrBlackboard("server_timeout", server_timeout_);
   getInput<unsigned int>("max_cost", max_cost_);
   getInput<bool>("consider_unknown_as_obstacle", consider_unknown_as_obstacle_);
 }

--- a/nav2_behavior_tree/plugins/condition/is_pose_occupied_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_pose_occupied_condition.cpp
@@ -24,24 +24,32 @@ IsPoseOccupiedCondition::IsPoseOccupiedCondition(
   const std::string & condition_name,
   const BT::NodeConfiguration & conf)
 : BT::ConditionNode(condition_name, conf),
-  use_footprint_(true), consider_unknown_as_obstacle_(false), cost_threshold_(254),
-  service_name_("global_costmap/get_cost_global_costmap")
+  use_footprint_(true), consider_unknown_as_obstacle_(false), cost_threshold_(254)
 {
-  node_ = config().blackboard->get<nav2::LifecycleNode::SharedPtr>("node");
-  server_timeout_ = config().blackboard->template get<std::chrono::milliseconds>("server_timeout");
+  initialize();
 }
 
 void IsPoseOccupiedCondition::initialize()
 {
-  getInput<std::string>("service_name", service_name_);
   getInput<double>("cost_threshold", cost_threshold_);
   getInput<bool>("use_footprint", use_footprint_);
   getInput<bool>("consider_unknown_as_obstacle", consider_unknown_as_obstacle_);
-  getInput<std::chrono::milliseconds>("server_timeout", server_timeout_);
-  client_ =
-    node_->create_client<nav2_msgs::srv::GetCosts>(
-    service_name_,
-    false /* Does not create and spin an internal executor*/);
+  getInputOrBlackboard("server_timeout", server_timeout_);
+  createROSInterfaces();
+}
+
+void IsPoseOccupiedCondition::createROSInterfaces()
+{
+  std::string service_new;
+  getInput<std::string>("service_name", service_new);
+  if (service_new != service_name_ || !client_) {
+    service_name_ = service_new;
+    node_ = config().blackboard->get<nav2::LifecycleNode::SharedPtr>("node");
+    client_ =
+      node_->create_client<nav2_msgs::srv::GetCosts>(
+      service_name_,
+      false /* Does not create and spin an internal executor*/);
+  }
 }
 
 BT::NodeStatus IsPoseOccupiedCondition::tick()


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Fixes #5690 |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
