### PR TITLE
nav2_costmap_2d: add type adapter for costmap messages

### DIFF
--- a/nav2_constrained_smoother/test/test_constrained_smoother.cpp
+++ b/nav2_constrained_smoother/test/test_constrained_smoother.cpp
@@ -27,6 +27,7 @@
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_costmap_2d/inflation_layer.hpp"
 #include "nav2_costmap_2d/footprint_collision_checker.hpp"
+#include "nav2_costmap_2d/costmap_type_adapter.hpp"
 #include "nav2_costmap_2d/costmap_2d_publisher.hpp"
 #include "angles/angles.h"
 
@@ -81,7 +82,11 @@ public:
 
   void setCostmap(nav2_msgs::msg::Costmap::SharedPtr msg)
   {
-    costmap_msg_ = msg;
+    auto stamped = std::make_shared<nav2_costmap_2d::Costmap2DStamped>();
+    rclcpp::TypeAdapter<nav2_costmap_2d::Costmap2DStamped, nav2_msgs::msg::Costmap>::
+    convert_to_custom(*msg, *stamped);
+
+    std::atomic_store(&costmap_msg_, stamped);
     costmap_received_ = true;
   }
 };

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_publisher.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_2d_publisher.hpp
@@ -53,6 +53,7 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "nav2_costmap_2d/costmap_type_adapter.hpp"
 
 namespace nav2_costmap_2d
 {
@@ -163,7 +164,8 @@ private:
     costmap_update_pub_;
 
   // Publisher for raw costmap values as msg::Costmap from layered costmap
-  rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::Costmap>::SharedPtr costmap_raw_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<nav2_costmap_2d::Costmap2DStamped>::SharedPtr
+    costmap_raw_pub_;
 
   // Service for getting the costmaps
   rclcpp::Service<nav2_msgs::srv::GetCostmap>::SharedPtr costmap_service_;
@@ -171,7 +173,7 @@ private:
   float grid_resolution;
   unsigned int grid_width, grid_height;
   std::unique_ptr<nav_msgs::msg::OccupancyGrid> grid_;
-  std::unique_ptr<nav2_msgs::msg::Costmap> costmap_raw_;
+  std::unique_ptr<nav2_costmap_2d::Costmap2DStamped> costmap_raw_;
   // Translate from 0-255 values in costmap to -1 to 100 values in message.
   static char * cost_translation_table_;
 };

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
@@ -20,8 +20,8 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
-#include "nav2_msgs/msg/costmap.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "nav2_costmap_2d/costmap_type_adapter.hpp"
 
 namespace nav2_costmap_2d
 {
@@ -63,16 +63,16 @@ public:
   /**
    * @brief Callback for the costmap topic
    */
-  void costmapCallback(const nav2_msgs::msg::Costmap::SharedPtr msg);
+  void costmapCallback(const std::shared_ptr<nav2_costmap_2d::Costmap2DStamped> msg);
 
 protected:
   std::shared_ptr<Costmap2D> costmap_;
-  nav2_msgs::msg::Costmap::SharedPtr costmap_msg_;
+  std::shared_ptr<nav2_costmap_2d::Costmap2DStamped> costmap_msg_;
   std::string topic_name_;
   bool costmap_received_{false};
-  rclcpp::Subscription<nav2_msgs::msg::Costmap>::SharedPtr costmap_sub_;
+  rclcpp::Subscription<nav2_costmap_2d::Costmap2DStamped>::SharedPtr costmap_sub_;
 };
 
-}  // namespace nav2_costmap_2d
+}
 
 #endif  // NAV2_COSTMAP_2D__COSTMAP_SUBSCRIBER_HPP_

--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_type_adapter.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_type_adapter.hpp
@@ -1,0 +1,89 @@
+#ifndef NAV2_COSTMAP_2D__COSTMAP_TYPE_ADAPTER_HPP_
+#define NAV2_COSTMAP_2D__COSTMAP_TYPE_ADAPTER_HPP_
+#include <type_traits>
+#include <algorithm>
+#include <memory>
+
+#include "std_msgs/msg/header.hpp"
+#include "rclcpp/rclcpp/type_adapter.hpp"
+
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_msgs/msg/costmap.hpp"
+
+namespace nav2_costmap_2d
+{
+
+// In-process type. On the wire it masquerades as nav2_msgs::msg::Costmap.
+struct Costmap2DStamped
+{
+  std_msgs::msg::Header header;
+  nav2_msgs::msg::CostmapMetaData metadata;
+  std::shared_ptr<nav2_costmap_2d::Costmap2D> costmap;
+};
+
+}  // namespace nav2_costmap_2d
+
+namespace rclcpp
+{
+
+template<>
+struct TypeAdapter<nav2_costmap_2d::Costmap2DStamped, nav2_msgs::msg::Costmap>
+{
+  using is_specialized = std::true_type;
+  using custom_type = nav2_costmap_2d::Costmap2DStamped;
+  using ros_message_type = nav2_msgs::msg::Costmap;
+
+  static void convert_to_ros_message(const custom_type & src, ros_message_type & dst)
+  {
+    dst.header = src.header;
+    dst.metadata = src.metadata;
+
+    if (!src.costmap) {
+      dst.data.clear();
+      return;
+    }
+
+    const size_t size_x = static_cast<size_t>(src.costmap->getSizeInCellsX());
+    const size_t size_y = static_cast<size_t>(src.costmap->getSizeInCellsY());
+    const size_t n = size_x * size_y;
+
+    dst.data.resize(n);
+    const unsigned char * p = src.costmap->getCharMap();
+    std::copy(p, p + n, dst.data.begin());
+  }
+
+  static void convert_to_custom(const ros_message_type & src, custom_type & dst)
+  {
+    dst.header = src.header;
+    dst.metadata = src.metadata;
+
+    const unsigned int size_x = src.metadata.size_x;
+    const unsigned int size_y = src.metadata.size_y;
+
+    auto cm = std::make_shared<nav2_costmap_2d::Costmap2D>(
+      size_x, size_y,
+      src.metadata.resolution,
+      src.metadata.origin.position.x,
+      src.metadata.origin.position.y);
+
+    const size_t expected = static_cast<size_t>(size_x) * static_cast<size_t>(size_y);
+    const size_t n = std::min(expected, src.data.size());
+
+    unsigned char * out = cm->getCharMap();
+    std::copy(src.data.begin(), src.data.begin() + n, out);
+
+    if (n < expected) {
+      std::fill(out + n, out + expected, 0u);
+    }
+
+    dst.costmap = std::move(cm);
+  }
+};
+
+}  // namespace rclcpp
+
+RCLCPP_USING_CUSTOM_TYPE_AS_ROS_MESSAGE_TYPE(
+  nav2_costmap_2d::Costmap2DStamped,
+  nav2_msgs::msg::Costmap);
+
+#endif  // NAV2_COSTMAP_2D__COSTMAP_TYPE_ADAPTER_HPP_

--- a/nav2_costmap_2d/src/costmap_2d_publisher.cpp
+++ b/nav2_costmap_2d/src/costmap_2d_publisher.cpp
@@ -71,9 +71,11 @@ Costmap2DPublisher::Costmap2DPublisher(
   costmap_pub_ = node->create_publisher<nav_msgs::msg::OccupancyGrid>(
     topic_name,
     custom_qos);
-  costmap_raw_pub_ = node->create_publisher<nav2_msgs::msg::Costmap>(
+
+  costmap_raw_pub_ = node->create_publisher<nav2_costmap_2d::Costmap2DStamped>(
     topic_name + "_raw",
     custom_qos);
+
   costmap_update_pub_ = node->create_publisher<map_msgs::msg::OccupancyGridUpdate>(
     topic_name + "_updates", custom_qos);
 
@@ -155,7 +157,7 @@ void Costmap2DPublisher::prepareCostmap()
   std::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
   double resolution = costmap_->getResolution();
 
-  costmap_raw_ = std::make_unique<nav2_msgs::msg::Costmap>();
+  costmap_raw_ = std::make_unique<nav2_costmap_2d::Costmap2DStamped>();
 
   costmap_raw_->header.frame_id = global_frame_;
   costmap_raw_->header.stamp = clock_->now();
@@ -173,12 +175,7 @@ void Costmap2DPublisher::prepareCostmap()
   costmap_raw_->metadata.origin.position.z = 0.0;
   costmap_raw_->metadata.origin.orientation.w = 1.0;
 
-  costmap_raw_->data.resize(costmap_raw_->metadata.size_x * costmap_raw_->metadata.size_y);
-
-  unsigned char * data = costmap_->getCharMap();
-  for (unsigned int i = 0; i < costmap_raw_->data.size(); i++) {
-    costmap_raw_->data[i] = data[i];
-  }
+  costmap_raw_->costmap = std::make_shared<nav2_costmap_2d::Costmap2D>(*costmap_);
 }
 
 void Costmap2DPublisher::publishCostmap()

--- a/nav2_costmap_2d/src/costmap_subscriber.cpp
+++ b/nav2_costmap_2d/src/costmap_subscriber.cpp
@@ -26,7 +26,7 @@ CostmapSubscriber::CostmapSubscriber(
 : topic_name_(topic_name)
 {
   auto node = parent.lock();
-  costmap_sub_ = node->create_subscription<nav2_msgs::msg::Costmap>(
+  costmap_sub_ = node->create_subscription<nav2_costmap_2d::Costmap2DStamped>(
     topic_name_,
     rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable(),
     std::bind(&CostmapSubscriber::costmapCallback, this, std::placeholders::_1));
@@ -38,7 +38,7 @@ CostmapSubscriber::CostmapSubscriber(
 : topic_name_(topic_name)
 {
   auto node = parent.lock();
-  costmap_sub_ = node->create_subscription<nav2_msgs::msg::Costmap>(
+  costmap_sub_ = node->create_subscription<nav2_costmap_2d::Costmap2DStamped>(
     topic_name_,
     rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable(),
     std::bind(&CostmapSubscriber::costmapCallback, this, std::placeholders::_1));
@@ -55,38 +55,15 @@ std::shared_ptr<Costmap2D> CostmapSubscriber::getCostmap()
 
 void CostmapSubscriber::toCostmap2D()
 {
-  auto current_costmap_msg = std::atomic_load(&costmap_msg_);
-
-  if (costmap_ == nullptr) {
-    costmap_ = std::make_shared<Costmap2D>(
-      current_costmap_msg->metadata.size_x, current_costmap_msg->metadata.size_y,
-      current_costmap_msg->metadata.resolution, current_costmap_msg->metadata.origin.position.x,
-      current_costmap_msg->metadata.origin.position.y);
-  } else if (costmap_->getSizeInCellsX() != current_costmap_msg->metadata.size_x ||  // NOLINT
-    costmap_->getSizeInCellsY() != current_costmap_msg->metadata.size_y ||
-    costmap_->getResolution() != current_costmap_msg->metadata.resolution ||
-    costmap_->getOriginX() != current_costmap_msg->metadata.origin.position.x ||
-    costmap_->getOriginY() != current_costmap_msg->metadata.origin.position.y)
-  {
-    // Update the size of the costmap
-    costmap_->resizeMap(
-      current_costmap_msg->metadata.size_x, current_costmap_msg->metadata.size_y,
-      current_costmap_msg->metadata.resolution,
-      current_costmap_msg->metadata.origin.position.x,
-      current_costmap_msg->metadata.origin.position.y);
+  auto current = std::atomic_load(&costmap_msg_);
+  if (!current || !current->costmap) {
+    return;
   }
-
-  unsigned char * master_array = costmap_->getCharMap();
-  unsigned int index = 0;
-  for (unsigned int i = 0; i < current_costmap_msg->metadata.size_x; ++i) {
-    for (unsigned int j = 0; j < current_costmap_msg->metadata.size_y; ++j) {
-      master_array[index] = current_costmap_msg->data[index];
-      ++index;
-    }
-  }
+  costmap_ = current->costmap;
 }
 
-void CostmapSubscriber::costmapCallback(const nav2_msgs::msg::Costmap::SharedPtr msg)
+void CostmapSubscriber::costmapCallback(
+  const std::shared_ptr<nav2_costmap_2d::Costmap2DStamped> msg)
 {
   std::atomic_store(&costmap_msg_, msg);
   if (!costmap_received_) {

--- a/nav2_smoother/test/test_savitzky_golay_smoother.cpp
+++ b/nav2_smoother/test/test_savitzky_golay_smoother.cpp
@@ -28,6 +28,7 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_smoother/savitzky_golay_smoother.hpp"
 #include "ament_index_cpp/get_package_share_directory.hpp"
+#include "nav2_costmap_2d/costmap_type_adapter.hpp"
 
 using namespace smoother_utils;  // NOLINT
 using namespace nav2_smoother;  // NOLINT
@@ -58,7 +59,15 @@ TEST(SmootherTest, test_sg_smoother_basics)
   std::weak_ptr<rclcpp_lifecycle::LifecycleNode> parent = node;
   std::shared_ptr<nav2_costmap_2d::CostmapSubscriber> dummy_costmap;
   dummy_costmap = std::make_shared<nav2_costmap_2d::CostmapSubscriber>(parent, "dummy_topic");
-  dummy_costmap->costmapCallback(costmap_msg);
+  using CostmapAdapter =
+    rclcpp::TypeAdapter<nav2_costmap_2d::Costmap2DStamped, nav2_msgs::msg::Costmap>;
+
+  auto stamped = std::make_shared<nav2_costmap_2d::Costmap2DStamped>();
+  CostmapAdapter::convert_to_custom(
+    *costmap_msg, *stamped);
+
+  dummy_costmap->costmapCallback(stamped);
+
 
   // Make smoother
   std::shared_ptr<tf2_ros::Buffer> dummy_tf;
@@ -132,7 +141,12 @@ TEST(SmootherTest, test_sg_smoother_noisey_path)
   std::weak_ptr<rclcpp_lifecycle::LifecycleNode> parent = node;
   std::shared_ptr<nav2_costmap_2d::CostmapSubscriber> dummy_costmap;
   dummy_costmap = std::make_shared<nav2_costmap_2d::CostmapSubscriber>(parent, "dummy_topic");
-  dummy_costmap->costmapCallback(costmap_msg);
+  auto stamped = std::make_shared<nav2_costmap_2d::Costmap2DStamped>();
+  CostmapAdapter::convert_to_custom(
+    *costmap_msg, *stamped);
+
+  dummy_costmap->costmapCallback(stamped);
+
 
   // Make smoother
   std::shared_ptr<tf2_ros::Buffer> dummy_tf;
@@ -236,7 +250,12 @@ TEST(SmootherTest, test_sg_smoother_reversing)
   std::weak_ptr<rclcpp_lifecycle::LifecycleNode> parent = node;
   std::shared_ptr<nav2_costmap_2d::CostmapSubscriber> dummy_costmap;
   dummy_costmap = std::make_shared<nav2_costmap_2d::CostmapSubscriber>(parent, "dummy_topic");
-  dummy_costmap->costmapCallback(costmap_msg);
+  auto stamped = std::make_shared<nav2_costmap_2d::Costmap2DStamped>();
+  CostmapAdapter::convert_to_custom(
+    *costmap_msg, *stamped);
+
+  dummy_costmap->costmapCallback(stamped);
+
 
   // Make smoother
   std::shared_ptr<tf2_ros::Buffer> dummy_tf;

--- a/nav2_smoother/test/test_simple_smoother.cpp
+++ b/nav2_smoother/test/test_simple_smoother.cpp
@@ -27,6 +27,7 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_smoother/simple_smoother.hpp"
 #include "ament_index_cpp/get_package_share_directory.hpp"
+#include "nav2_costmap_2d/costmap_type_adapter.hpp"
 
 using namespace smoother_utils;  // NOLINT
 using namespace nav2_smoother;  // NOLINT
@@ -83,7 +84,14 @@ TEST(SmootherTest, test_simple_smoother)
   std::weak_ptr<rclcpp_lifecycle::LifecycleNode> parent = node;
   std::shared_ptr<nav2_costmap_2d::CostmapSubscriber> dummy_costmap;
   dummy_costmap = std::make_shared<nav2_costmap_2d::CostmapSubscriber>(parent, "dummy_topic");
-  dummy_costmap->costmapCallback(costmap_msg);
+  using CostmapAdapter =
+    rclcpp::TypeAdapter<nav2_costmap_2d::Costmap2DStamped, nav2_msgs::msg::Costmap>;
+
+  auto stamped = std::make_shared<nav2_costmap_2d::Costmap2DStamped>();
+  CostmapAdapter::convert_to_custom(
+    *costmap_msg, *stamped);
+  dummy_costmap->costmapCallback(stamped);
+
 
   // Make smoother
   std::shared_ptr<tf2_ros::Buffer> dummy_tf;

--- a/nav2_smoother/test/test_smoother_server.cpp
+++ b/nav2_smoother/test/test_smoother_server.cpp
@@ -30,6 +30,7 @@
 #include "nav2_msgs/action/smooth_path.hpp"
 #include "nav2_smoother/nav2_smoother.hpp"
 #include "tf2_ros/create_timer_ros.h"
+#include "nav2_costmap_2d/costmap_type_adapter.hpp"
 
 using SmoothAction = nav2_msgs::action::SmoothPath;
 using ClientGoalHandle = rclcpp_action::ClientGoalHandle<SmoothAction>;
@@ -148,7 +149,14 @@ public:
 
   void setCostmap(nav2_msgs::msg::Costmap::SharedPtr msg)
   {
-    costmap_msg_ = msg;
+    using CostmapAdapter =
+      rclcpp::TypeAdapter<nav2_costmap_2d::Costmap2DStamped, nav2_msgs::msg::Costmap>;
+
+    auto stamped = std::make_shared<nav2_costmap_2d::Costmap2DStamped>();
+    CostmapAdapter::convert_to_custom(
+      *msg, *stamped);
+
+    std::atomic_store(&costmap_msg_, stamped);
     costmap_received_ = true;
   }
 };


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| --- | --- |
| Ticket(s) this addresses | #4829 |
| Primary OS tested on | Ubuntu 22.04 (ROS 2 Humble) |
| Robotic platform tested on | N/A (unit/integration tests only) |
| Does this PR contain AI generated software? | Yes (assisted), reviewed and edited by me |
| Was this PR description generated by AI software? | Yes (assisted), edited by me |

## Description of contribution in a few bullet points

- Add ROS 2 TypeAdapter for `nav2_costmap_2d::Costmap2DStamped` ↔ `nav2_msgs::msg::Costmap`
- Update costmap publisher/subscriber to use the adapter path (avoid extra copies)
- Update smoother + constrained smoother tests to publish/consume stamped costmap via adapter

## Description of documentation updates required

- None

## Description of how this change was tested

- `colcon build --symlink-install --packages-select nav2_costmap_2d nav2_smoother nav2_constrained_smoother`
- `colcon test --packages-select nav2_costmap_2d nav2_smoother nav2_constrained_smoother`
- `colcon test --packages-select nav2_smoother nav2_constrained_smoother --ctest-args -R "cpplint|uncrustify" -V --output-on-failure`