### PR TITLE
Add out_dir parameter to RewrittenYaml substitution (#6001)

### DIFF
--- a/nav2_common/nav2_common/launch/rewritten_yaml.py
+++ b/nav2_common/nav2_common/launch/rewritten_yaml.py
@@ -50,6 +50,7 @@ class RewrittenYaml(launch.Substitution):
         key_rewrites: Optional[dict[str, launch.SomeSubstitutionsType]] = None,
         value_rewrites: Optional[dict[str, launch.SomeSubstitutionsType]] = None,
         convert_types: bool = False,
+        out_dir: Optional[launch.SomeSubstitutionsType] = None,
     ) -> None:
         super().__init__()
         """
@@ -61,6 +62,7 @@ class RewrittenYaml(launch.Substitution):
         :param: key_rewrites keys of mappings to replace
         :param: value_rewrites values to replace
         :param: convert_types whether to attempt converting the string to a number or boolean
+        :param: out_dir if provided, the directory where the temporary YAML file will be created
         """
 
         # import here to avoid loop
@@ -73,6 +75,8 @@ class RewrittenYaml(launch.Substitution):
         self.__value_rewrites = {}
         self.__convert_types = convert_types
         self.__root_key = None
+        self.__out_dir = None
+
         for key in param_rewrites:
             self.__param_rewrites[key] = normalize_to_list_of_substitutions(
                 param_rewrites[key]
@@ -90,6 +94,9 @@ class RewrittenYaml(launch.Substitution):
         if root_key is not None:
             self.__root_key = normalize_to_list_of_substitutions(root_key)
 
+        if out_dir is not None:
+            self.__out_dir = normalize_to_list_of_substitutions(out_dir)
+
     @property
     def name(self) -> list[launch.Substitution]:
         """Getter for name."""
@@ -101,7 +108,12 @@ class RewrittenYaml(launch.Substitution):
 
     def perform(self, context: launch.LaunchContext) -> str:
         yaml_filename = launch.utilities.perform_substitutions(context, self.name)
-        rewritten_yaml = tempfile.NamedTemporaryFile(mode='w', delete=False)
+
+        out_dir = None
+        if self.__out_dir is not None:
+            out_dir = launch.utilities.perform_substitutions(context, self.__out_dir)
+
+        rewritten_yaml = tempfile.NamedTemporaryFile(mode='w', delete=False, dir=out_dir)
         param_rewrites, keys_rewrites, value_rewrites = self.resolve_rewrites(context)
 
         with open(yaml_filename, 'r') as yaml_file:


### PR DESCRIPTION
This commit introduces an optional `out_dir` parameter to the `RewrittenYaml` class constructor. Passing this parameter to the underlying temporary file generator allows developers to specify a custom output directory instead of defaulting to the system's temporary folder.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6001 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | / |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
