### PR TITLE
[mppi] Don't reset zone-based speed limits

### DIFF
--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -122,8 +122,7 @@ void Optimizer::getParams()
   s.constraints = s.base_constraints;
 
   setMotionModel(motion_model_name);
-  // Don't reset zone-based speed limits after params changes
-  parameters_handler_->addPostCallback([this]() {reset(false);});
+  parameters_handler_->addPostCallback([this]() {reset();});
 
   double controller_frequency;
   getParentParam(controller_frequency, "controller_frequency", 0.0, ParameterType::Static);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo sim |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Fix 2 bugs:
1. Set the `reset()` flag correctly to avoid resetting speed limits when other parameters are changed and after a fallback.
2. initialize the motion model in `setSpeedLimit()` so that the new speed limit is updated in the motion model settings. This way the `predict()` function is also aware of the new speed limit.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
None

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->
Tested in simulation:
Bug 1:
- Cause Controller to fail while inside a speed limit filter (e.g. with an obstacle). then check that the speed limit is still set after the controller is reset
- Changed param with reconfigure, and test the speed limit is still set

Bug 2:
Print the value of one of the constraints params inside `predict()`. Without this PR, it is never updated. With it, is it updated when entering/leaving a speed limit zone.

---

## Future work that may be required in bullet points
None
<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
