### PR TITLE
[Kilted] Do not publish costmap unless enabled

### DIFF
--- a/nav2_costmap_2d/src/costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_publisher.cpp
@@ -37,6 +37,7 @@
  *         David V. Lu!!
  *********************************************************************/
 #include "nav2_costmap_2d/costmap_2d_publisher.hpp"
+#include "nav2_costmap_2d/costmap_layer.hpp"
 
 #include <string>
 #include <memory>
@@ -238,6 +239,11 @@ std::unique_ptr<nav2_msgs::msg::CostmapUpdate> Costmap2DPublisher::createCostmap
 
 void Costmap2DPublisher::publishCostmap()
 {
+  auto const costmap_layer = dynamic_cast<CostmapLayer *>(costmap_);
+  if (costmap_layer != nullptr && !costmap_layer->isEnabled()) {
+    return;
+  }
+
   float resolution = costmap_->getResolution();
   if (always_send_full_costmap_ || grid_resolution_ != resolution ||
     grid_width_ != costmap_->getSizeInCellsX() ||


### PR DESCRIPTION
---

## Basic Info

Backport of https://github.com/ros-navigation/navigation2/pull/5748 to Kilted

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5710 |
| Primary OS tested on | Ubuntu 24.04 docker container |
| Robotic platform tested on | Gazebo simulation of a USV |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Prevent the costmap_2d_publisher from trying to publish when it is not enabled.

## Description of documentation updates required from your changes

N/A

## Description of how this change was tested

Replicated the steps to produce the issue in #5710 and did not see the issue.

---

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
