### PR TITLE
Feature: Add fixed_frame_id parameter to VectorObjectServer

### DIFF
--- a/nav2_map_server/include/nav2_map_server/vector_object_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/vector_object_server.hpp
@@ -202,6 +202,8 @@ protected:
 
   /// @brief Frame of output map
   std::string global_frame_id_;
+  /// @brief Fixed frame required for incoming shape requests (optional)
+  std::string fixed_frame_id_;
   /// @brief Transform tolerance
   double transform_tolerance_;
 

--- a/nav2_map_server/params/vector_object_server_params.yaml
+++ b/nav2_map_server/params/vector_object_server_params.yaml
@@ -2,6 +2,7 @@ vector_object_server:
   ros__parameters:
     map_topic: "vo_map"
     global_frame_id: "map"
+    fixed_frame_id: ""
     resolution: 0.05
     default_value: -1
     overlay_type: 0

--- a/nav2_map_server/src/vo_server/vector_object_server.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_server.cpp
@@ -42,17 +42,23 @@ VectorObjectServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Configuring");
 
-  // Transform buffer and listener initialization
-  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    this->get_node_base_interface(),
-    this->get_node_timers_interface());
-  tf_buffer_->setCreateTimerInterface(timer_interface);
-  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
-
   // Obtaining ROS parameters
   if (!obtainParams()) {
     return nav2::CallbackReturn::FAILURE;
+  }
+
+  if (fixed_frame_id_.empty()) {
+    // Transform buffer and listener initialization
+    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
+    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+      this->get_node_base_interface(),
+      this->get_node_timers_interface());
+    tf_buffer_->setCreateTimerInterface(timer_interface);
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  } else {
+    RCLCPP_INFO(
+      get_logger(), "Parameter fixed_frame_id is set to '%s'. TF listener is disabled.",
+      fixed_frame_id_.c_str());
   }
 
   map_pub_ = create_publisher<nav_msgs::msg::OccupancyGrid>(
@@ -144,6 +150,7 @@ bool VectorObjectServer::obtainParams()
   // Main ROS-parameters
   map_topic_ = nav2::declare_or_get_parameter(node, "map_topic", std::string{"vo_map"});
   global_frame_id_ = nav2::declare_or_get_parameter(node, "global_frame_id", std::string{"map"});
+  fixed_frame_id_ = nav2::declare_or_get_parameter(node, "fixed_frame_id", std::string{""});
   resolution_ = nav2::declare_or_get_parameter(node, "resolution", 0.05);
   default_value_ = nav2::declare_or_get_parameter(
     node, "default_value",
@@ -205,6 +212,13 @@ bool VectorObjectServer::transformVectorObjects()
 {
   for (auto shape : shapes_) {
     if (shape->getFrameID() != global_frame_id_ && !shape->getFrameID().empty()) {
+      if (!tf_buffer_) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "Can not transform vector object from %s to %s frame because TF is not available",
+          shape->getFrameID().c_str(), global_frame_id_.c_str());
+        return false;
+      }
       // Shape to be updated dynamically
       if (!shape->toFrame(global_frame_id_, tf_buffer_, transform_tolerance_)) {
         RCLCPP_ERROR(
@@ -366,6 +380,13 @@ void VectorObjectServer::switchMapUpdate()
 {
   for (auto shape : shapes_) {
     if (shape->getFrameID() != global_frame_id_ && !shape->getFrameID().empty()) {
+      if (!tf_buffer_) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "Can not publish map dynamically for shape frame %s without TF support",
+          shape->getFrameID().c_str());
+        break;
+      }
       if (!map_timer_) {
         map_timer_ = this->create_timer(
           std::chrono::duration<double>(1.0 / update_frequency_),
@@ -392,6 +413,30 @@ void VectorObjectServer::addShapesCallback(
   // Initialize result with true. If one of the required vector object was not added properly,
   // set it to false.
   response->success = true;
+
+  if (!fixed_frame_id_.empty()) {
+    for (const auto & req_poly : request->polygons) {
+      if (req_poly.header.frame_id != fixed_frame_id_) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "Polygon frame id '%s' does not match fixed_frame_id '%s'. Rejecting request.",
+          req_poly.header.frame_id.c_str(), fixed_frame_id_.c_str());
+        response->success = false;
+        return;
+      }
+    }
+
+    for (const auto & req_crcl : request->circles) {
+      if (req_crcl.header.frame_id != fixed_frame_id_) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "Circle frame id '%s' does not match fixed_frame_id '%s'. Rejecting request.",
+          req_crcl.header.frame_id.c_str(), fixed_frame_id_.c_str());
+        response->success = false;
+        return;
+      }
+    }
+  }
 
   auto node = shared_from_this();
 

--- a/nav2_map_server/test/unit/test_vector_object_server.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_server.cpp
@@ -205,6 +205,11 @@ void Tester::setVOServerParams()
     rclcpp::Parameter("global_frame_id", "map"));
 
   vo_server_->declare_parameter(
+    "fixed_frame_id", rclcpp::ParameterValue(""));
+  vo_server_->set_parameter(
+    rclcpp::Parameter("fixed_frame_id", ""));
+
+  vo_server_->declare_parameter(
     "resolution", rclcpp::ParameterValue(0.1));
   vo_server_->set_parameter(
     rclcpp::Parameter("resolution", 0.1));
@@ -1225,6 +1230,37 @@ TEST_F(Tester, testSwitchDynamicStatic)
   ASSERT_TRUE(add_shapes_result->success);
 
   verifyMap(true);
+
+  vo_server_->stop();
+}
+
+TEST_F(Tester, testFixedFrameRejectsDifferentFrame)
+{
+  setVOServerParams();
+  vo_server_->set_parameter(
+    rclcpp::Parameter("fixed_frame_id", GLOBAL_FRAME_ID));
+  vo_server_->start();
+
+  auto add_shapes_msg = std::make_shared<nav2_msgs::srv::AddShapes::Request>();
+  auto po_msg = makePolygonObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+  auto co_msg = makeCircleObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2});
+  co_msg->header.frame_id = SHAPE_FRAME_ID;
+  add_shapes_msg->polygons.push_back(*po_msg);
+  add_shapes_msg->circles.push_back(*co_msg);
+
+  auto add_shapes_result =
+    sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
+  ASSERT_NE(add_shapes_result, nullptr);
+  ASSERT_FALSE(add_shapes_result->success);
+
+  auto get_shapes_msg = std::make_shared<nav2_msgs::srv::GetShapes::Request>();
+  auto get_shapes_result =
+    sendRequest<nav2_msgs::srv::GetShapes>(get_shapes_client_, get_shapes_msg, 2s);
+  ASSERT_NE(get_shapes_result, nullptr);
+  ASSERT_TRUE(get_shapes_result->polygons.empty());
+  ASSERT_TRUE(get_shapes_result->circles.empty());
 
   vo_server_->stop();
 }


### PR DESCRIPTION
The current implementation of the Vector Object Server always starts a TF Listener at initialization. However, in our use-case, we do not require it and it causes increases in computation loads that grow with the number of objects. This PR adds a parameter, `fixed_frame_id`, in the Vector Object Server. If the parameter is defined as a non-empty string, a TF listener will not be created. 

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A  |
| Primary OS tested on | Ubuntu (dev container) |
| Robotic platform tested on |  / |
| Does this PR contain AI generated software? |  (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

* Added a parameter, `fixed_frame_id`, in the Vector Object Server. If the parameter is defined as a non-empty string, a TF listener will not be created. 
* If the `fixed_frame_id` is non-empty and in the `AddShapesSrv`  service call any shape has a frame id different than the `fixed_frame_id` , the service request will fail.

## Description of documentation updates required from your changes

## Description of how this change was tested

---

## Future work that may be required in bullet points


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
