### PR TITLE
Add LatchedPublisher QoS for dock and staging pose.

### DIFF
--- a/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
@@ -152,10 +152,12 @@ void SimpleChargingDock::configure(
       nav2::qos::StandardTopicQoS());
   }
 
-  dock_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>("dock_pose");
+  dock_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>(
+    "dock_pose", nav2::qos::LatchedPublisherQoS());
   filtered_dock_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>(
-    "filtered_dock_pose");
-  staging_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>("staging_pose");
+    "filtered_dock_pose", nav2::qos::LatchedPublisherQoS());
+  staging_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>(
+    "staging_pose", nav2::qos::LatchedPublisherQoS());
 }
 
 geometry_msgs::msg::PoseStamped SimpleChargingDock::getStagingPose(

--- a/nav2_docking/opennav_docking/src/simple_non_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_non_charging_dock.cpp
@@ -135,10 +135,12 @@ void SimpleNonChargingDock::configure(
       nav2::qos::StandardTopicQoS());
   }
 
-  dock_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>("dock_pose");
+  dock_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>(
+    "dock_pose", nav2::qos::LatchedPublisherQoS());
   filtered_dock_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>(
-    "filtered_dock_pose");
-  staging_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>("staging_pose");
+    "filtered_dock_pose", nav2::qos::LatchedPublisherQoS());
+  staging_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>(
+    "staging_pose", nav2::qos::LatchedPublisherQoS());
 }
 
 geometry_msgs::msg::PoseStamped SimpleNonChargingDock::getStagingPose(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

* Change QoS to transient local allow watch it after the dock goal is sent if not subscribed 

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
