### PR TITLE
Ensure proper reinflation handling to avoid double full-map updates

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -141,6 +141,7 @@ public:
   {
     matchSize();
     current_ = false;
+    need_reinflation_ = true;
   }
 
   /** @brief  Given a distance, compute a cost.

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -135,10 +135,10 @@ InflationLayer::updateBounds(
 {
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   if (need_reinflation_) {
-    last_min_x_ = *min_x;
-    last_min_y_ = *min_y;
-    last_max_x_ = *max_x;
-    last_max_y_ = *max_y;
+    // Reset last_* to "no expansion" values so the next cycle won't
+    // merge with these full-map bounds (avoids double full-map update after reset)
+    last_min_x_ = last_min_y_ = std::numeric_limits<double>::max();
+    last_max_x_ = last_max_y_ = std::numeric_limits<double>::lowest();
 
     *min_x = std::numeric_limits<double>::lowest();
     *min_y = std::numeric_limits<double>::lowest();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | Dexory simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

**Problem**
When calling the costmap reset service (clear_entirely), all layers update over the full costmap bounds twice in consecutive cycles, instead of once.

**Root Cause**
The InflationLayer maintains last_min_x_/y_ and last_max_x_/y_ variables to track the previous update region. During normal operation, it merges these with the current bounds to ensure old inflation is properly cleared when obstacles move.

When a reset occurs:

First updateMap():

 - Static layer reports full-map bounds (because has_updated_data_ = true)
 - Inflation layer stores these full-map bounds into last_*
 - Static layer clears its flag

Second updateMap():

- Static layer returns early (flag is false, no update needed)
- Inflation layer combines last_* (full-map!) with current small bounds
- Result: min/max(full_map, small) = full_map → another full-map update


**Solution**

My solution aims to specifically solve the issue when using `clearEntirely`, that is when `resetLayers()` is called. The problem will still persist if we are clearing a large a region that is most-but-not-all of the costmap (reset() is not called)

- Change `need_reinflation_` branch to set `last_min_*_` to values that will not add any area to the union, practically "forgetting" what the previous bounds were. 
- Set `need_reinflation_` to `true` in `reset` so that on the first cycle, we use the full bounds + don't save the full bounds for the next iteration.


## Description of how this change was tested

* Added logs in layered_costmap to know when a full map update is triggered
* Call service to clear entire costmap
* Check that only one full map update occurs

---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
