### PR TITLE
fix: change warning to exception when goal poses cannot be transformed

### DIFF
--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -17,6 +17,7 @@
 #include <set>
 #include <memory>
 #include <limits>
+#include <stdexcept>
 #include "nav2_bt_navigator/navigators/navigate_through_poses.hpp"
 
 namespace nav2_bt_navigator
@@ -217,11 +218,9 @@ NavigateThroughPosesNavigator::onPreempt(ActionT::Goal::ConstSharedPtr goal)
     // if pending goal has an empty behavior_tree field, it requests the default BT file
     // accept the pending goal if the current goal is running the default BT file
     if (!initializeGoalPoses(bt_action_server_->acceptPendingGoal())) {
-      RCLCPP_WARN(
-        logger_,
+      throw std::runtime_error(
         "Preemption request was rejected since the goal poses could not be "
-        "transformed. For now, continuing to track the last goal until completion.");
-      bt_action_server_->terminatePendingGoal();
+        "transformed.");
     }
   } else {
     RCLCPP_WARN(


### PR DESCRIPTION
This PR fixes issue #5758 where navigators accept pending goals but are not properly terminated if rejected.

## Changes
- Replace RCLCPP_WARN with std::runtime_error exception in onPreempt method
- Remove bt_action_server_::terminatePendingGoal() call after accepting goal
- Add required stdexcept include for exception handling

Fixes #5758

Generated with [Claude Code](https://claude.ai/code)