### PR TITLE
Fix memory leak in AmclNode by deleting Laser objects before clearing vector

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -300,9 +300,9 @@ protected:
   /*
    * @brief Create a laser object
    */
-  nav2_amcl::Laser * createLaserObject();
+  std::unique_ptr<nav2_amcl::Laser> createLaserObject();
   int scan_error_count_{0};
-  std::vector<nav2_amcl::Laser *> lasers_;
+  std::vector<std::unique_ptr<nav2_amcl::Laser>> lasers_;
   std::vector<bool> lasers_update_;
   std::map<std::string, int> frame_to_laser_;
   rclcpp::Time last_laser_received_ts_;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Fixes memory leak detected by |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | Fuzz Harness / Simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Added explicit deletion of `nav2_amcl::Laser` pointers before clearing the `lasers_` vector in `AmclNode`.

Before, when the `lasers_.clear()` is called, when the node's actions terminate, the LSan will give an error like this

```
Direct leak of 88 byte(s) in 1 object(s) allocated from:
#0 0x5d07fa4a7e11 in operator new(unsigned long) (<WORKSPACE>/build/nav2_amcl_fuzz_harness/amcl_fuzz_harness+0x112e11) (BuildId: c2cc3fd2d8e06fd4ca4e841867c7517e9512dde4)
#1 0x7f23e49d883b in nav2_amcl::AmclNode::createLaserObject() <WORKSPACE>/src/navigation2/nav2_amcl/src/amcl_node.cpp:1068:10
#2 0x7f23e49c8239 in nav2_amcl::AmclNode::addNewScanner(int&, std::shared_ptr<sensor_msgs::msg::LaserScan_<std::allocator<void>> const> const&, std::cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, geometry_msgs::msg::PoseStamped<std::allocator<void>>&) <WORKSPACE>/src/navigation2/nav2_amcl/src/amcl_node.cpp:761:21
#3 0x7f23e49c37fd in nav2_amcl::AmclNode::laserReceived(std::shared_ptr<sensor_msgs::msg::LaserScan<std::allocator<void>> const>) <WORKSPACE>/src/navigation2/nav2_amcl/src/amcl_node.cpp:662:10
#4 0x5d07fa4bd0d3 in nav2_amcl::AmclNodeFuzzable::fuzz_laserReceived(std::shared_ptr<sensor_msgs::msg::LaserScan_<std::allocator<void>> const>) <WORKSPACE>/install/nav2_amcl/include/nav2_amcl/amcl_node_fuzzable.hpp:44:11
#5 0x5d07fa4c01cb in fuzzLaserSequence(unsigned char const*, unsigned long) <WORKSPACE>/src/fuzz_harness/amcl_fuzz_harness.cpp:235:15
#6 0x5d07fa4b9728 in main <WORKSPACE>/src/fuzz_harness/amcl_fuzz_harness.cpp:174:9
#7 0x7f23e1e2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
#8 0x7f23e1e2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
#9 0x5d07fa3ce9a4 in _start (<WORKSPACE>/build/nav2_amcl_fuzz_harness/amcl_fuzz_harness+0x399a4) (BuildId: c2cc3fd2d8e06fd4ca4e841867c7517e9512dde4)

SUMMARY: AddressSanitizer: 88 byte(s) leaked in 1 allocation(s).

```

In the backtrace above, the `nav2_amcl::AmclNodeFuzzable` is the class defined as a wrapper to facilitate the fuzzing harness.

This LSAN error is because the `lasers_` vector is defined as `std::vector<nav2_amcl::Laser *> lasers_`. As a vector of pointers, **the object in `lasers_` will not be destructed** upon the `clear` of the `lasers_` vector.

The fix is to destruct each `nav2_amcl::Laser` object in the `lasers_` vector explicitly, as implemented in this PR.


<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->


## Description of how this change was tested

- Validated using a custom fuzz harness with AddressSanitizer (ASan) and LeakSanitizer (LSan) enabled.
- Verified that the direct memory leak of `laser_` is resolved during lifecycle transitions and map updates.

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->


<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
