### PR TITLE
Add max_lookahead_distance parameter to path validation

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/validate_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/validate_path_action.hpp
@@ -87,8 +87,8 @@ public:
         "Custom footprint specification as bracketed array of arrays, e.g., "
         "[[x1,y1],[x2,y2],...] (empty = use robot footprint)"),
         BT::InputPort<bool>(
-        "check_full_path", false,
-        "Whether to check all poses (true) or stop at first invalid pose (false)"),
+        "stop_at_first_collision", true,
+        "Whether to stop validation at first collision (true) or check all poses (false)"),
         BT::InputPort<double>(
         "max_lookahead_distance", -1.0,
         "Maximum distance ahead of the robot to validate (-1 = full path)"),
@@ -103,7 +103,7 @@ private:
   bool consider_unknown_as_obstacle_;
   std::string layer_name_;
   std::string footprint_;
-  bool check_full_path_;
+  bool stop_at_first_collision_;
   double max_lookahead_distance_;
   nav_msgs::msg::Path path_;
 };

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -389,7 +389,8 @@
       <input_port name="path">Path to Check</input_port>
       <input_port name="max_cost">Maximum cost of the path</input_port>
       <input_port name="consider_unknown_as_obstacle">Whether to consider unknown cost as obstacle</input_port>
-      <input_port name="check_full_path">Whether to check all poses (true) or stop at first invalid pose (false)</input_port>
+      <input_port name="stop_at_first_collision">Whether to stop validation at first collision (true) or check all poses (false)</input_port>
+      <input_port name="max_lookahead_distance">Maximum distance ahead of the robot to validate (-1 = full path)</input_port>
       <input_port name="layer_name">Name of the costmap layer to check against (empty = full costmap)</input_port>
       <input_port name="footprint">Custom footprint specification as bracketed array of arrays, e.g., [[x1,y1],[x2,y2],...] (empty = use robot footprint)</input_port>
       <input_port name="server_timeout">Server timeout</input_port>

--- a/nav2_behavior_tree/plugins/action/validate_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/validate_path_action.cpp
@@ -35,7 +35,7 @@ void ValidatePath::on_tick()
   getInput<bool>("consider_unknown_as_obstacle", consider_unknown_as_obstacle_);
   getInput<std::string>("layer_name", layer_name_);
   getInput<std::string>("footprint", footprint_);
-  getInput<bool>("check_full_path", check_full_path_);
+  getInput<bool>("stop_at_first_collision", stop_at_first_collision_);
   getInput<double>("max_lookahead_distance", max_lookahead_distance_);
   getInput("path", path_);
 
@@ -45,7 +45,7 @@ void ValidatePath::on_tick()
   request_->consider_unknown_as_obstacle = consider_unknown_as_obstacle_;
   request_->layer_name = layer_name_;
   request_->footprint = footprint_;
-  request_->check_full_path = check_full_path_;
+  request_->stop_at_first_collision = stop_at_first_collision_;
   request_->max_lookahead_distance = max_lookahead_distance_;
 }
 

--- a/nav2_msgs/srv/IsPathValid.srv
+++ b/nav2_msgs/srv/IsPathValid.srv
@@ -5,7 +5,7 @@ uint8 max_cost 254
 bool consider_unknown_as_obstacle false
 string layer_name ""
 string footprint ""
-bool check_full_path false
+bool stop_at_first_collision true
 float64 max_lookahead_distance -1.0
 ---
 bool success

--- a/nav2_planner/include/nav2_planner/is_path_valid_service.hpp
+++ b/nav2_planner/include/nav2_planner/is_path_valid_service.hpp
@@ -282,13 +282,13 @@ private:
       {
         response->is_valid = false;
         response->invalid_pose_indices.push_back(i);
-        if (!request->check_full_path) {
+        if (request->stop_at_first_collision) {
           break;
         }
       } else if (cost == nav2_costmap_2d::LETHAL_OBSTACLE || cost >= request->max_cost) {
         response->is_valid = false;
         response->invalid_pose_indices.push_back(i);
-        if (!request->check_full_path) {
+        if (request->stop_at_first_collision) {
           break;
         }
       }

--- a/nav2_system_tests/src/planning/planner_tester.cpp
+++ b/nav2_system_tests/src/planning/planner_tester.cpp
@@ -401,7 +401,8 @@ TaskStatus PlannerTester::createPlan(
 std::shared_ptr<nav2_msgs::srv::IsPathValid::Response> PlannerTester::isPathValid(
   nav_msgs::msg::Path & path, unsigned int max_cost,
   bool consider_unknown_as_obstacle, const std::string & layer_name,
-  const std::string & footprint, bool check_full_path)
+  const std::string & footprint, bool stop_at_first_collision,
+  double max_lookahead_distance)
 {
   planner_tester_->setCostmap(costmap_.get());
   // create a fake service request
@@ -411,7 +412,8 @@ std::shared_ptr<nav2_msgs::srv::IsPathValid::Response> PlannerTester::isPathVali
   request->consider_unknown_as_obstacle = consider_unknown_as_obstacle;
   request->layer_name = layer_name;
   request->footprint = footprint;
-  request->check_full_path = check_full_path;
+  request->stop_at_first_collision = stop_at_first_collision;
+  request->max_lookahead_distance = max_lookahead_distance;
   auto result = path_valid_client_->async_call(request);
 
   RCLCPP_INFO(this->get_logger(), "Waiting for service complete");

--- a/nav2_system_tests/src/planning/planner_tester.hpp
+++ b/nav2_system_tests/src/planning/planner_tester.hpp
@@ -161,7 +161,8 @@ public:
   std::shared_ptr<nav2_msgs::srv::IsPathValid::Response> isPathValid(
     nav_msgs::msg::Path & path, unsigned int max_cost,
     bool consider_unknown_as_obstacle, const std::string & layer_name = "",
-    const std::string & footprint = "", bool check_full_path = false);
+    const std::string & footprint = "", bool stop_at_first_collision = true,
+    double max_lookahead_distance = -1.0);
 
 private:
   void setCostmap();

--- a/nav2_system_tests/src/planning/test_planner_is_path_valid.cpp
+++ b/nav2_system_tests/src/planning/test_planner_is_path_valid.cpp
@@ -257,7 +257,7 @@ TEST(testIsPathValid, testFootprintCollisionChecking)
   }
 }
 
-TEST(testIsPathValid, testCheckFullPath)
+TEST(testIsPathValid, testStopAtFirstCollision)
 {
   auto planner_tester = std::make_shared<PlannerTester>();
   planner_tester->activate();
@@ -277,21 +277,79 @@ TEST(testIsPathValid, testCheckFullPath)
     }
   }
 
-  // Test with check_full_path = false (default, stops at first invalid pose)
+  // Test with stop_at_first_collision = true (default, stops at first invalid pose)
   auto response = planner_tester->isPathValid(
-    path, max_cost, consider_unknown_as_obstacle, "", "", false);
+    path, max_cost, consider_unknown_as_obstacle, "", "", true);
   ASSERT_NE(response, nullptr);
   EXPECT_TRUE(response->success);
   EXPECT_FALSE(response->is_valid);
   EXPECT_EQ(response->invalid_pose_indices.size(), 1u);
 
-  // Test with check_full_path = true (checks all poses)
+  // Test with stop_at_first_collision = false (checks all poses)
   response = planner_tester->isPathValid(
-    path, max_cost, consider_unknown_as_obstacle, "", "", true);
+    path, max_cost, consider_unknown_as_obstacle, "", "", false);
   ASSERT_NE(response, nullptr);
   EXPECT_TRUE(response->success);
   EXPECT_FALSE(response->is_valid);
   EXPECT_GT(response->invalid_pose_indices.size(), 1u);
+}
+
+TEST(testIsPathValid, testMaxLookaheadDistance)
+{
+  auto planner_tester = std::make_shared<PlannerTester>();
+  planner_tester->activate();
+  planner_tester->loadSimpleCostmap(TestCostmap::top_left_obstacle);
+
+  nav_msgs::msg::Path path;
+  unsigned int max_cost = 253;
+  bool consider_unknown_as_obstacle = false;
+
+  // Create a long straight path along y-axis at x=1.0 (clear of top-left obstacle)
+  for (float i = 0; i < 10; i += 0.5) {
+    geometry_msgs::msg::PoseStamped pose;
+    pose.pose.position.x = 1.0;
+    pose.pose.position.y = i;
+    path.poses.push_back(pose);
+  }
+
+  // Full path should be valid (no obstacle at x=1.0)
+  auto response = planner_tester->isPathValid(
+    path, max_cost, consider_unknown_as_obstacle, "", "", true, -1.0);
+  ASSERT_NE(response, nullptr);
+  EXPECT_TRUE(response->success);
+  EXPECT_TRUE(response->is_valid);
+
+  // With a short lookahead distance, should also be valid (subset of valid path)
+  response = planner_tester->isPathValid(
+    path, max_cost, consider_unknown_as_obstacle, "", "", true, 2.0);
+  ASSERT_NE(response, nullptr);
+  EXPECT_TRUE(response->success);
+  EXPECT_TRUE(response->is_valid);
+
+  // Now create a path that goes through the obstacle area
+  nav_msgs::msg::Path obstacle_path;
+  for (float i = 0; i < 10; i += 1.0) {
+    for (float j = 0; j < 10; j += 1.0) {
+      geometry_msgs::msg::PoseStamped pose;
+      pose.pose.position.x = i;
+      pose.pose.position.y = j;
+      obstacle_path.poses.push_back(pose);
+    }
+  }
+
+  // Full path validation should find obstacles
+  response = planner_tester->isPathValid(
+    obstacle_path, max_cost, consider_unknown_as_obstacle, "", "", true, -1.0);
+  ASSERT_NE(response, nullptr);
+  EXPECT_TRUE(response->success);
+  EXPECT_FALSE(response->is_valid);
+
+  // With a very short lookahead, may not reach the obstacle
+  response = planner_tester->isPathValid(
+    obstacle_path, max_cost, consider_unknown_as_obstacle, "", "", true, 0.5);
+  ASSERT_NE(response, nullptr);
+  EXPECT_TRUE(response->success);
+  // With short lookahead, the path segment validated may not reach obstacles
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Dexory simulation|
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

* Added a new input port `max_lookahead_distance` to the `ValidatePath` behavior tree node, allowing users to specify how far ahead along the path to validate. (-1 means validate the full path) * Introduced a new field `max_lookahead_distance` in the `IsPathValid` service request definition to support this feature 
* Updated the `ValidatePath` node implementation to read and forward the `max_lookahead_distance` input to the service request
* Modified the path validation logic in the planner to only check poses up to the specified lookahead distance, improving efficiency when full path validation is not necessary 

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

- I have a BT that replans when the path is no longer valid so I checked that it only replanned once the robot is at `max_lookahead_distance` from the obstacle and not earlier

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
