### PR TITLE
[mppi] Fix division by zero in Constraint Critic

### DIFF
--- a/nav2_mppi_controller/src/critics/constraint_critic.cpp
+++ b/nav2_mppi_controller/src/critics/constraint_critic.cpp
@@ -83,7 +83,8 @@ void ConstraintCritic::score(CriticData & data)
     auto & vx = data.state.vx;
     auto & wz = data.state.wz;
     float min_turning_rad = acker->getMinTurningRadius();
-    auto out_of_turning_rad_motion = (min_turning_rad - (vx.abs() / wz.abs())).max(0.0f);
+    // Avoid division by zero for wz near 0
+    auto out_of_turning_rad_motion = (min_turning_rad - (vx.abs() / (wz.abs().max(1e-6)))).max(0.0f);
     if (power_ > 1u) {
       data.costs += ((((vx - max_vel_).max(0.0f) + (min_vel_ - vx).max(0.0f) +
         out_of_turning_rad_motion) * data.model_dt).rowwise().sum().eval() *


### PR DESCRIPTION

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | Custom simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

This pull request is a backport of #5636 to the `humble_main` branch.
This issue leads to nan costs when wz is zero with ackermann enabled, and results in the robot moving only in circles.

## Description of how this change was tested
I used a test nav2 setup with a dummy local costmap and global costmap with all values equal to 0.
Motion model is set to Ackermann. 

Before the fix to any goal the optimal trajectory correspond to  high vx and wz and the robot going only in circles, failing after a while. The constraint critic compute NaN costs, verified by adding prints in the code.

After the fix, the previous behaviour does not happen anymore and the optimal trajectory is correct.


---

## Future work that may be required in bullet points

* #5636 also adds a minor change on applycontraints() to avoid using raw pointers and use instead Eigen operations. This change was not added to the PR.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
