### PR TITLE
Remove default values for input ports on IsGoalNearby condition to behave in line with similar nodes

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_goal_nearby_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_goal_nearby_condition.hpp
@@ -74,8 +74,8 @@ public:
         "Maximum forward integrated distance along the path "
         "(starting from the last detected pose) to bound the search for the closest pose "
         "to the robot. When set to negative value (default), whole path is searched every time"),
-      BT::InputPort<std::string>("global_frame", "map", "Global frame"),
-      BT::InputPort<std::string>("robot_base_frame", "base_link", "Robot base frame"),
+      BT::InputPort<std::string>("global_frame", "Global frame"),
+      BT::InputPort<std::string>("robot_base_frame", "Robot base frame"),
     };
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_goal_nearby_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_goal_nearby_condition.hpp
@@ -15,17 +15,18 @@
 #ifndef NAV2_BEHAVIOR_TREE__PLUGINS__CONDITION__IS_GOAL_NEARBY_CONDITION_HPP_
 #define NAV2_BEHAVIOR_TREE__PLUGINS__CONDITION__IS_GOAL_NEARBY_CONDITION_HPP_
 
-#include <string>
 #include <limits>
 #include <memory>
+#include <string>
 #include <vector>
-#include "geometry_msgs/msg/pose_stamped.hpp"
-#include "nav_msgs/msg/path.hpp"
-#include "tf2_ros/buffer.hpp"
-#include "rclcpp/rclcpp.hpp"
+
 #include "behaviortree_cpp/condition_node.h"
-#include "nav2_ros_common/lifecycle_node.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_behavior_tree/bt_utils.hpp"
+#include "nav2_ros_common/lifecycle_node.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2_ros/buffer.hpp"
 
 namespace nav2_behavior_tree
 {
@@ -46,9 +47,7 @@ public:
    * @param condition_name Name for the XML tag for this node
    * @param conf BT node configuration
    */
-  IsGoalNearbyCondition(
-    const std::string & condition_name,
-    const BT::NodeConfiguration & conf);
+  IsGoalNearbyCondition(const std::string & condition_name, const BT::NodeConfiguration & conf);
 
   IsGoalNearbyCondition() = delete;
 

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -483,6 +483,8 @@
       <input_port name="path">Planned path</input_port>
       <input_port name="proximity_threshold">Proximity length (m) of the remaining path considered as a nearby</input_port>
       <input_port name="max_robot_pose_search_dist">Maximum forward integrated distance along the path (starting from the last detected pose) to bound the search for the closest pose to the robot. When set to infinity (default), whole path is searched every time</input_port>
+      <input_port name="global_frame">Global frame</input_port>
+      <input_port name="robot_base_frame">Robot base frame</input_port>
     </Condition>
 
     <Condition ID="IsWithinPathTrackingBounds">

--- a/nav2_behavior_tree/plugins/condition/is_goal_nearby_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_goal_nearby_condition.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "nav2_behavior_tree/plugins/condition/is_goal_nearby_condition.hpp"
+
 #include "nav2_util/geometry_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
 
@@ -20,19 +21,15 @@ namespace nav2_behavior_tree
 {
 
 IsGoalNearbyCondition::IsGoalNearbyCondition(
-  const std::string & condition_name,
-  const BT::NodeConfiguration & conf)
-: BT::ConditionNode(condition_name, conf),
-  transform_tolerance_(0.1)
+  const std::string & condition_name, const BT::NodeConfiguration & conf)
+: BT::ConditionNode(condition_name, conf), transform_tolerance_(0.1)
 {
   node_ = config().blackboard->get<nav2::LifecycleNode::SharedPtr>("node");
   tf_buffer_ = config().blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
   node_->get_parameter("transform_tolerance", transform_tolerance_);
 
-  global_frame_ = BT::deconflictPortAndParamFrame<std::string>(
-    node_, "global_frame", this);
-  robot_base_frame_ = BT::deconflictPortAndParamFrame<std::string>(
-    node_, "robot_base_frame", this);
+  global_frame_ = BT::deconflictPortAndParamFrame<std::string>(node_, "global_frame", this);
+  robot_base_frame_ = BT::deconflictPortAndParamFrame<std::string>(node_, "robot_base_frame", this);
 }
 
 BT::NodeStatus IsGoalNearbyCondition::tick()
@@ -44,7 +41,7 @@ BT::NodeStatus IsGoalNearbyCondition::tick()
   getInput("proximity_threshold", prox_thr);
   getInput("max_robot_pose_search_dist", max_robot_pose_search_dist);
 
-  if(new_path.poses.empty()) {
+  if (new_path.poses.empty()) {
     RCLCPP_WARN(node_->get_logger(), "Path is empty");
     return BT::NodeStatus::FAILURE;
   }
@@ -53,7 +50,6 @@ BT::NodeStatus IsGoalNearbyCondition::tick()
   if (max_robot_pose_search_dist < 0.0) {
     path_pruning = false;
   }
-
 
   if (!path_pruning || new_path != path_) {
     path_ = new_path;
@@ -70,8 +66,8 @@ BT::NodeStatus IsGoalNearbyCondition::tick()
 
   // let's get the pose of the robot in the frame of the plan
   geometry_msgs::msg::PoseStamped robot_pose;
-  if (!nav2_util::transformPoseInTargetFrame(pose, robot_pose, *tf_buffer_,
-    path_.header.frame_id))
+  if (!nav2_util::transformPoseInTargetFrame(
+      pose, robot_pose, *tf_buffer_, path_.header.frame_id))
   {
     RCLCPP_ERROR(
       node_->get_logger(), "Failed to transform robot pose to path frame '%s'",
@@ -81,26 +77,22 @@ BT::NodeStatus IsGoalNearbyCondition::tick()
 
   auto closest_pose_upper_bound = path_.poses.end();
   if (path_pruning) {
-    closest_pose_upper_bound =
-      nav2_util::geometry_utils::first_after_integrated_distance(
+    closest_pose_upper_bound = nav2_util::geometry_utils::first_after_integrated_distance(
       closest_pose_detection_begin_, path_.poses.end(), max_robot_pose_search_dist);
   }
 
   // First find the closest pose on the path to the robot
   // bounded by when the path turns around (if it does) so we don't get a pose from a later
   // portion of the path
-  auto closest_pose_it =
-    nav2_util::geometry_utils::min_by(
+  auto closest_pose_it = nav2_util::geometry_utils::min_by(
     closest_pose_detection_begin_, closest_pose_upper_bound,
-    [&robot_pose](const geometry_msgs::msg::PoseStamped & ps)
-    {
+    [&robot_pose](const geometry_msgs::msg::PoseStamped & ps) {
       return nav2_util::geometry_utils::euclidean_distance(robot_pose, ps);
     });
 
   closest_pose_detection_begin_ = closest_pose_it;
 
-  const std::size_t closest_index =
-    static_cast<std::size_t>(closest_pose_it - path_.poses.begin());
+  const std::size_t closest_index = static_cast<std::size_t>(closest_pose_it - path_.poses.begin());
   const double remaining_length =
     nav2_util::geometry_utils::calculate_path_length(path_, closest_index);
 

--- a/nav2_behavior_tree/test/plugins/condition/test_is_goal_nearby.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_goal_nearby.cpp
@@ -36,8 +36,8 @@ public:
   void SetUp() override
   {
     BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
-      return std::make_unique<nav2_behavior_tree::IsGoalNearbyCondition>(name, config);
-    };
+        return std::make_unique<nav2_behavior_tree::IsGoalNearbyCondition>(name, config);
+      };
     nav2::declare_parameter_if_not_declared(
       node_, "robot_base_frame", rclcpp::ParameterValue("base_link"));
 
@@ -50,7 +50,7 @@ public:
     tf_buffer_ = config_->blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
   }
 
-  void TearDown() override { tree_.reset(); }
+  void TearDown() override {tree_.reset();}
 
 protected:
   void setRobotPoseInMap(double x, double y, std::string frame_id = "base_link")
@@ -305,7 +305,8 @@ TEST_F(IsGoalNearbyConditionTestFixture, parameter_from_ros_node)
         </BehaviorTree>
       </root>)";
 
-  // Change robot_base_frame parameter to non-standard frame and verify that it is correctly used for transforms in the node
+  // Change robot_base_frame parameter to non-standard frame and verify that it is correctly used
+  // for transforms in the node
   std::string non_standard_frame = "sensor_frame";
   node_->set_parameter(rclcpp::Parameter("robot_base_frame", non_standard_frame));
 

--- a/nav2_behavior_tree/test/plugins/condition/test_is_goal_nearby.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_goal_nearby.cpp
@@ -40,10 +40,8 @@ public:
     };
     nav2::declare_parameter_if_not_declared(
       node_, "robot_base_frame", rclcpp::ParameterValue("base_link"));
-    node_->set_parameter(rclcpp::Parameter("robot_base_frame", "base_link"));
 
     nav2::declare_parameter_if_not_declared(node_, "global_frame", rclcpp::ParameterValue("map"));
-    node_->set_parameter(rclcpp::Parameter("global_frame", "map"));
 
     try {
       factory_->registerBuilder<nav2_behavior_tree::IsGoalNearbyCondition>("IsGoalNearby", builder);

--- a/nav2_behavior_tree/test/plugins/condition/test_is_goal_nearby.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_is_goal_nearby.cpp
@@ -20,16 +20,13 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
-
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include "nav_msgs/msg/path.hpp"
-
-#include "tf2_ros/buffer.hpp"
-
-#include "utils/test_behavior_tree_fixture.hpp"
 #include "nav2_behavior_tree/plugins/condition/is_goal_nearby_condition.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2_ros/buffer.hpp"
+#include "utils/test_behavior_tree_fixture.hpp"
 
 using namespace std::chrono_literals;
 
@@ -38,11 +35,15 @@ class IsGoalNearbyConditionTestFixture : public nav2_behavior_tree::BehaviorTree
 public:
   void SetUp() override
   {
-    BT::NodeBuilder builder =
-      [](const std::string & name, const BT::NodeConfiguration & config)
-      {
-        return std::make_unique<nav2_behavior_tree::IsGoalNearbyCondition>(name, config);
-      };
+    BT::NodeBuilder builder = [](const std::string & name, const BT::NodeConfiguration & config) {
+      return std::make_unique<nav2_behavior_tree::IsGoalNearbyCondition>(name, config);
+    };
+    nav2::declare_parameter_if_not_declared(
+      node_, "robot_base_frame", rclcpp::ParameterValue("base_link"));
+    node_->set_parameter(rclcpp::Parameter("robot_base_frame", "base_link"));
+
+    nav2::declare_parameter_if_not_declared(node_, "global_frame", rclcpp::ParameterValue("map"));
+    node_->set_parameter(rclcpp::Parameter("global_frame", "map"));
 
     try {
       factory_->registerBuilder<nav2_behavior_tree::IsGoalNearbyCondition>("IsGoalNearby", builder);
@@ -51,18 +52,15 @@ public:
     tf_buffer_ = config_->blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
   }
 
-  void TearDown() override
-  {
-    tree_.reset();
-  }
+  void TearDown() override { tree_.reset(); }
 
 protected:
-  void setRobotPoseInMap(double x, double y)
+  void setRobotPoseInMap(double x, double y, std::string frame_id = "base_link")
   {
     geometry_msgs::msg::TransformStamped tf;
     tf.header.stamp = node_->now();
     tf.header.frame_id = "map";
-    tf.child_frame_id = "base_link";
+    tf.child_frame_id = frame_id;
     tf.transform.translation.x = x;
     tf.transform.translation.y = y;
     tf.transform.translation.z = 0.0;
@@ -71,8 +69,7 @@ protected:
     tf_buffer_->setTransform(tf, "unit_test", true);
   }
 
-  static nav_msgs::msg::Path makePathInMap(
-    const std::vector<std::pair<double, double>> & pts)
+  static nav_msgs::msg::Path makePathInMap(const std::vector<std::pair<double, double>> & pts)
   {
     nav_msgs::msg::Path path;
     path.header.frame_id = "map";
@@ -88,8 +85,7 @@ protected:
     return path;
   }
 
-  static nav_msgs::msg::Path makeStraightPathInMap(
-    const std::vector<double> & xs)
+  static nav_msgs::msg::Path makeStraightPathInMap(const std::vector<double> & xs)
   {
     std::vector<std::pair<double, double>> pts;
     pts.reserve(xs.size());
@@ -182,8 +178,7 @@ TEST_F(IsGoalNearbyConditionTestFixture, near_goal_returns_success)
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
 }
 
-TEST_F(IsGoalNearbyConditionTestFixture,
-  pruning_bounded_search_ignores_far_ahead_close_point)
+TEST_F(IsGoalNearbyConditionTestFixture, pruning_bounded_search_ignores_far_ahead_close_point)
 {
   std::string xml_txt =
     R"(
@@ -199,8 +194,7 @@ TEST_F(IsGoalNearbyConditionTestFixture,
 
   tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
 
-  auto path = makeStraightPathInMap({
-    0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0});
+  auto path = makeStraightPathInMap({0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0});
   config_->blackboard->set("path", path);
 
   setRobotPoseInMap(5.0, 0.0);
@@ -298,6 +292,47 @@ TEST_F(IsGoalNearbyConditionTestFixture, invalid_path_frame_returns_failure)
 
   tree_->rootNode()->executeTick();
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::FAILURE);
+}
+
+TEST_F(IsGoalNearbyConditionTestFixture, parameter_from_ros_node)
+{
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+          <IsGoalNearby
+            path="{path}"
+            proximity_threshold="0.5"
+          />
+        </BehaviorTree>
+      </root>)";
+
+  // Change robot_base_frame parameter to non-standard frame and verify that it is correctly used for transforms in the node
+  std::string non_standard_frame = "sensor_frame";
+  node_->set_parameter(rclcpp::Parameter("robot_base_frame", non_standard_frame));
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  nav_msgs::msg::Path path;
+  path.header.frame_id = "map";
+  geometry_msgs::msg::PoseStamped ps;
+  ps.header.frame_id = "map";
+  ps.pose.orientation.w = 1.0;
+  ps.pose.position.x = 0.0;
+  path.poses.push_back(ps);
+  ps.pose.position.x = 10.0;
+  path.poses.push_back(ps);
+
+  // Set robot pose in non-standard frame at start of path
+  config_->blackboard->set("path", path);
+  setRobotPoseInMap(0.0, 0.0, non_standard_frame);
+  tree_->rootNode()->executeTick();
+  EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::FAILURE);
+
+  // Set robot pose in non-standard frame near end of path
+  setRobotPoseInMap(9.5, 0.0, non_standard_frame);
+  tree_->rootNode()->executeTick();
+  EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/issues/6096 |
| Primary OS tested on | Ubuntu|
| Robotic platform tested on | Simulation of custom robot |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Removal of default values for input ports for frame ids - if input ports are not provided, the node is supposed to fall back to ros parameters. This is in line with other behavior nodes.
* Documentation of input ports for frame ids

## Description of documentation updates required from your changes

https://docs.nav2.org/configuration/packages/bt-plugins/conditions/IsGoalNearby.html lists default values as `base_link` and `map`. Those are technically not the default values for the input ports any longer, but are still the defaults for the parameters, to which this node will fall back if no input ports are provided. So the documentation does not need an update, as it now matches exactly how e.g. [GoalReached](https://docs.nav2.org/configuration/packages/bt-plugins/conditions/GoalReached.html) behaves and is documented.

## Description of how this change was tested
* Updated existing unit tests to set frames through parameters on the node
* Added additional unit tests where a non-standard frame is used

---

## Future work that may be required in bullet points

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
