### PR TITLE
feat(PlannerServer): BaseGlobalPlanner plugin accepts viapoints as part of API

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
@@ -16,6 +16,7 @@
 #define NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__COMPUTE_PATH_TO_POSE_ACTION_HPP_
 
 #include <string>
+#include <vector>
 
 #include "nav2_msgs/action/compute_path_to_pose.hpp"
 #include "nav_msgs/msg/path.hpp"
@@ -94,6 +95,9 @@ public:
           "start",
           "Used as the planner start pose instead of the current robot pose, if use_start is"
           " not false (i.e. not provided or set to true)"),
+        BT::InputPort<std::vector<geometry_msgs::msg::PoseStamped>>(
+          "viapoints",
+          "A list of intermediate viapoints (excluding goal) to consider for planning"),
         BT::InputPort<bool>(
           "use_start", "For using or not using (i.e. ignoring) the provided start pose"),
         BT::InputPort<std::string>(

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -96,6 +96,7 @@
     <Action ID="ComputePathToPose">
       <input_port name="goal">Destination to plan to</input_port>
       <input_port name="start">Use as the planner start pose instead of the current robot pose, if use_start is not false (i.e. not provided or set to true)</input_port>
+      <input_port name="viapoints">A vector of intermediate viapoints (excluding goal) to consider for planning</input_port>
       <input_port name="use_start">For using or not using (i.e. ignoring) the provided start pose</input_port>
       <input_port name="planner_id">Mapped name to the planner plugin type to use</input_port>
       <input_port name="server_name">Server name</input_port>

--- a/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
@@ -33,6 +33,11 @@ void ComputePathToPoseAction::on_tick()
   getInput("goal", goal_.goal);
   getInput("planner_id", goal_.planner_id);
 
+  // use waypoints if available
+  if (!getInput("viapoints", goal_.viapoints)) {
+    goal_.viapoints = std::vector<geometry_msgs::msg::PoseStamped>();
+  }
+
   // if "use_start" is provided try to enforce it (true or false), but we cannot enforce true if
   // start is not provided
   goal_.use_start = false;

--- a/nav2_core/include/nav2_core/global_planner.hpp
+++ b/nav2_core/include/nav2_core/global_planner.hpp
@@ -21,7 +21,6 @@
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "tf2_ros/buffer.hpp"
 #include "nav_msgs/msg/path.hpp"
-#include "nav_msgs/msg/goals.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
 

--- a/nav2_core/include/nav2_core/global_planner.hpp
+++ b/nav2_core/include/nav2_core/global_planner.hpp
@@ -17,9 +17,11 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "tf2_ros/buffer.hpp"
 #include "nav_msgs/msg/path.hpp"
+#include "nav_msgs/msg/goals.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
 
@@ -67,15 +69,17 @@ public:
   virtual void deactivate() = 0;
 
   /**
-   * @brief Method create the plan from a starting and ending goal.
+   * @brief Method to create the plan from a starting pose, a goal pose, and intermediate viapoints.
    * @param start The starting pose of the robot
    * @param goal  The goal pose of the robot
+   * @param viapoints The intermediate viapoints for the robot
    * @param cancel_checker Function to check if the action has been canceled
    * @return      The sequence of poses to get from start to goal, if any
    */
   virtual nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped & start,
     const geometry_msgs::msg::PoseStamped & goal,
+    const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
     std::function<bool()> cancel_checker) = 0;
 };
 

--- a/nav2_msgs/action/ComputePathToPose.action
+++ b/nav2_msgs/action/ComputePathToPose.action
@@ -1,6 +1,7 @@
 #goal definition
 geometry_msgs/PoseStamped goal
 geometry_msgs/PoseStamped start
+geometry_msgs/PoseStamped[] viapoints
 string planner_id
 bool use_start # If false, use current robot pose as path start, if true, use start above instead
 ---

--- a/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
+++ b/nav2_navfn_planner/include/nav2_navfn_planner/navfn_planner.hpp
@@ -88,6 +88,7 @@ public:
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped & start,
     const geometry_msgs::msg::PoseStamped & goal,
+    const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
     std::function<bool()> cancel_checker) override;
 
 protected:

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -127,8 +127,9 @@ nav_msgs::msg::Path NavfnPlanner::createPlan(
   steady_clock::time_point a = steady_clock::now();
 #endif
 
-  if (!viapoints.size()) {
-    RCLCPP_DEBUG(logger_, "Planning triggered with no viapoints");
+  if (!viapoints.empty()) {
+    RCLCPP_WARN(logger_, "Received %zu viapoints, but this planner ignores them",
+      viapoints.size());
   }
 
   std::lock_guard<std::mutex> lock_reinit(param_handler_->getMutex());

--- a/nav2_navfn_planner/src/navfn_planner.cpp
+++ b/nav2_navfn_planner/src/navfn_planner.cpp
@@ -120,11 +120,17 @@ NavfnPlanner::cleanup()
 nav_msgs::msg::Path NavfnPlanner::createPlan(
   const geometry_msgs::msg::PoseStamped & start,
   const geometry_msgs::msg::PoseStamped & goal,
+  const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   std::function<bool()> cancel_checker)
 {
 #ifdef BENCHMARK_TESTING
   steady_clock::time_point a = steady_clock::now();
 #endif
+
+  if (!viapoints.size()) {
+    RCLCPP_DEBUG(logger_, "Planning triggered with no viapoints");
+  }
+
   std::lock_guard<std::mutex> lock_reinit(param_handler_->getMutex());
   unsigned int mx_start, my_start, mx_goal, my_goal;
   if (!costmap_->worldToMap(start.pose.position.x, start.pose.position.y, mx_start, my_start)) {

--- a/nav2_planner/include/nav2_planner/planner_server.hpp
+++ b/nav2_planner/include/nav2_planner/planner_server.hpp
@@ -76,6 +76,7 @@ public:
   nav_msgs::msg::Path getPlan(
     const geometry_msgs::msg::PoseStamped & start,
     const geometry_msgs::msg::PoseStamped & goal,
+    const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
     const std::string & planner_id,
     std::function<bool()> cancel_checker);
 

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -313,7 +313,8 @@ bool PlannerServer::transformPosesToGlobalFrame(
 }
 
 template<typename T>
-bool PlannerServer::validatePath(
+bool
+PlannerServer::validatePath(
   const geometry_msgs::msg::PoseStamped & goal,
   const nav_msgs::msg::Path & path,
   const std::string & planner_id)
@@ -394,8 +395,9 @@ void PlannerServer::computePlanThroughPoses()
 
       // Get plan from start -> goal
       nav_msgs::msg::Path curr_path;
+      std::vector<geometry_msgs::msg::PoseStamped> viapoints;
       try {
-        curr_path = getPlan(curr_start, curr_goal, goal->planner_id, cancel_checker);
+        curr_path = getPlan(curr_start, curr_goal, viapoints, goal->planner_id, cancel_checker);
       } catch (nav2_core::PlannerException & ex) {
         if (i == 0 || !params_->partial_plan_allowed) {
           throw;
@@ -546,7 +548,7 @@ PlannerServer::computePlan()
         return action_server_pose_->is_cancel_requested();
       };
 
-    result->path = getPlan(start, goal_pose, goal->planner_id, cancel_checker);
+    result->path = getPlan(start, goal_pose, goal->viapoints, goal->planner_id, cancel_checker);
 
     if (!validatePath<ActionThroughPoses>(goal_pose, result->path, goal->planner_id)) {
       throw nav2_core::NoValidPathCouldBeFound(goal->planner_id + " generated a empty path");
@@ -615,6 +617,7 @@ nav_msgs::msg::Path
 PlannerServer::getPlan(
   const geometry_msgs::msg::PoseStamped & start,
   const geometry_msgs::msg::PoseStamped & goal,
+  const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   const std::string & planner_id,
   std::function<bool()> cancel_checker)
 {
@@ -624,14 +627,15 @@ PlannerServer::getPlan(
     goal.pose.position.x, goal.pose.position.y);
 
   if (planners_.find(planner_id) != planners_.end()) {
-    return planners_[planner_id]->createPlan(start, goal, cancel_checker);
+    return planners_[planner_id]->createPlan(start, goal, viapoints, cancel_checker);
   } else {
     if (planners_.size() == 1 && planner_id.empty()) {
       RCLCPP_WARN_ONCE(
         get_logger(), "No planners specified in action call. "
         "Server will use only plugin %s in server."
         " This warning will appear once.", planner_ids_concat_.c_str());
-      return planners_[planners_.begin()->first]->createPlan(start, goal, cancel_checker);
+      return planners_[planners_.begin()->first]->createPlan(start, goal, viapoints,
+        cancel_checker);
     } else {
       RCLCPP_ERROR(
         get_logger(), "planner %s is not a valid planner. "

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -313,8 +313,7 @@ bool PlannerServer::transformPosesToGlobalFrame(
 }
 
 template<typename T>
-bool
-PlannerServer::validatePath(
+bool PlannerServer::validatePath(
   const geometry_msgs::msg::PoseStamped & goal,
   const nav_msgs::msg::Path & path,
   const std::string & planner_id)

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_2d.hpp
@@ -88,6 +88,7 @@ public:
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped & start,
     const geometry_msgs::msg::PoseStamped & goal,
+    const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
     std::function<bool()> cancel_checker) override;
 
 protected:

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_hybrid.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_hybrid.hpp
@@ -87,6 +87,7 @@ public:
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped & start,
     const geometry_msgs::msg::PoseStamped & goal,
+    const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
     std::function<bool()> cancel_checker)  override;
 
 protected:

--- a/nav2_smac_planner/include/nav2_smac_planner/smac_planner_lattice.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/smac_planner_lattice.hpp
@@ -86,6 +86,7 @@ public:
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped & start,
     const geometry_msgs::msg::PoseStamped & goal,
+    const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
     std::function<bool()> cancel_checker) override;
 
 protected:

--- a/nav2_smac_planner/src/smac_planner_2d.cpp
+++ b/nav2_smac_planner/src/smac_planner_2d.cpp
@@ -197,8 +197,9 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
   const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   std::function<bool()> cancel_checker)
 {
-  if (!viapoints.size()) {
-    RCLCPP_DEBUG(_logger, "Planning triggered with no viapoints");
+  if (!viapoints.empty()) {
+    RCLCPP_WARN(_logger, "Received %zu viapoints, but this planner ignores them",
+      viapoints.size());
   }
 
   std::lock_guard<std::mutex> lock_reinit(_mutex);

--- a/nav2_smac_planner/src/smac_planner_2d.cpp
+++ b/nav2_smac_planner/src/smac_planner_2d.cpp
@@ -194,8 +194,13 @@ void SmacPlanner2D::cleanup()
 nav_msgs::msg::Path SmacPlanner2D::createPlan(
   const geometry_msgs::msg::PoseStamped & start,
   const geometry_msgs::msg::PoseStamped & goal,
+  const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   std::function<bool()> cancel_checker)
 {
+  if (!viapoints.size()) {
+    RCLCPP_DEBUG(_logger, "Planning triggered with no viapoints");
+  }
+
   std::lock_guard<std::mutex> lock_reinit(_mutex);
   steady_clock::time_point a = steady_clock::now();
 

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -342,8 +342,9 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
   const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   std::function<bool()> cancel_checker)
 {
-  if (!viapoints.size()) {
-    RCLCPP_DEBUG(_logger, "Planning triggered with no viapoints");
+  if (!viapoints.empty()) {
+    RCLCPP_WARN(_logger, "Received %zu viapoints, but this planner ignores them",
+      viapoints.size());
   }
 
   std::lock_guard<std::mutex> lock_reinit(_mutex);

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -339,8 +339,13 @@ void SmacPlannerHybrid::cleanup()
 nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
   const geometry_msgs::msg::PoseStamped & start,
   const geometry_msgs::msg::PoseStamped & goal,
+  const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   std::function<bool()> cancel_checker)
 {
+  if (!viapoints.size()) {
+    RCLCPP_DEBUG(_logger, "Planning triggered with no viapoints");
+  }
+
   std::lock_guard<std::mutex> lock_reinit(_mutex);
   steady_clock::time_point a = steady_clock::now();
 

--- a/nav2_smac_planner/src/smac_planner_lattice.cpp
+++ b/nav2_smac_planner/src/smac_planner_lattice.cpp
@@ -303,8 +303,9 @@ nav_msgs::msg::Path SmacPlannerLattice::createPlan(
   const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   std::function<bool()> cancel_checker)
 {
-  if (!viapoints.size()) {
-    RCLCPP_DEBUG(_logger, "Planning triggered with no viapoints");
+  if (!viapoints.empty()) {
+    RCLCPP_WARN(_logger, "Received %zu viapoints, but this planner ignores them",
+      viapoints.size());
   }
 
   std::lock_guard<std::mutex> lock_reinit(_mutex);

--- a/nav2_smac_planner/src/smac_planner_lattice.cpp
+++ b/nav2_smac_planner/src/smac_planner_lattice.cpp
@@ -300,8 +300,13 @@ void SmacPlannerLattice::cleanup()
 nav_msgs::msg::Path SmacPlannerLattice::createPlan(
   const geometry_msgs::msg::PoseStamped & start,
   const geometry_msgs::msg::PoseStamped & goal,
+  const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   std::function<bool()> cancel_checker)
 {
+  if (!viapoints.size()) {
+    RCLCPP_DEBUG(_logger, "Planning triggered with no viapoints");
+  }
+
   std::lock_guard<std::mutex> lock_reinit(_mutex);
   steady_clock::time_point a = steady_clock::now();
 

--- a/nav2_smac_planner/test/test_smac_2d.cpp
+++ b/nav2_smac_planner/test/test_smac_2d.cpp
@@ -56,8 +56,7 @@ TEST(SmacTest, test_smac_2d) {
       return false;
     };
 
-  std::vector<geometry_msgs::msg::PoseStamped> viapoints{};
-  geometry_msgs::msg::PoseStamped start, goal;
+  geometry_msgs::msg::PoseStamped start, goal, viapoint;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
   start.pose.orientation.w = 1.0;
@@ -65,6 +64,11 @@ TEST(SmacTest, test_smac_2d) {
   goal.pose.position.x = 7.0;
   goal.pose.position.y = 0.0;
   goal.pose.orientation.w = 1.0;
+  // viapoint = start;
+  goal.pose.position.x = 3.5;
+  goal.pose.position.y = 0.0;
+  goal.pose.orientation.w = 1.0;
+  std::vector<geometry_msgs::msg::PoseStamped> viapoints{viapoint};
   auto planner_2d = std::make_unique<nav2_smac_planner::SmacPlanner2D>();
   planner_2d->configure(node2D, "test", nullptr, costmap_ros);
   planner_2d->activate();

--- a/nav2_smac_planner/test/test_smac_2d.cpp
+++ b/nav2_smac_planner/test/test_smac_2d.cpp
@@ -56,6 +56,7 @@ TEST(SmacTest, test_smac_2d) {
       return false;
     };
 
+  std::vector<geometry_msgs::msg::PoseStamped> viapoints{};
   geometry_msgs::msg::PoseStamped start, goal;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
@@ -68,7 +69,7 @@ TEST(SmacTest, test_smac_2d) {
   planner_2d->configure(node2D, "test", nullptr, costmap_ros);
   planner_2d->activate();
   try {
-    planner_2d->createPlan(start, goal, dummy_cancel_checker);
+    planner_2d->createPlan(start, goal, viapoints, dummy_cancel_checker);
   } catch (...) {
   }
 
@@ -76,7 +77,7 @@ TEST(SmacTest, test_smac_2d) {
   goal.pose.position.x = 0.01;
   goal.pose.position.y = 0.01;
 
-  nav_msgs::msg::Path plan = planner_2d->createPlan(start, goal, dummy_cancel_checker);
+  nav_msgs::msg::Path plan = planner_2d->createPlan(start, goal, viapoints, dummy_cancel_checker);
   EXPECT_EQ(plan.poses.size(), 1);  // single point path
 
   planner_2d->deactivate();

--- a/nav2_smac_planner/test/test_smac_hybrid.cpp
+++ b/nav2_smac_planner/test/test_smac_hybrid.cpp
@@ -109,6 +109,7 @@ TEST(SmacTest, test_smac_se2)
       return false;
     };
 
+  std::vector<geometry_msgs::msg::PoseStamped> no_viapoints{};
   geometry_msgs::msg::PoseStamped start, goal;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
@@ -160,7 +161,7 @@ TEST(SmacTest, test_smac_se2)
   planner->activate();
 
   try {
-    planner->createPlan(start, goal, dummy_cancel_checker);
+    planner->createPlan(start, goal, no_viapoints, dummy_cancel_checker);
   } catch (...) {
   }
 
@@ -186,7 +187,8 @@ TEST(SmacTest, test_smac_se2)
   goal.pose.position.x = 0.01;
   goal.pose.position.y = 0.01;
 
-  nav_msgs::msg::Path plan = planner->createPlan(start, goal, dummy_cancel_checker);
+  nav_msgs::msg::Path plan = planner->createPlan(
+    start, goal, no_viapoints, dummy_cancel_checker);
   EXPECT_EQ(plan.poses.size(), 1);  // single point path
 
   auto rec_param = std::make_shared<rclcpp::AsyncParametersClient>(
@@ -200,7 +202,8 @@ TEST(SmacTest, test_smac_se2)
   executor.spin_until_future_complete(results);
   goal.pose.position.x = 4.0;
   goal.pose.position.y = 4.0;
-  EXPECT_THROW(planner->createPlan(start, goal, dummy_cancel_checker), std::runtime_error);
+  EXPECT_THROW(planner->createPlan(
+    start, goal, no_viapoints, dummy_cancel_checker), std::runtime_error);
 
   planner->deactivate();
   planner->cleanup();

--- a/nav2_smac_planner/test/test_smac_hybrid.cpp
+++ b/nav2_smac_planner/test/test_smac_hybrid.cpp
@@ -110,13 +110,17 @@ TEST(SmacTest, test_smac_se2)
     };
 
   std::vector<geometry_msgs::msg::PoseStamped> no_viapoints{};
-  geometry_msgs::msg::PoseStamped start, goal;
+  geometry_msgs::msg::PoseStamped start, goal, viapoint;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
   start.pose.orientation.w = 1.0;
   goal.pose.position.x = 1.0;
   goal.pose.position.y = 1.0;
   goal.pose.orientation.w = 1.0;
+  viapoint.pose.position.x = 0.5;
+  viapoint.pose.position.y = 0.5;
+  viapoint.pose.orientation.w = 1.0;
+  std::vector<geometry_msgs::msg::PoseStamped> viapoints{viapoint};
   auto planner = std::make_unique<HybridWrap>();
 
   // invalid goal heading mode
@@ -161,7 +165,7 @@ TEST(SmacTest, test_smac_se2)
   planner->activate();
 
   try {
-    planner->createPlan(start, goal, no_viapoints, dummy_cancel_checker);
+    planner->createPlan(start, goal, viapoints, dummy_cancel_checker);
   } catch (...) {
   }
 

--- a/nav2_smac_planner/test/test_smac_lattice.cpp
+++ b/nav2_smac_planner/test/test_smac_lattice.cpp
@@ -122,13 +122,17 @@ TEST(SmacTest, test_smac_lattice)
     };
 
   std::vector<geometry_msgs::msg::PoseStamped> no_viapoints{};
-  geometry_msgs::msg::PoseStamped start, goal;
+  geometry_msgs::msg::PoseStamped start, goal, viapoint;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
   start.pose.orientation.w = 1.0;
   goal.pose.position.x = 1.0;
   goal.pose.position.y = 1.0;
   goal.pose.orientation.w = 1.0;
+  viapoint.pose.position.x = 0.5;
+  viapoint.pose.position.y = 0.5;
+  viapoint.pose.orientation.w = 1.0;
+  std::vector<geometry_msgs::msg::PoseStamped> viapoints{viapoint};
   auto planner = std::make_unique<LatticeWrap>();
   try {
     // invalid goal heading mode
@@ -166,7 +170,7 @@ TEST(SmacTest, test_smac_lattice)
   planner->activate();
 
   try {
-    planner->createPlan(start, goal, no_viapoints, dummy_cancel_checker);
+    planner->createPlan(start, goal, viapoints, dummy_cancel_checker);
   } catch (...) {
   }
 

--- a/nav2_smac_planner/test/test_smac_lattice.cpp
+++ b/nav2_smac_planner/test/test_smac_lattice.cpp
@@ -121,6 +121,7 @@ TEST(SmacTest, test_smac_lattice)
       return false;
     };
 
+  std::vector<geometry_msgs::msg::PoseStamped> no_viapoints{};
   geometry_msgs::msg::PoseStamped start, goal;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
@@ -165,7 +166,7 @@ TEST(SmacTest, test_smac_lattice)
   planner->activate();
 
   try {
-    planner->createPlan(start, goal, dummy_cancel_checker);
+    planner->createPlan(start, goal, no_viapoints, dummy_cancel_checker);
   } catch (...) {
   }
 
@@ -192,7 +193,7 @@ TEST(SmacTest, test_smac_lattice)
   goal.pose.position.x = 0.01;
   goal.pose.position.y = 0.01;
 
-  nav_msgs::msg::Path plan = planner->createPlan(start, goal, dummy_cancel_checker);
+  nav_msgs::msg::Path plan = planner->createPlan(start, goal, no_viapoints, dummy_cancel_checker);
   EXPECT_EQ(plan.poses.size(), 1);  // single point path
 
   auto rec_param = std::make_shared<rclcpp::AsyncParametersClient>(
@@ -206,7 +207,8 @@ TEST(SmacTest, test_smac_lattice)
   executor.spin_until_future_complete(results);
   goal.pose.position.x = 4.0;
   goal.pose.position.y = 4.0;
-  EXPECT_THROW(planner->createPlan(start, goal, dummy_cancel_checker), std::runtime_error);
+  EXPECT_THROW(planner->createPlan(
+    start, goal, no_viapoints, dummy_cancel_checker), std::runtime_error);
 
   planner->deactivate();
   planner->cleanup();

--- a/nav2_system_tests/src/error_codes/planner/planner_error_plugin.hpp
+++ b/nav2_system_tests/src/error_codes/planner/planner_error_plugin.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <memory>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/point.hpp"
@@ -52,6 +53,7 @@ public:
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped &,
     const geometry_msgs::msg::PoseStamped &,
+    const std::vector<geometry_msgs::msg::PoseStamped> &,
     std::function<bool()>) override
   {
     throw nav2_core::PlannerException("Unknown Error");
@@ -63,6 +65,7 @@ class StartOccupiedErrorPlanner : public UnknownErrorPlanner
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped &,
     const geometry_msgs::msg::PoseStamped &,
+    const std::vector<geometry_msgs::msg::PoseStamped> &,
     std::function<bool()>) override
   {
     throw nav2_core::StartOccupied("Start Occupied");
@@ -74,6 +77,7 @@ class GoalOccupiedErrorPlanner : public UnknownErrorPlanner
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped &,
     const geometry_msgs::msg::PoseStamped &,
+    const std::vector<geometry_msgs::msg::PoseStamped> &,
     std::function<bool()>) override
   {
     throw nav2_core::GoalOccupied("Goal occupied");
@@ -85,6 +89,7 @@ class StartOutsideMapErrorPlanner : public UnknownErrorPlanner
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped &,
     const geometry_msgs::msg::PoseStamped &,
+    const std::vector<geometry_msgs::msg::PoseStamped> &,
     std::function<bool()>) override
   {
     throw nav2_core::StartOutsideMapBounds("Start OutsideMapBounds");
@@ -96,6 +101,7 @@ class GoalOutsideMapErrorPlanner : public UnknownErrorPlanner
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped &,
     const geometry_msgs::msg::PoseStamped &,
+    const std::vector<geometry_msgs::msg::PoseStamped> &,
     std::function<bool()>) override
   {
     throw nav2_core::GoalOutsideMapBounds("Goal outside map bounds");
@@ -107,6 +113,7 @@ class NoValidPathErrorPlanner : public UnknownErrorPlanner
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped &,
     const geometry_msgs::msg::PoseStamped &,
+    const std::vector<geometry_msgs::msg::PoseStamped> &,
     std::function<bool()>) override
   {
     return nav_msgs::msg::Path();
@@ -119,6 +126,7 @@ class TimedOutErrorPlanner : public UnknownErrorPlanner
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped &,
     const geometry_msgs::msg::PoseStamped &,
+    const std::vector<geometry_msgs::msg::PoseStamped> &,
     std::function<bool()>) override
   {
     throw nav2_core::PlannerTimedOut("Planner Timed Out");
@@ -130,6 +138,7 @@ class TFErrorPlanner : public UnknownErrorPlanner
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped &,
     const geometry_msgs::msg::PoseStamped &,
+    const std::vector<geometry_msgs::msg::PoseStamped> &,
     std::function<bool()>) override
   {
     throw nav2_core::PlannerTFError("TF Error");
@@ -141,6 +150,7 @@ class NoViapointsGivenErrorPlanner : public UnknownErrorPlanner
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped &,
     const geometry_msgs::msg::PoseStamped &,
+    const std::vector<geometry_msgs::msg::PoseStamped> &,
     std::function<bool()>) override
   {
     throw nav2_core::NoViapointsGiven("No Via points given");
@@ -152,6 +162,7 @@ class CancelledPlanner : public UnknownErrorPlanner
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped &,
     const geometry_msgs::msg::PoseStamped &,
+    const std::vector<geometry_msgs::msg::PoseStamped> &,
     std::function<bool()> cancel_checker) override
   {
     auto start_time = std::chrono::steady_clock::now();

--- a/nav2_system_tests/src/planning/planner_tester.hpp
+++ b/nav2_system_tests/src/planning/planner_tester.hpp
@@ -86,7 +86,7 @@ public:
     }
     try {
       auto dummy_cancel_checker = []() {return false;};
-      std::vector<geometry_msgs::msg::PoseStamped> viapoints{};
+      std::vector<geometry_msgs::msg::PoseStamped> viapoints{start};
       path = planners_["GridBased"]->createPlan(start, goal, viapoints, dummy_cancel_checker);
       // The situation when createPlan() did not throw any exception
       // does not guarantee that plan was created correctly.

--- a/nav2_system_tests/src/planning/planner_tester.hpp
+++ b/nav2_system_tests/src/planning/planner_tester.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 #include <algorithm>
 
 #include "nav2_ros_common/lifecycle_node.hpp"
@@ -85,7 +86,8 @@ public:
     }
     try {
       auto dummy_cancel_checker = []() {return false;};
-      path = planners_["GridBased"]->createPlan(start, goal, dummy_cancel_checker);
+      std::vector<geometry_msgs::msg::PoseStamped> viapoints{};
+      path = planners_["GridBased"]->createPlan(start, goal, viapoints, dummy_cancel_checker);
       // The situation when createPlan() did not throw any exception
       // does not guarantee that plan was created correctly.
       // So it should be checked additionally that path is correct.

--- a/nav2_system_tests/src/planning/test_planner_plugins.cpp
+++ b/nav2_system_tests/src/planning/test_planner_plugins.cpp
@@ -19,6 +19,7 @@
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav_msgs/msg/path.hpp"
+#include "nav_msgs/msg/goals.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "planner_tester.hpp"
 #include "nav2_util/geometry_utils.hpp"
@@ -47,6 +48,7 @@ void testSmallPathValidityAndOrientation(std::string plugin, double length)
 
   geometry_msgs::msg::PoseStamped start;
   geometry_msgs::msg::PoseStamped goal;
+  std::vector<geometry_msgs::msg::PoseStamped> no_viapoints;
 
   start.pose.position.x = 0.5;
   start.pose.position.y = 0.5;
@@ -62,7 +64,7 @@ void testSmallPathValidityAndOrientation(std::string plugin, double length)
 
   // Test without use_final_approach_orientation
   // expecting end path pose orientation to be equal to goal orientation
-  auto path = obj->getPlan(start, goal, "GridBased", dummy_cancel_checker);
+  auto path = obj->getPlan(start, goal, no_viapoints, "GridBased", dummy_cancel_checker);
   EXPECT_GT((int)path.poses.size(), 0);
   EXPECT_NEAR(tf2::getYaw(path.poses.back().pose.orientation), -M_PI, 0.01);
   obj->onCleanup(state);
@@ -84,6 +86,7 @@ void testSmallPathValidityAndNoOrientation(std::string plugin, double length)
 
   geometry_msgs::msg::PoseStamped start;
   geometry_msgs::msg::PoseStamped goal;
+  std::vector<geometry_msgs::msg::PoseStamped> no_viapoints;
 
   start.pose.position.x = 0.5;
   start.pose.position.y = 0.5;
@@ -97,7 +100,7 @@ void testSmallPathValidityAndNoOrientation(std::string plugin, double length)
 
   auto dummy_cancel_checker = []() {return false;};
 
-  auto path = obj->getPlan(start, goal, "GridBased", dummy_cancel_checker);
+  auto path = obj->getPlan(start, goal, no_viapoints, "GridBased", dummy_cancel_checker);
   EXPECT_GT((int)path.poses.size(), 0);
 
   int path_size = path.poses.size();
@@ -128,6 +131,7 @@ void testCancel(std::string plugin)
 
   geometry_msgs::msg::PoseStamped start;
   geometry_msgs::msg::PoseStamped goal;
+  std::vector<geometry_msgs::msg::PoseStamped> no_viapoints;
 
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
@@ -142,7 +146,7 @@ void testCancel(std::string plugin)
   auto always_cancelled = []() {return true;};
 
   EXPECT_THROW(
-    obj->getPlan(start, goal, "GridBased", always_cancelled),
+    obj->getPlan(start, goal, no_viapoints, "GridBased", always_cancelled),
     nav2_core::PlannerCancelled);
   obj->onCleanup(state);
   obj.reset();
@@ -159,16 +163,17 @@ TEST(testPluginMap, Failures)
 
   geometry_msgs::msg::PoseStamped start;
   geometry_msgs::msg::PoseStamped goal;
+  std::vector<geometry_msgs::msg::PoseStamped> no_viapoints;
   std::string plugin_fake = "fake";
   std::string plugin_none = "";
 
   auto dummy_cancel_checker = []() {return false;};
 
-  auto path = obj->getPlan(start, goal, plugin_none, dummy_cancel_checker);
+  auto path = obj->getPlan(start, goal, no_viapoints, plugin_none, dummy_cancel_checker);
   EXPECT_EQ(path.header.frame_id, std::string("map"));
 
   try {
-    path = obj->getPlan(start, goal, plugin_fake, dummy_cancel_checker);
+    path = obj->getPlan(start, goal, no_viapoints, plugin_fake, dummy_cancel_checker);
     FAIL() << "Failed to throw invalid planner id exception";
   } catch (const nav2_core::InvalidPlanner & ex) {
     EXPECT_EQ(ex.what(), std::string("Planner id fake is invalid"));

--- a/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star_planner.hpp
+++ b/nav2_theta_star_planner/include/nav2_theta_star_planner/theta_star_planner.hpp
@@ -65,6 +65,7 @@ public:
   nav_msgs::msg::Path createPlan(
     const geometry_msgs::msg::PoseStamped & start,
     const geometry_msgs::msg::PoseStamped & goal,
+    const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
     std::function<bool()> cancel_checker) override;
 
 protected:

--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -71,8 +71,9 @@ nav_msgs::msg::Path ThetaStarPlanner::createPlan(
   const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   std::function<bool()> cancel_checker)
 {
-  if (!viapoints.size()) {
-    RCLCPP_DEBUG(logger_, "Planning triggered with no viapoints");
+  if (!viapoints.empty()) {
+    RCLCPP_WARN(logger_, "Received %zu viapoints, but this planner ignores them",
+      viapoints.size());
   }
 
   std::lock_guard<std::mutex> lock_reinit(param_handler_->getMutex());

--- a/nav2_theta_star_planner/src/theta_star_planner.cpp
+++ b/nav2_theta_star_planner/src/theta_star_planner.cpp
@@ -68,8 +68,13 @@ void ThetaStarPlanner::deactivate()
 nav_msgs::msg::Path ThetaStarPlanner::createPlan(
   const geometry_msgs::msg::PoseStamped & start,
   const geometry_msgs::msg::PoseStamped & goal,
+  const std::vector<geometry_msgs::msg::PoseStamped> & viapoints,
   std::function<bool()> cancel_checker)
 {
+  if (!viapoints.size()) {
+    RCLCPP_DEBUG(logger_, "Planning triggered with no viapoints");
+  }
+
   std::lock_guard<std::mutex> lock_reinit(param_handler_->getMutex());
   nav_msgs::msg::Path global_path;
   auto start_time = std::chrono::steady_clock::now();

--- a/nav2_theta_star_planner/test/test_theta_star.cpp
+++ b/nav2_theta_star_planner/test/test_theta_star.cpp
@@ -155,6 +155,7 @@ TEST(ThetaStarPlanner, test_theta_star_planner) {
     std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
   costmap_ros->on_configure(rclcpp_lifecycle::State());
 
+  std::vector<geometry_msgs::msg::PoseStamped> no_viapoints{};
   geometry_msgs::msg::PoseStamped start, goal;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
@@ -168,7 +169,8 @@ TEST(ThetaStarPlanner, test_theta_star_planner) {
       return false;
     };
 
-  nav_msgs::msg::Path path = planner_2d->createPlan(start, goal, dummy_cancel_checker);
+  nav_msgs::msg::Path path = planner_2d->createPlan(
+    start, goal, no_viapoints, dummy_cancel_checker);
   EXPECT_GT(static_cast<int>(path.poses.size()), 0);
 
   // test if the goal is unsafe
@@ -180,7 +182,8 @@ TEST(ThetaStarPlanner, test_theta_star_planner) {
   goal.pose.position.x = 1.0;
   goal.pose.position.y = 1.0;
 
-  EXPECT_THROW(planner_2d->createPlan(start, goal, dummy_cancel_checker), nav2_core::GoalOccupied);
+  EXPECT_THROW(planner_2d->createPlan(start, goal, no_viapoints, dummy_cancel_checker),
+    nav2_core::GoalOccupied);
 
   planner_2d->deactivate();
   planner_2d->cleanup();

--- a/nav2_theta_star_planner/test/test_theta_star.cpp
+++ b/nav2_theta_star_planner/test/test_theta_star.cpp
@@ -155,12 +155,12 @@ TEST(ThetaStarPlanner, test_theta_star_planner) {
     std::make_shared<nav2_costmap_2d::Costmap2DROS>("global_costmap");
   costmap_ros->on_configure(rclcpp_lifecycle::State());
 
-  std::vector<geometry_msgs::msg::PoseStamped> no_viapoints{};
-  geometry_msgs::msg::PoseStamped start, goal;
+  geometry_msgs::msg::PoseStamped start, goal, viapoint;
   start.pose.position.x = 0.0;
   start.pose.position.y = 0.0;
   start.pose.orientation.w = 1.0;
   goal = start;
+  viapoint = start;
   auto planner_2d = std::make_unique<nav2_theta_star_planner::ThetaStarPlanner>();
   planner_2d->configure(life_node, "test", nullptr, costmap_ros);
   planner_2d->activate();
@@ -169,8 +169,9 @@ TEST(ThetaStarPlanner, test_theta_star_planner) {
       return false;
     };
 
+  std::vector<geometry_msgs::msg::PoseStamped> viapoints{viapoint};
   nav_msgs::msg::Path path = planner_2d->createPlan(
-    start, goal, no_viapoints, dummy_cancel_checker);
+    start, goal, viapoints, dummy_cancel_checker);
   EXPECT_GT(static_cast<int>(path.poses.size()), 0);
 
   // test if the goal is unsafe
@@ -182,7 +183,7 @@ TEST(ThetaStarPlanner, test_theta_star_planner) {
   goal.pose.position.x = 1.0;
   goal.pose.position.y = 1.0;
 
-  EXPECT_THROW(planner_2d->createPlan(start, goal, no_viapoints, dummy_cancel_checker),
+  EXPECT_THROW(planner_2d->createPlan(start, goal, viapoints, dummy_cancel_checker),
     nav2_core::GoalOccupied);
 
   planner_2d->deactivate();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5988  |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Gazebo simulation of  Turtlebot3 Waffle |
| Does this PR contain AI generated software? | Noe |
| Was this PR description generated by AI software? | No | 

---

## Description of contribution in a few bullet points

* Added a new createPlan() interface to the BaseGlobalPlanner that accepts a vector of geometry_msgs/PoseStamped for intermediate viapoints (excluding goal)
* The ComputePlanToPose action now accepts a list of stamped poses as intermediate viapoints that are forwarded to the planner plugin.
* The ComputePlanToPose BT node accepts an input port for a std::vector of intermediate viapoints

## Description of documentation updates required from your changes

* Updated interface will have to be added to BaseGlobalPlanner documentation as optional
* Implementation of updated interface will have to be added to Planner Plugin How-Tos as optional 
* ComputePathToPose documentation will have to be updated include description for viapoints

## Description of how this change was tested

* Performed validation through colcon test for all system and planner tests
* Executed path planning with all permutations of following classes:
  * Worlds:
    * TB3 Sandbox
    * TB4 Warehouse
  * Planners:
    * NavFn
    * SmacPlanner2D
    * ThetaStartPlanner
  * Replan frequency:
    * 0 Hz
    * 20 Hz

Tests included:
* Single goal & planner throughout navigation sequence
* Switching goals & planners mid navigation

Corresponding PRs:
https://github.com/ros-navigation/docs.nav2.org/pull/904
https://github.com/ros-navigation/navigation2_tutorials/pull/139

---

## Future work that may be required in bullet points

* Existing planner plugins may be upgraded to include viapoints for path computation
* Tolerances for navigation goals may be included as part of the action goal for ComputePathToPose & ComputePathThroughPoses
* Tolerances for viapoints may be included as part of action goal for ComputePathToPose & ComputePathThroughPoses

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
