### PR TITLE
Fix SpinAction not forwarding disable_collision_checks to goal

### DIFF
--- a/nav2_behavior_tree/plugins/action/spin_action.cpp
+++ b/nav2_behavior_tree/plugins/action/spin_action.cpp
@@ -31,8 +31,11 @@ void SpinAction::initialize()
   getInput("spin_dist", dist);
   double time_allowance;
   getInput("time_allowance", time_allowance);
+  bool disable_collision_checks;
+  getInput("disable_collision_checks", disable_collision_checks);
   goal_.target_yaw = dist;
   goal_.time_allowance = rclcpp::Duration::from_seconds(time_allowance);
+  goal_.disable_collision_checks = disable_collision_checks;
   getInput("is_recovery", is_recovery_);
 }
 

--- a/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
+++ b/nav2_behavior_tree/test/plugins/action/test_spin_action.cpp
@@ -165,6 +165,28 @@ TEST_F(SpinActionTestFixture, test_tick)
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
   EXPECT_EQ(config_->blackboard->get<int>("number_recoveries"), 1);
   EXPECT_EQ(action_server_->getCurrentGoal()->target_yaw, 3.14f);
+  EXPECT_EQ(action_server_->getCurrentGoal()->disable_collision_checks, false);
+}
+
+TEST_F(SpinActionTestFixture, test_tick_disable_collision_checks)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+            <Spin spin_dist="3.14" disable_collision_checks="true" />
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
+    tree_->rootNode()->executeTick();
+  }
+
+  EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(action_server_->getCurrentGoal()->target_yaw, 3.14f);
+  EXPECT_EQ(action_server_->getCurrentGoal()->disable_collision_checks, true);
 }
 
 TEST_F(SpinActionTestFixture, test_failure)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | Ubuntu, jetpack |
| Robotic platform tested on | Pixel Robotics , gazebo simulation |
| Does this PR contain AI generated software? | yes, all of it - I couldn't find an example on how to mark it as such |
| Was this PR description generated by AI software? | no |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

DriveOnHeading supports disabling collision checks, Spin should as well. It was just not forwarded to the action.
## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

Also added a unit test
<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
