### PR TITLE
Fix Layer::current_ data races in costmap layers

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/inflation_layer.hpp
@@ -111,7 +111,7 @@ public:
   void reset() override
   {
     matchSize();
-    current_ = false;
+    setCurrent(false);
     need_reinflation_ = true;
   }
 

--- a/nav2_costmap_2d/include/nav2_costmap_2d/layer.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/layer.hpp
@@ -37,6 +37,7 @@
 #ifndef NAV2_COSTMAP_2D__LAYER_HPP_
 #define NAV2_COSTMAP_2D__LAYER_HPP_
 
+#include <atomic>
 #include <string>
 #include <vector>
 #include <unordered_set>
@@ -193,7 +194,7 @@ protected:
    */
   virtual void onInitialize() {}
 
-  bool current_;
+  std::atomic_bool current_;
   // Currently this var is managed by subclasses.
   // TODO(bpwilcox): make this managed by this class and/or container class.
   bool enabled_;

--- a/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
@@ -104,7 +104,7 @@ void CostmapFilter::reset()
 {
   resetFilter();
   initializeFilter(filter_info_topic_);
-  current_ = false;
+  setCurrent(false);
 }
 
 void CostmapFilter::updateBounds(
@@ -130,7 +130,7 @@ void CostmapFilter::updateCosts(
   }
 
   process(master_grid, min_i, min_j, max_i, max_j, latest_pose_);
-  current_ = true;
+  setCurrent(true);
 }
 
 void CostmapFilter::enableCallback(

--- a/nav2_costmap_2d/plugins/denoise_layer.cpp
+++ b/nav2_costmap_2d/plugins/denoise_layer.cpp
@@ -66,13 +66,13 @@ DenoiseLayer::onInitialize()
     }
   }
 
-  current_ = true;
+  setCurrent(true);
 }
 
 void
 DenoiseLayer::reset()
 {
-  current_ = false;
+  setCurrent(false);
 }
 
 bool
@@ -114,7 +114,7 @@ DenoiseLayer::updateCosts(
     RCLCPP_ERROR(logger_, "%s", (std::string("Inner error: ") + ex.what()).c_str());
   }
 
-  current_ = true;
+  setCurrent(true);
 }
 
 void

--- a/nav2_costmap_2d/plugins/inflation_layer.cpp
+++ b/nav2_costmap_2d/plugins/inflation_layer.cpp
@@ -82,7 +82,7 @@ InflationLayer::onInitialize()
       name_ + "." + "num_threads", -1);
   }
 
-  current_ = true;
+  setCurrent(true);
   need_reinflation_ = false;
   matchSize();
 }
@@ -322,7 +322,7 @@ InflationLayer::updateCosts(
     min_i, min_j, max_i, max_j,
     roi_min_i, roi_min_j, size_x);
 
-  current_ = true;
+  setCurrent(true);
 }
 
 
@@ -390,14 +390,14 @@ InflationLayer::updateParametersCallback(
         inflation_radius_ = parameter.as_double();
         need_reinflation_ = true;
         need_cache_recompute = true;
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "cost_scaling_factor" && // NOLINT
         getCostScalingFactor() != parameter.as_double())
       {
         cost_scaling_factor_ = parameter.as_double();
         need_reinflation_ = true;
         need_cache_recompute = true;
-        current_ = false;
+        setCurrent(false);
       }
     } else if (param_type == ParameterType::PARAMETER_INTEGER) {
       if (param_name == name_ + "." + "num_threads" && // NOLINT
@@ -438,19 +438,19 @@ InflationLayer::updateParametersCallback(
       if (param_name == name_ + "." + "enabled" && enabled_ != parameter.as_bool()) {
         enabled_ = parameter.as_bool();
         need_reinflation_ = true;
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "inflate_unknown" && // NOLINT
         inflate_unknown_ != parameter.as_bool())
       {
         inflate_unknown_ = parameter.as_bool();
         need_reinflation_ = true;
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "inflate_around_unknown" && // NOLINT
         inflate_around_unknown_ != parameter.as_bool())
       {
         inflate_around_unknown_ = parameter.as_bool();
         need_reinflation_ = true;
-        current_ = false;
+        setCurrent(false);
       }
     }
   }

--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -117,7 +117,7 @@ void ObstacleLayer::onInitialize()
   }
 
   ObstacleLayer::matchSize();
-  current_ = true;
+  setCurrent(true);
   was_reset_ = false;
 
   global_frame_ = layered_costmap_->getGlobalFrameID();
@@ -366,17 +366,17 @@ ObstacleLayer::updateParametersCallback(
         min_obstacle_height_ != parameter.as_double())
       {
         min_obstacle_height_ = parameter.as_double();
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "max_obstacle_height" &&  // NOLINT(readability/braces)
         max_obstacle_height_ != parameter.as_double())
       {
         max_obstacle_height_ = parameter.as_double();
-        current_ = false;
+        setCurrent(false);
       }
     } else if (param_type == ParameterType::PARAMETER_BOOL) {
       if (param_name == name_ + "." + "enabled" && enabled_ != parameter.as_bool()) {
         enabled_ = parameter.as_bool();
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "footprint_clearing_enabled") {
         footprint_clearing_enabled_ = parameter.as_bool();
       }
@@ -500,7 +500,7 @@ ObstacleLayer::updateBounds(
   current = current && getClearingObservations(clearing_observations);
 
   // update the global current status
-  current_ = current;
+  setCurrent(current);
 
   // raytrace freespace
   for (const auto & clearing_observation : clearing_observations) {
@@ -604,9 +604,9 @@ ObstacleLayer::updateCosts(
   }
 
   // if not current due to reset, set current now after clearing
-  if (!current_ && was_reset_) {
+  if (!isCurrent() && was_reset_) {
     was_reset_ = false;
-    current_ = true;
+    setCurrent(true);
   }
 
   if (footprint_clearing_enabled_) {
@@ -851,7 +851,7 @@ ObstacleLayer::reset()
 {
   resetMaps();
   resetBuffersLastUpdated();
-  current_ = false;
+  setCurrent(false);
   was_reset_ = true;
 }
 

--- a/nav2_costmap_2d/plugins/plugin_container_layer.cpp
+++ b/nav2_costmap_2d/plugins/plugin_container_layer.cpp
@@ -53,7 +53,7 @@ void PluginContainerLayer::onInitialize()
   default_value_ = nav2_costmap_2d::NO_INFORMATION;
 
   PluginContainerLayer::matchSize();
-  current_ = true;
+  setCurrent(true);
 }
 
 void PluginContainerLayer::addPlugin(std::shared_ptr<Layer> plugin, std::string layer_name)
@@ -111,7 +111,7 @@ void PluginContainerLayer::updateCosts(
       break;
   }
 
-  current_ = true;
+  setCurrent(true);
 }
 
 void PluginContainerLayer::activate()
@@ -160,7 +160,7 @@ void PluginContainerLayer::reset()
     (*plugin)->reset();
   }
   resetMaps();
-  current_ = false;
+  setCurrent(false);
 }
 
 void PluginContainerLayer::onFootprintChanged()
@@ -239,7 +239,7 @@ void PluginContainerLayer::updateParametersCallback(
     } else if (param_type == ParameterType::PARAMETER_BOOL) {
       if (param_name == name_ + "." + "enabled" && enabled_ != parameter.as_bool()) {
         enabled_ = parameter.as_bool();
-        current_ = false;
+        setCurrent(false);
       }
     }
   }

--- a/nav2_costmap_2d/plugins/range_sensor_layer.cpp
+++ b/nav2_costmap_2d/plugins/range_sensor_layer.cpp
@@ -59,7 +59,7 @@ RangeSensorLayer::RangeSensorLayer() {}
 
 void RangeSensorLayer::onInitialize()
 {
-  current_ = true;
+  setCurrent(true);
   was_reset_ = false;
   buffered_readings_ = 0;
   last_reading_time_ = clock_->now();
@@ -452,7 +452,7 @@ void RangeSensorLayer::updateBounds(
   resetRange();
 
   if (!enabled_) {
-    current_ = true;
+    setCurrent(true);
     return;
   }
 
@@ -466,7 +466,7 @@ void RangeSensorLayer::updateBounds(
         "No range readings received for %.2f seconds, while expected at least every %.2f seconds.",
         (clock_->now() - last_reading_time_).seconds(),
         no_readings_timeout_);
-      current_ = false;
+      setCurrent(false);
     }
   }
 }
@@ -512,9 +512,9 @@ void RangeSensorLayer::updateCosts(
   buffered_readings_ = 0;
 
   // if not current due to reset, set current now after clearing
-  if (!current_ && was_reset_) {
+  if (!isCurrent() && was_reset_) {
     was_reset_ = false;
-    current_ = true;
+    setCurrent(true);
   }
 }
 

--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -138,7 +138,7 @@ void
 StaticLayer::reset()
 {
   has_updated_data_ = true;
-  current_ = false;
+  setCurrent(false);
 }
 
 void
@@ -248,7 +248,7 @@ StaticLayer::processMap(const nav_msgs::msg::OccupancyGrid & new_map)
   height_ = size_y_;
   has_updated_data_ = true;
 
-  current_ = true;
+  setCurrent(true);
 }
 
 void
@@ -298,7 +298,7 @@ StaticLayer::incomingMap(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr & ne
   }
   std::lock_guard<Costmap2D::mutex_t> guard(*getMutex());
   map_buffer_ = new_map;
-  current_ = false;
+  setCurrent(false);
 }
 
 void
@@ -476,7 +476,7 @@ StaticLayer::updateCosts(
     // restore the map region occupied by the polygon using cached data
     restoreMapRegionOccupiedByPolygon(map_region_to_restore);
   }
-  current_ = true;
+  setCurrent(true);
 }
 
 /**
@@ -545,7 +545,7 @@ StaticLayer::updateParametersCallback(
         width_ = size_x_;
         height_ = size_y_;
         has_updated_data_ = true;
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "footprint_clearing_enabled") {
         footprint_clearing_enabled_ = parameter.as_bool();
       } else if (param_name == name_ + "." + "restore_cleared_footprint") {

--- a/nav2_costmap_2d/plugins/voxel_layer.cpp
+++ b/nav2_costmap_2d/plugins/voxel_layer.cpp
@@ -182,7 +182,7 @@ void VoxelLayer::updateBounds(
   current = getClearingObservations(clearing_observations) && current;
 
   // update the global current status
-  current_ = current;
+  setCurrent(current);
 
   // raytrace freespace
   for (const auto & clearing_observation : clearing_observations) {
@@ -558,24 +558,24 @@ VoxelLayer::updateParametersCallback(
         min_obstacle_height_ != parameter.as_double())
       {
         min_obstacle_height_ = parameter.as_double();
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "max_obstacle_height" &&  // NOLINT(readability/braces)
         max_obstacle_height_ != parameter.as_double())
       {
         max_obstacle_height_ = parameter.as_double();
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "origin_z" &&  // NOLINT(readability/braces)
         origin_z_ != parameter.as_double())
       {
         origin_z_ = parameter.as_double();
         resize_map_needed = true;
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "z_resolution" &&  // NOLINT(readability/braces)
         z_resolution_ != parameter.as_double())
       {
         z_resolution_ = parameter.as_double();
         resize_map_needed = true;
-        current_ = false;
+        setCurrent(false);
       }
 
     } else if (param_type == ParameterType::PARAMETER_BOOL) {
@@ -583,7 +583,7 @@ VoxelLayer::updateParametersCallback(
         enabled_ != parameter.as_bool())
       {
         enabled_ = parameter.as_bool();
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "footprint_clearing_enabled") {
         footprint_clearing_enabled_ = parameter.as_bool();
       }
@@ -594,13 +594,13 @@ VoxelLayer::updateParametersCallback(
       {
         size_z_ = parameter.as_int();
         resize_map_needed = true;
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "unknown_threshold") {
         unknown_threshold_ = parameter.as_int() + (VOXEL_BITS - size_z_);
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "mark_threshold") {
         mark_threshold_ = parameter.as_int();
-        current_ = false;
+        setCurrent(false);
       } else if (param_name == name_ + "." + "combination_method") {
         combination_method_ = combination_method_from_int(parameter.as_int());
       }

--- a/nav2_costmap_2d/src/costmap_layer.cpp
+++ b/nav2_costmap_2d/src/costmap_layer.cpp
@@ -70,7 +70,7 @@ void CostmapLayer::matchSize()
 
 void CostmapLayer::clearArea(int start_x, int start_y, int end_x, int end_y, bool invert)
 {
-  current_ = false;
+  setCurrent(false);
   unsigned char * grid = getCharMap();
 
   int size_x = getSizeInCellsX();

--- a/nav2_costmap_2d/test/unit/denoise_layer_test.cpp
+++ b/nav2_costmap_2d/test/unit/denoise_layer_test.cpp
@@ -64,19 +64,14 @@ public:
 
   bool reset()
   {
-    denoise_.current_ = true;
+    denoise_.setCurrent(true);
     denoise_.reset();
-    return denoise_.current_;
+    return denoise_.isCurrent();
   }
 
   static void initialize(nav2_costmap_2d::DenoiseLayer & d)
   {
     d.onInitialize();
-  }
-
-  static bool & touchCurrent(nav2_costmap_2d::DenoiseLayer & d)
-  {
-    return d.current_;
   }
 
   static void configure(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#6009 ) |
| Primary OS tested on | (Ubuntu 24.04 (Docker container) |
| Robotic platform tested on | (Just testing) |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
- change Layer::current_ from bool to std::atomic_bool
- consistently use setCurrent()/isCurrent() for current_ accesses


## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested
<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->
* Reproduced the Layer::current_ read/write races with local TSan repro tests before the fix. 
* Verified that the original races no longer reproduce after the fix.
---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
