### PR TITLE
Add NavigateToPose and NavigateThroughPoses RViz panels for manual goal sending

### DIFF
--- a/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
+++ b/nav2_rviz_plugins/include/nav2_rviz_plugins/nav2_panel.hpp
@@ -181,6 +181,7 @@ private:
   QPushButton * save_waypoints_button_{nullptr};
   QPushButton * load_waypoints_button_{nullptr};
   QPushButton * pause_waypoint_button_{nullptr};
+  QPushButton * start_nav_to_pose_button_{nullptr};
 
   QLabel * navigation_status_indicator_{nullptr};
   QLabel * localization_status_indicator_{nullptr};
@@ -202,7 +203,6 @@ private:
   QDoubleSpinBox * nav_to_pose_x_{nullptr};
   QDoubleSpinBox * nav_to_pose_y_{nullptr};
   QDoubleSpinBox * nav_to_pose_yaw_{nullptr};
-  QPushButton * send_nav_to_pose_button_{nullptr};
 
   // NavigateThroughPoses manual input widgets
   QTabWidget * nav_through_poses_tabs_{nullptr};

--- a/nav2_rviz_plugins/src/nav2_panel.cpp
+++ b/nav2_rviz_plugins/src/nav2_panel.cpp
@@ -59,6 +59,7 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   save_waypoints_button_ = new QPushButton;
   load_waypoints_button_ = new QPushButton;
   pause_waypoint_button_ = new QPushButton;
+  start_nav_to_pose_button_ = new QPushButton;
   navigation_status_indicator_ = new QLabel;
   localization_status_indicator_ = new QLabel;
   navigation_goal_status_indicator_ = new QLabel;
@@ -116,6 +117,8 @@ Nav2Panel::Nav2Panel(QWidget * parent)
 
   pre_initial_->assignProperty(pause_resume_button_, "text", "Pause");
   pre_initial_->assignProperty(pause_resume_button_, "enabled", false);
+
+  pre_initial_->assignProperty(start_nav_to_pose_button_, "text", "Start NavigateToPose");
 
   pre_initial_->assignProperty(
     navigation_mode_button_, "text",
@@ -196,6 +199,7 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   idle_->assignProperty(nr_of_loops_, "enabled", false);
 
   idle_->assignProperty(store_initial_pose_checkbox_, "enabled", false);
+  idle_->assignProperty(start_nav_to_pose_button_, "enabled", true);
 
   // State entered when navigate_to_pose action is not active
   accumulating_ = new QState();
@@ -313,6 +317,8 @@ Nav2Panel::Nav2Panel(QWidget * parent)
     "text", "Waypoint Following / NavigateThroughPoses Mode");
   running_->assignProperty(navigation_mode_button_, "enabled", false);
 
+  running_->assignProperty(start_nav_to_pose_button_, "enabled", false);
+
   running_->assignProperty(add_pose_button_, "enabled", false);
   running_->assignProperty(remove_pose_button_, "enabled", false);
 
@@ -339,6 +345,8 @@ Nav2Panel::Nav2Panel(QWidget * parent)
 
   paused_->assignProperty(navigation_mode_button_, "text", "");
   paused_->assignProperty(navigation_mode_button_, "enabled", false);
+
+  paused_->assignProperty(start_nav_to_pose_button_, "enabled", false);
 
   paused_->assignProperty(add_pose_button_, "enabled", false);
   paused_->assignProperty(remove_pose_button_, "enabled", false);
@@ -602,10 +610,9 @@ Nav2Panel::Nav2Panel(QWidget * parent)
   nav_to_pose_yaw_->setSingleStep(0.01);
   nav_to_pose_layout->addWidget(nav_to_pose_yaw_, 3, 1);
 
-  send_nav_to_pose_button_ = new QPushButton("Start NavigateToPose");
-  QObject::connect(send_nav_to_pose_button_,
+  QObject::connect(start_nav_to_pose_button_,
     &QPushButton::clicked, this, &Nav2Panel::onSendNavToPose);
-  nav_to_pose_layout->addWidget(send_nav_to_pose_button_, 4, 0, 1, 2);
+  nav_to_pose_layout->addWidget(start_nav_to_pose_button_, 4, 0, 1, 2);
 
   nav_to_pose_tab->setLayout(nav_to_pose_layout);
   tools_tab_widget_->addTab(nav_to_pose_tab, "NavigateToPose");


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A (New feature) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo simulation of TB3 |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Added NavigateToPose Panel plugin for RViz2 that allows manual sending of NavigateToPose action goals including goal pose.
* Added NavigateThroughPoses Panel plugin for RViz2 that allows manual sending of NavigateThroughPoses action goals including variable-length list of goal poses.
* Both panels provide full control over pose parameters (position, orientation, frame_id) and behavior tree selection through XML file specification.
* Integrated plugins into nav2_rviz_plugins package with proper CMake and plugin registration.

## Description of documentation updates required from your changes

* Need to document the new RViz plugins in the Navigation2 documentation.
* Should add screenshots and usage examples for both panels.
* May need to update the RViz plugins section of the user guide.

## Description of how this change was tested

* Compiled successfully with colcon build.
* Basic UI functionality tested in development environment with Gazebo simulator.
* Tested normal operation for both plugins, including failure situations such as invalid pose frame, out-of-the-range coordinates or inexistend Behavior Tree file selection.
* Plugin registration verified through CMakeLists.txt and plugins_description.xml updates.

---

## Future work that may be required in bullet points

* Add visual feedback/status display for action execution.
* Consider adding preset pose saving/loading functionality.
* Potential integration with interactive markers for visual pose selection.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
