### PR TITLE
test: add goal tolerance boundary checks and timeout TF wait

### DIFF
--- a/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
@@ -33,6 +33,7 @@ public:
   void SetUp()
   {
     node_->declare_parameter("transform_tolerance", rclcpp::ParameterValue{0.1});
+    node_->declare_parameter("goal_reached_tol", rclcpp::ParameterValue{0.25});
 
     geometry_msgs::msg::PoseStamped goal;
     goal.header.stamp = node_->now();
@@ -92,6 +93,21 @@ TEST_F(GoalReachedConditionTestFixture, test_behavior)
   transform_handler_->updateRobotPose(pose);
   std::this_thread::sleep_for(500ms);
   EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::SUCCESS);
+
+  // Just outside tolerance (dx = 0.26 > 0.25) -> should fail
+  pose.position.x = 0.74;
+  pose.position.y = 1.0;
+  transform_handler_->updateRobotPose(pose);
+  std::this_thread::sleep_for(500ms);
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::FAILURE);
+
+  // Just inside tolerance (dx = 0.24 < 0.25) -> should succeed
+  pose.position.x = 0.76;
+  pose.position.y = 1.0;
+  transform_handler_->updateRobotPose(pose);
+  std::this_thread::sleep_for(500ms);
+  EXPECT_EQ(tree_->tickOnce(), BT::NodeStatus::SUCCESS);
+
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A (unit tests only) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* Added explicit boundary test coverage around `goal_reached_tol` for the GoalReachedCondition BT node
* Added a timeout to TF update waiting in the DistanceTraveledCondition test to avoid potential infinite waits
* No changes to production code or runtime behavior
-->

## Description of documentation updates required from your changes

<!--
* None. This PR only updates unit tests and does not introduce new parameters or behavior changes.
-->

## Description of how this change was tested

<!--
* Extended existing GoogleTest unit tests for Nav2 behavior tree condition nodes
* Tests were executed locally using the existing Nav2 test infrastructure
-->

---

## Future work that may be required in bullet points

<!--
* Replace fixed sleep calls in tests with wait-until-condition helpers to further reduce potential flakiness
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
