### PR TITLE
[Jazzy] Optimize MPPI visualization to skip processing when no subscribers

### DIFF
--- a/nav2_mppi_controller/src/trajectory_visualizer.cpp
+++ b/nav2_mppi_controller/src/trajectory_visualizer.cpp
@@ -65,8 +65,8 @@ void TrajectoryVisualizer::add(
   const std::string & marker_namespace,
   const builtin_interfaces::msg::Time & cmd_stamp)
 {
-  if ((optimal_path_pub_->get_subscription_count() == 0) &&
-    (trajectories_publisher_->get_subscription_count() == 0))
+  if (optimal_path_pub_->get_subscription_count() == 0 &&
+    trajectories_publisher_->get_subscription_count() == 0)
   {
     return;
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Issue #5801 |
| Primary OS tested on | Ubuntu 24.04.3 LTS (via nav2_dev Docker container) |
| Robotic platform tested on | Gazebo Simulation (TurtleBot3 Waffle) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points 

* Updated both overloaded instances of `TrajectoryVisualizer::add` to check subscription counts before executing the marker generation loops.
    * **Topics involved:** Checks `get_subscription_count()` on the `/trajectories` (MarkerArray) and `/optimal_trajectory` (Path) publishers.
* When `visualize` is set to `true`:
    * **0 Subscribers (Both topics):** The method returns immediately. No markers or paths are calculated.
    * **Subscriber for `/optimal_trajectory` only:** Generates and publishes the visualization data for only the optimal trajectory.
    *  **Subscriber for `/trajectories`:** Generates the visualization data for all the trajectories (including the optimal_trajectory). 
* Reduces `controller_server` CPU usage.

## Description of documentation updates required from your changes

* Since these changes are for the jazzy branch and the[ documentation only tracks main (rolling)](https://github.com/ros-navigation/navigation2/issues/5801#issuecomment-3677760440), I don't think we need to update any documentation pages. 

## Description of how this change was tested

* Unit Testing: 
    * Ran the `nav2_mppi_controller` GTest suite locally. Passed 17/17 (100%) tests. 
    * Verified that the logic changes did not break existing functionality or style guidelines. (passed ament_uncrustify and cpplint). 
 * Performance Testing: 
    * Used a non-composable launch configuration to run the controller_server as a standalone process.
    * Isolated the specific PID of the controller_server to track its CPU usage exclusively
    * Executed a NavigateThroughPoses action for ~30 seconds across 6 subscription cases and 2 base cases. 
 * Results:
    * Before: Enabling visualization caused a constant CPU spike even with 0 subscribers.
    * After: CPU spikes only when there are subscribers to `/trajectories`

**Cases** 
<img width="984" height="733" alt="image" src="https://github.com/user-attachments/assets/58561c42-8b92-4790-9a23-2aa6ec899f1e" />
<img width="1229" height="843" alt="image" src="https://github.com/user-attachments/assets/8fadbf82-ead5-4e9b-b0f5-0f42751bd41c" />


**Navigation Task** 
<img width="864" height="866" alt="NavigateThroughPoses_task" src="https://github.com/user-attachments/assets/2df41915-5aad-42dc-82a8-1485576c4f86" />

**Average CPU Load Summary**
<img width="1500" height="900" alt="comparison_barchart" src="https://github.com/user-attachments/assets/ca226cb9-4643-4a5b-a827-aaaf7ae48433" />

**CPU Usage Timeline (Before vs After)**
<img width="1600" height="600" alt="comparison_timeline" src="https://github.com/user-attachments/assets/d074a7c7-14c6-4126-b6d5-c8ddc63979e2" />

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
