### PR TITLE
Fix mismatch between eigen_decomposition declaration and definition

### DIFF
--- a/nav2_amcl/include/nav2_amcl/pf/eig3.hpp
+++ b/nav2_amcl/include/nav2_amcl/pf/eig3.hpp
@@ -24,8 +24,16 @@
 #ifndef NAV2_AMCL__PF__EIG3_HPP_
 #define NAV2_AMCL__PF__EIG3_HPP_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Symmetric matrix A => eigenvectors in columns of V, corresponding
    eigenvalues in d. */
 void eigen_decomposition(double A[3][3], double V[3][3], double d[3]);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // NAV2_AMCL__PF__EIG3_HPP_

--- a/nav2_amcl/include/nav2_amcl/pf/pf_kdtree.hpp
+++ b/nav2_amcl/include/nav2_amcl/pf/pf_kdtree.hpp
@@ -32,6 +32,9 @@
 #include <rtk.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // Info for a node in the tree
 typedef struct pf_kdtree_node
@@ -102,6 +105,10 @@ extern int pf_kdtree_get_cluster(pf_kdtree_t * self, pf_vector_t pose);
 // Draw the tree
 extern void pf_kdtree_draw(pf_kdtree_t * self, rtk_fig_t * fig);
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif  // NAV2_AMCL__PF__PF_KDTREE_HPP_

--- a/nav2_amcl/src/pf/eig3.c
+++ b/nav2_amcl/src/pf/eig3.c
@@ -23,15 +23,13 @@
 
 #include <math.h>
 
+#include "nav2_amcl/pf/eig3.hpp"
+
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
-#ifdef _MSC_VER
 #define n 3
-#else
-static int n = 3;
-#endif
 
 // Symmetric Householder reduction to tridiagonal form.
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #6085  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Custom |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Add missing `extern "C"` in eig3.hpp and pf_kdtree.hpp
* Include eig3.hpp in eig3.c to ensure the definition of eigen_decomposition matches its declaration.
* Remove the useless use of a variable length array for the parameters for eigen_decomposition, which fixes the mismatch between the declaration and the definition, which was an undefined behavior.

This PR was made when I tried to debug #6085. Because it is very rare and difficult to reproduce, I couldn't confirm this solves the issue. The issue might also have been solve by initializing init_pose_ and init_cov_ in ec72aaf8.

## Description of documentation updates required from your changes

No documentation to change.

## Description of how this change was tested

~~I simply ran amcl_node with valgrind before and after. No issue found.~~

I first included eig3.hpp in eig3.c and got compile errors. I replaced the `static int n = 3;` by the `#define n 3` and it compiled again.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
