### PR TITLE
Expose CostmapSubscriber's callback group

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
@@ -59,7 +59,7 @@ public:
     costmap_update_sub_ = nav2::interfaces::create_subscription<nav2_msgs::msg::CostmapUpdate>(
       parent, topic_name_ + "_updates",
       std::bind(&CostmapSubscriber::costmapUpdateCallback, this, std::placeholders::_1),
-      nav2::qos::LatchedSubscriptionQoS());
+      nav2::qos::LatchedSubscriptionQoS(), callback_group);
   }
 
   /**


### PR DESCRIPTION
My motivation for exposing the callback group as an input is to spin that node independently within a BT node: 

(pseudo-code)
```c++
  callback_group_ = node_->create_callback_group(
    rclcpp::CallbackGroupType::MutuallyExclusive,
    false);
  callback_group_executor_.add_callback_group(callback_group_, node_->get_node_base_interface());
  costmap_sub_ = std::make_shared<nav2_costmap_2d::CostmapSubscriber>(
    node_, costmap_topic, callback_group_);
  callback_group_executor_.spin_all(bt_loop_duration_);
```