### PR TITLE
Add mini-1235 to allowed GitHub actors

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,6 +23,7 @@ jobs:
         github.actor == 'tonynajjar' ||
         github.actor == 'ruffsl' ||
         github.actor == 'doisyg' ||
+        github.actor == 'mini-1235' ||
         github.actor == 'padhupradheep'
       )
 


### PR DESCRIPTION
@mini-1235 this allows you to do "@claude" to request Claude code to do something or even respond to a comment with ideas. This is my personal token, so don't go too crazy with it, but its nice to fix small things like this inline (for example) https://github.com/ros-navigation/navigation2/issues/5758. I've not found it overly useful, but it has actually been nice for documentation updates for docs.nav2.org. I've just given it a PR link and the names of the parameters and it generates the appropriate rst. Saves a couple of minutes I suppose. This is more of an experiment than anything else since I pay for the subscription anyway.

Feel free to experiment to your heart's desire :-) 