### PR TITLE
Fix CostmapSubscriber isCostmapReceived data race (#6009)

### DIFF
--- a/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
+++ b/nav2_costmap_2d/include/nav2_costmap_2d/costmap_subscriber.hpp
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 
 
@@ -88,10 +89,11 @@ public:
   }
 
 protected:
-  bool isCostmapReceived()  
-{
-  std::lock_guard<std::mutex> guard(costmap_msg_mutex_); return costmap_ != nullptr;
-}
+  bool isCostmapReceived()
+  {
+    std::lock_guard<std::mutex> guard(costmap_msg_mutex_);
+    return costmap_ != nullptr;
+  }
   void processCurrentCostmapMsg();
 
   bool haveCostmapParametersChanged();


### PR DESCRIPTION
Fixes #6009.

- Add std::lock_guard<std::mutex> around access to costmap_ in CostmapSubscriber::isCostmapReceived().