### PR TITLE
fix: correct external detection rotation in opennav_docking

### DIFF
--- a/nav2_docking/README.md
+++ b/nav2_docking/README.md
@@ -266,6 +266,10 @@ Note: `dock_plugins` and either `docks` or `dock_database` are required.
 
 Note: The external detection rotation angles are setup to work out of the box with Apriltags detectors in `image_proc` and `isaac_ros`.
 
+Note: The external detection rotation order has changed in ROS2 L-turtle to Rx -> Ry -> Rz (was: Rz -> Rx -> Ry). Behavior is retained only when
+* `external_detection_rotation_yaw` equals 0.0, or
+* `external_detection_rotation_pitch` and `external_detection_rotation_roll` both equal 0.0
+
 ## Etc
 
 ### On Staging Poses

--- a/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_charging_dock.cpp
@@ -125,7 +125,7 @@ void SimpleChargingDock::configure(
   }
 
   // Setup filter
-  external_detection_rotation_.setEuler(pitch, roll, yaw);
+  external_detection_rotation_.setRPY(roll, pitch, yaw);
   filter_ = std::make_unique<PoseFilter>(filter_coef, external_detection_timeout_);
 
   if (!detector_service_name_.empty()) {
@@ -180,7 +180,7 @@ geometry_msgs::msg::PoseStamped SimpleChargingDock::getStagingPose(
   staging_pose.pose.position.x += cos(yaw) * staging_x_offset_;
   staging_pose.pose.position.y += sin(yaw) * staging_x_offset_;
   tf2::Quaternion orientation;
-  orientation.setEuler(0.0, 0.0, yaw + staging_yaw_offset_);
+  orientation.setRPY(0.0, 0.0, yaw + staging_yaw_offset_);
   staging_pose.pose.orientation = tf2::toMsg(orientation);
 
   // Publish staging pose for debugging purposes
@@ -254,7 +254,7 @@ bool SimpleChargingDock::getRefinedPose(geometry_msgs::msg::PoseStamped & pose, 
   tf2::doTransform(just_orientation, just_orientation, transform);
 
   tf2::Quaternion orientation;
-  orientation.setEuler(0.0, 0.0, tf2::getYaw(just_orientation.pose.orientation));
+  orientation.setRPY(0.0, 0.0, tf2::getYaw(just_orientation.pose.orientation));
   dock_pose_.pose.orientation = tf2::toMsg(orientation);
 
   // Construct dock_pose_ by applying translation/rotation

--- a/nav2_docking/opennav_docking/src/simple_non_charging_dock.cpp
+++ b/nav2_docking/opennav_docking/src/simple_non_charging_dock.cpp
@@ -116,7 +116,7 @@ void SimpleNonChargingDock::configure(
   }
 
   // Setup filter
-  external_detection_rotation_.setEuler(pitch, roll, yaw);
+  external_detection_rotation_.setRPY(roll, pitch, yaw);
   filter_ = std::make_unique<PoseFilter>(filter_coef, external_detection_timeout_);
 
   if (!detector_service_name_.empty()) {
@@ -163,7 +163,7 @@ geometry_msgs::msg::PoseStamped SimpleNonChargingDock::getStagingPose(
   staging_pose.pose.position.x += cos(yaw) * staging_x_offset_;
   staging_pose.pose.position.y += sin(yaw) * staging_x_offset_;
   tf2::Quaternion orientation;
-  orientation.setEuler(0.0, 0.0, yaw + staging_yaw_offset_);
+  orientation.setRPY(0.0, 0.0, yaw + staging_yaw_offset_);
   staging_pose.pose.orientation = tf2::toMsg(orientation);
 
   // Publish staging pose for debugging purposes
@@ -227,7 +227,7 @@ bool SimpleNonChargingDock::getRefinedPose(geometry_msgs::msg::PoseStamped & pos
   tf2::doTransform(just_orientation, just_orientation, transform);
 
   tf2::Quaternion orientation;
-  orientation.setEuler(0.0, 0.0, tf2::getYaw(just_orientation.pose.orientation));
+  orientation.setRPY(0.0, 0.0, tf2::getYaw(just_orientation.pose.orientation));
   dock_pose_.pose.orientation = tf2::toMsg(orientation);
 
   // Construct dock_pose_ by applying translation/rotation

--- a/nav2_docking/opennav_docking/test/test_pose_filter.cpp
+++ b/nav2_docking/opennav_docking/test/test_pose_filter.cpp
@@ -57,7 +57,7 @@ TEST(PoseFilterTests, FilterTests)
   meas2.pose.position.z = 6.0;
   double yaw = 0.5, pitch = 0.0, roll = 0.0;
   tf2::Quaternion quat;
-  quat.setEuler(pitch, roll, yaw);
+  quat.setRPY(roll, pitch, yaw);
   meas2.pose.orientation = tf2::toMsg(quat);
 
   // Update filter, check expectations

--- a/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/utils.hpp
@@ -61,7 +61,7 @@ inline geometry_msgs::msg::Quaternion getWorldOrientation(
 {
   // theta is in radians already
   tf2::Quaternion q;
-  q.setEuler(0.0, 0.0, theta);
+  q.setRPY(0.0, 0.0, theta);
   return tf2::toMsg(q);
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6045 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | ros iron simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* correct argument order in `tf2::Quaternion::setEuler()` calls
  - previous order: (pitch, roll, yaw)
  - correct order: (yaw, pitch, roll)
* preserve previous behavior in `external_detection_rotation_` parameters:
  - `external_detection_rotation_yaw`: set to old pitch value
  - `external_detection_rotation_pitch`: set to old roll value
  - `external_detection_rotation_roll`: set to old yaw value
* update documentation for backwards incompatible change

## Description of documentation updates required from your changes

This is a backwards-incompatible fix, that requires update of docs.nav2.org.

## Description of how this change was tested

Tested on simulation only.
---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
