### PR TITLE
Fix MAX_NON_OBSTACLE_COST in theta star planner

### DIFF
--- a/nav2_theta_star_planner/README.md
+++ b/nav2_theta_star_planner/README.md
@@ -25,9 +25,6 @@ The parameters were set to - `w_euc_cost: 1.0`, `w_traversal_cost: 5.0` and the 
 
 **f(a)** - total cost (g(a) + h(a)) for the node 'a'
 
-**LETHAL_COST** - a value of the costmap traversal cost that inscribes an obstacle with
-respect to a function, value = 253
-
 **curr** - represents the node whose neighbours are being added to the list
 
 **neigh** - one of the neighboring nodes of curr
@@ -36,7 +33,7 @@ respect to a function, value = 253
 
 **euc_cost(a,b)** - euclidean distance between the node type 'a' and type 'b'
 
-**costmap_cost(a,b)** - the costmap traversal cost (ranges from 0 - 252, 254 = unknown value) between the node type 'a' and type 'b'
+**costmap_cost(a,b)** - the costmap traversal cost (ranges from 0 - 252, 255 = unknown value) between the node type 'a' and type 'b'
 
 ### Cost function
 ```

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star.hpp
@@ -25,8 +25,8 @@
 
 const double INF_COST = DBL_MAX;
 const int UNKNOWN_COST = 255;
-const int OBS_COST = 254;
-const int LETHAL_COST = 252;
+const int OCCUPIED_COST = 254;
+const int MAX_NON_OBSTACLE_COST = 252;
 
 struct coordsM
 {
@@ -92,14 +92,13 @@ public:
   bool generatePath(std::vector<coordsW> & raw_path, std::function<bool()> cancel_checker);
 
   /**
-   * @brief this function checks whether the cost of a point(cx, cy) on the costmap is less than the LETHAL_COST
+   * @brief this function checks whether the cost of a point(cx, cy) on the costmap is less than or equal to the MAX_NON_OBSTACLE_COST
    * @return the result of the check
    */
   inline bool isSafe(const int & cx, const int & cy) const
   {
-    return (costmap_->getCost(
-             cx,
-             cy) == UNKNOWN_COST && allow_unknown_) || costmap_->getCost(cx, cy) < LETHAL_COST;
+    return (costmap_->getCost(cx, cy) == UNKNOWN_COST && allow_unknown_) ||
+           costmap_->getCost(cx, cy) <= MAX_NON_OBSTACLE_COST;
   }
 
   /**
@@ -110,8 +109,8 @@ public:
     const geometry_msgs::msg::PoseStamped & goal);
 
   /**
-   * @brief checks whether the start and goal points have costmap costs greater than LETHAL_COST
-   * @return true if the cost of any one of the points is greater than LETHAL_COST
+   * @brief checks whether the start and goal points have costmap costs greater than MAX_NON_OBSTACLE_COST
+   * @return true if the cost of any one of the points is greater than MAX_NON_OBSTACLE_COST
    */
   bool isUnsafeToPlan() const
   {
@@ -193,16 +192,19 @@ protected:
   /**
    * @brief it is an overloaded function to ease the cost calculations while performing the LOS check
    * @param cost denotes the total straight line traversal cost; it adds the traversal cost for the node (cx, cy) at every instance; it is also being returned
-   * @return false if the traversal cost is greater than / equal to the LETHAL_COST and true otherwise
+   * @return false if the traversal cost is greater than the MAX_NON_OBSTACLE_COST and true otherwise
    */
   bool isSafe(const int & cx, const int & cy, double & cost) const
   {
     double curr_cost = getCost(cx, cy);
-    if ((costmap_->getCost(cx, cy) == UNKNOWN_COST && allow_unknown_) || curr_cost < LETHAL_COST) {
+    if ((costmap_->getCost(cx, cy) == UNKNOWN_COST && allow_unknown_) ||
+      curr_cost <= MAX_NON_OBSTACLE_COST)
+    {
       if (costmap_->getCost(cx, cy) == UNKNOWN_COST) {
-        curr_cost = OBS_COST - 1;
+        curr_cost = OCCUPIED_COST - 1;
       }
-      cost += w_traversal_cost_ * curr_cost * curr_cost / LETHAL_COST / LETHAL_COST;
+      cost += w_traversal_cost_ * curr_cost * curr_cost / MAX_NON_OBSTACLE_COST /
+        MAX_NON_OBSTACLE_COST;
       return true;
     } else {
       return false;
@@ -226,7 +228,8 @@ protected:
   inline double getTraversalCost(const int & cx, const int & cy)
   {
     double curr_cost = getCost(cx, cy);
-    return w_traversal_cost_ * curr_cost * curr_cost / LETHAL_COST / LETHAL_COST;
+    return w_traversal_cost_ * curr_cost * curr_cost / MAX_NON_OBSTACLE_COST /
+           MAX_NON_OBSTACLE_COST;
   }
 
   /**


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
