### PR TITLE
fix unit tests from commit 797a171's float32 precision issues.

### DIFF
--- a/nav2_ros_common/test/test_validation_messages.cpp
+++ b/nav2_ros_common/test/test_validation_messages.cpp
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
 #include "nav2_ros_common/validate_messages.hpp"
 
 TEST(ValidateMessagesTest, DoubleValueCheck) {
@@ -213,7 +217,8 @@ TEST(ValidateMessagesTest, MapMetaDataCheck) {
   EXPECT_FALSE(nav2::validateMsg(invalid_map_meta_data));
 
   // Test borderline resolution message (minimum accepted)
-  valid_map_meta_data.resolution = 1e-6;
+  valid_map_meta_data.resolution = std::nextafterf(
+    1e-6f, std::numeric_limits<float>::infinity());
   EXPECT_TRUE(nav2::validateMsg(valid_map_meta_data));
 
   // Test invalid MapMetaData message with zero width
@@ -245,7 +250,8 @@ TEST(ValidateMessagesTest, OccupancyGridCheck) {
   EXPECT_TRUE(nav2::validateMsg(valid_occupancy_grid));
 
   // Test borderline resolution message
-  valid_occupancy_grid.info.resolution = 1e-6;
+  valid_occupancy_grid.info.resolution = std::nextafterf(
+    1e-6f, std::numeric_limits<float>::infinity());
   EXPECT_TRUE(nav2::validateMsg(valid_occupancy_grid));
 
   // Test invalid resolution message (too small)


### PR DESCRIPTION

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Unit tests |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

The unit tests added in commit 797a171 has floating point precision issues (caused by converting 1e-6 to float32). Fixed this problem by using `std::nextafterf(1e-6f, std::numeric_limits<float>::infinity());` for comparison.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->





#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
