### PR TITLE
Fix parameters in route server (backport Kilted)

### DIFF
--- a/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
+++ b/nav2_route/src/plugins/edge_cost_functions/costmap_scorer.cpp
@@ -34,19 +34,19 @@ void CostmapScorer::configure(
   // Find whether to use average or maximum cost values
   nav2_util::declare_parameter_if_not_declared(
     node, getName() + ".use_maximum", rclcpp::ParameterValue(true));
-  use_max_ = static_cast<float>(node->get_parameter(getName() + ".use_maximum").as_bool());
+  use_max_ = node->get_parameter(getName() + ".use_maximum").as_bool();
 
   // Edge is invalid if its in collision
   nav2_util::declare_parameter_if_not_declared(
     node, getName() + ".invalid_on_collision", rclcpp::ParameterValue(true));
   invalid_on_collision_ =
-    static_cast<float>(node->get_parameter(getName() + ".invalid_on_collision").as_bool());
+    node->get_parameter(getName() + ".invalid_on_collision").as_bool();
 
   // Edge is invalid if edge is off the costmap
   nav2_util::declare_parameter_if_not_declared(
     node, getName() + ".invalid_off_map", rclcpp::ParameterValue(true));
   invalid_off_map_ =
-    static_cast<float>(node->get_parameter(getName() + ".invalid_off_map").as_bool());
+    node->get_parameter(getName() + ".invalid_off_map").as_bool();
 
   // Max cost to be considered valid
   nav2_util::declare_parameter_if_not_declared(

--- a/nav2_route/src/plugins/route_operations/adjust_speed_limit.cpp
+++ b/nav2_route/src/plugins/route_operations/adjust_speed_limit.cpp
@@ -36,7 +36,7 @@ void AdjustSpeedLimit::configure(
 
   nav2_util::declare_parameter_if_not_declared(
     node, getName() + ".speed_limit_topic", rclcpp::ParameterValue("speed_limit"));
-  std::string topic = node->get_parameter(getName() + ".speed_tag").as_string();
+  std::string topic = node->get_parameter(getName() + ".speed_limit_topic").as_string();
 
   speed_limit_pub_ = node->create_publisher<nav2_msgs::msg::SpeedLimit>(topic, 1);
   speed_limit_pub_->on_activate();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
