### PR TITLE
Also mark functions with override in binary and speed filter

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/binary_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/binary_filter.hpp
@@ -66,7 +66,7 @@ public:
    * @brief Initialize the filter and subscribe to the info topic
    */
   void initializeFilter(
-    const std::string & filter_info_topic);
+    const std::string & filter_info_topic) override;
 
   /**
    * @brief Process the keepout layer at the current pose / bounds / grid
@@ -74,12 +74,12 @@ public:
   void process(
     nav2_costmap_2d::Costmap2D & master_grid,
     int min_i, int min_j, int max_i, int max_j,
-    const geometry_msgs::msg::Pose & pose);
+    const geometry_msgs::msg::Pose & pose) override;
 
   /**
    * @brief Reset the costmap filter / topic / info
    */
-  void resetFilter();
+  void resetFilter() override;
 
   /**
    * @brief If this filter is active

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_filters/speed_filter.hpp
@@ -66,7 +66,7 @@ public:
    * @brief Initialize the filter and subscribe to the info topic
    */
   void initializeFilter(
-    const std::string & filter_info_topic);
+    const std::string & filter_info_topic) override;
 
   /**
    * @brief Process the keepout layer at the current pose / bounds / grid
@@ -74,12 +74,12 @@ public:
   void process(
     nav2_costmap_2d::Costmap2D & master_grid,
     int min_i, int min_j, int max_i, int max_j,
-    const geometry_msgs::msg::Pose & pose);
+    const geometry_msgs::msg::Pose & pose) override;
 
   /**
    * @brief Reset the costmap filter / topic / info
    */
-  void resetFilter();
+  void resetFilter() override;
 
   /**
    * @brief If this filter is active


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/pull/5782#discussion_r2614757388 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | CI |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No|

---

## Description of contribution in a few bullet points

This PR is a continuation from:
https://github.com/ros-navigation/navigation2/pull/5782#discussion_r2614757388

In this PR I've fixed some more clang-tidy override warnings.

## Description of how this change was tested

CI

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
