### PR TITLE
Fix: wait for drive_on_heading_client instead of backup_client

### DIFF
--- a/nav2_simple_commander/nav2_simple_commander/robot_navigator.py
+++ b/nav2_simple_commander/nav2_simple_commander/robot_navigator.py
@@ -474,7 +474,7 @@ class BasicNavigator(Node):
             disable_collision_checks: bool = False) -> Optional[RunningTask]:
         self.clearTaskError()
         self.debug("Waiting for 'DriveOnHeading' action server")
-        while not self.backup_client.wait_for_server(timeout_sec=1.0):
+        while not self.drive_on_heading_client.wait_for_server(timeout_sec=1.0):
             self.info("'DriveOnHeading' action server not available, waiting...")
         goal_msg = DriveOnHeading.Goal()
         goal_msg.target = Point(x=float(dist))


### PR DESCRIPTION
The basic navigator was waiting for the backup_client in the driveOnHeading function while it should have waited for the drive_on_heading_client.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |gazebo|
| Does this PR contain AI generated software? | |
| Was this PR description generated by AI software? |  |

---

## Description of contribution in a few bullet points

Fix a typo probably due to copy paste when implementing the driveOnHeading function.

## Description of documentation updates required from your changes

NA

## Description of how this change was tested

- Test that the project builds,

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
