### PR TITLE
fix: update updown test

### DIFF
--- a/nav2_system_tests/src/updown/test_updown.cpp
+++ b/nav2_system_tests/src/updown/test_updown.cpp
@@ -31,8 +31,10 @@ int main(int argc, char ** argv)
   auto node = std::make_shared<rclcpp::Node>("lifecycle_manager_service_client");
   nav2_lifecycle_manager::LifecycleManagerClient client_nav("lifecycle_manager_navigation", node);
   nav2_lifecycle_manager::LifecycleManagerClient client_loc("lifecycle_manager_localization", node);
-  nav2_lifecycle_manager::LifecycleManagerClient client_keepout_zone("lifecycle_manager_keepout_zone", node);
-  nav2_lifecycle_manager::LifecycleManagerClient client_speed_zone("lifecycle_manager_speed_zone", node);
+  nav2_lifecycle_manager::LifecycleManagerClient client_keepout_zone(
+    "lifecycle_manager_keepout_zone", node);
+  nav2_lifecycle_manager::LifecycleManagerClient client_speed_zone(
+    "lifecycle_manager_speed_zone", node);
 
   // Wait for a few seconds to let all of the nodes come up
   std::this_thread::sleep_for(5s);
@@ -55,12 +57,12 @@ int main(int argc, char ** argv)
     if (client_nav.is_active() == nav2_lifecycle_manager::SystemStatus::ACTIVE &&
       client_loc.is_active() == nav2_lifecycle_manager::SystemStatus::ACTIVE &&
       client_keepout_zone.is_active() == nav2_lifecycle_manager::SystemStatus::ACTIVE &&
-      client_speed_zone.is_active() == nav2_lifecycle_manager::SystemStatus::ACTIVE) 
+      client_speed_zone.is_active() == nav2_lifecycle_manager::SystemStatus::ACTIVE)
     {
       test_passed = true;
       break;
     }
-    
+
     RCLCPP_WARN(logger, "Not all nodes are active. Repeat status request.");
     std::this_thread::sleep_for(2s);
     retries_number--;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  Second part of https://github.com/ros-navigation/navigation2/issues/5763#issuecomment-3627668531 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | - |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

- Added the necessary lifecycle manager clients to satisfy the current bringup launch process.
- Changed the condition for passing the test. Previously, there was a check if all lifecycle managers were inactive, only in this case we increased the retry counter. So this led to a false test passing.
- Added a warning message that not all nodes are active.
- Added a common logger for all logging macros.

## Description of documentation updates required from your changes



## Description of how this change was tested

- Checked if the test passes under normal conditions.
- Checked whether the test fails if at least one lifecycle manager is inactive.
- Checked `pre-commit` locally.


## Future work that may be required in bullet points

This PR solves the problem for the current configuration file and parameters for `bringup_launch.py` in `test_updown_launch.py`, but at the moment I see following limitation:
- If parameters will be changed, for example if we want to use `slam` we will miss check of `lifecycle_manager_slam`.
- If in the feature will be added new lifecycle managers, they may also be missed in this test.

I'd like to propose the option to collect all active nodes with the `/lifecycle_manager_` prefix in name, for example, using the `get_node_names()` method. Activate all of them and only then check the activity status. This way, there will be automatic detection of which nodes to work with.
I haven't added this yet because I want to discuss first if there may be any alternatives or additional improvements.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
