### PR TITLE
Fix typo in rviz Route Tool plugin name for Jazzy

### DIFF
--- a/nav2_rviz_plugins/plugins_description.xml
+++ b/nav2_rviz_plugins/plugins_description.xml
@@ -36,7 +36,7 @@
     <description>The Particle Cloud rviz display.</description>
   </class>
   
-  <class name="nav2_rviz_plugins/RouteTool"
+  <class name="nav2_rviz_plugins/Route Tool"
          type="nav2_rviz_plugins::RouteTool"
          base_class_type="rviz_common::Panel">
     <description>A tool used to create route graphs.</description>


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |-- |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on |-- |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points
Fix typo on RouteTool plugin port. 
All other functionalities were working fine. However, when launching rviz through the rviz_plugins launch file, the panel could not be loaded because it expected Route Tool instead of RouteTool.

## Description of documentation updates required from your changes
--

## Description of how this change was tested
Ran route_tool launch from nav2_rviz_plugins and confirmed that the Route Tool panel now loads correctly in rviz.

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
