### PR TITLE
feature/add fix_frame_id to vector object server

### DIFF
--- a/nav2_map_server/include/nav2_map_server/vector_object_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/vector_object_server.hpp
@@ -202,6 +202,8 @@ protected:
 
   /// @brief Frame of output map
   std::string global_frame_id_;
+  /// @brief Fixed frame required for incoming shape requests (optional)
+  std::string fixed_frame_id_;
   /// @brief Transform tolerance
   double transform_tolerance_;
 

--- a/nav2_map_server/include/nav2_map_server/vector_object_server.hpp
+++ b/nav2_map_server/include/nav2_map_server/vector_object_server.hpp
@@ -202,8 +202,9 @@ protected:
 
   /// @brief Frame of output map
   std::string global_frame_id_;
-  /// @brief Fixed frame required for incoming shape requests (optional)
-  std::string fixed_frame_id_;
+  /// @brief If true, disables TF listener and requires all incoming shapes
+  /// to have frame_id empty or equal to global_frame_id_
+  bool enforce_global_frame_id_;
   /// @brief Transform tolerance
   double transform_tolerance_;
 

--- a/nav2_map_server/params/vector_object_server_params.yaml
+++ b/nav2_map_server/params/vector_object_server_params.yaml
@@ -2,7 +2,6 @@ vector_object_server:
   ros__parameters:
     map_topic: "vo_map"
     global_frame_id: "map"
-    fixed_frame_id: ""
     resolution: 0.05
     default_value: -1
     overlay_type: 0

--- a/nav2_map_server/params/vector_object_server_params.yaml
+++ b/nav2_map_server/params/vector_object_server_params.yaml
@@ -2,6 +2,7 @@ vector_object_server:
   ros__parameters:
     map_topic: "vo_map"
     global_frame_id: "map"
+    fixed_frame_id: ""
     resolution: 0.05
     default_value: -1
     overlay_type: 0

--- a/nav2_map_server/src/vo_server/vector_object_server.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_server.cpp
@@ -47,7 +47,7 @@ VectorObjectServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     return nav2::CallbackReturn::FAILURE;
   }
 
-  if (fixed_frame_id_.empty()) {
+  if (!enforce_global_frame_id_) {
     // Transform buffer and listener initialization
     tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
     auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
@@ -57,8 +57,10 @@ VectorObjectServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
   } else {
     RCLCPP_INFO(
-      get_logger(), "Parameter fixed_frame_id is set to '%s'. TF listener is disabled.",
-      fixed_frame_id_.c_str());
+      get_logger(),
+      "Parameter enforce_global_frame_id is true. TF listener is disabled. "
+      "All incoming shapes must have frame_id empty or equal to global_frame_id '%s'.",
+      global_frame_id_.c_str());
   }
 
   map_pub_ = create_publisher<nav_msgs::msg::OccupancyGrid>(
@@ -150,7 +152,7 @@ bool VectorObjectServer::obtainParams()
   // Main ROS-parameters
   map_topic_ = nav2::declare_or_get_parameter(node, "map_topic", std::string{"vo_map"});
   global_frame_id_ = nav2::declare_or_get_parameter(node, "global_frame_id", std::string{"map"});
-  fixed_frame_id_ = nav2::declare_or_get_parameter(node, "fixed_frame_id", std::string{""});
+  enforce_global_frame_id_ = nav2::declare_or_get_parameter(node, "enforce_global_frame_id", false);
   resolution_ = nav2::declare_or_get_parameter(node, "resolution", 0.05);
   default_value_ = nav2::declare_or_get_parameter(
     node, "default_value",
@@ -194,6 +196,23 @@ bool VectorObjectServer::obtainParams()
     }
   }
 
+  // if any shapes has non-global frame id, no shapes will be added and return false.
+  if (enforce_global_frame_id_) {
+    for (const auto & shape : shapes_) {
+      const std::string & frame_id = shape->getFrameID();
+      if (!frame_id.empty() && frame_id != global_frame_id_) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "Shape '%s' has frame_id '%s' which differs from global_frame_id '%s'. "
+          "All shapes must have frame_id empty or equal to global_frame_id "
+          "when enforce_global_frame_id is true.",
+          shape->getUUID().c_str(), frame_id.c_str(), global_frame_id_.c_str());
+        shapes_.clear();
+        return false;
+      }
+    }
+  }
+
   return true;
 }
 
@@ -212,14 +231,6 @@ bool VectorObjectServer::transformVectorObjects()
 {
   for (auto shape : shapes_) {
     if (shape->getFrameID() != global_frame_id_ && !shape->getFrameID().empty()) {
-      // AI-generated contribution marker:
-      if (!tf_buffer_) {
-        RCLCPP_ERROR(
-          get_logger(),
-          "Can not transform vector object from %s to %s frame because TF is not available",
-          shape->getFrameID().c_str(), global_frame_id_.c_str());
-        return false;
-      }
       // Shape to be updated dynamically
       if (!shape->toFrame(global_frame_id_, tf_buffer_, transform_tolerance_)) {
         RCLCPP_ERROR(
@@ -381,14 +392,6 @@ void VectorObjectServer::switchMapUpdate()
 {
   for (auto shape : shapes_) {
     if (shape->getFrameID() != global_frame_id_ && !shape->getFrameID().empty()) {
-      // AI-generated contribution marker:
-      if (!tf_buffer_) {
-        RCLCPP_ERROR(
-          get_logger(),
-          "Can not publish map dynamically for shape frame %s without TF support",
-          shape->getFrameID().c_str());
-        break;
-      }
       if (!map_timer_) {
         map_timer_ = this->create_timer(
           std::chrono::duration<double>(1.0 / update_frequency_),
@@ -416,25 +419,26 @@ void VectorObjectServer::addShapesCallback(
   // set it to false.
   response->success = true;
 
-  // AI-generated contribution marker:
-  if (!fixed_frame_id_.empty()) {
+  if (enforce_global_frame_id_) {
     for (const auto & req_poly : request->polygons) {
-      if (req_poly.header.frame_id != fixed_frame_id_) {
+      if (!req_poly.header.frame_id.empty() && req_poly.header.frame_id != global_frame_id_) {
         RCLCPP_ERROR(
           get_logger(),
-          "Polygon frame id '%s' does not match fixed_frame_id '%s'. Rejecting request.",
-          req_poly.header.frame_id.c_str(), fixed_frame_id_.c_str());
+          "Polygon frame_id '%s' must be empty or equal to global_frame_id '%s' "
+          "when enforce_global_frame_id is true. Rejecting request.",
+          req_poly.header.frame_id.c_str(), global_frame_id_.c_str());
         response->success = false;
         return;
       }
     }
 
     for (const auto & req_crcl : request->circles) {
-      if (req_crcl.header.frame_id != fixed_frame_id_) {
+      if (!req_crcl.header.frame_id.empty() && req_crcl.header.frame_id != global_frame_id_) {
         RCLCPP_ERROR(
           get_logger(),
-          "Circle frame id '%s' does not match fixed_frame_id '%s'. Rejecting request.",
-          req_crcl.header.frame_id.c_str(), fixed_frame_id_.c_str());
+          "Circle frame_id '%s' must be empty or equal to global_frame_id '%s' "
+          "when enforce_global_frame_id is true. Rejecting request.",
+          req_crcl.header.frame_id.c_str(), global_frame_id_.c_str());
         response->success = false;
         return;
       }

--- a/nav2_map_server/src/vo_server/vector_object_server.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_server.cpp
@@ -41,7 +41,6 @@ nav2::CallbackReturn
 VectorObjectServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Configuring");
-  // AI-generated contribution marker:
   // Obtaining ROS parameters
   if (!obtainParams()) {
     return nav2::CallbackReturn::FAILURE;

--- a/nav2_map_server/src/vo_server/vector_object_server.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_server.cpp
@@ -421,7 +421,7 @@ void VectorObjectServer::addShapesCallback(
 
   if (enforce_global_frame_id_) {
     // Lambda for checking frame_id consistency
-    auto check_frame_id = [this, &response](
+    auto check_frame_id = [this](
       const auto & shapes, const std::string & shape_type_name)
       {
         for (const auto & shape : shapes) {
@@ -431,7 +431,6 @@ void VectorObjectServer::addShapesCallback(
             "%s frame_id '%s' must be empty or equal to global_frame_id '%s' "
             "when enforce_global_frame_id is true. Rejecting request.",
             shape_type_name.c_str(), shape.header.frame_id.c_str(), global_frame_id_.c_str());
-            response->success = false;
             return false;
           }
         }
@@ -441,6 +440,7 @@ void VectorObjectServer::addShapesCallback(
     if (!check_frame_id(request->polygons, "Polygon") ||
       !check_frame_id(request->circles, "Circle"))
     {
+      response->success = false;
       return;
     }
   }

--- a/nav2_map_server/src/vo_server/vector_object_server.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_server.cpp
@@ -420,28 +420,28 @@ void VectorObjectServer::addShapesCallback(
   response->success = true;
 
   if (enforce_global_frame_id_) {
-    for (const auto & req_poly : request->polygons) {
-      if (!req_poly.header.frame_id.empty() && req_poly.header.frame_id != global_frame_id_) {
-        RCLCPP_ERROR(
-          get_logger(),
-          "Polygon frame_id '%s' must be empty or equal to global_frame_id '%s' "
-          "when enforce_global_frame_id is true. Rejecting request.",
-          req_poly.header.frame_id.c_str(), global_frame_id_.c_str());
-        response->success = false;
-        return;
-      }
-    }
+    // Lambda for checking frame_id consistency
+    auto check_frame_id = [this, &response](
+      const auto & shapes, const std::string & shape_type_name)
+      {
+        for (const auto & shape : shapes) {
+          if (!shape.header.frame_id.empty() && shape.header.frame_id != global_frame_id_) {
+            RCLCPP_ERROR(
+            get_logger(),
+            "%s frame_id '%s' must be empty or equal to global_frame_id '%s' "
+            "when enforce_global_frame_id is true. Rejecting request.",
+            shape_type_name.c_str(), shape.header.frame_id.c_str(), global_frame_id_.c_str());
+            response->success = false;
+            return false;
+          }
+        }
+        return true;
+      };
 
-    for (const auto & req_crcl : request->circles) {
-      if (!req_crcl.header.frame_id.empty() && req_crcl.header.frame_id != global_frame_id_) {
-        RCLCPP_ERROR(
-          get_logger(),
-          "Circle frame_id '%s' must be empty or equal to global_frame_id '%s' "
-          "when enforce_global_frame_id is true. Rejecting request.",
-          req_crcl.header.frame_id.c_str(), global_frame_id_.c_str());
-        response->success = false;
-        return;
-      }
+    if (!check_frame_id(request->polygons, "Polygon") ||
+      !check_frame_id(request->circles, "Circle"))
+    {
+      return;
     }
   }
 

--- a/nav2_map_server/src/vo_server/vector_object_server.cpp
+++ b/nav2_map_server/src/vo_server/vector_object_server.cpp
@@ -41,18 +41,24 @@ nav2::CallbackReturn
 VectorObjectServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
 {
   RCLCPP_INFO(get_logger(), "Configuring");
-
-  // Transform buffer and listener initialization
-  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
-  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
-    this->get_node_base_interface(),
-    this->get_node_timers_interface());
-  tf_buffer_->setCreateTimerInterface(timer_interface);
-  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
-
+  // AI-generated contribution marker:
   // Obtaining ROS parameters
   if (!obtainParams()) {
     return nav2::CallbackReturn::FAILURE;
+  }
+
+  if (fixed_frame_id_.empty()) {
+    // Transform buffer and listener initialization
+    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
+    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+      this->get_node_base_interface(),
+      this->get_node_timers_interface());
+    tf_buffer_->setCreateTimerInterface(timer_interface);
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  } else {
+    RCLCPP_INFO(
+      get_logger(), "Parameter fixed_frame_id is set to '%s'. TF listener is disabled.",
+      fixed_frame_id_.c_str());
   }
 
   map_pub_ = create_publisher<nav_msgs::msg::OccupancyGrid>(
@@ -144,6 +150,7 @@ bool VectorObjectServer::obtainParams()
   // Main ROS-parameters
   map_topic_ = nav2::declare_or_get_parameter(node, "map_topic", std::string{"vo_map"});
   global_frame_id_ = nav2::declare_or_get_parameter(node, "global_frame_id", std::string{"map"});
+  fixed_frame_id_ = nav2::declare_or_get_parameter(node, "fixed_frame_id", std::string{""});
   resolution_ = nav2::declare_or_get_parameter(node, "resolution", 0.05);
   default_value_ = nav2::declare_or_get_parameter(
     node, "default_value",
@@ -205,6 +212,14 @@ bool VectorObjectServer::transformVectorObjects()
 {
   for (auto shape : shapes_) {
     if (shape->getFrameID() != global_frame_id_ && !shape->getFrameID().empty()) {
+      // AI-generated contribution marker:
+      if (!tf_buffer_) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "Can not transform vector object from %s to %s frame because TF is not available",
+          shape->getFrameID().c_str(), global_frame_id_.c_str());
+        return false;
+      }
       // Shape to be updated dynamically
       if (!shape->toFrame(global_frame_id_, tf_buffer_, transform_tolerance_)) {
         RCLCPP_ERROR(
@@ -366,6 +381,14 @@ void VectorObjectServer::switchMapUpdate()
 {
   for (auto shape : shapes_) {
     if (shape->getFrameID() != global_frame_id_ && !shape->getFrameID().empty()) {
+      // AI-generated contribution marker:
+      if (!tf_buffer_) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "Can not publish map dynamically for shape frame %s without TF support",
+          shape->getFrameID().c_str());
+        break;
+      }
       if (!map_timer_) {
         map_timer_ = this->create_timer(
           std::chrono::duration<double>(1.0 / update_frequency_),
@@ -392,6 +415,31 @@ void VectorObjectServer::addShapesCallback(
   // Initialize result with true. If one of the required vector object was not added properly,
   // set it to false.
   response->success = true;
+
+  // AI-generated contribution marker:
+  if (!fixed_frame_id_.empty()) {
+    for (const auto & req_poly : request->polygons) {
+      if (req_poly.header.frame_id != fixed_frame_id_) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "Polygon frame id '%s' does not match fixed_frame_id '%s'. Rejecting request.",
+          req_poly.header.frame_id.c_str(), fixed_frame_id_.c_str());
+        response->success = false;
+        return;
+      }
+    }
+
+    for (const auto & req_crcl : request->circles) {
+      if (req_crcl.header.frame_id != fixed_frame_id_) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "Circle frame id '%s' does not match fixed_frame_id '%s'. Rejecting request.",
+          req_crcl.header.frame_id.c_str(), fixed_frame_id_.c_str());
+        response->success = false;
+        return;
+      }
+    }
+  }
 
   auto node = shared_from_this();
 

--- a/nav2_map_server/test/unit/test_vector_object_server.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_server.cpp
@@ -1250,17 +1250,6 @@ TEST_F(Tester, testEnforceGlobalFrameIdDisablesTfListener)
   vo_server_->stop();
 }
 
-TEST_F(Tester, testEnforceGlobalFrameIdFalseKeepsTfListener)
-{
-  setVOServerParams();
-  // enforce_global_frame_id defaults to false: TF listener must be created
-  vo_server_->start();
-
-  ASSERT_TRUE(vo_server_->hasTfListener());
-
-  vo_server_->stop();
-}
-
 TEST_F(Tester, testEnforceGlobalFrameIdAcceptsValidFrames)
 {
   setVOServerParams();
@@ -1339,13 +1328,16 @@ TEST_F(Tester, testEnforceGlobalFrameIdAcceptsValidFrames)
   vo_server_->stop();
 }
 
-TEST_F(Tester, testEnforceGlobalFrameIdRejectsPolygonDifferentFrame)
+TEST_F(Tester, testEnforceGlobalFrameIdRejectsDifferentFrame)
 {
   setVOServerParams();
   vo_server_->set_parameter(rclcpp::Parameter("enforce_global_frame_id", true));
   vo_server_->start();
 
   auto add_shapes_msg = std::make_shared<nav2_msgs::srv::AddShapes::Request>();
+  auto get_shapes_msg = std::make_shared<nav2_msgs::srv::GetShapes::Request>();
+
+  // Case 1: polygon with a non-global, non-empty frame_id must be rejected.
   auto po_msg = makePolygonObject(
     std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
   po_msg->header.frame_id = SHAPE_FRAME_ID;  // different from global_frame_id
@@ -1356,38 +1348,28 @@ TEST_F(Tester, testEnforceGlobalFrameIdRejectsPolygonDifferentFrame)
   ASSERT_NE(add_shapes_result, nullptr);
   ASSERT_FALSE(add_shapes_result->success);
 
-  // No shapes should have been added
   auto get_shapes_result =
-    sendRequest<nav2_msgs::srv::GetShapes>(
-    get_shapes_client_, std::make_shared<nav2_msgs::srv::GetShapes::Request>(), 2s);
+    sendRequest<nav2_msgs::srv::GetShapes>(get_shapes_client_, get_shapes_msg, 2s);
   ASSERT_NE(get_shapes_result, nullptr);
   ASSERT_TRUE(get_shapes_result->polygons.empty());
   ASSERT_TRUE(get_shapes_result->circles.empty());
 
-  vo_server_->stop();
-}
-
-TEST_F(Tester, testEnforceGlobalFrameIdRejectsCircleDifferentFrame)
-{
-  setVOServerParams();
-  vo_server_->set_parameter(rclcpp::Parameter("enforce_global_frame_id", true));
-  vo_server_->start();
-
-  auto add_shapes_msg = std::make_shared<nav2_msgs::srv::AddShapes::Request>();
+  // Case 2: circle with a non-global, non-empty frame_id must be rejected.
+  add_shapes_msg->polygons.clear();
+  add_shapes_msg->circles.clear();
   auto co_msg = makeCircleObject(
     std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2});
   co_msg->header.frame_id = SHAPE_FRAME_ID;  // different from global_frame_id
   add_shapes_msg->circles.push_back(*co_msg);
 
-  auto add_shapes_result =
+  add_shapes_result =
     sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
   ASSERT_NE(add_shapes_result, nullptr);
   ASSERT_FALSE(add_shapes_result->success);
 
   // No shapes should have been added
-  auto get_shapes_result =
-    sendRequest<nav2_msgs::srv::GetShapes>(
-    get_shapes_client_, std::make_shared<nav2_msgs::srv::GetShapes::Request>(), 2s);
+  get_shapes_result =
+    sendRequest<nav2_msgs::srv::GetShapes>(get_shapes_client_, get_shapes_msg, 2s);
   ASSERT_NE(get_shapes_result, nullptr);
   ASSERT_TRUE(get_shapes_result->polygons.empty());
   ASSERT_TRUE(get_shapes_result->circles.empty());

--- a/nav2_map_server/test/unit/test_vector_object_server.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_server.cpp
@@ -97,6 +97,12 @@ public:
   {
     VectorObjectServer::putVectorObjectsOnMap();
   }
+
+  // AI-generated contribution marker:
+  bool hasTfListener() const
+  {
+    return static_cast<bool>(tf_listener_);
+  }
 };  // VOServerWrapper
 
 class Tester : public ::testing::Test
@@ -203,6 +209,12 @@ void Tester::setVOServerParams()
     "global_frame_id", rclcpp::ParameterValue("map"));
   vo_server_->set_parameter(
     rclcpp::Parameter("global_frame_id", "map"));
+
+  // AI-generated contribution marker:
+  vo_server_->declare_parameter(
+    "fixed_frame_id", rclcpp::ParameterValue(""));
+  vo_server_->set_parameter(
+    rclcpp::Parameter("fixed_frame_id", ""));
 
   vo_server_->declare_parameter(
     "resolution", rclcpp::ParameterValue(0.1));
@@ -1225,6 +1237,55 @@ TEST_F(Tester, testSwitchDynamicStatic)
   ASSERT_TRUE(add_shapes_result->success);
 
   verifyMap(true);
+
+  vo_server_->stop();
+}
+
+// AI-generated contribution marker:
+TEST_F(Tester, testFixedFrameDisablesTfListener)
+{
+  setVOServerParams();
+  // Setting fixed_frame_id should disable tf listener
+  vo_server_->set_parameter(
+    rclcpp::Parameter("fixed_frame_id", GLOBAL_FRAME_ID));
+  vo_server_->start();
+
+  ASSERT_FALSE(vo_server_->hasTfListener());
+
+  vo_server_->stop();
+}
+
+TEST_F(Tester, testFixedFrameRejectsDifferentFrame)
+{
+  setVOServerParams();
+  // Setting fixed_frame_id
+  vo_server_->set_parameter(
+    rclcpp::Parameter("fixed_frame_id", GLOBAL_FRAME_ID));
+  vo_server_->start();
+
+  // Add polygon and circle on map with different frame_id than fixed_frame_id
+  auto add_shapes_msg = std::make_shared<nav2_msgs::srv::AddShapes::Request>();
+  auto po_msg = makePolygonObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+  auto co_msg = makeCircleObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2});
+  co_msg->header.frame_id = SHAPE_FRAME_ID;
+  add_shapes_msg->polygons.push_back(*po_msg);
+  add_shapes_msg->circles.push_back(*co_msg);
+  auto add_shapes_result =
+    sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
+
+  // Verify that the service call fails due to frame mismatch
+  ASSERT_NE(add_shapes_result, nullptr);
+  ASSERT_FALSE(add_shapes_result->success);
+
+  // Verify that no shapes were added to the map
+  auto get_shapes_msg = std::make_shared<nav2_msgs::srv::GetShapes::Request>();
+  auto get_shapes_result =
+    sendRequest<nav2_msgs::srv::GetShapes>(get_shapes_client_, get_shapes_msg, 2s);
+  ASSERT_NE(get_shapes_result, nullptr);
+  ASSERT_TRUE(get_shapes_result->polygons.empty());
+  ASSERT_TRUE(get_shapes_result->circles.empty());
 
   vo_server_->stop();
 }

--- a/nav2_map_server/test/unit/test_vector_object_server.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_server.cpp
@@ -210,11 +210,10 @@ void Tester::setVOServerParams()
   vo_server_->set_parameter(
     rclcpp::Parameter("global_frame_id", "map"));
 
-  // AI-generated contribution marker:
   vo_server_->declare_parameter(
-    "fixed_frame_id", rclcpp::ParameterValue(""));
+    "enforce_global_frame_id", rclcpp::ParameterValue(false));
   vo_server_->set_parameter(
-    rclcpp::Parameter("fixed_frame_id", ""));
+    rclcpp::Parameter("enforce_global_frame_id", false));
 
   vo_server_->declare_parameter(
     "resolution", rclcpp::ParameterValue(0.1));
@@ -1241,13 +1240,10 @@ TEST_F(Tester, testSwitchDynamicStatic)
   vo_server_->stop();
 }
 
-// AI-generated contribution marker:
-TEST_F(Tester, testFixedFrameDisablesTfListener)
+TEST_F(Tester, testEnforceGlobalFrameIdDisablesTfListener)
 {
   setVOServerParams();
-  // Setting fixed_frame_id should disable tf listener
-  vo_server_->set_parameter(
-    rclcpp::Parameter("fixed_frame_id", GLOBAL_FRAME_ID));
+  vo_server_->set_parameter(rclcpp::Parameter("enforce_global_frame_id", true));
   vo_server_->start();
 
   ASSERT_FALSE(vo_server_->hasTfListener());
@@ -1255,37 +1251,184 @@ TEST_F(Tester, testFixedFrameDisablesTfListener)
   vo_server_->stop();
 }
 
-TEST_F(Tester, testFixedFrameRejectsDifferentFrame)
+TEST_F(Tester, testEnforceGlobalFrameIdFalseKeepsTfListener)
 {
   setVOServerParams();
-  // Setting fixed_frame_id
-  vo_server_->set_parameter(
-    rclcpp::Parameter("fixed_frame_id", GLOBAL_FRAME_ID));
+  // enforce_global_frame_id defaults to false: TF listener must be created
   vo_server_->start();
 
-  // Add polygon and circle on map with different frame_id than fixed_frame_id
+  ASSERT_TRUE(vo_server_->hasTfListener());
+
+  vo_server_->stop();
+}
+
+TEST_F(Tester, testEnforceGlobalFrameIdAcceptsValidFrames)
+{
+  setVOServerParams();
+  vo_server_->set_parameter(rclcpp::Parameter("enforce_global_frame_id", true));
+  vo_server_->start();
+
+  auto add_shapes_msg = std::make_shared<nav2_msgs::srv::AddShapes::Request>();
+  auto get_shapes_msg = std::make_shared<nav2_msgs::srv::GetShapes::Request>();
+
+  // Case 1: polygon with global_frame_id, circle with global_frame_id
+  auto po_msg = makePolygonObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+  po_msg->header.frame_id = GLOBAL_FRAME_ID;
+  auto co_msg = makeCircleObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2});
+  co_msg->header.frame_id = GLOBAL_FRAME_ID;
+  add_shapes_msg->polygons.push_back(*po_msg);
+  add_shapes_msg->circles.push_back(*co_msg);
+  map_.reset();
+  auto add_shapes_result =
+    sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
+  ASSERT_NE(add_shapes_result, nullptr);
+  ASSERT_TRUE(add_shapes_result->success);
+  verifyMap(true);
+
+  // Case 2: polygon with empty frame_id, circle with empty frame_id
+  auto remove_all_msg = std::make_shared<nav2_msgs::srv::RemoveShapes::Request>();
+  remove_all_msg->all_objects = true;
+  sendRequest<nav2_msgs::srv::RemoveShapes>(remove_shapes_client_, remove_all_msg, 2s);
+
+  po_msg->header.frame_id = "";
+  co_msg->header.frame_id = "";
+  add_shapes_msg->polygons.clear();
+  add_shapes_msg->circles.clear();
+  add_shapes_msg->polygons.push_back(*po_msg);
+  add_shapes_msg->circles.push_back(*co_msg);
+  map_.reset();
+  add_shapes_result =
+    sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
+  ASSERT_NE(add_shapes_result, nullptr);
+  ASSERT_TRUE(add_shapes_result->success);
+  verifyMap(true);
+
+  // Case 3: polygon with global_frame_id, circle with empty frame_id
+  sendRequest<nav2_msgs::srv::RemoveShapes>(remove_shapes_client_, remove_all_msg, 2s);
+
+  po_msg->header.frame_id = GLOBAL_FRAME_ID;
+  co_msg->header.frame_id = "";
+  add_shapes_msg->polygons.clear();
+  add_shapes_msg->circles.clear();
+  add_shapes_msg->polygons.push_back(*po_msg);
+  add_shapes_msg->circles.push_back(*co_msg);
+  map_.reset();
+  add_shapes_result =
+    sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
+  ASSERT_NE(add_shapes_result, nullptr);
+  ASSERT_TRUE(add_shapes_result->success);
+  verifyMap(true);
+
+  // Case 4: polygon with empty frame_id, circle with global_frame_id
+  sendRequest<nav2_msgs::srv::RemoveShapes>(remove_shapes_client_, remove_all_msg, 2s);
+
+  po_msg->header.frame_id = "";
+  co_msg->header.frame_id = GLOBAL_FRAME_ID;
+  add_shapes_msg->polygons.clear();
+  add_shapes_msg->circles.clear();
+  add_shapes_msg->polygons.push_back(*po_msg);
+  add_shapes_msg->circles.push_back(*co_msg);
+  map_.reset();
+  add_shapes_result =
+    sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
+  ASSERT_NE(add_shapes_result, nullptr);
+  ASSERT_TRUE(add_shapes_result->success);
+  verifyMap(true);
+
+  vo_server_->stop();
+}
+
+TEST_F(Tester, testEnforceGlobalFrameIdRejectsPolygonDifferentFrame)
+{
+  setVOServerParams();
+  vo_server_->set_parameter(rclcpp::Parameter("enforce_global_frame_id", true));
+  vo_server_->start();
+
   auto add_shapes_msg = std::make_shared<nav2_msgs::srv::AddShapes::Request>();
   auto po_msg = makePolygonObject(
     std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
-  auto co_msg = makeCircleObject(
-    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2});
-  co_msg->header.frame_id = SHAPE_FRAME_ID;
+  po_msg->header.frame_id = SHAPE_FRAME_ID;  // different from global_frame_id
   add_shapes_msg->polygons.push_back(*po_msg);
-  add_shapes_msg->circles.push_back(*co_msg);
+
   auto add_shapes_result =
     sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
-
-  // Verify that the service call fails due to frame mismatch
   ASSERT_NE(add_shapes_result, nullptr);
   ASSERT_FALSE(add_shapes_result->success);
 
-  // Verify that no shapes were added to the map
-  auto get_shapes_msg = std::make_shared<nav2_msgs::srv::GetShapes::Request>();
+  // No shapes should have been added
   auto get_shapes_result =
-    sendRequest<nav2_msgs::srv::GetShapes>(get_shapes_client_, get_shapes_msg, 2s);
+    sendRequest<nav2_msgs::srv::GetShapes>(
+    get_shapes_client_, std::make_shared<nav2_msgs::srv::GetShapes::Request>(), 2s);
   ASSERT_NE(get_shapes_result, nullptr);
   ASSERT_TRUE(get_shapes_result->polygons.empty());
   ASSERT_TRUE(get_shapes_result->circles.empty());
+
+  vo_server_->stop();
+}
+
+TEST_F(Tester, testEnforceGlobalFrameIdRejectsCircleDifferentFrame)
+{
+  setVOServerParams();
+  vo_server_->set_parameter(rclcpp::Parameter("enforce_global_frame_id", true));
+  vo_server_->start();
+
+  auto add_shapes_msg = std::make_shared<nav2_msgs::srv::AddShapes::Request>();
+  auto co_msg = makeCircleObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2});
+  co_msg->header.frame_id = SHAPE_FRAME_ID;  // different from global_frame_id
+  add_shapes_msg->circles.push_back(*co_msg);
+
+  auto add_shapes_result =
+    sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
+  ASSERT_NE(add_shapes_result, nullptr);
+  ASSERT_FALSE(add_shapes_result->success);
+
+  // No shapes should have been added
+  auto get_shapes_result =
+    sendRequest<nav2_msgs::srv::GetShapes>(
+    get_shapes_client_, std::make_shared<nav2_msgs::srv::GetShapes::Request>(), 2s);
+  ASSERT_NE(get_shapes_result, nullptr);
+  ASSERT_TRUE(get_shapes_result->polygons.empty());
+  ASSERT_TRUE(get_shapes_result->circles.empty());
+
+  vo_server_->stop();
+}
+
+TEST_F(Tester, testEnforceGlobalFrameIdYamlShapesMismatch)
+{
+  setVOServerParams();
+  vo_server_->set_parameter(rclcpp::Parameter("enforce_global_frame_id", true));
+  setShapesParams(
+    "01010101-0101-0101-0101-010101010101",
+    "01010101-0101-0101-0101-010101010102");
+  // Override polygon's frame_id to a frame different from global_frame_id
+  vo_server_->set_parameter(
+    rclcpp::Parameter(std::string(POLYGON_NAME) + ".frame_id", SHAPE_FRAME_ID));
+
+  // obtainParams() should detect the mismatch and return false
+  vo_server_->configureFail();
+
+  vo_server_->cleanup();
+}
+
+TEST_F(Tester, testEnforceGlobalFrameIdYamlShapesValid)
+{
+  setVOServerParams();
+  vo_server_->set_parameter(rclcpp::Parameter("enforce_global_frame_id", true));
+  // setShapesParams already sets frame_id to GLOBAL_FRAME_ID for both shapes
+  setShapesParams(
+    "01010101-0101-0101-0101-010101010101",
+    "01010101-0101-0101-0101-010101010102");
+
+  vo_server_->start();
+
+  // TF listener must not have been created
+  ASSERT_FALSE(vo_server_->hasTfListener());
+
+  // Map should still be published correctly without TF
+  verifyMap(true);
 
   vo_server_->stop();
 }

--- a/nav2_map_server/test/unit/test_vector_object_server.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_server.cpp
@@ -98,7 +98,6 @@ public:
     VectorObjectServer::putVectorObjectsOnMap();
   }
 
-  // AI-generated contribution marker:
   bool hasTfListener() const
   {
     return static_cast<bool>(tf_listener_);

--- a/nav2_map_server/test/unit/test_vector_object_server.cpp
+++ b/nav2_map_server/test/unit/test_vector_object_server.cpp
@@ -1257,7 +1257,6 @@ TEST_F(Tester, testEnforceGlobalFrameIdAcceptsValidFrames)
   vo_server_->start();
 
   auto add_shapes_msg = std::make_shared<nav2_msgs::srv::AddShapes::Request>();
-  auto get_shapes_msg = std::make_shared<nav2_msgs::srv::GetShapes::Request>();
 
   // Case 1: polygon with global_frame_id, circle with global_frame_id
   auto po_msg = makePolygonObject(
@@ -1337,10 +1336,10 @@ TEST_F(Tester, testEnforceGlobalFrameIdRejectsDifferentFrame)
   auto add_shapes_msg = std::make_shared<nav2_msgs::srv::AddShapes::Request>();
   auto get_shapes_msg = std::make_shared<nav2_msgs::srv::GetShapes::Request>();
 
-  // Case 1: polygon with a non-global, non-empty frame_id must be rejected.
+  // Case 1: polygon only with non-global frame_id.
   auto po_msg = makePolygonObject(
     std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
-  po_msg->header.frame_id = SHAPE_FRAME_ID;  // different from global_frame_id
+  po_msg->header.frame_id = SHAPE_FRAME_ID;
   add_shapes_msg->polygons.push_back(*po_msg);
 
   auto add_shapes_result =
@@ -1354,12 +1353,60 @@ TEST_F(Tester, testEnforceGlobalFrameIdRejectsDifferentFrame)
   ASSERT_TRUE(get_shapes_result->polygons.empty());
   ASSERT_TRUE(get_shapes_result->circles.empty());
 
-  // Case 2: circle with a non-global, non-empty frame_id must be rejected.
+  // Case 2: circle only with non-global frame_id.
   add_shapes_msg->polygons.clear();
   add_shapes_msg->circles.clear();
   auto co_msg = makeCircleObject(
     std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2});
-  co_msg->header.frame_id = SHAPE_FRAME_ID;  // different from global_frame_id
+  co_msg->header.frame_id = SHAPE_FRAME_ID;
+  add_shapes_msg->circles.push_back(*co_msg);
+
+  add_shapes_result =
+    sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
+  ASSERT_NE(add_shapes_result, nullptr);
+  ASSERT_FALSE(add_shapes_result->success);
+
+  // No shapes should have been added
+  get_shapes_result =
+    sendRequest<nav2_msgs::srv::GetShapes>(get_shapes_client_, get_shapes_msg, 2s);
+  ASSERT_NE(get_shapes_result, nullptr);
+  ASSERT_TRUE(get_shapes_result->polygons.empty());
+  ASSERT_TRUE(get_shapes_result->circles.empty());
+
+  // Case 3: polygon global, circle non-global.
+  add_shapes_msg->polygons.clear();
+  add_shapes_msg->circles.clear();
+  po_msg = makePolygonObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+  po_msg->header.frame_id = GLOBAL_FRAME_ID;
+  co_msg = makeCircleObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2});
+  co_msg->header.frame_id = SHAPE_FRAME_ID;
+  add_shapes_msg->polygons.push_back(*po_msg);
+  add_shapes_msg->circles.push_back(*co_msg);
+
+  add_shapes_result =
+    sendRequest<nav2_msgs::srv::AddShapes>(add_shapes_client_, add_shapes_msg, 2s);
+  ASSERT_NE(add_shapes_result, nullptr);
+  ASSERT_FALSE(add_shapes_result->success);
+
+  // No shapes should have been added
+  get_shapes_result =
+    sendRequest<nav2_msgs::srv::GetShapes>(get_shapes_client_, get_shapes_msg, 2s);
+  ASSERT_NE(get_shapes_result, nullptr);
+  ASSERT_TRUE(get_shapes_result->polygons.empty());
+  ASSERT_TRUE(get_shapes_result->circles.empty());
+
+  // Case 4: polygon non-global, circle global.
+  add_shapes_msg->polygons.clear();
+  add_shapes_msg->circles.clear();
+  po_msg = makePolygonObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+  po_msg->header.frame_id = SHAPE_FRAME_ID;
+  co_msg = makeCircleObject(
+    std::vector<unsigned char>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2});
+  co_msg->header.frame_id = GLOBAL_FRAME_ID;
+  add_shapes_msg->polygons.push_back(*po_msg);
   add_shapes_msg->circles.push_back(*co_msg);
 
   add_shapes_result =


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | Yes and it is marked inline in the code |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

* Added a parameter, `fixed_frame_id`, in the Vector Object Server. If the parameter is defined as a non-empty string, a TF listener will not be created. 
* If the `fixed_frame_id` is non-empty and in the `AddShapesSrv`  service call any shape has a frame id different than the `fixed_frame_id` , the service request will fail.

## Description of documentation updates required from your changes

* Added new parameter, `fixed_frame_id`, so need to add that to default configs and documentation page

## Description of how this change was tested

* Tested with added unit tests

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
