### PR TITLE
[Collision Monitor] fix Z base frame transformation

### DIFF
--- a/nav2_collision_monitor/src/pointcloud.cpp
+++ b/nav2_collision_monitor/src/pointcloud.cpp
@@ -144,6 +144,11 @@ bool PointCloud::getData(
 
     tf2::Vector3 p_v3_b = tf_transform * p_v3_s;
 
+    // Still need to transfer height from "z" field if not using global height
+    if (!use_global_height_) {
+      data_height = p_v3_b.z();
+    }
+
     // Refill data array
     if (data_height >= min_height_ && data_height <= max_height_) {
       data.push_back({p_v3_b.x(), p_v3_b.y()});


### PR DESCRIPTION
`min_height` / `max_height` applied to a pointcloud source in the CM is not anymore relative to `base_frame_id` but relative to the frame_id of that source when not using `use_global_height`.
Can be quite critical as impacting which part of a pointcloud are used in the collision monitor/detector.
I believe since: https://github.com/ros-navigation/navigation2/pull/5586
Draft to get the info out asap but not yet 100% checked. Will need extra sanity checks.