### PR TITLE
Initialize init_pose_ and init_cov_ when starting AMCL

### DIFF
--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -64,6 +64,13 @@ AmclNode::AmclNode(const rclcpp::NodeOptions & options)
 {
   RCLCPP_INFO(get_logger(), "Creating");
 
+  init_pose_[0] = 0.0;
+  init_pose_[1] = 0.0;
+  init_pose_[2] = 0.0;
+  init_cov_[0] = 0.0;
+  init_cov_[1] = 0.0;
+  init_cov_[2] = 0.0;
+
   add_parameter(
     "alpha1", rclcpp::ParameterValue(0.2),
     "This is the alpha1 parameter", "These are additional constraints for alpha1");


### PR DESCRIPTION
This prevents pf_init from reading uninitialized values. Backported from ec72aaf8.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | 6085 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | Custom |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

When running AMCL with valgrind, I read a few "Conditional jump or move depends on uninitialised value" in pf_init :

```
==246882== Conditional jump or move depends on uninitialised value(s)
==246882==    at 0x555C756: UnknownInlinedFun (eig3.c:177)
==246882==    by 0x555C756: eigen_decomposition (eig3.c:281)
==246882==    by 0x555CD51: pf_matrix_unitary (pf_vector.c:255)
==246882==    by 0x555CEA2: pf_pdf_gaussian_alloc (pf_pdf.c:61)
==246882==    by 0x555CFD5: pf_init (pf.c:141)
==246882==    by 0x4941A42: nav2_amcl::AmclNode::initParticleFilter() (amcl_node.cpp:1633)
==246882==    by 0x49315BB: nav2_amcl::AmclNode::on_configure(rclcpp_lifecycle::State const&) (amcl_node.cpp:249)
```

## Description of documentation updates required from your changes

None, this is a bug fix.

## Description of how this change was tested

AMCL was runned with valgrind with and without the fix. This fix removes the Valgrinds errors. I also can't reproduce the stack smash with this fix.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
