### PR TITLE
Increase timeout for test_planner_plugins

### DIFF
--- a/nav2_system_tests/src/planning/CMakeLists.txt
+++ b/nav2_system_tests/src/planning/CMakeLists.txt
@@ -73,7 +73,7 @@ nav2_add_test(test_planner_random
 nav2_add_gtest(test_planner_plugins
   planner_tester.cpp
   test_planner_plugins.cpp
-  TIMEOUT 10
+  TIMEOUT 30
 )
 target_link_libraries(test_planner_plugins
   ${geometry_msgs_TARGETS}


### PR DESCRIPTION
No idea what changed but the test fails because it timeouts (locally too): https://app.circleci.com/pipelines/github/ros-navigation/navigation2/17618/workflows/3a987b22-ff86-4db3-8922-380a47517439/jobs/52396