### PR TITLE
fix: add check for keepout filter mask if it is not nullptr

### DIFF
--- a/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/keepout_filter.cpp
@@ -177,8 +177,9 @@ void KeepoutFilter::updateBounds(
   CostmapFilter::updateBounds(robot_x, robot_y, robot_yaw, min_x, min_y, max_x, max_y);
 
   if (!filter_mask_) {
-    RCLCPP_WARN_ONCE(
-      logger_, "KeepoutFilter: Filter mask was not received");
+    RCLCPP_WARN_THROTTLE(
+      logger_, *(clock_), 2000,
+      "KeepoutFilter: Filter mask was not received");
     return;
   }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5763  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points
- I added a check whether filter_mask is nullptr.
- Warning if it hasn't been received yet.


## Description of documentation updates required from your changes


## Description of how this change was tested
- Checked whether a warning is printing if the filter mask is not received.
- Checked if it was still possible to leave the keep-out zone if the robot was inside this zone (same as in #5187).
- Checked if it was still possible dynamically update keep-out zone (same as in #5410):
```
ros2 launch nav2_bringup tb4_simulation_launch.py headless:=False
```

Update filter mask:
```
ros2 service call /keepout_filter_mask_server/load_map nav2_msgs/srv/LoadMap "{map_url: '/opt/overlay_ws/src/navigation2/nav2_bringup/maps/depot_keepout_new.yaml'}"
```

<img width="1144" height="583" alt="Pasted image 20251208204620" src="https://github.com/user-attachments/assets/ab6e0ce5-9ad2-4794-8c3e-508dcbad122f" />

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

- Initially, I chose the logging type `RCLCPP_WARN_THROTTLE` identical to the check that in `KeepoutFilter::process`. But this type does't work correctly due to issue: [Issue with RCLCPP THROTTLE logging in the plugin based approach #2587](https://github.com/ros2/rclcpp/issues/2587). 
	Alternatively, we can **temporarily** use:
	- `RCLCPP_WARN`, but it fills the terminal too quickly.
	- `RCLCPP_WARN_ONCE`, this type also does not work correctly (it does not print once), but at least it provides information and with less frequency than the first option.

- Replace `RCLCPP_WARN_ONCE` with `RCLCPP_WARN_THROTTLE`, when the above issue will be solved. 
- If you agree with the current implementation, I will also change the warning type in `Keepout Filter::process`.

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
