### PR TITLE
feat(nav2_behavior_tree): add server failure callback to bt_action_node

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -184,6 +184,15 @@ public:
   }
 
   /**
+   * @brief Function to perform some user-defined operation when the action server fails to respond.
+   * @return BT::NodeStatus Returns FAILURE by default, user may override return another value
+   */
+  virtual BT::NodeStatus on_server_failure()
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+
+  /**
    * @brief The main override required by a BT action
    * @return BT::NodeStatus Status of tick execution
    */
@@ -223,7 +232,7 @@ public:
             "Timed out while waiting for action server to acknowledge goal request for %s",
             action_name_.c_str());
           future_goal_handle_.reset();
-          return BT::NodeStatus::FAILURE;
+          return on_server_failure();
         }
       }
 
@@ -253,7 +262,7 @@ public:
               "Timed out while waiting for action server to acknowledge goal request for %s",
               action_name_.c_str());
             future_goal_handle_.reset();
-            return BT::NodeStatus::FAILURE;
+            return on_server_failure();
           }
         }
 
@@ -270,7 +279,7 @@ public:
         e.what() == std::string("Goal was rejected by the action server"))
       {
         // Action related failure that should not fail the tree, but the node
-        return BT::NodeStatus::FAILURE;
+        return on_server_failure();
       } else {
         // Internal exception to propagate to the tree
         throw e;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |Custom sim|
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? |No |

---

## Description of contribution in a few bullet points

- Add an overridable on_server_failure() callback to nav2_behavior_tree::BtActionNode to let derived BT action nodes do custom handling when the action server rejects the goal or times out acknowledging it. Like it might be required to set a blackboard variable etc.
- Keeps default behavior unchanged (FAILURE) unless overridden.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
