### PR TITLE
Fix not waiting for obstacle layer disabling before planning

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layer.hpp
@@ -139,6 +139,15 @@ public:
     return current_;
   }
 
+  /**
+   * @brief Set whether the data in the layer is up to date.
+   * @param current Whether the layer is current.
+   */
+  void setCurrent(bool current)
+  {
+    current_ = current;
+  }
+
   /**@brief Gets whether the layer is enabled. */
   bool isEnabled() const
   {

--- a/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layered_costmap.hpp
@@ -222,7 +222,6 @@ private:
 
   bool rolling_window_;  /// < @brief Whether or not the costmap should roll with the robot
 
-  bool current_;
   double minx_, miny_, maxx_, maxy_;
   unsigned int bx0_, bxn_, by0_, byn_;
 

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -385,9 +385,7 @@ ObstacleLayer::dynamicParametersCallback(
     } else if (param_type == ParameterType::PARAMETER_BOOL) {
       if (param_name == name_ + "." + "enabled" && enabled_ != parameter.as_bool()) {
         enabled_ = parameter.as_bool();
-        if (enabled_) {
-          current_ = false;
-        }
+        current_ = false;
       } else if (param_name == name_ + "." + "footprint_clearing_enabled") {
         footprint_clearing_enabled_ = parameter.as_bool();
       }


### PR DESCRIPTION
# Bug

**How to reproduce**

1. Disable obstacle layer
2. Plan immediately
3. Observation: the resulting plan still considers the obstacle layer as activated. It's a race condition because replanning a few seconds later works as expected - without the obstacle layer

**Investigation**

From my investigation, this is caused by:

- The obstacle layer only sets `current_` to false if we enable it, [and not when we disable it. ](https://github.com/ros-navigation/navigation2/blob/018dca9a43793b3944c3058526589530c4148034/nav2_costmap_2d/plugins/obstacle_layer.cpp#L388)
- `LayeredCostmap::isCurrent()` [ignores disabled plugins](https://github.com/ros-navigation/navigation2/blob/018dca9a43793b3944c3058526589530c4148034/nav2_costmap_2d/src/layered_costmap.cpp#L272
), so even if they are not current, it will still return `true`

# Fix

- Set ObstacleLayer's `current_` to false both when enabling and disabling it 
- Make `LayeredCostmap::isCurrent()` still check the current_ status of layers even if they are disabled. This however, has the unwanted effect that disabled layers will be checked for currency, which can be unnecessarily blocking (e.g. we don't care about source timeout of a disabled layer). To remedy that, we set all the disabled layers to current at the end of `updateMap`. That way, we guarantee at least one `updateMap` cycle after the disabling of layers.



**Notes**

> This however, has the unwanted effect that disabled layers will be checked for currency, which can be unnecessarily blocking (e.g. we don't care about source timeout of a disabled layer). To remedy that, we set all the disabled layers to current at the end of `updateMap`. That way, we guarantee at least one `updateMap` cycle after the disabling of layers.

This adds some complexity - do you think it's worth it or is it fine to let disabled layers be blocking because for some reason they are not current?


Question: Why aren't we setting `current_ = false` for all the dynamic param changes that would affect the master costmap? Shouldn't we do that to ensure that one cycle of `UpdateMap` occurs before `isCurrent` returns `true`?
