### PR TITLE
nav2_costmap_2d: warn on origin misalignment in StaticLayer

### DIFF
--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -216,9 +216,9 @@ StaticLayer::processMap(const nav_msgs::msg::OccupancyGrid & new_map)
         logger_,
         "StaticLayer: Costmap origin coordinates are not perfectly aligned with the resolution. "
         "This may cause misalignment aliasing between rolling and non-rolling costmaps.\n"
-        "Map origin: (%.f, %.f) | Resolution: %.f | Offsets: (%.f, %.f)",
+        "Map origin: (%.f, %.f) | Resolution: %.f",
         new_map.info.origin.position.x, new_map.info.origin.position.y,
-        new_map.info.resolution, fmod_x, fmod_y);
+        new_map.info.resolution);
     }
 
     layered_costmap_->resizeMap(


### PR DESCRIPTION
This commit adds a warning in the static layer's map processing logic when the incoming map's origin is not aligned on the grid anchored at (0, 0) and defined by the costmap resolution. This can typically lead to misalignment between the global and local (rolling) costmap.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #5232 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | / |
| Does this PR contain AI generated software? | / |
| Was this PR description generated by AI software? | / |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
