### PR TITLE
feat: add parameter to log transitions to IDLE state in behavior tree

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -295,7 +295,7 @@ protected:
   bool always_reload_bt_ = false;
 
   // Whether to log BT transitions to IDLE state
-  bool log_idle_ = false;
+  bool log_idle_ = true;
 
   // Parameters for Groot2 monitoring
   bool enable_groot_monitoring_ = false;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -170,7 +170,7 @@ bool BtActionServer<ActionT, NodeT>::on_configure()
     "always_reload_bt_xml", false);
 
   log_idle_ = node->declare_or_get_parameter(
-    "bt_log_idle_transitions", false);
+    "bt_log_idle_transitions", true);
 
   // Get error code id names to grab off of the blackboard
   error_code_name_prefixes_ = node->get_parameter("error_code_name_prefixes").as_string_array();

--- a/nav2_behavior_tree/include/nav2_behavior_tree/ros_topic_logger.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/ros_topic_logger.hpp
@@ -45,7 +45,7 @@ public:
   RosTopicLogger(
     const nav2::LifecycleNode::WeakPtr & ros_node,
     const BT::Tree & tree,
-    bool log_idle = false)
+    bool log_idle = true)
   : StatusChangeLogger(tree.rootNode())
   {
     auto node = ros_node.lock();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

* add parameter to log transitions to IDLE state in behavior tree

## Description of documentation updates required from your changes

[https://docs.nav2.org/configuration/packages/configuring-bt-navigator.html needs to be updated
](https://github.com/ros-navigation/docs.nav2.org/pull/875)

## Description of how this change was tested

- set `true` and `false` and see the difference in logs 

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
