### PR TITLE
Use a child logger in ros_topic_logger for better log categorization + nicer logging

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/ros_topic_logger.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/ros_topic_logger.hpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include <memory>
 #include <utility>
+#include <string>
 
 #include "behaviortree_cpp/loggers/abstract_logger.h"
 #include "rclcpp/rclcpp.hpp"
@@ -74,12 +75,14 @@ public:
     event.current_status = toStr(status, false);
     event_log_.push_back(std::move(event));
 
+    auto prev_pad = std::string(kStatusWidth - toStr(prev_status, false).size(), ' ');
+    auto curr_pad = std::string(kStatusWidth - toStr(status, false).size(), ' ');
     RCLCPP_DEBUG(
-      logger_, "[%.3f]: %25s %s -> %s",
+      logger_, "[%.3f]: %s%s -> %s%s  %s",
       std::chrono::duration<double>(timestamp).count(),
-      node.name().c_str(),
-      toStr(prev_status, true).c_str(),
-      toStr(status, true).c_str() );
+      toStr(prev_status, true).c_str(), prev_pad.c_str(),
+      toStr(status, true).c_str(), curr_pad.c_str(),
+      node.name().c_str() );
   }
 
   /**
@@ -97,6 +100,8 @@ public:
   }
 
 protected:
+  // Longest BT status string is 7 chars (RUNNING, SUCCESS, FAILURE); pad shorter ones (IDLE)
+  static constexpr size_t kStatusWidth = 7;
   rclcpp::Clock::SharedPtr clock_;
   rclcpp::Logger logger_{rclcpp::get_logger("bt_navigator")};
   rclcpp::Publisher<nav2_msgs::msg::BehaviorTreeLog>::SharedPtr log_pub_;


### PR DESCRIPTION
I'd like to get the ros_topic_logger debug logs without all the other debug logs from the client node logger, so this PR creates a child-logger so we can specify its log level individually, e.g.:
` arguments=["--ros-args", "--log-level", "bt_navigator_nav_to_pose_rclcpp_node.ros_topic_logger:=debug"]`

P.S: Bonus, I also added nicer logging to align so that it all aligns nicely. Will share screenshots privately for confidentiality