### PR TITLE
Fix SMAC Hybrid visualization offset from expansions to path

### DIFF
--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -192,8 +192,8 @@ void AStarAlgorithm<NodeT>::populateExpansionsLog(
 {
   typename NodeT::Coordinates coords = node->pose;
   expansions_log->emplace_back(
-    _costmap->getOriginX() + ((coords.x + 0.5) * _costmap->getResolution()),
-    _costmap->getOriginY() + ((coords.y + 0.5) * _costmap->getResolution()),
+    _costmap->getOriginX() + (coords.x * _costmap->getResolution()),
+    _costmap->getOriginY() + (coords.y * _costmap->getResolution()),
     _shared_ctx->motion_table.getAngleFromBin(coords.theta));
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Fixes #5671 |
| Primary OS tested on | Ubuntu (WSL2) |
| Robotic platform tested on | Gazebo simulation of Turtlebot3 |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Removed the hardcoded `+ 0.5` grid cell offset in the `populateExpansionsLog` function in `nav2_smac_planner/src/a_star.cpp`.
* Resolves the visual bug where the SMAC Hybrid planner expansion arrows are misaligned from the unsmoothed path due to the planner using continuous coordinates.

## Description of documentation updates required from your changes

Not Required

## Description of how this change was tested

* Built from source, tested with `tb3_simulation_launch.py`.
* Sent goal poses with RViz2's `Nav2 Goal`, and the expansion arrows were verified to be perfectly flush with the line that represents the generated path.
* As specifically requested by @SteveMacenski, this was tested with the standard `SmacPlanner2D` plugin, as well as the `SmacPlannerHybrid` plugin, which is an SE2 plugin.

---

## Future work that may be required in bullet points

Not required 

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
