### PR TITLE
Fix map server rolling

### DIFF
--- a/nav2_map_server/src/costmap_filter_info/costmap_filter_info_server.cpp
+++ b/nav2_map_server/src/costmap_filter_info/costmap_filter_info_server.cpp
@@ -27,12 +27,6 @@ namespace nav2_map_server
 CostmapFilterInfoServer::CostmapFilterInfoServer(const rclcpp::NodeOptions & options)
 : nav2::LifecycleNode("costmap_filter_info_server", "", options)
 {
-  // Declare parameters so they exist from construction (for test compatibility)
-  declare_or_get_parameter("filter_info_topic", std::string("costmap_filter_info"));
-  declare_or_get_parameter("type", 0);
-  declare_or_get_parameter("mask_topic", std::string("filter_mask"));
-  declare_or_get_parameter("base", 0.0);
-  declare_or_get_parameter("multiplier", 1.0);
 }
 
 CostmapFilterInfoServer::~CostmapFilterInfoServer()

--- a/nav2_map_server/src/map_saver/map_saver.cpp
+++ b/nav2_map_server/src/map_saver/map_saver.cpp
@@ -45,12 +45,6 @@ MapSaver::MapSaver(const rclcpp::NodeOptions & options)
 : nav2::LifecycleNode("map_saver", "", options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
-
-  // Declare parameters so they exist from construction (for test compatibility)
-  declare_or_get_parameter("save_map_timeout", 2.0);
-  declare_or_get_parameter("free_thresh_default", 0.25);
-  declare_or_get_parameter("occupied_thresh_default", 0.65);
-  declare_or_get_parameter("map_subscribe_transient_local", true);
 }
 
 MapSaver::~MapSaver()

--- a/nav2_map_server/src/map_server/map_server.cpp
+++ b/nav2_map_server/src/map_server/map_server.cpp
@@ -66,11 +66,6 @@ MapServer::MapServer(const rclcpp::NodeOptions & options)
 : nav2::LifecycleNode("map_server", "", options), map_available_(false)
 {
   RCLCPP_INFO(get_logger(), "Creating");
-
-  // Declare parameters so they exist from construction (for test compatibility)
-  declare_or_get_parameter("yaml_filename", std::string());
-  declare_or_get_parameter("topic_name", std::string("map"));
-  declare_or_get_parameter("frame_id", std::string("map"));
 }
 
 MapServer::~MapServer()


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5299 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Migrated the get_parameter and declare_parameter fields to use the new `declare_or_get_parameter` API for `nav2_map_server`.
Updated `MapServer`, `MapSaver` and `CostmapFilterInfoServer`.

## Description of documentation updates required from your changes

N/A

## Description of how this change was tested

I built the package `nav2_map_server` in my local repo, and then 
```bash
colcon build --packages-up-to nav2_map_server
```
to compile without errors.

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
