### PR TITLE
fix: add world-distance pre-filter to ObstacleLayer

### DIFF
--- a/nav2_costmap_2d/plugins/obstacle_layer.cpp
+++ b/nav2_costmap_2d/plugins/obstacle_layer.cpp
@@ -548,6 +548,18 @@ ObstacleLayer::updateBounds(
         continue;
       }
 
+      // Pre-filter by world distance to avoid cell discretization boundary
+      // effects where hypot(dx,dy) truncation makes far points appear in range
+      const double wdx = px - obs.origin_.x;
+      const double wdy = py - obs.origin_.y;
+      const double world_dist_sq = wdx * wdx + wdy * wdy;
+      if (world_dist_sq > obs.obstacle_max_range_ * obs.obstacle_max_range_) {
+        continue;
+      }
+      if (world_dist_sq < obs.obstacle_min_range_ * obs.obstacle_min_range_) {
+        continue;
+      }
+
       // compute the distance from the hitpoint to the pointcloud's origin
       // Calculate the distance in cell space to match the ray trace algorithm
       // used for clearing obstacles (see Costmap2D::raytraceLine).

--- a/nav2_costmap_2d/test/unit/obstacle_layer_test.cpp
+++ b/nav2_costmap_2d/test/unit/obstacle_layer_test.cpp
@@ -204,24 +204,22 @@ TEST_F(ObstacleLayerTest, testDiagonalDistanceWithinRange)
 }
 
 /**
- * Test that point beyond obstacle max range but in same cell as max range is
- * marked as obstacle.
+ * World distance beyond obstacle_max_range must not mark, even if the hit
+ * shares the same map cell as a point at the range boundary (resolution 0.1 m).
  */
-TEST_F(ObstacleLayerTest, testPointBeyondRangeButInSameCellAsMaxRange) {
-  // Observation at (0.79, 0.0)
-  // obstacle_max_range = 0.72m
-  // obstacle range = 0.79m, > 0.72m but at same cell distance as max range so
-  // should be marked as obstacle, since it could be cleared by raytracing with
-  // the same max range.
+TEST_F(ObstacleLayerTest, testPointBeyondObstacleMaxRangeNotMarkedWhenSameMapCell)
+{
+  constexpr double k_obstacle_max_range = 0.72;
+  // (0.79, 0) and (0.72, 0) both map to mx == 7; world distance 0.79 m > 0.72 m.
   addObservation(obstacle_layer_, 0.79, 0.0, MAX_Z / 2, 0.0, 0.0, MAX_Z / 2,
-                 true, true, 100.0, 0.0, 0.72, 0.0);
+    true, true, 100.0, 0.0, k_obstacle_max_range, 0.0);
   update();
 
   unsigned int mx, my;
   obstacle_layer_->worldToMap(0.79, 0.0, mx, my);
   unsigned char cost = obstacle_layer_->getCost(mx, my);
 
-  ASSERT_EQ(cost, nav2_costmap_2d::LETHAL_OBSTACLE);
+  ASSERT_NE(cost, nav2_costmap_2d::LETHAL_OBSTACLE);
 }
 
 /**


### PR DESCRIPTION
Fixes ros-navigation/navigation2#6084

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | ros-navigation/navigation2#6084 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Fixed a range-filtering edge case in `ObstacleLayer` obstacle marking where map-cell discretization near boundaries could make out-of-range points appear valid.
* Added a world-space pre-filter using squared Euclidean distance (`world_dist_sq`) from observation origin before applying obstacle min/max range checks.
* This prevents false obstacle marking caused by truncation/rounding effects during world-to-map conversion, while preserving existing obstacle range semantics.

## Description of documentation updates required from your changes

* No documentation updates are required.
* No new parameters, interfaces, or user-facing behavior configuration were introduced.

## Description of how this change was tested

* Built and tested on Ubuntu using Nav2 in simulation.
* Validated obstacle marking behavior with points near obstacle range boundaries to confirm out-of-range points are ignored.
* Verified no regressions in normal obstacle marking for in-range observations.

---

## Future work that may be required in bullet points

* Add/extend automated tests to explicitly cover discretization boundary cases for obstacle range filtering.
* Consider applying the same world-space boundary-check pattern to other costmap paths if similar edge conditions are found.

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.