### PR TITLE
Revert "Support loading multiple behavior tree files as subtrees" in Kilted

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
@@ -99,12 +99,6 @@ public:
   void resetGrootMonitor();
 
   /**
-   * @brief Function to register a BT from an XML file
-   * @param file_path Path to BT XML file
-   */
-  void registerTreeFromFile(const std::string & file_path);
-
-  /**
    * @brief Function to explicitly reset all BT nodes to initial state
    * @param tree Tree to halt
    */

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -55,7 +55,6 @@ public:
     const std::string & action_name,
     const std::vector<std::string> & plugin_lib_names,
     const std::string & default_bt_xml_filename,
-    const std::vector<std::string> & search_directories,
     OnGoalReceivedCallback on_goal_received_callback,
     OnLoopCallback on_loop_callback,
     OnPreemptCallback on_preempt_callback,
@@ -105,8 +104,7 @@ public:
    * @return bool true if the resulting BT correspond to the one in bt_xml_filename. false
    * if something went wrong, and previous BT is maintained
    */
-  bool loadBehaviorTree(
-    const std::string & bt_xml_filename = "");
+  bool loadBehaviorTree(const std::string & bt_xml_filename = "");
 
   /**
    * @brief Getter function for BT Blackboard
@@ -249,7 +247,6 @@ protected:
   // The XML file that contains the Behavior Tree to create
   std::string current_bt_xml_filename_;
   std::string default_bt_xml_filename_;
-  std::vector<std::string> search_directories_;
 
   // The wrapper class for the BT functionality
   std::unique_ptr<nav2_behavior_tree::BehaviorTreeEngine> bt_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -39,14 +39,12 @@ BtActionServer<ActionT>::BtActionServer(
   const std::string & action_name,
   const std::vector<std::string> & plugin_lib_names,
   const std::string & default_bt_xml_filename,
-  const std::vector<std::string> & search_directories,
   OnGoalReceivedCallback on_goal_received_callback,
   OnLoopCallback on_loop_callback,
   OnPreemptCallback on_preempt_callback,
   OnCompletionCallback on_completion_callback)
 : action_name_(action_name),
   default_bt_xml_filename_(default_bt_xml_filename),
-  search_directories_(search_directories),
   plugin_lib_names_(plugin_lib_names),
   node_(parent),
   on_goal_received_callback_(on_goal_received_callback),
@@ -247,8 +245,6 @@ void BtActionServer<ActionT>::setGrootMonitoring(const bool enable, const unsign
 template<class ActionT>
 bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filename)
 {
-  namespace fs = std::filesystem;
-
   // Empty filename is default for backward compatibility
   auto filename = bt_xml_filename.empty() ? default_bt_xml_filename_ : bt_xml_filename;
 
@@ -258,38 +254,19 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
     return true;
   }
 
-  // Reset any existing Groot2 monitoring
+  // if a new tree is created, than the Groot2 Publisher must be destroyed
   bt_->resetGrootMonitor();
 
+  // Read the input BT XML from the specified file into a string
   std::ifstream xml_file(filename);
+
   if (!xml_file.good()) {
     setInternalError(ActionT::Result::FAILED_TO_LOAD_BEHAVIOR_TREE,
-      "Couldn't open BT XML file: " + filename);
+      "Couldn't open input XML file: " + filename);
     return false;
   }
 
-  const auto canonical_main_bt = fs::canonical(filename);
-
-  // Register all XML behavior Subtrees found in the given directories
-  for (const auto & directory : search_directories_) {
-    try {
-      for (const auto & entry : fs::directory_iterator(directory)) {
-        if (entry.path().extension() == ".xml") {
-          // Skip registering the main tree file
-          if (fs::equivalent(fs::canonical(entry.path()), canonical_main_bt)) {
-            continue;
-          }
-          bt_->registerTreeFromFile(entry.path().string());
-        }
-      }
-    } catch (const std::exception & e) {
-      setInternalError(ActionT::Result::FAILED_TO_LOAD_BEHAVIOR_TREE,
-        "Exception reading behavior tree directory: " + std::string(e.what()));
-      return false;
-    }
-  }
-
-  // Try to load the main BT tree
+  // Create the Behavior Tree from the XML input
   try {
     tree_ = bt_->createTreeFromFile(filename, blackboard_);
     for (auto & subtree : tree_.subtrees) {
@@ -303,15 +280,15 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
     }
   } catch (const std::exception & e) {
     setInternalError(ActionT::Result::FAILED_TO_LOAD_BEHAVIOR_TREE,
-      std::string("Exception when creating BT tree from file: ") + e.what());
+      std::string("Exception when loading BT: ") + e.what());
     return false;
   }
 
-  // Optional logging and monitoring
   topic_logger_ = std::make_unique<RosTopicLogger>(client_node_, tree_);
 
   current_bt_xml_filename_ = filename;
 
+  // Enable monitoring with Groot2
   if (enable_groot_monitoring_) {
     bt_->addGrootMonitoring(&tree_, groot_server_port_);
     RCLCPP_DEBUG(

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -101,13 +101,6 @@ BehaviorTreeEngine::createTreeFromFile(
   return factory_.createTreeFromFile(file_path, blackboard);
 }
 
-/// @brief Register a tree from an XML file and return the tree
-void BehaviorTreeEngine::registerTreeFromFile(
-  const std::string & file_path)
-{
-  factory_.registerBehaviorTreeFromFile(file_path);
-}
-
 void
 BehaviorTreeEngine::addGrootMonitoring(
   BT::Tree * tree,

--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -58,8 +58,6 @@ bt_navigator:
       plugin: "nav2_bt_navigator::NavigateThroughPosesNavigator"
       enable_groot_monitoring: false
       groot_server_port: 1669
-    bt_search_directories:
-      - $(find-pkg-share nav2_bt_navigator)/behavior_trees
     # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
     # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
     # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml

--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -92,6 +92,7 @@ bool
 NavigateThroughPosesNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 {
   auto bt_xml_filename = goal->behavior_tree;
+
   if (!bt_action_server_->loadBehaviorTree(bt_xml_filename)) {
     bt_action_server_->setInternalError(ActionT::Result::FAILED_TO_LOAD_BEHAVIOR_TREE,
       "Error loading XML file: " + bt_xml_filename + ". Navigation canceled.");

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -99,6 +99,7 @@ bool
 NavigateToPoseNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 {
   auto bt_xml_filename = goal->behavior_tree;
+
   if (!bt_action_server_->loadBehaviorTree(bt_xml_filename)) {
     bt_action_server_->setInternalError(ActionT::Result::FAILED_TO_LOAD_BEHAVIOR_TREE,
       std::string("Error loading XML file: ") + bt_xml_filename + ". Navigation canceled.");

--- a/nav2_core/include/nav2_core/behavior_tree_navigator.hpp
+++ b/nav2_core/include/nav2_core/behavior_tree_navigator.hpp
@@ -201,22 +201,12 @@ public:
     // get the default behavior tree for this navigator
     std::string default_bt_xml_filename = getDefaultBTFilepath(parent_node);
 
-    if (!node->has_parameter("bt_search_directories")) {
-      node->declare_parameter(
-        "bt_search_directories",
-        std::vector<std::string>{ament_index_cpp::get_package_share_directory(
-        "nav2_bt_navigator") + "/behavior_trees"}
-      );
-    }
-    auto search_directories = node->get_parameter("bt_search_directories").as_string_array();
-
     // Create the Behavior Tree Action Server for this navigator
     bt_action_server_ = std::make_unique<nav2_behavior_tree::BtActionServer<ActionT>>(
       node,
       getName(),
       plugin_lib_names,
       default_bt_xml_filename,
-      search_directories,
       std::bind(&BehaviorTreeNavigator::onGoalReceived, this, std::placeholders::_1),
       std::bind(&BehaviorTreeNavigator::onLoop, this),
       std::bind(&BehaviorTreeNavigator::onPreempt, this, std::placeholders::_1),

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -70,80 +70,55 @@ public:
     }
   }
 
-  BT::Blackboard::Ptr setBlackboardVariables()
+  bool loadBehaviorTree(const std::string & filename)
   {
-     // Create and populate the blackboard
-    blackboard = BT::Blackboard::create();
-    blackboard->set("node", node_);
-    blackboard->set<std::chrono::milliseconds>("server_timeout", std::chrono::milliseconds(20));
-    blackboard->set<std::chrono::milliseconds>("bt_loop_duration", std::chrono::milliseconds(10));
-    blackboard->set<std::chrono::milliseconds>("wait_for_service_timeout",
-             std::chrono::milliseconds(1000));
-    blackboard->set("tf_buffer", tf_);
-    blackboard->set("initial_pose_received", false);
-    blackboard->set("number_recoveries", 0);
-    blackboard->set("odom_smoother", odom_smoother_);
+    // Read the input BT XML from the specified file into a string
+    std::ifstream xml_file(filename);
 
-    // Create dummy goal
+    if (!xml_file.good()) {
+      RCLCPP_ERROR(node_->get_logger(), "Couldn't open input XML file: %s", filename.c_str());
+      return false;
+    }
+
+    std::stringstream buffer;
+    buffer << xml_file.rdbuf();
+    xml_file.close();
+    std::string xml_string = buffer.str();
+    // Create the blackboard that will be shared by all of the nodes in the tree
+    blackboard = BT::Blackboard::create();
+
+    // Put items on the blackboard
+    blackboard->set("node", node_);  // NOLINT
+    blackboard->set<std::chrono::milliseconds>(
+      "server_timeout", std::chrono::milliseconds(20));  // NOLINT
+    blackboard->set<std::chrono::milliseconds>(
+      "bt_loop_duration", std::chrono::milliseconds(10));  // NOLINT
+    blackboard->set<std::chrono::milliseconds>(
+      "wait_for_service_timeout", std::chrono::milliseconds(1000));  // NOLINT
+    blackboard->set("tf_buffer", tf_);  // NOLINT
+    blackboard->set("initial_pose_received", false);  // NOLINT
+    blackboard->set("number_recoveries", 0);  // NOLINT
+    blackboard->set("odom_smoother", odom_smoother_);  // NOLINT
+
+    // set dummy goal on blackboard
     geometry_msgs::msg::PoseStamped goal;
     goal.header.stamp = node_->now();
     goal.header.frame_id = "map";
-    blackboard->set("goal", goal);
-    return blackboard;
-  }
+    goal.pose.position.x = 0.0;
+    goal.pose.position.y = 0.0;
+    goal.pose.position.z = 0.0;
+    goal.pose.orientation.x = 0.0;
+    goal.pose.orientation.y = 0.0;
+    goal.pose.orientation.z = 0.0;
+    goal.pose.orientation.w = 1.0;
 
-  bool behaviorTreeFileValidation(
-    const std::string & filename)
-  {
-    std::ifstream xml_file(filename);
-    if (!xml_file.good()) {
-      RCLCPP_ERROR(node_->get_logger(),
-        "Couldn't open BT XML file: %s", filename.c_str());
-      return false;
-    }
-    return true;
-  }
+    blackboard->set("goal", goal);  // NOLINT
 
-
-  bool loadBehaviorTree(
-    const std::string & filename,
-    const std::vector<std::string> & search_directories)
-  {
-    if (!behaviorTreeFileValidation(filename)) {
-      return false;
-    }
-
-    namespace fs = std::filesystem;
-    const auto canonical_main_bt = fs::canonical(filename);
-
-    // Register all XML behavior Subtrees found in the given directories
-    for (const auto & directory : search_directories) {
-      try {
-        for (const auto & entry : fs::directory_iterator(directory)) {
-          if (entry.path().extension() == ".xml") {
-          // Skip registering the main tree file
-            if (fs::equivalent(fs::canonical(entry.path()), canonical_main_bt)) {
-              continue;
-            }
-            factory_.registerBehaviorTreeFromFile(entry.path().string());
-          }
-        }
-      } catch (const std::exception & e) {
-        RCLCPP_ERROR(node_->get_logger(),
-          "Exception reading behavior tree directory: %s", e.what());
-        return false;
-      }
-    }
-
-    // Create and populate the blackboard
-    blackboard = setBlackboardVariables();
-
-    // Build the tree from the XML string
+    // Create the Behavior Tree from the XML input
     try {
-      tree = factory_.createTreeFromFile(filename, blackboard);
+      tree = factory_.createTreeFromText(xml_string, blackboard);
     } catch (BT::RuntimeError & exp) {
-      RCLCPP_ERROR(node_->get_logger(), "Failed to create BT from %s: %s", filename.c_str(),
-          exp.what());
+      RCLCPP_ERROR(node_->get_logger(), "%s: %s", filename.c_str(), exp.what());
       return false;
     }
 
@@ -220,73 +195,17 @@ std::shared_ptr<BehaviorTreeHandler> BehaviorTreeTestFixture::bt_handler = nullp
 
 TEST_F(BehaviorTreeTestFixture, TestBTXMLFiles)
 {
-  // Get the BT root directory
-  const auto root_dir = std::filesystem::path(
-    ament_index_cpp::get_package_share_directory("nav2_bt_navigator")
-    ) / "behavior_trees";
+  std::filesystem::path root = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  root /= "behavior_trees/";
 
-  ASSERT_TRUE(std::filesystem::exists(root_dir));
-  ASSERT_TRUE(std::filesystem::is_directory(root_dir));
-
-  std::vector<std::string> search_directories = {root_dir.string()};
-
-  for (auto const & entry : std::filesystem::recursive_directory_iterator(root_dir)) {
-    if (entry.is_regular_file() && entry.path().extension() == ".xml") {
-      std::string main_bt = entry.path().string();
-      std::cout << "Testing BT file: " << main_bt << std::endl;
-
-      EXPECT_TRUE(bt_handler->loadBehaviorTree(main_bt, search_directories))
-        << "Failed to load: " << main_bt;
+  if (std::filesystem::exists(root) && std::filesystem::is_directory(root)) {
+    for (auto const & entry : std::filesystem::recursive_directory_iterator(root)) {
+      if (std::filesystem::is_regular_file(entry) && entry.path().extension() == ".xml") {
+        std::cout << entry.path().string() << std::endl;
+        EXPECT_EQ(bt_handler->loadBehaviorTree(entry.path().string()), true);
+      }
     }
   }
-}
-
-TEST_F(BehaviorTreeTestFixture, TestWrongBTFormatXML)
-{
-  auto write_file = [](const std::string & path, const std::string & content) {
-      std::ofstream ofs(path);
-      ofs << content;
-    };
-
-  // File paths
-  std::string valid_subtree = "/tmp/valid_subtree.xml";
-  std::string invalid_subtree = "/tmp/invalid_subtree.xml";
-  std::string main_file = "/tmp/test_main_tree.xml";
-  std::string malformed_main = "/tmp/malformed_main.xml";
-
-  // Valid subtree
-  write_file(valid_subtree,
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-    "<root BTCPP_format=\"4\">\n"
-    "    <BehaviorTree ID=\"NoopTree\">\n"
-    "        <AlwaysSuccess />\n"
-    "    </BehaviorTree>\n"
-    "</root>\n");
-
-  // Invalid subtree (malformed XML)
-  write_file(invalid_subtree, "<root><invalid></root>");
-
-  // Main tree referencing the valid subtree
-  write_file(main_file,
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-    "<root BTCPP_format=\"4\" main_tree_to_execute=\"MainTree\">\n"
-    "  <BehaviorTree ID=\"MainTree\">\n"
-    "    <Subtree ID=\"NoopTree\"/>\n"
-    "  </BehaviorTree>\n"
-    "</root>\n");
-
-  // Malformed main tree
-  write_file(malformed_main, "<root><invalid></root>");
-
-  std::vector<std::string> search_directories = {"/tmp"};
-
-  EXPECT_FALSE(bt_handler->loadBehaviorTree(main_file, search_directories));
-  EXPECT_FALSE(bt_handler->loadBehaviorTree(malformed_main, search_directories));
-
-  std::remove(valid_subtree.c_str());
-  std::remove(main_file.c_str());
-  std::remove(invalid_subtree.c_str());
-  std::remove(malformed_main.c_str());
 }
 
 /**
@@ -298,14 +217,10 @@ TEST_F(BehaviorTreeTestFixture, TestWrongBTFormatXML)
 TEST_F(BehaviorTreeTestFixture, TestAllSuccess)
 {
   // Load behavior tree from file
-  const auto root_dir = std::filesystem::path(
-    ament_index_cpp::get_package_share_directory("nav2_bt_navigator")
-    ) / "behavior_trees";
-  auto bt_file = root_dir / "navigate_to_pose_w_replanning_and_recovery.xml";
-
-  std::vector<std::string> search_directories = {root_dir.string()};
-
-  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string(), search_directories), true);
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  bt_file /= "behavior_trees/";
+  bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
+  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
 
   BT::NodeStatus result = BT::NodeStatus::RUNNING;
 
@@ -349,14 +264,10 @@ TEST_F(BehaviorTreeTestFixture, TestAllSuccess)
 TEST_F(BehaviorTreeTestFixture, TestAllFailure)
 {
   // Load behavior tree from file
-  const auto root_dir = std::filesystem::path(
-    ament_index_cpp::get_package_share_directory("nav2_bt_navigator")
-    ) / "behavior_trees";
-  auto bt_file = root_dir / "navigate_to_pose_w_replanning_and_recovery.xml";
-
-  std::vector<std::string> search_directories = {root_dir.string()};
-
-  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string(), search_directories), true);
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  bt_file /= "behavior_trees/";
+  bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
+  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
 
   // Set all action server to fail the first 100 times
   Ranges failureRange;
@@ -409,14 +320,10 @@ TEST_F(BehaviorTreeTestFixture, TestAllFailure)
 TEST_F(BehaviorTreeTestFixture, TestNavigateSubtreeRecoveries)
 {
   // Load behavior tree from file
-  const auto root_dir = std::filesystem::path(
-    ament_index_cpp::get_package_share_directory("nav2_bt_navigator")
-    ) / "behavior_trees";
-  auto bt_file = root_dir / "navigate_to_pose_w_replanning_and_recovery.xml";
-
-  std::vector<std::string> search_directories = {root_dir.string()};
-
-  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string(), search_directories), true);
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  bt_file /= "behavior_trees/";
+  bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
+  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
 
   // Set ComputePathToPose and FollowPath action servers to fail for the first action
   Ranges failureRange;
@@ -472,14 +379,10 @@ TEST_F(BehaviorTreeTestFixture, TestNavigateSubtreeRecoveries)
 TEST_F(BehaviorTreeTestFixture, TestNavigateRecoverySimple)
 {
   // Load behavior tree from file
-  const auto root_dir = std::filesystem::path(
-    ament_index_cpp::get_package_share_directory("nav2_bt_navigator")
-    ) / "behavior_trees";
-  auto bt_file = root_dir / "navigate_to_pose_w_replanning_and_recovery.xml";
-
-  std::vector<std::string> search_directories = {root_dir.string()};
-
-  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string(), search_directories), true);
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  bt_file /= "behavior_trees/";
+  bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
+  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
 
   // Set ComputePathToPose action server to fail for the first action
   Ranges plannerFailureRange;
@@ -574,14 +477,10 @@ TEST_F(BehaviorTreeTestFixture, TestNavigateRecoverySimple)
 TEST_F(BehaviorTreeTestFixture, TestNavigateRecoveryComplex)
 {
   // Load behavior tree from file
-  const auto root_dir = std::filesystem::path(
-    ament_index_cpp::get_package_share_directory("nav2_bt_navigator")
-    ) / "behavior_trees";
-  auto bt_file = root_dir / "navigate_to_pose_w_replanning_and_recovery.xml";
-
-  std::vector<std::string> search_directories = {root_dir.string()};
-
-  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string(), search_directories), true);
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  bt_file /= "behavior_trees/";
+  bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
+  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
 
   // Set FollowPath action server to fail for the first 2 actions
   Ranges controllerFailureRange;
@@ -646,14 +545,10 @@ TEST_F(BehaviorTreeTestFixture, TestNavigateRecoveryComplex)
 TEST_F(BehaviorTreeTestFixture, TestRecoverySubtreeGoalUpdated)
 {
   // Load behavior tree from file
-  const auto root_dir = std::filesystem::path(
-    ament_index_cpp::get_package_share_directory("nav2_bt_navigator")
-    ) / "behavior_trees";
-  auto bt_file = root_dir / "navigate_to_pose_w_replanning_and_recovery.xml";
-
-  std::vector<std::string> search_directories = {root_dir.string()};
-
-  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string(), search_directories), true);
+  std::filesystem::path bt_file = ament_index_cpp::get_package_share_directory("nav2_bt_navigator");
+  bt_file /= "behavior_trees/";
+  bt_file /= "navigate_to_pose_w_replanning_and_recovery.xml";
+  EXPECT_EQ(bt_handler->loadBehaviorTree(bt_file.string()), true);
 
   // Set FollowPath action server to fail for the first 2 actions
   Ranges controllerFailureRange;


### PR DESCRIPTION
The PR was backported to Kilted in https://github.com/ros-navigation/navigation2/commit/47f84de34d58891685bb2722bd02ea77cbf7739d, however, as reported in https://github.com/ros-navigation/navigation2/pull/5426, I think it is better to revert this commit in Kilted